### PR TITLE
Revert "Allow users to sort traces (#8497)"

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -3,11 +3,10 @@ package clickhouse
 import (
 	"context"
 	"fmt"
+	"github.com/openlyinc/pointy"
 	"math"
 	"strings"
 	"time"
-
-	"github.com/openlyinc/pointy"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	e "github.com/pkg/errors"
@@ -37,7 +36,6 @@ var logKeysToColumns = map[modelInputs.ReservedLogKey]string{
 	modelInputs.ReservedLogKeyServiceVersion:  "ServiceVersion",
 	modelInputs.ReservedLogKeyEnvironment:     "Environment",
 	modelInputs.ReservedLogKeyMessage:         "Body",
-	modelInputs.ReservedLogKeyTimestamp:       "Timestamp",
 }
 
 // These keys show up as recommendations, but with no recommended values due to high cardinality
@@ -200,8 +198,9 @@ func (client *Client) ReadSessionLogs(ctx context.Context, projectID int, params
 		selectCols,
 		[]int{projectID},
 		params,
-		Pagination{Direction: modelInputs.SortDirectionAsc},
-	)
+		Pagination{},
+		OrderBackwardInverted,
+		OrderForwardInverted)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +251,9 @@ func (client *Client) ReadLogsTotalCount(ctx context.Context, projectID int, par
 		[]string{"COUNT(*)"},
 		[]int{projectID},
 		params,
-		Pagination{CountOnly: true})
+		Pagination{CountOnly: true},
+		OrderBackwardNatural,
+		OrderForwardNatural)
 	if err != nil {
 		return 0, err
 	}
@@ -339,6 +340,8 @@ func (client *Client) ReadLogsHistogram(ctx context.Context, projectID int, para
 			[]int{projectID},
 			params,
 			Pagination{CountOnly: true},
+			OrderBackwardNatural,
+			OrderForwardNatural,
 		)
 	} else {
 		fromSb, err = makeSelectBuilder(
@@ -347,6 +350,8 @@ func (client *Client) ReadLogsHistogram(ctx context.Context, projectID int, para
 			[]int{projectID},
 			params,
 			Pagination{CountOnly: true},
+			OrderBackwardNatural,
+			OrderForwardNatural,
 		)
 	}
 	if err != nil {

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -43,9 +43,6 @@ func setupTest(tb testing.TB) (*Client, func(tb testing.TB)) {
 
 		err = client.conn.Exec(context.Background(), fmt.Sprintf("TRUNCATE TABLE %s", TracesTable))
 		assert.NoError(tb, err)
-
-		err = client.conn.Exec(context.Background(), fmt.Sprintf("TRUNCATE TABLE %s", TracesSamplingTable))
-		assert.NoError(tb, err)
 	}
 }
 

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -39,7 +39,12 @@ func readObjects[TObj interface{}, TReservedKey ~string](ctx context.Context, cl
 	var err error
 	var args []interface{}
 
-	orderForward, _ := getSortOrders[TReservedKey](sb, pagination.Direction, config, params)
+	orderForward := OrderForwardNatural
+	orderBackward := OrderBackwardNatural
+	if pagination.Direction == modelInputs.SortDirectionAsc {
+		orderForward = OrderForwardInverted
+		orderBackward = OrderBackwardInverted
+	}
 
 	outerSelect := strings.Join(config.SelectColumns, ", ")
 	innerSelect := []string{"Timestamp", "UUID"}
@@ -53,7 +58,9 @@ func readObjects[TObj interface{}, TReservedKey ~string](ctx context.Context, cl
 			params,
 			Pagination{
 				Before: pagination.At,
-			})
+			},
+			orderBackward,
+			orderForward)
 		if err != nil {
 			return nil, err
 		}
@@ -66,7 +73,9 @@ func readObjects[TObj interface{}, TReservedKey ~string](ctx context.Context, cl
 			params,
 			Pagination{
 				At: pagination.At,
-			})
+			},
+			orderBackward,
+			orderForward)
 		if err != nil {
 			return nil, err
 		}
@@ -79,7 +88,9 @@ func readObjects[TObj interface{}, TReservedKey ~string](ctx context.Context, cl
 			params,
 			Pagination{
 				After: pagination.At,
-			})
+			},
+			orderBackward,
+			orderForward)
 		if err != nil {
 			return nil, err
 		}
@@ -98,7 +109,9 @@ func readObjects[TObj interface{}, TReservedKey ~string](ctx context.Context, cl
 			innerSelect,
 			[]int{projectID},
 			params,
-			pagination)
+			pagination,
+			orderBackward,
+			orderForward)
 		if err != nil {
 			return nil, err
 		}
@@ -150,10 +163,10 @@ func makeSelectBuilder[T ~string](
 	projectIDs []int,
 	params modelInputs.QueryInput,
 	pagination Pagination,
+	orderBackward string,
+	orderForward string,
 ) (*sqlbuilder.SelectBuilder, error) {
 	sb := sqlbuilder.NewSelectBuilder()
-
-	orderForward, orderBackward := getSortOrders[T](sb, pagination.Direction, config, params)
 
 	sb.Select(selectCols...)
 	sb.From(config.TableName)
@@ -599,6 +612,8 @@ func readWorkspaceMetrics[T ~string](ctx context.Context, client *Client, sample
 		projectIDs,
 		params,
 		Pagination{CountOnly: true},
+		OrderBackwardNatural,
+		OrderForwardNatural,
 	)
 
 	var col string
@@ -880,6 +895,8 @@ func logLines[T ~string](ctx context.Context, client *Client, tableConfig model.
 		[]int{projectID},
 		params,
 		Pagination{CountOnly: true},
+		OrderBackwardNatural,
+		OrderForwardNatural,
 	)
 	if err != nil {
 		return nil, err
@@ -941,37 +958,4 @@ func repr(val reflect.Value) string {
 	default:
 		return val.String()
 	}
-}
-
-func getSortOrders[TReservedKey ~string](
-	sb *sqlbuilder.SelectBuilder,
-	paginationDirection modelInputs.SortDirection,
-	config model.TableConfig[TReservedKey],
-	params modelInputs.QueryInput,
-) (string, string) {
-	sortColumn := "timestamp"
-	sortDirection := modelInputs.SortDirectionDesc
-	if params.Sort != nil {
-		sortColumn = params.Sort.Column
-		sortDirection = params.Sort.Direction
-	}
-
-	if col, found := config.KeysToColumns[TReservedKey(sortColumn)]; found {
-		sortColumn = col
-	} else {
-		sortColumn = fmt.Sprintf("%s[%s]", config.AttributesColumn, sb.Var(sortColumn))
-	}
-
-	forwardDirection := "DESC"
-	backwardDirection := "ASC"
-	if paginationDirection == modelInputs.SortDirectionAsc || sortDirection == modelInputs.SortDirectionAsc {
-		forwardDirection = "ASC"
-	} else {
-		backwardDirection = "DESC"
-	}
-
-	orderForward := fmt.Sprintf("%s %s, UUID %s", sortColumn, forwardDirection, forwardDirection)
-	orderBackward := fmt.Sprintf("%s %s, UUID %s", sortColumn, backwardDirection, backwardDirection)
-
-	return orderForward, orderBackward
 }

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -46,7 +46,6 @@ var traceKeysToColumns = map[modelInputs.ReservedTraceKey]string{
 	modelInputs.ReservedTraceKeyMetricValue:     "MetricValue",
 	modelInputs.ReservedTraceKeyEnvironment:     "Environment",
 	modelInputs.ReservedTraceKeyHasErrors:       "HasErrors",
-	modelInputs.ReservedTraceKeyTimestamp:       "Timestamp",
 }
 
 var traceColumns = []string{
@@ -269,12 +268,7 @@ func (client *Client) ReadTraces(ctx context.Context, projectID int, params mode
 		}, nil
 	}
 
-	tableConfig := TracesTableConfig
-	if params.Sort != nil {
-		tableConfig = tracesSamplingTableConfig
-	}
-
-	conn, err := readObjects(ctx, client, tableConfig, projectID, params, pagination, scanTrace)
+	conn, err := readObjects(ctx, client, TracesTableConfig, projectID, params, pagination, scanTrace)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -11020,7 +11020,6 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputSanitizedSlackChannelInput,
 		ec.unmarshalInputSessionAlertInput,
 		ec.unmarshalInputSessionCommentTagInput,
-		ec.unmarshalInputSortInput,
 		ec.unmarshalInputTrackPropertyInput,
 		ec.unmarshalInputUserPropertyInput,
 		ec.unmarshalInputVercelProjectMappingInput,
@@ -12093,7 +12092,6 @@ enum ReservedLogKey {
 	source
 	service_name
 	service_version
-	timestamp
 }
 
 enum ReservedTraceKey {
@@ -12113,7 +12111,6 @@ enum ReservedTraceKey {
 	duration
 	service_name
 	service_version
-	timestamp
 }
 
 enum ReservedErrorObjectKey {
@@ -12323,15 +12320,9 @@ input ErrorGroupFrequenciesParamsInput {
 	resolution_minutes: Int!
 }
 
-input SortInput {
-	column: String!
-	direction: SortDirection!
-}
-
 input QueryInput {
 	query: String!
 	date_range: DateRangeRequiredInput!
-	sort: SortInput
 }
 
 enum MetricTagFilterOp {
@@ -80446,7 +80437,7 @@ func (ec *executionContext) unmarshalInputQueryInput(ctx context.Context, obj in
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"query", "date_range", "sort"}
+	fieldsInOrder := [...]string{"query", "date_range"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -80467,13 +80458,6 @@ func (ec *executionContext) unmarshalInputQueryInput(ctx context.Context, obj in
 				return it, err
 			}
 			it.DateRange = data
-		case "sort":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sort"))
-			data, err := ec.unmarshalOSortInput2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSortInput(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Sort = data
 		}
 	}
 
@@ -80819,40 +80803,6 @@ func (ec *executionContext) unmarshalInputSessionCommentTagInput(ctx context.Con
 				return it, err
 			}
 			it.Name = data
-		}
-	}
-
-	return it, nil
-}
-
-func (ec *executionContext) unmarshalInputSortInput(ctx context.Context, obj interface{}) (model.SortInput, error) {
-	var it model.SortInput
-	asMap := map[string]interface{}{}
-	for k, v := range obj.(map[string]interface{}) {
-		asMap[k] = v
-	}
-
-	fieldsInOrder := [...]string{"column", "direction"}
-	for _, k := range fieldsInOrder {
-		v, ok := asMap[k]
-		if !ok {
-			continue
-		}
-		switch k {
-		case "column":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("column"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Column = data
-		case "direction":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("direction"))
-			data, err := ec.unmarshalNSortDirection2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSortDirection(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Direction = data
 		}
 	}
 
@@ -102765,14 +102715,6 @@ func (ec *executionContext) marshalOSocialLink2ᚖgithubᚗcomᚋhighlightᚑrun
 		return graphql.Null
 	}
 	return ec._SocialLink(ctx, sel, v)
-}
-
-func (ec *executionContext) unmarshalOSortInput2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSortInput(ctx context.Context, v interface{}) (*model.SortInput, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := ec.unmarshalInputSortInput(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOSourceMappingError2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSourceMappingError(ctx context.Context, sel ast.SelectionSet, v *model.SourceMappingError) graphql.Marshaler {

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -658,7 +658,6 @@ type Plan struct {
 type QueryInput struct {
 	Query     string                  `json:"query"`
 	DateRange *DateRangeRequiredInput `json:"date_range"`
-	Sort      *SortInput              `json:"sort,omitempty"`
 }
 
 type QueryKey struct {
@@ -824,11 +823,6 @@ type SlackSyncResponse struct {
 type SocialLink struct {
 	Type SocialType `json:"type"`
 	Link *string    `json:"link,omitempty"`
-}
-
-type SortInput struct {
-	Column    string        `json:"column"`
-	Direction SortDirection `json:"direction"`
 }
 
 type SourceMappingError struct {
@@ -2065,7 +2059,6 @@ const (
 	ReservedLogKeySource          ReservedLogKey = "source"
 	ReservedLogKeyServiceName     ReservedLogKey = "service_name"
 	ReservedLogKeyServiceVersion  ReservedLogKey = "service_version"
-	ReservedLogKeyTimestamp       ReservedLogKey = "timestamp"
 )
 
 var AllReservedLogKey = []ReservedLogKey{
@@ -2078,12 +2071,11 @@ var AllReservedLogKey = []ReservedLogKey{
 	ReservedLogKeySource,
 	ReservedLogKeyServiceName,
 	ReservedLogKeyServiceVersion,
-	ReservedLogKeyTimestamp,
 }
 
 func (e ReservedLogKey) IsValid() bool {
 	switch e {
-	case ReservedLogKeyEnvironment, ReservedLogKeyLevel, ReservedLogKeyMessage, ReservedLogKeySecureSessionID, ReservedLogKeySpanID, ReservedLogKeyTraceID, ReservedLogKeySource, ReservedLogKeyServiceName, ReservedLogKeyServiceVersion, ReservedLogKeyTimestamp:
+	case ReservedLogKeyEnvironment, ReservedLogKeyLevel, ReservedLogKeyMessage, ReservedLogKeySecureSessionID, ReservedLogKeySpanID, ReservedLogKeyTraceID, ReservedLogKeySource, ReservedLogKeyServiceName, ReservedLogKeyServiceVersion:
 		return true
 	}
 	return false
@@ -2228,7 +2220,6 @@ const (
 	ReservedTraceKeyDuration        ReservedTraceKey = "duration"
 	ReservedTraceKeyServiceName     ReservedTraceKey = "service_name"
 	ReservedTraceKeyServiceVersion  ReservedTraceKey = "service_version"
-	ReservedTraceKeyTimestamp       ReservedTraceKey = "timestamp"
 )
 
 var AllReservedTraceKey = []ReservedTraceKey{
@@ -2248,12 +2239,11 @@ var AllReservedTraceKey = []ReservedTraceKey{
 	ReservedTraceKeyDuration,
 	ReservedTraceKeyServiceName,
 	ReservedTraceKeyServiceVersion,
-	ReservedTraceKeyTimestamp,
 }
 
 func (e ReservedTraceKey) IsValid() bool {
 	switch e {
-	case ReservedTraceKeyEnvironment, ReservedTraceKeyHasErrors, ReservedTraceKeyLevel, ReservedTraceKeyMessage, ReservedTraceKeyMetricName, ReservedTraceKeyMetricValue, ReservedTraceKeySecureSessionID, ReservedTraceKeySpanID, ReservedTraceKeyTraceID, ReservedTraceKeyParentSpanID, ReservedTraceKeyTraceState, ReservedTraceKeySpanName, ReservedTraceKeySpanKind, ReservedTraceKeyDuration, ReservedTraceKeyServiceName, ReservedTraceKeyServiceVersion, ReservedTraceKeyTimestamp:
+	case ReservedTraceKeyEnvironment, ReservedTraceKeyHasErrors, ReservedTraceKeyLevel, ReservedTraceKeyMessage, ReservedTraceKeyMetricName, ReservedTraceKeyMetricValue, ReservedTraceKeySecureSessionID, ReservedTraceKeySpanID, ReservedTraceKeyTraceID, ReservedTraceKeyParentSpanID, ReservedTraceKeyTraceState, ReservedTraceKeySpanName, ReservedTraceKeySpanKind, ReservedTraceKeyDuration, ReservedTraceKeyServiceName, ReservedTraceKeyServiceVersion:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -951,7 +951,6 @@ enum ReservedLogKey {
 	source
 	service_name
 	service_version
-	timestamp
 }
 
 enum ReservedTraceKey {
@@ -971,7 +970,6 @@ enum ReservedTraceKey {
 	duration
 	service_name
 	service_version
-	timestamp
 }
 
 enum ReservedErrorObjectKey {
@@ -1181,15 +1179,9 @@ input ErrorGroupFrequenciesParamsInput {
 	resolution_minutes: Int!
 }
 
-input SortInput {
-	column: String!
-	direction: SortDirection!
-}
-
 input QueryInput {
 	query: String!
 	date_range: DateRangeRequiredInput!
-	sort: SortInput
 }
 
 enum MetricTagFilterOp {

--- a/frontend/src/components/CustomColumnActions/index.tsx
+++ b/frontend/src/components/CustomColumnActions/index.tsx
@@ -8,8 +8,6 @@ import {
 	IconSolidClipboardCopy,
 	IconSolidCloudUpload,
 	IconSolidRefresh,
-	IconSolidSortAscending,
-	IconSolidSortDescending,
 	IconSolidXCircle,
 	Menu,
 	Stack,
@@ -21,7 +19,6 @@ import { useMemo } from 'react'
 
 import { ValidCustomColumn } from '@/components/CustomColumnPopover'
 import { Modal } from '@/components/Modal/ModalV2'
-import { SortDirection } from '@/graph/generated/schemas'
 import analytics from '@/util/analytics'
 
 type Props = {
@@ -30,9 +27,6 @@ type Props = {
 	columnId: string
 	trackingId: string
 	standardColumns: Record<string, ValidCustomColumn>
-	sortColumn: string | null | undefined
-	sortDirection: string | null | undefined
-	onSort?: (direction?: SortDirection | null) => void
 }
 
 export const CustomColumnActions: React.FC<Props> = ({
@@ -41,9 +35,6 @@ export const CustomColumnActions: React.FC<Props> = ({
 	columnId,
 	trackingId,
 	standardColumns,
-	sortColumn,
-	sortDirection,
-	onSort,
 }) => {
 	const [labelModalOpen, setLabelModalOpen] = React.useState(false)
 
@@ -51,20 +42,17 @@ export const CustomColumnActions: React.FC<Props> = ({
 		() => selectedColumns.findIndex((c) => c.id === columnId),
 		[selectedColumns, columnId],
 	)
-	const isSorted = sortColumn === columnId
 
 	const trackEvent = (action: string) => {
 		analytics.track(`Button-${trackingId}_${action}`, { columnId })
 	}
 
-	const removeColumn = (e: React.MouseEvent) => {
-		e.stopPropagation()
+	const removeColumn = () => {
 		trackEvent('hide')
 		setSelectedColumns(selectedColumns.filter((c) => c.id !== columnId))
 	}
 
-	const moveColumnLeft = (e: React.MouseEvent) => {
-		e.stopPropagation()
+	const moveColumnLeft = () => {
 		trackEvent('left')
 		const newColumns = [...selectedColumns]
 		newColumns[columnIndex] = selectedColumns[columnIndex - 1]
@@ -72,8 +60,7 @@ export const CustomColumnActions: React.FC<Props> = ({
 		setSelectedColumns(newColumns)
 	}
 
-	const moveColumnRight = (e: React.MouseEvent) => {
-		e.stopPropagation()
+	const moveColumnRight = () => {
 		trackEvent('right')
 		const newColumns = [...selectedColumns]
 		newColumns[columnIndex] = selectedColumns[columnIndex + 1]
@@ -81,16 +68,14 @@ export const CustomColumnActions: React.FC<Props> = ({
 		setSelectedColumns(newColumns)
 	}
 
-	const copyColumn = (e: React.MouseEvent) => {
-		e.stopPropagation()
+	const copyColumn = () => {
 		trackEvent('copy')
 		copyToClipboard(columnId, {
 			onCopyText: 'Copied to clipboard',
 		})
 	}
 
-	const handleLabelUpdateColumn = (e: React.MouseEvent) => {
-		e.stopPropagation()
+	const handleLabelUpdateColumn = () => {
 		trackEvent('rename')
 		setLabelModalOpen(true)
 	}
@@ -101,8 +86,7 @@ export const CustomColumnActions: React.FC<Props> = ({
 		setSelectedColumns(newColumns)
 	}
 
-	const resetSize = (e: React.MouseEvent) => {
-		e.stopPropagation()
+	const resetSize = () => {
 		trackEvent('resetSize')
 		const newColumns = [...selectedColumns]
 
@@ -121,7 +105,7 @@ export const CustomColumnActions: React.FC<Props> = ({
 
 	return (
 		<>
-			<Menu placement="bottom-end">
+			<Menu>
 				<Table.Discoverable trigger="header">
 					<Menu.Button
 						style={{
@@ -131,57 +115,12 @@ export const CustomColumnActions: React.FC<Props> = ({
 						size="small"
 						emphasis="low"
 						kind="secondary"
-						onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-							e.stopPropagation()
-							trackEvent('open')
-						}}
+						onClick={() => trackEvent('open')}
 					>
 						<IconOutlineDotsHorizontal />
 					</Menu.Button>
 				</Table.Discoverable>
 				<Menu.List>
-					{onSort && (
-						<>
-							<Menu.Item
-								disabled={
-									isSorted &&
-									sortDirection === SortDirection.Desc
-								}
-								onClick={(e) => {
-									e.stopPropagation()
-									onSort(SortDirection.Desc)
-								}}
-							>
-								<IconSolidSortDescending size={16} />
-								Sort Descending
-							</Menu.Item>
-							<Menu.Item
-								disabled={
-									isSorted &&
-									sortDirection === SortDirection.Asc
-								}
-								onClick={(e) => {
-									e.stopPropagation()
-									onSort(SortDirection.Asc)
-								}}
-							>
-								<IconSolidSortAscending size={16} />
-								Sort Ascending
-							</Menu.Item>
-							{isSorted && (
-								<Menu.Item
-									onClick={(e) => {
-										e.stopPropagation()
-										onSort(null)
-									}}
-								>
-									<IconSolidXCircle size={16} />
-									Remove Sort
-								</Menu.Item>
-							)}
-							<Menu.Divider />
-						</>
-					)}
 					<Menu.Item disabled={disableLeft} onClick={moveColumnLeft}>
 						<Box display="flex" alignItems="center" gap="4">
 							<IconSolidArrowLeft size={16} />

--- a/frontend/src/components/CustomColumnHeader/index.tsx
+++ b/frontend/src/components/CustomColumnHeader/index.tsx
@@ -1,23 +1,14 @@
-import {
-	Box,
-	IconSolidSortAscending,
-	IconSolidSortDescending,
-	Stack,
-	Table,
-	Text,
-} from '@highlight-run/ui/components'
+import { Box, Table, Text } from '@highlight-run/ui/components'
 import { useMemo, useRef } from 'react'
 
 import { CustomColumnActions } from '@/components/CustomColumnActions'
 import { ValidCustomColumn } from '@/components/CustomColumnPopover'
-import { SortDirection } from '@/graph/generated/schemas'
 
 export type ColumnHeader = {
 	id: string
 	component: React.ReactNode
 	showActions?: boolean
 	noPadding?: boolean
-	onSort?: (direction?: SortDirection | null) => void
 }
 
 type Props = {
@@ -26,8 +17,6 @@ type Props = {
 	setSelectedColumns: (columns: ValidCustomColumn[]) => void
 	standardColumns: Record<string, ValidCustomColumn>
 	trackingIdPrefix: string
-	sortColumn?: string | null
-	sortDirection?: string | null
 }
 
 const MINIMUM_COLUMN_WIDTH = 50
@@ -38,8 +27,6 @@ export const CustomColumnHeader: React.FC<Props> = ({
 	setSelectedColumns,
 	standardColumns,
 	trackingIdPrefix,
-	sortColumn,
-	sortDirection,
 }) => {
 	const headerRef = useRef<HTMLDivElement>(null)
 
@@ -87,51 +74,22 @@ export const CustomColumnHeader: React.FC<Props> = ({
 			key={header.id}
 			noPadding={header.noPadding}
 			ref={headerRef}
-			cursor={header.onSort ? 'pointer' : 'default'}
-			onClick={() => {
-				if (!header.onSort) {
-					return
-				}
-
-				header.onSort()
-			}}
 		>
 			<Box
 				display="flex"
 				alignItems="center"
 				justifyContent="space-between"
 			>
-				<Stack direction="row" gap="6" align="center">
-					<Text lines="1">{header.component}</Text>
-					{sortColumn === header.id &&
-						sortDirection &&
-						(sortDirection === SortDirection.Desc ? (
-							<IconSolidSortDescending
-								size={13}
-								style={{ flexShrink: 0 }}
-							/>
-						) : (
-							<IconSolidSortAscending
-								size={13}
-								style={{ flexShrink: 0 }}
-							/>
-						))}
-				</Stack>
-
-				<Stack align="center" direction="row" gap="6">
-					{header.showActions && (
-						<CustomColumnActions
-							columnId={header.id}
-							selectedColumns={selectedColumns}
-							setSelectedColumns={setSelectedColumns}
-							trackingId={trackingIdPrefix}
-							standardColumns={standardColumns}
-							onSort={header.onSort}
-							sortColumn={sortColumn}
-							sortDirection={sortDirection}
-						/>
-					)}
-				</Stack>
+				<Text lines="1">{header.component}</Text>
+				{header.showActions && (
+					<CustomColumnActions
+						columnId={header.id}
+						selectedColumns={selectedColumns}
+						setSelectedColumns={setSelectedColumns}
+						trackingId={trackingIdPrefix}
+						standardColumns={standardColumns}
+					/>
+				)}
 			</Box>
 			{resizeable && (
 				<Box

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2897,7 +2897,6 @@ export type QueryWorkspace_Invite_LinksArgs = {
 export type QueryInput = {
 	date_range: DateRangeRequiredInput
 	query: Scalars['String']
-	sort?: InputMaybe<SortInput>
 }
 
 export type QueryKey = {
@@ -2985,7 +2984,6 @@ export enum ReservedLogKey {
 	ServiceVersion = 'service_version',
 	Source = 'source',
 	SpanId = 'span_id',
-	Timestamp = 'timestamp',
 	TraceId = 'trace_id',
 }
 
@@ -3038,7 +3036,6 @@ export enum ReservedTraceKey {
 	SpanId = 'span_id',
 	SpanKind = 'span_kind',
 	SpanName = 'span_name',
-	Timestamp = 'timestamp',
 	TraceId = 'trace_id',
 	TraceState = 'trace_state',
 }
@@ -3443,11 +3440,6 @@ export enum SocialType {
 export enum SortDirection {
 	Asc = 'ASC',
 	Desc = 'DESC',
-}
-
-export type SortInput = {
-	column: Scalars['String']
-	direction: SortDirection
 }
 
 export type SourceMappingError = {

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -74,7 +74,7 @@ export const LogDetails: React.FC<Props> = ({
 		level: LogLevel
 		message: string
 	} & {
-		[key in ReservedLogKey]?: Maybe<string> | undefined
+		[key in ReservedLogKey]: Maybe<string> | undefined
 	} = {
 		environment,
 		level,

--- a/frontend/src/pages/Traces/TraceProvider.tsx
+++ b/frontend/src/pages/Traces/TraceProvider.tsx
@@ -10,7 +10,6 @@ import {
 	getTraceTimes,
 	organizeSpansForFlameGraph,
 	organizeSpansWithChildren,
-	traceSortFn,
 } from '@/pages/Traces/utils'
 
 type TraceContext = {
@@ -128,7 +127,7 @@ export const TraceProvider: React.FC<React.PropsWithChildren<Props>> = ({
 			return []
 		}
 
-		const spans = [...data.trace.trace].sort(traceSortFn)
+		const spans = data.trace.trace //.sort(traceSortFn)
 		return organizeSpansWithChildren(spans)
 	}, [data?.trace?.trace])
 

--- a/frontend/src/pages/Traces/TracesList.tsx
+++ b/frontend/src/pages/Traces/TracesList.tsx
@@ -16,8 +16,7 @@ import {
 } from '@tanstack/react-table'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { isEqual } from 'lodash'
-import React, { Key, useCallback, useEffect, useMemo, useRef } from 'react'
-import { StringParam, useQueryParam } from 'use-query-params'
+import React, { Key, useMemo, useRef } from 'react'
 
 import {
 	ColumnHeader,
@@ -31,15 +30,8 @@ import {
 	RelatedTrace,
 	useRelatedResource,
 } from '@/components/RelatedResources/hooks'
-import {
-	DEFAULT_INPUT_HEIGHT,
-	QueryParam,
-} from '@/components/Search/SearchForm/SearchForm'
-import {
-	ProductType,
-	SortDirection,
-	TraceEdge,
-} from '@/graph/generated/schemas'
+import { DEFAULT_INPUT_HEIGHT } from '@/components/Search/SearchForm/SearchForm'
+import { ProductType, TraceEdge } from '@/graph/generated/schemas'
 import { MAX_TRACES } from '@/pages/Traces/useGetTraces'
 
 import {
@@ -79,38 +71,6 @@ export const TracesList: React.FC<Props> = ({
 		`highlight-traces-table-columns`,
 		DEFAULT_TRACE_COLUMNS,
 	)
-	const [sortColumn, setSortColumn] = useQueryParam(
-		'sort_column',
-		StringParam,
-	)
-	const [sortDirection, setSortDirection] = useQueryParam(
-		'sort_direction',
-		StringParam,
-	)
-	const [query] = useQueryParam('query', QueryParam)
-
-	const handleSort = useCallback(
-		(column: string, direction?: SortDirection | null) => {
-			if (
-				column === sortColumn &&
-				(direction === null || sortDirection === SortDirection.Asc)
-			) {
-				setSortColumn(undefined)
-				setSortDirection(undefined)
-			} else {
-				const nextDirection =
-					direction ??
-					(column === sortColumn &&
-					sortDirection === SortDirection.Desc
-						? SortDirection.Asc
-						: SortDirection.Desc)
-
-				setSortColumn(column)
-				setSortDirection(nextDirection)
-			}
-		},
-		[setSortColumn, setSortDirection, sortColumn, sortDirection],
-	)
 
 	const bodyRef = useRef<HTMLDivElement>(null)
 	const enableFetchMoreTraces =
@@ -133,9 +93,6 @@ export const TracesList: React.FC<Props> = ({
 				id: column.id,
 				component: column.label,
 				showActions: true,
-				onSort: (direction?: SortDirection | null) => {
-					handleSort(column.id, direction)
-				},
 			})
 
 			// @ts-ignore
@@ -179,7 +136,7 @@ export const TracesList: React.FC<Props> = ({
 			columnHeaders,
 			columns,
 		}
-	}, [columnHelper, handleSort, selectedColumns, setSelectedColumns])
+	}, [columnHelper, selectedColumns, setSelectedColumns])
 
 	const table = useReactTable({
 		data: traceEdges,
@@ -231,14 +188,11 @@ export const TracesList: React.FC<Props> = ({
 		}, 0)
 	}
 
-	useEffect(() => {
-		if (query.trim() === '') {
-			setSortColumn(undefined)
-			setSortDirection(undefined)
-		}
-	}, [query, setSortColumn, setSortDirection])
+	if (loading) {
+		return <LoadingBox />
+	}
 
-	if (!loading && !traceEdges.length) {
+	if (!traceEdges.length) {
 		return (
 			<Box m="8">
 				<Box
@@ -297,8 +251,6 @@ export const TracesList: React.FC<Props> = ({
 							setSelectedColumns={setSelectedColumns!}
 							standardColumns={HIGHLIGHT_STANDARD_COLUMNS}
 							trackingIdPrefix="TracesTableColumn"
-							sortColumn={sortColumn}
-							sortDirection={sortDirection}
 						/>
 					))}
 				</Table.Row>
@@ -318,55 +270,49 @@ export const TracesList: React.FC<Props> = ({
 					</Table.Row>
 				)}
 			</Table.Head>
-			{loading ? (
-				<LoadingBox />
-			) : (
-				<Table.Body
-					ref={bodyRef}
-					height="full"
-					overflowY="auto"
-					onScroll={handleFetchMoreWhenScrolled}
-					style={{
-						height: `calc(100% - ${otherElementsHeight}px)`,
-					}}
-					hiddenScroll
-				>
-					{paddingTop > 0 && <Box style={{ height: paddingTop }} />}
-					{virtualRows.map((virtualRow) => {
-						const row = rows[virtualRow.index]
-						const isSelected =
-							row.original.node.spanID === trace?.spanID
+			<Table.Body
+				ref={bodyRef}
+				height="full"
+				overflowY="auto"
+				onScroll={handleFetchMoreWhenScrolled}
+				style={{
+					height: `calc(100% - ${otherElementsHeight}px)`,
+				}}
+				hiddenScroll
+			>
+				{paddingTop > 0 && <Box style={{ height: paddingTop }} />}
+				{virtualRows.map((virtualRow) => {
+					const row = rows[virtualRow.index]
+					const isSelected =
+						row.original.node.spanID === trace?.spanID
 
-						return (
-							<TracesTableRow
-								key={virtualRow.key}
-								row={row}
-								rowVirtualizer={rowVirtualizer}
-								virtualRowKey={virtualRow.key}
-								isSelected={isSelected}
-								gridColumns={columnData.gridColumns}
-								selectedColumnsIds={selectedColumns.map(
-									(c) => c.id,
-								)}
-							/>
-						)
-					})}
+					return (
+						<TracesTableRow
+							key={virtualRow.key}
+							row={row}
+							rowVirtualizer={rowVirtualizer}
+							virtualRowKey={virtualRow.key}
+							isSelected={isSelected}
+							gridColumns={columnData.gridColumns}
+							selectedColumnsIds={selectedColumns.map(
+								(c) => c.id,
+							)}
+						/>
+					)
+				})}
 
-					{paddingBottom > 0 && (
-						<Box style={{ height: paddingBottom }} />
-					)}
+				{paddingBottom > 0 && <Box style={{ height: paddingBottom }} />}
 
-					{loadingAfter && (
-						<Box
-							style={{
-								height: `${LOADING_AFTER_HEIGHT}px`,
-							}}
-						>
-							<LoadingBox />
-						</Box>
-					)}
-				</Table.Body>
-			)}
+				{loadingAfter && (
+					<Box
+						style={{
+							height: `${LOADING_AFTER_HEIGHT}px`,
+						}}
+					>
+						<LoadingBox />
+					</Box>
+				)}
+			</Table.Body>
 		</Table>
 	)
 }

--- a/frontend/src/pages/Traces/TracesPage.tsx
+++ b/frontend/src/pages/Traces/TracesPage.tsx
@@ -12,7 +12,7 @@ import moment from 'moment'
 import React, { useEffect, useRef } from 'react'
 import { Helmet } from 'react-helmet'
 import { useNavigate } from 'react-router-dom'
-import { StringParam, useQueryParam } from 'use-query-params'
+import { useQueryParam } from 'use-query-params'
 
 import { loadingIcon } from '@/components/Button/style.css'
 import {
@@ -35,7 +35,6 @@ import {
 	MetricColumn,
 	ProductType,
 	SavedSegmentEntityType,
-	SortDirection,
 	Trace,
 } from '@/graph/generated/schemas'
 import { useProjectId } from '@/hooks/useProjectId'
@@ -61,8 +60,6 @@ export const TracesPage: React.FC = () => {
 	} = useParams<{ trace_id: string; span_id: string; trace_cursor: string }>()
 	const textAreaRef = useRef<HTMLTextAreaElement | null>(null)
 	const [query, setQuery] = useQueryParam('query', QueryParam)
-	const [sortColumn] = useQueryParam('sort_column', StringParam)
-	const [sortDirection] = useQueryParam('sort_direction', StringParam)
 	const {
 		startDate,
 		endDate,
@@ -90,8 +87,6 @@ export const TracesPage: React.FC = () => {
 		startDate,
 		endDate,
 		skipPolling: !selectedPreset,
-		sortColumn,
-		sortDirection: sortDirection as SortDirection,
 	})
 
 	const { data: metricsData, loading: metricsLoading } =

--- a/frontend/src/pages/Traces/useGetTraces.ts
+++ b/frontend/src/pages/Traces/useGetTraces.ts
@@ -24,8 +24,6 @@ export const useGetTraces = ({
 	startDate,
 	endDate,
 	skipPolling,
-	sortColumn,
-	sortDirection,
 }: {
 	query: string
 	projectId: string | undefined
@@ -33,8 +31,6 @@ export const useGetTraces = ({
 	startDate: Date
 	endDate: Date
 	skipPolling?: boolean
-	sortColumn?: string | null | undefined
-	sortDirection?: Types.SortDirection | null | undefined
 }) => {
 	// The backend can only tell us page info about a single page.
 	// It has no idea what pages have already been loaded.
@@ -62,10 +58,6 @@ export const useGetTraces = ({
 				date_range: {
 					start_date: moment(startDate).format(TIME_FORMAT),
 					end_date: moment(endDate).format(TIME_FORMAT),
-				},
-				sort: {
-					column: sortColumn ?? 'timestamp',
-					direction: sortDirection ?? Types.SortDirection.Desc,
 				},
 			},
 		},

--- a/packages/ui/src/components/Table/Header/Header.tsx
+++ b/packages/ui/src/components/Table/Header/Header.tsx
@@ -2,23 +2,22 @@ import clsx from 'clsx'
 import React, { forwardRef } from 'react'
 
 import { Text } from '../../../components/Text/Text'
-import { Box, BoxProps } from '../../Box/Box'
+import { Box } from '../../Box/Box'
 import * as styles from './styles.css'
 
 export type Props = {
 	children?: React.ReactNode
 	noPadding?: boolean
-} & BoxProps
+}
 
 export const Header = forwardRef<HTMLDivElement, Props>(
-	({ children, noPadding, ...boxProps }, ref) => {
+	({ children, noPadding }, ref) => {
 		return (
 			<Box
 				cssClass={clsx(styles.header, {
 					[styles.noPadding]: noPadding,
 				})}
 				ref={ref}
-				{...boxProps}
 			>
 				<Text size="xSmall">{children}</Text>
 			</Box>


### PR DESCRIPTION
This reverts commit 73d46ef992b844108101f294ab8927ce3e216163.

## Summary

Believe this might be breaking fetching traces... It's working locally, but we're not seeing traces in the traces list in prod. Metrics are still loading, and the "X new traces" is still returning results sometimes 🤔

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
