### PR TITLE
Allow users to sort traces (take 2)

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -3,10 +3,11 @@ package clickhouse
 import (
 	"context"
 	"fmt"
-	"github.com/openlyinc/pointy"
 	"math"
 	"strings"
 	"time"
+
+	"github.com/openlyinc/pointy"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	e "github.com/pkg/errors"
@@ -36,6 +37,7 @@ var logKeysToColumns = map[modelInputs.ReservedLogKey]string{
 	modelInputs.ReservedLogKeyServiceVersion:  "ServiceVersion",
 	modelInputs.ReservedLogKeyEnvironment:     "Environment",
 	modelInputs.ReservedLogKeyMessage:         "Body",
+	modelInputs.ReservedLogKeyTimestamp:       "Timestamp",
 }
 
 // These keys show up as recommendations, but with no recommended values due to high cardinality
@@ -198,9 +200,8 @@ func (client *Client) ReadSessionLogs(ctx context.Context, projectID int, params
 		selectCols,
 		[]int{projectID},
 		params,
-		Pagination{},
-		OrderBackwardInverted,
-		OrderForwardInverted)
+		Pagination{Direction: modelInputs.SortDirectionAsc},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -251,9 +252,7 @@ func (client *Client) ReadLogsTotalCount(ctx context.Context, projectID int, par
 		[]string{"COUNT(*)"},
 		[]int{projectID},
 		params,
-		Pagination{CountOnly: true},
-		OrderBackwardNatural,
-		OrderForwardNatural)
+		Pagination{CountOnly: true})
 	if err != nil {
 		return 0, err
 	}
@@ -340,8 +339,6 @@ func (client *Client) ReadLogsHistogram(ctx context.Context, projectID int, para
 			[]int{projectID},
 			params,
 			Pagination{CountOnly: true},
-			OrderBackwardNatural,
-			OrderForwardNatural,
 		)
 	} else {
 		fromSb, err = makeSelectBuilder(
@@ -350,8 +347,6 @@ func (client *Client) ReadLogsHistogram(ctx context.Context, projectID int, para
 			[]int{projectID},
 			params,
 			Pagination{CountOnly: true},
-			OrderBackwardNatural,
-			OrderForwardNatural,
 		)
 	}
 	if err != nil {

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -172,7 +172,7 @@ func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelI
 		}, nil
 	}
 
-	conn, err := readObjects(ctx, client, LogsTableConfig, projectID, params, pagination, scanLog)
+	conn, err := readObjects(ctx, client, LogsTableConfig, logsSamplingTableConfig, projectID, params, pagination, scanLog)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -43,6 +43,9 @@ func setupTest(tb testing.TB) (*Client, func(tb testing.TB)) {
 
 		err = client.conn.Exec(context.Background(), fmt.Sprintf("TRUNCATE TABLE %s", TracesTable))
 		assert.NoError(tb, err)
+
+		err = client.conn.Exec(context.Background(), fmt.Sprintf("TRUNCATE TABLE %s", TracesSamplingTable))
+		assert.NoError(tb, err)
 	}
 }
 

--- a/backend/clickhouse/migrations/000103_add_highlight_type_to_trace_sampling.down.sql
+++ b/backend/clickhouse/migrations/000103_add_highlight_type_to_trace_sampling.down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE traces RESET SETTING min_rows_for_wide_part,
+    min_bytes_for_wide_part;
+ALTER TABLE traces_by_id RESET SETTING min_rows_for_wide_part,
+    min_bytes_for_wide_part;
+ALTER TABLE traces_sampling RESET SETTING min_rows_for_wide_part,
+    min_bytes_for_wide_part;
+ALTER TABLE traces_sampling DROP COLUMN IF EXISTS HighlightType;

--- a/backend/clickhouse/migrations/000103_add_highlight_type_to_trace_sampling.up.sql
+++ b/backend/clickhouse/migrations/000103_add_highlight_type_to_trace_sampling.up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE traces
+MODIFY SETTING min_rows_for_wide_part = 0,
+    min_bytes_for_wide_part = 0;
+ALTER TABLE traces_by_id
+MODIFY SETTING min_rows_for_wide_part = 0,
+    min_bytes_for_wide_part = 0;
+ALTER TABLE traces_sampling
+MODIFY SETTING min_rows_for_wide_part = 0,
+    min_bytes_for_wide_part = 0;
+ALTER TABLE traces_sampling
+ADD COLUMN IF NOT EXISTS HighlightType String MATERIALIZED TraceAttributes ['highlight.type'];

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -46,6 +46,7 @@ var traceKeysToColumns = map[modelInputs.ReservedTraceKey]string{
 	modelInputs.ReservedTraceKeyMetricValue:     "MetricValue",
 	modelInputs.ReservedTraceKeyEnvironment:     "Environment",
 	modelInputs.ReservedTraceKeyHasErrors:       "HasErrors",
+	modelInputs.ReservedTraceKeyTimestamp:       "Timestamp",
 }
 
 var traceColumns = []string{
@@ -268,7 +269,12 @@ func (client *Client) ReadTraces(ctx context.Context, projectID int, params mode
 		}, nil
 	}
 
-	conn, err := readObjects(ctx, client, TracesTableConfig, projectID, params, pagination, scanTrace)
+	tableConfig := TracesTableConfig
+	if params.Sort != nil {
+		tableConfig = tracesSamplingTableConfig
+	}
+
+	conn, err := readObjects(ctx, client, tableConfig, projectID, params, pagination, scanTrace)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -269,12 +269,7 @@ func (client *Client) ReadTraces(ctx context.Context, projectID int, params mode
 		}, nil
 	}
 
-	tableConfig := TracesTableConfig
-	if params.Sort != nil {
-		tableConfig = tracesSamplingTableConfig
-	}
-
-	conn, err := readObjects(ctx, client, tableConfig, projectID, params, pagination, scanTrace)
+	conn, err := readObjects(ctx, client, TracesTableConfig, tracesSamplingTableConfig, projectID, params, pagination, scanTrace)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -47,6 +47,7 @@ var traceKeysToColumns = map[modelInputs.ReservedTraceKey]string{
 	modelInputs.ReservedTraceKeyEnvironment:     "Environment",
 	modelInputs.ReservedTraceKeyHasErrors:       "HasErrors",
 	modelInputs.ReservedTraceKeyTimestamp:       "Timestamp",
+	modelInputs.ReservedTraceKeyHighlightType:   "HighlightType",
 }
 
 var traceColumns = []string{
@@ -96,7 +97,7 @@ var TracesTableConfig = model.TableConfig[modelInputs.ReservedTraceKey]{
 	BodyColumn:       TracesTableNoDefaultConfig.BodyColumn,
 	AttributesColumn: TracesTableNoDefaultConfig.AttributesColumn,
 	SelectColumns:    TracesTableNoDefaultConfig.SelectColumns,
-	DefaultFilter:    fmt.Sprintf("%s!=%s %s!=%s", modelInputs.ReservedTraceKeySpanName, highlight.MetricSpanName, highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
+	DefaultFilter:    fmt.Sprintf("%s!=%s %s!=%s", modelInputs.ReservedTraceKeySpanName, highlight.MetricSpanName, modelInputs.ReservedTraceKeyHighlightType, highlight.TraceTypeHighlightInternal),
 }
 
 var tracesSamplingTableConfig = model.TableConfig[modelInputs.ReservedTraceKey]{
@@ -106,7 +107,7 @@ var tracesSamplingTableConfig = model.TableConfig[modelInputs.ReservedTraceKey]{
 	ReservedKeys:     modelInputs.AllReservedTraceKey,
 	AttributesColumn: "TraceAttributes",
 	SelectColumns:    traceColumns,
-	DefaultFilter:    fmt.Sprintf("%s!=%s %s!=%s", modelInputs.ReservedTraceKeySpanName, highlight.MetricSpanName, highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
+	DefaultFilter:    fmt.Sprintf("%s!=%s %s!=%s", modelInputs.ReservedTraceKeySpanName, highlight.MetricSpanName, modelInputs.ReservedTraceKeyHighlightType, highlight.TraceTypeHighlightInternal),
 }
 
 var tracesSampleableTableConfig = sampleableTableConfig[modelInputs.ReservedTraceKey]{

--- a/backend/clickhouse/traces_test.go
+++ b/backend/clickhouse/traces_test.go
@@ -2,6 +2,7 @@ package clickhouse
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -190,4 +191,52 @@ func TestReadTracesWithEnvironmentFilter(t *testing.T) {
 	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 2)
+}
+
+func TestReadTracesWithSorting(t *testing.T) {
+	ctx := context.Background()
+	client, teardown := setupTest(t)
+	defer teardown(t)
+
+	now := time.Now()
+	rows := []*ClickhouseTraceRow{
+		NewTraceRow(now, 1).WithSpanName("Span A").WithDuration(now, now.Add(100*time.Nanosecond)).WithTraceAttributes(map[string]string{"host.name": "b"}).AsClickhouseTraceRow(),
+		NewTraceRow(now, 1).WithSpanName("Span B").WithDuration(now, now.Add(300*time.Nanosecond)).WithTraceAttributes(map[string]string{"host.name": "c"}).AsClickhouseTraceRow(),
+		NewTraceRow(now, 1).WithSpanName("Span C").WithDuration(now, now.Add(200*time.Nanosecond)).WithTraceAttributes(map[string]string{"host.name": "a"}).AsClickhouseTraceRow(),
+	}
+
+	assert.NoError(t, client.BatchWriteTraceRows(ctx, rows))
+
+	payload, err := client.ReadTraces(ctx, 1, modelInputs.QueryInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     "",
+		Sort: &modelInputs.SortInput{
+			Column:    "duration",
+			Direction: "DESC",
+		},
+	}, Pagination{})
+	assert.NoError(t, err)
+	assert.Len(t, payload.Edges, 3)
+
+	assert.Equal(t, "Span B", payload.Edges[0].Node.SpanName)
+	assert.Equal(t, "Span C", payload.Edges[1].Node.SpanName)
+	assert.Equal(t, "Span A", payload.Edges[2].Node.SpanName)
+
+	payload, err = client.ReadTraces(ctx, 1, modelInputs.QueryInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     "",
+		Sort: &modelInputs.SortInput{
+			Column:    "host.name",
+			Direction: "DESC",
+		},
+	}, Pagination{})
+	assert.NoError(t, err)
+	assert.Len(t, payload.Edges, 3)
+
+	for i, edge := range payload.Edges {
+		fmt.Printf("Edge %d: %v\n", i, edge.Node)
+	}
+	assert.Equal(t, "Span B", payload.Edges[0].Node.SpanName)
+	assert.Equal(t, "Span A", payload.Edges[1].Node.SpanName)
+	assert.Equal(t, "Span C", payload.Edges[2].Node.SpanName)
 }

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -11020,6 +11020,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputSanitizedSlackChannelInput,
 		ec.unmarshalInputSessionAlertInput,
 		ec.unmarshalInputSessionCommentTagInput,
+		ec.unmarshalInputSortInput,
 		ec.unmarshalInputTrackPropertyInput,
 		ec.unmarshalInputUserPropertyInput,
 		ec.unmarshalInputVercelProjectMappingInput,
@@ -12092,6 +12093,7 @@ enum ReservedLogKey {
 	source
 	service_name
 	service_version
+	timestamp
 }
 
 enum ReservedTraceKey {
@@ -12111,6 +12113,7 @@ enum ReservedTraceKey {
 	duration
 	service_name
 	service_version
+	timestamp
 }
 
 enum ReservedErrorObjectKey {
@@ -12320,9 +12323,15 @@ input ErrorGroupFrequenciesParamsInput {
 	resolution_minutes: Int!
 }
 
+input SortInput {
+	column: String!
+	direction: SortDirection!
+}
+
 input QueryInput {
 	query: String!
 	date_range: DateRangeRequiredInput!
+	sort: SortInput
 }
 
 enum MetricTagFilterOp {
@@ -80437,7 +80446,7 @@ func (ec *executionContext) unmarshalInputQueryInput(ctx context.Context, obj in
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"query", "date_range"}
+	fieldsInOrder := [...]string{"query", "date_range", "sort"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -80458,6 +80467,13 @@ func (ec *executionContext) unmarshalInputQueryInput(ctx context.Context, obj in
 				return it, err
 			}
 			it.DateRange = data
+		case "sort":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sort"))
+			data, err := ec.unmarshalOSortInput2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSortInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Sort = data
 		}
 	}
 
@@ -80803,6 +80819,40 @@ func (ec *executionContext) unmarshalInputSessionCommentTagInput(ctx context.Con
 				return it, err
 			}
 			it.Name = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputSortInput(ctx context.Context, obj interface{}) (model.SortInput, error) {
+	var it model.SortInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"column", "direction"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "column":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("column"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Column = data
+		case "direction":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("direction"))
+			data, err := ec.unmarshalNSortDirection2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSortDirection(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Direction = data
 		}
 	}
 
@@ -102715,6 +102765,14 @@ func (ec *executionContext) marshalOSocialLink2ᚖgithubᚗcomᚋhighlightᚑrun
 		return graphql.Null
 	}
 	return ec._SocialLink(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOSortInput2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSortInput(ctx context.Context, v interface{}) (*model.SortInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputSortInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOSourceMappingError2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSourceMappingError(ctx context.Context, sel ast.SelectionSet, v *model.SourceMappingError) graphql.Marshaler {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -12114,6 +12114,7 @@ enum ReservedTraceKey {
 	service_name
 	service_version
 	timestamp
+	highlight_type
 }
 
 enum ReservedErrorObjectKey {

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -658,6 +658,7 @@ type Plan struct {
 type QueryInput struct {
 	Query     string                  `json:"query"`
 	DateRange *DateRangeRequiredInput `json:"date_range"`
+	Sort      *SortInput              `json:"sort,omitempty"`
 }
 
 type QueryKey struct {
@@ -823,6 +824,11 @@ type SlackSyncResponse struct {
 type SocialLink struct {
 	Type SocialType `json:"type"`
 	Link *string    `json:"link,omitempty"`
+}
+
+type SortInput struct {
+	Column    string        `json:"column"`
+	Direction SortDirection `json:"direction"`
 }
 
 type SourceMappingError struct {
@@ -2059,6 +2065,7 @@ const (
 	ReservedLogKeySource          ReservedLogKey = "source"
 	ReservedLogKeyServiceName     ReservedLogKey = "service_name"
 	ReservedLogKeyServiceVersion  ReservedLogKey = "service_version"
+	ReservedLogKeyTimestamp       ReservedLogKey = "timestamp"
 )
 
 var AllReservedLogKey = []ReservedLogKey{
@@ -2071,11 +2078,12 @@ var AllReservedLogKey = []ReservedLogKey{
 	ReservedLogKeySource,
 	ReservedLogKeyServiceName,
 	ReservedLogKeyServiceVersion,
+	ReservedLogKeyTimestamp,
 }
 
 func (e ReservedLogKey) IsValid() bool {
 	switch e {
-	case ReservedLogKeyEnvironment, ReservedLogKeyLevel, ReservedLogKeyMessage, ReservedLogKeySecureSessionID, ReservedLogKeySpanID, ReservedLogKeyTraceID, ReservedLogKeySource, ReservedLogKeyServiceName, ReservedLogKeyServiceVersion:
+	case ReservedLogKeyEnvironment, ReservedLogKeyLevel, ReservedLogKeyMessage, ReservedLogKeySecureSessionID, ReservedLogKeySpanID, ReservedLogKeyTraceID, ReservedLogKeySource, ReservedLogKeyServiceName, ReservedLogKeyServiceVersion, ReservedLogKeyTimestamp:
 		return true
 	}
 	return false
@@ -2220,6 +2228,7 @@ const (
 	ReservedTraceKeyDuration        ReservedTraceKey = "duration"
 	ReservedTraceKeyServiceName     ReservedTraceKey = "service_name"
 	ReservedTraceKeyServiceVersion  ReservedTraceKey = "service_version"
+	ReservedTraceKeyTimestamp       ReservedTraceKey = "timestamp"
 )
 
 var AllReservedTraceKey = []ReservedTraceKey{
@@ -2239,11 +2248,12 @@ var AllReservedTraceKey = []ReservedTraceKey{
 	ReservedTraceKeyDuration,
 	ReservedTraceKeyServiceName,
 	ReservedTraceKeyServiceVersion,
+	ReservedTraceKeyTimestamp,
 }
 
 func (e ReservedTraceKey) IsValid() bool {
 	switch e {
-	case ReservedTraceKeyEnvironment, ReservedTraceKeyHasErrors, ReservedTraceKeyLevel, ReservedTraceKeyMessage, ReservedTraceKeyMetricName, ReservedTraceKeyMetricValue, ReservedTraceKeySecureSessionID, ReservedTraceKeySpanID, ReservedTraceKeyTraceID, ReservedTraceKeyParentSpanID, ReservedTraceKeyTraceState, ReservedTraceKeySpanName, ReservedTraceKeySpanKind, ReservedTraceKeyDuration, ReservedTraceKeyServiceName, ReservedTraceKeyServiceVersion:
+	case ReservedTraceKeyEnvironment, ReservedTraceKeyHasErrors, ReservedTraceKeyLevel, ReservedTraceKeyMessage, ReservedTraceKeyMetricName, ReservedTraceKeyMetricValue, ReservedTraceKeySecureSessionID, ReservedTraceKeySpanID, ReservedTraceKeyTraceID, ReservedTraceKeyParentSpanID, ReservedTraceKeyTraceState, ReservedTraceKeySpanName, ReservedTraceKeySpanKind, ReservedTraceKeyDuration, ReservedTraceKeyServiceName, ReservedTraceKeyServiceVersion, ReservedTraceKeyTimestamp:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -2229,6 +2229,7 @@ const (
 	ReservedTraceKeyServiceName     ReservedTraceKey = "service_name"
 	ReservedTraceKeyServiceVersion  ReservedTraceKey = "service_version"
 	ReservedTraceKeyTimestamp       ReservedTraceKey = "timestamp"
+	ReservedTraceKeyHighlightType   ReservedTraceKey = "highlight_type"
 )
 
 var AllReservedTraceKey = []ReservedTraceKey{
@@ -2249,11 +2250,12 @@ var AllReservedTraceKey = []ReservedTraceKey{
 	ReservedTraceKeyServiceName,
 	ReservedTraceKeyServiceVersion,
 	ReservedTraceKeyTimestamp,
+	ReservedTraceKeyHighlightType,
 }
 
 func (e ReservedTraceKey) IsValid() bool {
 	switch e {
-	case ReservedTraceKeyEnvironment, ReservedTraceKeyHasErrors, ReservedTraceKeyLevel, ReservedTraceKeyMessage, ReservedTraceKeyMetricName, ReservedTraceKeyMetricValue, ReservedTraceKeySecureSessionID, ReservedTraceKeySpanID, ReservedTraceKeyTraceID, ReservedTraceKeyParentSpanID, ReservedTraceKeyTraceState, ReservedTraceKeySpanName, ReservedTraceKeySpanKind, ReservedTraceKeyDuration, ReservedTraceKeyServiceName, ReservedTraceKeyServiceVersion, ReservedTraceKeyTimestamp:
+	case ReservedTraceKeyEnvironment, ReservedTraceKeyHasErrors, ReservedTraceKeyLevel, ReservedTraceKeyMessage, ReservedTraceKeyMetricName, ReservedTraceKeyMetricValue, ReservedTraceKeySecureSessionID, ReservedTraceKeySpanID, ReservedTraceKeyTraceID, ReservedTraceKeyParentSpanID, ReservedTraceKeyTraceState, ReservedTraceKeySpanName, ReservedTraceKeySpanKind, ReservedTraceKeyDuration, ReservedTraceKeyServiceName, ReservedTraceKeyServiceVersion, ReservedTraceKeyTimestamp, ReservedTraceKeyHighlightType:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -951,6 +951,7 @@ enum ReservedLogKey {
 	source
 	service_name
 	service_version
+	timestamp
 }
 
 enum ReservedTraceKey {
@@ -970,6 +971,7 @@ enum ReservedTraceKey {
 	duration
 	service_name
 	service_version
+	timestamp
 }
 
 enum ReservedErrorObjectKey {
@@ -1179,9 +1181,15 @@ input ErrorGroupFrequenciesParamsInput {
 	resolution_minutes: Int!
 }
 
+input SortInput {
+	column: String!
+	direction: SortDirection!
+}
+
 input QueryInput {
 	query: String!
 	date_range: DateRangeRequiredInput!
+	sort: SortInput
 }
 
 enum MetricTagFilterOp {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -972,6 +972,7 @@ enum ReservedTraceKey {
 	service_name
 	service_version
 	timestamp
+	highlight_type
 }
 
 enum ReservedErrorObjectKey {

--- a/frontend/src/components/CustomColumnActions/index.tsx
+++ b/frontend/src/components/CustomColumnActions/index.tsx
@@ -8,6 +8,8 @@ import {
 	IconSolidClipboardCopy,
 	IconSolidCloudUpload,
 	IconSolidRefresh,
+	IconSolidSortAscending,
+	IconSolidSortDescending,
 	IconSolidXCircle,
 	Menu,
 	Stack,
@@ -19,6 +21,7 @@ import { useMemo } from 'react'
 
 import { ValidCustomColumn } from '@/components/CustomColumnPopover'
 import { Modal } from '@/components/Modal/ModalV2'
+import { SortDirection } from '@/graph/generated/schemas'
 import analytics from '@/util/analytics'
 
 type Props = {
@@ -27,6 +30,9 @@ type Props = {
 	columnId: string
 	trackingId: string
 	standardColumns: Record<string, ValidCustomColumn>
+	sortColumn: string | null | undefined
+	sortDirection: string | null | undefined
+	onSort?: (direction?: SortDirection | null) => void
 }
 
 export const CustomColumnActions: React.FC<Props> = ({
@@ -35,6 +41,9 @@ export const CustomColumnActions: React.FC<Props> = ({
 	columnId,
 	trackingId,
 	standardColumns,
+	sortColumn,
+	sortDirection,
+	onSort,
 }) => {
 	const [labelModalOpen, setLabelModalOpen] = React.useState(false)
 
@@ -42,17 +51,20 @@ export const CustomColumnActions: React.FC<Props> = ({
 		() => selectedColumns.findIndex((c) => c.id === columnId),
 		[selectedColumns, columnId],
 	)
+	const isSorted = sortColumn === columnId
 
 	const trackEvent = (action: string) => {
 		analytics.track(`Button-${trackingId}_${action}`, { columnId })
 	}
 
-	const removeColumn = () => {
+	const removeColumn = (e: React.MouseEvent) => {
+		e.stopPropagation()
 		trackEvent('hide')
 		setSelectedColumns(selectedColumns.filter((c) => c.id !== columnId))
 	}
 
-	const moveColumnLeft = () => {
+	const moveColumnLeft = (e: React.MouseEvent) => {
+		e.stopPropagation()
 		trackEvent('left')
 		const newColumns = [...selectedColumns]
 		newColumns[columnIndex] = selectedColumns[columnIndex - 1]
@@ -60,7 +72,8 @@ export const CustomColumnActions: React.FC<Props> = ({
 		setSelectedColumns(newColumns)
 	}
 
-	const moveColumnRight = () => {
+	const moveColumnRight = (e: React.MouseEvent) => {
+		e.stopPropagation()
 		trackEvent('right')
 		const newColumns = [...selectedColumns]
 		newColumns[columnIndex] = selectedColumns[columnIndex + 1]
@@ -68,14 +81,16 @@ export const CustomColumnActions: React.FC<Props> = ({
 		setSelectedColumns(newColumns)
 	}
 
-	const copyColumn = () => {
+	const copyColumn = (e: React.MouseEvent) => {
+		e.stopPropagation()
 		trackEvent('copy')
 		copyToClipboard(columnId, {
 			onCopyText: 'Copied to clipboard',
 		})
 	}
 
-	const handleLabelUpdateColumn = () => {
+	const handleLabelUpdateColumn = (e: React.MouseEvent) => {
+		e.stopPropagation()
 		trackEvent('rename')
 		setLabelModalOpen(true)
 	}
@@ -86,7 +101,8 @@ export const CustomColumnActions: React.FC<Props> = ({
 		setSelectedColumns(newColumns)
 	}
 
-	const resetSize = () => {
+	const resetSize = (e: React.MouseEvent) => {
+		e.stopPropagation()
 		trackEvent('resetSize')
 		const newColumns = [...selectedColumns]
 
@@ -105,7 +121,7 @@ export const CustomColumnActions: React.FC<Props> = ({
 
 	return (
 		<>
-			<Menu>
+			<Menu placement="bottom-end">
 				<Table.Discoverable trigger="header">
 					<Menu.Button
 						style={{
@@ -115,12 +131,57 @@ export const CustomColumnActions: React.FC<Props> = ({
 						size="small"
 						emphasis="low"
 						kind="secondary"
-						onClick={() => trackEvent('open')}
+						onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+							e.stopPropagation()
+							trackEvent('open')
+						}}
 					>
 						<IconOutlineDotsHorizontal />
 					</Menu.Button>
 				</Table.Discoverable>
 				<Menu.List>
+					{onSort && (
+						<>
+							<Menu.Item
+								disabled={
+									isSorted &&
+									sortDirection === SortDirection.Desc
+								}
+								onClick={(e) => {
+									e.stopPropagation()
+									onSort(SortDirection.Desc)
+								}}
+							>
+								<IconSolidSortDescending size={16} />
+								Sort Descending
+							</Menu.Item>
+							<Menu.Item
+								disabled={
+									isSorted &&
+									sortDirection === SortDirection.Asc
+								}
+								onClick={(e) => {
+									e.stopPropagation()
+									onSort(SortDirection.Asc)
+								}}
+							>
+								<IconSolidSortAscending size={16} />
+								Sort Ascending
+							</Menu.Item>
+							{isSorted && (
+								<Menu.Item
+									onClick={(e) => {
+										e.stopPropagation()
+										onSort(null)
+									}}
+								>
+									<IconSolidXCircle size={16} />
+									Remove Sort
+								</Menu.Item>
+							)}
+							<Menu.Divider />
+						</>
+					)}
 					<Menu.Item disabled={disableLeft} onClick={moveColumnLeft}>
 						<Box display="flex" alignItems="center" gap="4">
 							<IconSolidArrowLeft size={16} />

--- a/frontend/src/components/CustomColumnHeader/index.tsx
+++ b/frontend/src/components/CustomColumnHeader/index.tsx
@@ -1,14 +1,23 @@
-import { Box, Table, Text } from '@highlight-run/ui/components'
+import {
+	Box,
+	IconSolidSortAscending,
+	IconSolidSortDescending,
+	Stack,
+	Table,
+	Text,
+} from '@highlight-run/ui/components'
 import { useMemo, useRef } from 'react'
 
 import { CustomColumnActions } from '@/components/CustomColumnActions'
 import { ValidCustomColumn } from '@/components/CustomColumnPopover'
+import { SortDirection } from '@/graph/generated/schemas'
 
 export type ColumnHeader = {
 	id: string
 	component: React.ReactNode
 	showActions?: boolean
 	noPadding?: boolean
+	onSort?: (direction?: SortDirection | null) => void
 }
 
 type Props = {
@@ -17,6 +26,8 @@ type Props = {
 	setSelectedColumns: (columns: ValidCustomColumn[]) => void
 	standardColumns: Record<string, ValidCustomColumn>
 	trackingIdPrefix: string
+	sortColumn?: string | null
+	sortDirection?: string | null
 }
 
 const MINIMUM_COLUMN_WIDTH = 50
@@ -27,6 +38,8 @@ export const CustomColumnHeader: React.FC<Props> = ({
 	setSelectedColumns,
 	standardColumns,
 	trackingIdPrefix,
+	sortColumn,
+	sortDirection,
 }) => {
 	const headerRef = useRef<HTMLDivElement>(null)
 
@@ -74,22 +87,51 @@ export const CustomColumnHeader: React.FC<Props> = ({
 			key={header.id}
 			noPadding={header.noPadding}
 			ref={headerRef}
+			cursor={header.onSort ? 'pointer' : 'default'}
+			onClick={() => {
+				if (!header.onSort) {
+					return
+				}
+
+				header.onSort()
+			}}
 		>
 			<Box
 				display="flex"
 				alignItems="center"
 				justifyContent="space-between"
 			>
-				<Text lines="1">{header.component}</Text>
-				{header.showActions && (
-					<CustomColumnActions
-						columnId={header.id}
-						selectedColumns={selectedColumns}
-						setSelectedColumns={setSelectedColumns}
-						trackingId={trackingIdPrefix}
-						standardColumns={standardColumns}
-					/>
-				)}
+				<Stack direction="row" gap="6" align="center">
+					<Text lines="1">{header.component}</Text>
+					{sortColumn === header.id &&
+						sortDirection &&
+						(sortDirection === SortDirection.Desc ? (
+							<IconSolidSortDescending
+								size={13}
+								style={{ flexShrink: 0 }}
+							/>
+						) : (
+							<IconSolidSortAscending
+								size={13}
+								style={{ flexShrink: 0 }}
+							/>
+						))}
+				</Stack>
+
+				<Stack align="center" direction="row" gap="6">
+					{header.showActions && (
+						<CustomColumnActions
+							columnId={header.id}
+							selectedColumns={selectedColumns}
+							setSelectedColumns={setSelectedColumns}
+							trackingId={trackingIdPrefix}
+							standardColumns={standardColumns}
+							onSort={header.onSort}
+							sortColumn={sortColumn}
+							sortDirection={sortDirection}
+						/>
+					)}
+				</Stack>
 			</Box>
 			{resizeable && (
 				<Box

--- a/frontend/src/components/Search/SearchContext.tsx
+++ b/frontend/src/components/Search/SearchContext.tsx
@@ -12,6 +12,9 @@ import { START_PAGE } from '@/components/SearchPagination/SearchPagination'
 import { DateHistogramBucketSize } from '@/graph/generated/schemas'
 import { useSearchTime } from '@/hooks/useSearchTime'
 
+export const SORT_COLUMN = 'sort_column'
+export const SORT_DIRECTION = 'sort_direction'
+
 interface SearchContext extends Partial<ReturnType<typeof useSearchTime>> {
 	disabled: boolean
 	loading: boolean

--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -24,14 +24,18 @@ import moment from 'moment'
 import React, { useEffect, useRef, useState } from 'react'
 import TextareaAutosize from 'react-autosize-textarea'
 import { useNavigate } from 'react-router-dom'
-import { StringParam, withDefault } from 'use-query-params'
+import { StringParam, useQueryParam, withDefault } from 'use-query-params'
 
 import { Button } from '@/components/Button'
 import { LinkButton } from '@/components/LinkButton'
 import LoadingBox from '@/components/LoadingBox'
 import SearchGrammarParser from '@/components/Search/Parser/antlr/SearchGrammarParser'
 import { SearchExpression } from '@/components/Search/Parser/listener'
-import { useSearchContext } from '@/components/Search/SearchContext'
+import {
+	SORT_COLUMN,
+	SORT_DIRECTION,
+	useSearchContext,
+} from '@/components/Search/SearchContext'
 import {
 	TIME_FORMAT,
 	TIME_MODE,
@@ -318,6 +322,8 @@ export const Search: React.FC<{
 		setQuery,
 	} = useSearchContext()
 	const { project_id } = useParams()
+	const [_, setSortColumn] = useQueryParam(SORT_COLUMN, StringParam)
+	const [__, setSortDirection] = useQueryParam(SORT_DIRECTION, StringParam)
 	const containerRef = useRef<HTMLDivElement | null>(null)
 	const defaultInputRef = useRef<HTMLTextAreaElement | null>(null)
 	const inputRef = textAreaRef || defaultInputRef
@@ -727,6 +733,8 @@ export const Search: React.FC<{
 
 								setQuery('')
 								submitQuery('')
+								setSortColumn(undefined)
+								setSortDirection(undefined)
 							}}
 							style={{ cursor: 'pointer' }}
 						/>

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2897,6 +2897,7 @@ export type QueryWorkspace_Invite_LinksArgs = {
 export type QueryInput = {
 	date_range: DateRangeRequiredInput
 	query: Scalars['String']
+	sort?: InputMaybe<SortInput>
 }
 
 export type QueryKey = {
@@ -2984,6 +2985,7 @@ export enum ReservedLogKey {
 	ServiceVersion = 'service_version',
 	Source = 'source',
 	SpanId = 'span_id',
+	Timestamp = 'timestamp',
 	TraceId = 'trace_id',
 }
 
@@ -3036,6 +3038,7 @@ export enum ReservedTraceKey {
 	SpanId = 'span_id',
 	SpanKind = 'span_kind',
 	SpanName = 'span_name',
+	Timestamp = 'timestamp',
 	TraceId = 'trace_id',
 	TraceState = 'trace_state',
 }
@@ -3440,6 +3443,11 @@ export enum SocialType {
 export enum SortDirection {
 	Asc = 'ASC',
 	Desc = 'DESC',
+}
+
+export type SortInput = {
+	column: Scalars['String']
+	direction: SortDirection
 }
 
 export type SourceMappingError = {

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -3027,6 +3027,7 @@ export enum ReservedTraceKey {
 	Duration = 'duration',
 	Environment = 'environment',
 	HasErrors = 'has_errors',
+	HighlightType = 'highlight_type',
 	Level = 'level',
 	Message = 'message',
 	MetricName = 'metric_name',

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -74,7 +74,7 @@ export const LogDetails: React.FC<Props> = ({
 		level: LogLevel
 		message: string
 	} & {
-		[key in ReservedLogKey]: Maybe<string> | undefined
+		[key in ReservedLogKey]?: Maybe<string> | undefined
 	} = {
 		environment,
 		level,

--- a/frontend/src/pages/Traces/TraceProvider.tsx
+++ b/frontend/src/pages/Traces/TraceProvider.tsx
@@ -10,6 +10,7 @@ import {
 	getTraceTimes,
 	organizeSpansForFlameGraph,
 	organizeSpansWithChildren,
+	traceSortFn,
 } from '@/pages/Traces/utils'
 
 type TraceContext = {
@@ -127,7 +128,7 @@ export const TraceProvider: React.FC<React.PropsWithChildren<Props>> = ({
 			return []
 		}
 
-		const spans = data.trace.trace //.sort(traceSortFn)
+		const spans = [...data.trace.trace].sort(traceSortFn)
 		return organizeSpansWithChildren(spans)
 	}, [data?.trace?.trace])
 

--- a/frontend/src/pages/Traces/TracesList.tsx
+++ b/frontend/src/pages/Traces/TracesList.tsx
@@ -16,7 +16,8 @@ import {
 } from '@tanstack/react-table'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { isEqual } from 'lodash'
-import React, { Key, useMemo, useRef } from 'react'
+import React, { Key, useCallback, useEffect, useMemo, useRef } from 'react'
+import { StringParam, useQueryParam } from 'use-query-params'
 
 import {
 	ColumnHeader,
@@ -30,8 +31,15 @@ import {
 	RelatedTrace,
 	useRelatedResource,
 } from '@/components/RelatedResources/hooks'
-import { DEFAULT_INPUT_HEIGHT } from '@/components/Search/SearchForm/SearchForm'
-import { ProductType, TraceEdge } from '@/graph/generated/schemas'
+import {
+	DEFAULT_INPUT_HEIGHT,
+	QueryParam,
+} from '@/components/Search/SearchForm/SearchForm'
+import {
+	ProductType,
+	SortDirection,
+	TraceEdge,
+} from '@/graph/generated/schemas'
 import { MAX_TRACES } from '@/pages/Traces/useGetTraces'
 
 import {
@@ -71,6 +79,38 @@ export const TracesList: React.FC<Props> = ({
 		`highlight-traces-table-columns`,
 		DEFAULT_TRACE_COLUMNS,
 	)
+	const [sortColumn, setSortColumn] = useQueryParam(
+		'sort_column',
+		StringParam,
+	)
+	const [sortDirection, setSortDirection] = useQueryParam(
+		'sort_direction',
+		StringParam,
+	)
+	const [query] = useQueryParam('query', QueryParam)
+
+	const handleSort = useCallback(
+		(column: string, direction?: SortDirection | null) => {
+			if (
+				column === sortColumn &&
+				(direction === null || sortDirection === SortDirection.Asc)
+			) {
+				setSortColumn(undefined)
+				setSortDirection(undefined)
+			} else {
+				const nextDirection =
+					direction ??
+					(column === sortColumn &&
+					sortDirection === SortDirection.Desc
+						? SortDirection.Asc
+						: SortDirection.Desc)
+
+				setSortColumn(column)
+				setSortDirection(nextDirection)
+			}
+		},
+		[setSortColumn, setSortDirection, sortColumn, sortDirection],
+	)
 
 	const bodyRef = useRef<HTMLDivElement>(null)
 	const enableFetchMoreTraces =
@@ -93,6 +133,9 @@ export const TracesList: React.FC<Props> = ({
 				id: column.id,
 				component: column.label,
 				showActions: true,
+				onSort: (direction?: SortDirection | null) => {
+					handleSort(column.id, direction)
+				},
 			})
 
 			// @ts-ignore
@@ -136,7 +179,7 @@ export const TracesList: React.FC<Props> = ({
 			columnHeaders,
 			columns,
 		}
-	}, [columnHelper, selectedColumns, setSelectedColumns])
+	}, [columnHelper, handleSort, selectedColumns, setSelectedColumns])
 
 	const table = useReactTable({
 		data: traceEdges,
@@ -188,11 +231,14 @@ export const TracesList: React.FC<Props> = ({
 		}, 0)
 	}
 
-	if (loading) {
-		return <LoadingBox />
-	}
+	useEffect(() => {
+		if (query.trim() === '') {
+			setSortColumn(undefined)
+			setSortDirection(undefined)
+		}
+	}, [query, setSortColumn, setSortDirection])
 
-	if (!traceEdges.length) {
+	if (!loading && !traceEdges.length) {
 		return (
 			<Box m="8">
 				<Box
@@ -251,6 +297,8 @@ export const TracesList: React.FC<Props> = ({
 							setSelectedColumns={setSelectedColumns!}
 							standardColumns={HIGHLIGHT_STANDARD_COLUMNS}
 							trackingIdPrefix="TracesTableColumn"
+							sortColumn={sortColumn}
+							sortDirection={sortDirection}
 						/>
 					))}
 				</Table.Row>
@@ -270,49 +318,55 @@ export const TracesList: React.FC<Props> = ({
 					</Table.Row>
 				)}
 			</Table.Head>
-			<Table.Body
-				ref={bodyRef}
-				height="full"
-				overflowY="auto"
-				onScroll={handleFetchMoreWhenScrolled}
-				style={{
-					height: `calc(100% - ${otherElementsHeight}px)`,
-				}}
-				hiddenScroll
-			>
-				{paddingTop > 0 && <Box style={{ height: paddingTop }} />}
-				{virtualRows.map((virtualRow) => {
-					const row = rows[virtualRow.index]
-					const isSelected =
-						row.original.node.spanID === trace?.spanID
+			{loading ? (
+				<LoadingBox />
+			) : (
+				<Table.Body
+					ref={bodyRef}
+					height="full"
+					overflowY="auto"
+					onScroll={handleFetchMoreWhenScrolled}
+					style={{
+						height: `calc(100% - ${otherElementsHeight}px)`,
+					}}
+					hiddenScroll
+				>
+					{paddingTop > 0 && <Box style={{ height: paddingTop }} />}
+					{virtualRows.map((virtualRow) => {
+						const row = rows[virtualRow.index]
+						const isSelected =
+							row.original.node.spanID === trace?.spanID
 
-					return (
-						<TracesTableRow
-							key={virtualRow.key}
-							row={row}
-							rowVirtualizer={rowVirtualizer}
-							virtualRowKey={virtualRow.key}
-							isSelected={isSelected}
-							gridColumns={columnData.gridColumns}
-							selectedColumnsIds={selectedColumns.map(
-								(c) => c.id,
-							)}
-						/>
-					)
-				})}
+						return (
+							<TracesTableRow
+								key={virtualRow.key}
+								row={row}
+								rowVirtualizer={rowVirtualizer}
+								virtualRowKey={virtualRow.key}
+								isSelected={isSelected}
+								gridColumns={columnData.gridColumns}
+								selectedColumnsIds={selectedColumns.map(
+									(c) => c.id,
+								)}
+							/>
+						)
+					})}
 
-				{paddingBottom > 0 && <Box style={{ height: paddingBottom }} />}
+					{paddingBottom > 0 && (
+						<Box style={{ height: paddingBottom }} />
+					)}
 
-				{loadingAfter && (
-					<Box
-						style={{
-							height: `${LOADING_AFTER_HEIGHT}px`,
-						}}
-					>
-						<LoadingBox />
-					</Box>
-				)}
-			</Table.Body>
+					{loadingAfter && (
+						<Box
+							style={{
+								height: `${LOADING_AFTER_HEIGHT}px`,
+							}}
+						>
+							<LoadingBox />
+						</Box>
+					)}
+				</Table.Body>
+			)}
 		</Table>
 	)
 }

--- a/frontend/src/pages/Traces/TracesList.tsx
+++ b/frontend/src/pages/Traces/TracesList.tsx
@@ -16,7 +16,7 @@ import {
 } from '@tanstack/react-table'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { isEqual } from 'lodash'
-import React, { Key, useCallback, useEffect, useMemo, useRef } from 'react'
+import React, { Key, useCallback, useMemo, useRef } from 'react'
 import { StringParam, useQueryParam } from 'use-query-params'
 
 import {
@@ -31,10 +31,8 @@ import {
 	RelatedTrace,
 	useRelatedResource,
 } from '@/components/RelatedResources/hooks'
-import {
-	DEFAULT_INPUT_HEIGHT,
-	QueryParam,
-} from '@/components/Search/SearchForm/SearchForm'
+import { SORT_COLUMN, SORT_DIRECTION } from '@/components/Search/SearchContext'
+import { DEFAULT_INPUT_HEIGHT } from '@/components/Search/SearchForm/SearchForm'
 import {
 	ProductType,
 	SortDirection,
@@ -79,15 +77,11 @@ export const TracesList: React.FC<Props> = ({
 		`highlight-traces-table-columns`,
 		DEFAULT_TRACE_COLUMNS,
 	)
-	const [sortColumn, setSortColumn] = useQueryParam(
-		'sort_column',
-		StringParam,
-	)
+	const [sortColumn, setSortColumn] = useQueryParam(SORT_COLUMN, StringParam)
 	const [sortDirection, setSortDirection] = useQueryParam(
-		'sort_direction',
+		SORT_DIRECTION,
 		StringParam,
 	)
-	const [query] = useQueryParam('query', QueryParam)
 
 	const handleSort = useCallback(
 		(column: string, direction?: SortDirection | null) => {
@@ -230,13 +224,6 @@ export const TracesList: React.FC<Props> = ({
 			fetchMoreWhenScrolled(e.target as HTMLDivElement)
 		}, 0)
 	}
-
-	useEffect(() => {
-		if (query.trim() === '') {
-			setSortColumn(undefined)
-			setSortDirection(undefined)
-		}
-	}, [query, setSortColumn, setSortDirection])
 
 	if (!loading && !traceEdges.length) {
 		return (

--- a/frontend/src/pages/Traces/TracesPage.tsx
+++ b/frontend/src/pages/Traces/TracesPage.tsx
@@ -12,7 +12,7 @@ import moment from 'moment'
 import React, { useEffect, useRef } from 'react'
 import { Helmet } from 'react-helmet'
 import { useNavigate } from 'react-router-dom'
-import { useQueryParam } from 'use-query-params'
+import { StringParam, useQueryParam } from 'use-query-params'
 
 import { loadingIcon } from '@/components/Button/style.css'
 import {
@@ -35,6 +35,7 @@ import {
 	MetricColumn,
 	ProductType,
 	SavedSegmentEntityType,
+	SortDirection,
 	Trace,
 } from '@/graph/generated/schemas'
 import { useProjectId } from '@/hooks/useProjectId'
@@ -60,6 +61,8 @@ export const TracesPage: React.FC = () => {
 	} = useParams<{ trace_id: string; span_id: string; trace_cursor: string }>()
 	const textAreaRef = useRef<HTMLTextAreaElement | null>(null)
 	const [query, setQuery] = useQueryParam('query', QueryParam)
+	const [sortColumn] = useQueryParam('sort_column', StringParam)
+	const [sortDirection] = useQueryParam('sort_direction', StringParam)
 	const {
 		startDate,
 		endDate,
@@ -87,6 +90,8 @@ export const TracesPage: React.FC = () => {
 		startDate,
 		endDate,
 		skipPolling: !selectedPreset,
+		sortColumn,
+		sortDirection: sortDirection as SortDirection,
 	})
 
 	const { data: metricsData, loading: metricsLoading } =

--- a/frontend/src/pages/Traces/TracesPage.tsx
+++ b/frontend/src/pages/Traces/TracesPage.tsx
@@ -19,7 +19,11 @@ import {
 	RelatedTrace,
 	useRelatedResource,
 } from '@/components/RelatedResources/hooks'
-import { SearchContext } from '@/components/Search/SearchContext'
+import {
+	SearchContext,
+	SORT_COLUMN,
+	SORT_DIRECTION,
+} from '@/components/Search/SearchContext'
 import {
 	TIME_FORMAT,
 	TIME_MODE,
@@ -61,8 +65,8 @@ export const TracesPage: React.FC = () => {
 	} = useParams<{ trace_id: string; span_id: string; trace_cursor: string }>()
 	const textAreaRef = useRef<HTMLTextAreaElement | null>(null)
 	const [query, setQuery] = useQueryParam('query', QueryParam)
-	const [sortColumn] = useQueryParam('sort_column', StringParam)
-	const [sortDirection] = useQueryParam('sort_direction', StringParam)
+	const [sortColumn] = useQueryParam(SORT_COLUMN, StringParam)
+	const [sortDirection] = useQueryParam(SORT_DIRECTION, StringParam)
 	const {
 		startDate,
 		endDate,

--- a/frontend/src/pages/Traces/useGetTraces.ts
+++ b/frontend/src/pages/Traces/useGetTraces.ts
@@ -24,6 +24,8 @@ export const useGetTraces = ({
 	startDate,
 	endDate,
 	skipPolling,
+	sortColumn,
+	sortDirection,
 }: {
 	query: string
 	projectId: string | undefined
@@ -31,6 +33,8 @@ export const useGetTraces = ({
 	startDate: Date
 	endDate: Date
 	skipPolling?: boolean
+	sortColumn?: string | null | undefined
+	sortDirection?: Types.SortDirection | null | undefined
 }) => {
 	// The backend can only tell us page info about a single page.
 	// It has no idea what pages have already been loaded.
@@ -58,6 +62,10 @@ export const useGetTraces = ({
 				date_range: {
 					start_date: moment(startDate).format(TIME_FORMAT),
 					end_date: moment(endDate).format(TIME_FORMAT),
+				},
+				sort: {
+					column: sortColumn ?? 'timestamp',
+					direction: sortDirection ?? Types.SortDirection.Desc,
 				},
 			},
 		},

--- a/frontend/src/pages/Traces/useGetTraces.ts
+++ b/frontend/src/pages/Traces/useGetTraces.ts
@@ -127,9 +127,20 @@ export const useGetTraces = ({
 							.format(TIME_FORMAT),
 						end_date: moment().format(TIME_FORMAT),
 					},
+					sort: {
+						column: sortColumn ?? 'timestamp',
+						direction: sortDirection ?? Types.SortDirection.Desc,
+					},
 				},
 			}),
-			[projectId, traceCursor, query, traceResultMetadata.endDate],
+			[
+				projectId,
+				traceCursor,
+				query,
+				traceResultMetadata.endDate,
+				sortColumn,
+				sortDirection,
+			],
 		),
 		moreDataQuery,
 		getResultCount: useCallback((result) => {

--- a/packages/ui/src/components/Table/Header/Header.tsx
+++ b/packages/ui/src/components/Table/Header/Header.tsx
@@ -2,22 +2,23 @@ import clsx from 'clsx'
 import React, { forwardRef } from 'react'
 
 import { Text } from '../../../components/Text/Text'
-import { Box } from '../../Box/Box'
+import { Box, BoxProps } from '../../Box/Box'
 import * as styles from './styles.css'
 
 export type Props = {
 	children?: React.ReactNode
 	noPadding?: boolean
-}
+} & BoxProps
 
 export const Header = forwardRef<HTMLDivElement, Props>(
-	({ children, noPadding }, ref) => {
+	({ children, noPadding, ...boxProps }, ref) => {
 		return (
 			<Box
 				cssClass={clsx(styles.header, {
 					[styles.noPadding]: noPadding,
 				})}
 				ref={ref}
+				{...boxProps}
 			>
 				<Text size="xSmall">{children}</Text>
 			</Box>


### PR DESCRIPTION
## Summary

This PR reverts the revert of #8497 and introduces some fixes + improvements.

* We started using the `HighlightType` column rather than `TraceAttributes['highlight.type']` for default trace filters, which should provide a performance improvement.
* We only hit the sampling table for the inner query when selecting traces.
* Adds the sort param to the queries fetching additional results.

## How did you test this change?

* Load the traces page and ensure results + stats in the top look correct
  * Inspect SQL statements to ensure the `traces` table is being hit
* Click on a column header to sort results
  * Ensure results are sorted correctly
  * Inspect SQL and ensure the `traces_sampling` table is hit for the inner query and `traces` is hit for the outer query
* Ensure all other querying behavior works as expected, including logs

## Are there any deployment considerations?

Will monitor as this goes out again to ensure it doesn't cause any more issues.

## Does this work require review from our design team?

Will have @julian-highlight click test in prod. We may do some follow up on the UX to trigger the dropdown menus on table headers.
