### PR TITLE
Fix unquoting queries with non escape characters

### DIFF
--- a/backend/parser/listener/listener.go
+++ b/backend/parser/listener/listener.go
@@ -273,7 +273,7 @@ func (s *SearchListener[T]) appendRules(value string) {
 	}
 	// Quotes are sometimes escaped on the client and need to be unescaped before
 	// being used in the query or they will be double escaped.
-	value = unquote(value)
+	value = Unquote(value)
 
 	// Body column filters
 	if s.currentKey == s.tableConfig.BodyColumn {
@@ -456,20 +456,19 @@ func wildcardValue(value string) string {
 	return value
 }
 
-func unquote(s string) string {
-	if strings.HasPrefix(s, "'") && strings.HasSuffix(s, "'") {
+func Unquote(s string) string {
+	if strings.HasPrefix(s, "\"") && strings.HasSuffix(s, "\"") {
+		s = strings.Trim(s, "\"")
+		s = strings.ReplaceAll(s, "\\\"", "\"")
+	} else if strings.HasPrefix(s, "'") && strings.HasSuffix(s, "'") {
 		s = strings.Trim(s, "'")
 		s = strings.ReplaceAll(s, "\\'", "'")
-		return s
+	} else if strings.HasPrefix(s, "`") && strings.HasSuffix(s, "`") {
+		s = strings.Trim(s, "`")
+		s = strings.ReplaceAll(s, "\\`", "`")
 	}
 
-	unquotedString, err := strconv.Unquote(s)
-	if err != nil {
-		// Will error if string is not quoted, so return original string
-		return s
-	}
-
-	return unquotedString
+	return s
 }
 
 var suffixToNumeric = map[string]int64{

--- a/backend/parser/listener/listener_test.go
+++ b/backend/parser/listener/listener_test.go
@@ -1,0 +1,37 @@
+package listener
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var testCases = []struct {
+	input          string
+	expectedOutput string
+}{
+	{
+		"test",
+		"test",
+	},
+	{
+		`"test"`,
+		"test",
+	},
+	{
+		`"\w\w"`,
+		"\\w\\w",
+	},
+	{
+		`'\w\w'`,
+		"\\w\\w",
+	},
+}
+
+func TestUnquote(t *testing.T) {
+	for _, tc := range testCases {
+		// Call the function with the test case
+		output := Unquote(tc.input)
+		assert.Equal(t, tc.expectedOutput, output)
+	}
+}


### PR DESCRIPTION
## Summary
The `strconv.Unquote` is intended for use in cases where you are processing go source code, so there are some rough edges when trying to unquote a string passed in from the frontend. Mainly, it cannot parse `\d` or \w` and other regex expressions since they are not valid go escape keys.

Update the method to trim the quotes and replace any internal quotes with the non escaped version - like we previously did for single quotes `'`

https://www.loom.com/share/e30f51d823d541e0a78d194139b95a85?sid=c5f92a46-e7df-4709-a30a-12b648bd0649

## How did you test this change?
1) Load one of the search experiences
2) Search with the `matches` operator
3) Add a search expression such as a number (`/n`) or word (`/w`) to the search within the quotes `"`
- [ ] Same results as without quotes

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
