### PR TITLE
Fix error when fetching more traces on demo project

### DIFF
--- a/frontend/src/pages/Traces/TracesPage.tsx
+++ b/frontend/src/pages/Traces/TracesPage.tsx
@@ -42,7 +42,7 @@ import {
 	SortDirection,
 	Trace,
 } from '@/graph/generated/schemas'
-import { useProjectId } from '@/hooks/useProjectId'
+import { useNumericProjectId } from '@/hooks/useProjectId'
 import { useSearchTime } from '@/hooks/useSearchTime'
 import LogsHistogram from '@/pages/LogsPage/LogsHistogram/LogsHistogram'
 import { LatencyChart } from '@/pages/Traces/LatencyChart'
@@ -56,7 +56,7 @@ import * as styles from './TracesPage.css'
 export type TracesOutletContext = Partial<Trace>[]
 
 export const TracesPage: React.FC = () => {
-	const { projectId } = useProjectId()
+	const { projectId } = useNumericProjectId()
 	const navigate = useNavigate()
 	const {
 		trace_id,


### PR DESCRIPTION
## Summary

Fixes an error we were seeing on the demo project when a user scrolls to the bottom and fetches more traces.

## How did you test this change?

Tested scroll behavior in prod on the demo project in the PR preview and confirmed it worked as expected.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A