### PR TITLE
Allow flame graph tooltips to expand to width of content

### DIFF
--- a/frontend/src/pages/Traces/TraceFlameGraph.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraph.tsx
@@ -462,7 +462,7 @@ export const TraceFlameGraph: React.FC = () => {
 						style={{
 							right: tooltipCoordinates.x,
 							bottom: tooltipCoordinates.y + 8,
-							width: 224,
+							minWidth: 224,
 							zIndex: 1000,
 						}}
 						shadow="small"


### PR DESCRIPTION
## Summary

**Before**
<img width="301" alt="Screenshot 2024-05-15 at 3 50 06 PM" src="https://github.com/highlight/highlight/assets/308182/88f1e441-07cc-4c78-bd9a-2f6bab52a03a">

**After**
<img width="375" alt="Screenshot 2024-05-14 at 4 15 47 PM" src="https://github.com/highlight/highlight/assets/308182/86a10d16-687e-4694-840d-212e09091b8a">

## How did you test this change?

* View the flame graph span tooltip on a span that has a long service name in prod - note the jankiness 😬
* View the same trace on the PR preview of this branch and config the jank is gone 🪄 

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A