### PR TITLE
[HIG-4638] revive loading overlay, show old data while loading

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -7178,7 +7178,7 @@ body {
 }
 .dg2vg60 {
   z-index: 2;
-  backdrop-filter: grayscale(50%);
+  pointer-events: none;
 }
 .dg2vg61 {
   border: var(--_1pyqka9j) solid 1px;

--- a/frontend/src/pages/Graphing/components/Graph.css.ts
+++ b/frontend/src/pages/Graphing/components/Graph.css.ts
@@ -3,7 +3,7 @@ import { style } from '@vanilla-extract/css'
 
 export const loadingOverlay = style({
 	zIndex: 2,
-	backdropFilter: 'grayscale(50%)',
+	pointerEvents: 'none',
 })
 
 export const loadingText = style({


### PR DESCRIPTION
## Summary
- brings back the loading overlay, styles it similarly to the "No data found" badge
- continues to show old data while new data is loading
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- @julian-highlight 
<!--
 Request review from julian-highlight / our design team 
-->
