### PR TITLE
Fix logs error when applying `message EXISTS` filter

### DIFF
--- a/frontend/src/components/JsonViewer/utils.ts
+++ b/frontend/src/components/JsonViewer/utils.ts
@@ -21,7 +21,7 @@ export const findMatchingAttributes = (
 			(term): term is SearchExpression =>
 				'key' in term && term.key === bodyKey,
 		)
-		.map((term) => term.value.replace(/^"|"$/g, ''))
+		.map((term) => term.value?.replace(/^"|"$/g, ''))
 
 	Object.entries(attributes).forEach(([key, value]) => {
 		const isString = typeof value === 'string'

--- a/frontend/src/components/JsonViewer/utils.ts
+++ b/frontend/src/components/JsonViewer/utils.ts
@@ -21,7 +21,7 @@ export const findMatchingAttributes = (
 			(term): term is SearchExpression =>
 				'key' in term && term.key === bodyKey,
 		)
-		.map((term) => term.value?.replace(/^"|"$/g, ''))
+		.map((term) => term.value.replace(/^"|"$/g, ''))
 
 	Object.entries(attributes).forEach(([key, value]) => {
 		const isString = typeof value === 'string'

--- a/frontend/src/components/Search/Parser/listener.ts
+++ b/frontend/src/components/Search/Parser/listener.ts
@@ -98,6 +98,7 @@ export class SearchListener extends SearchGrammarListener {
 
 	enterExists_op = (ctx: Exists_opContext) => {
 		this.currentExpression.operator = ctx.getText() as SearchOperator
+		this.currentExpression.value = ''
 	}
 
 	enterBin_op = (ctx: Bin_opContext) => {


### PR DESCRIPTION
## Summary

Fixes an error we were seeing when trying to parse an `EXISTS` or `NOT EXISTS` value on the `message` key of logs. Not sure what the use case was of this query, but we were [seeing a number of these errors](https://app.highlight.io/1/errors/TvTw1F1gtLqIwKV15U9Gh4ZDXCry/instances/269122414?referrer=slack).

## How did you test this change?

* Load https://app.highlight.io/demo/logs?query=message%20EXISTS on prod - you should see the error boundry
* Load the same URL in the PR preview - it should load and render results correctly

## Are there any deployment considerations?

N/A - client-side only bug fix

## Does this work require review from our design team?

Nope!