### PR TITLE
more dashboard polishing

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -7188,6 +7188,7 @@ body {
 }
 .dg2vg62 {
   left: -6px;
+  flex-shrink: 0;
   max-height: 40px;
   padding-top: 2px;
   padding-bottom: 2px;

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -7162,18 +7162,20 @@ body {
   height: calc(100% - 50px);
 }
 ._1s4anja2 {
-  overflow-y: scroll;
-}
-._1s4anja2::-webkit-scrollbar {
-  display: none;
+  overflow-y: hidden;
+  scrollbar-gutter: stable;
 }
 ._1s4anja3 {
-  overflow-y: hidden;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
 }
 ._1s4anja4 {
-  min-width: 106px;
+  overflow-y: hidden;
 }
 ._1s4anja5 {
+  min-width: 106px;
+}
+._1s4anja6 {
   overflow: hidden;
 }
 .dg2vg60 {

--- a/frontend/src/__generated/ve/pages/Graphing/components/Table.css.js
+++ b/frontend/src/__generated/ve/pages/Graphing/components/Table.css.js
@@ -1,15 +1,17 @@
 // src/pages/Graphing/components/Table.css.ts
-var firstCell = "_1s4anja4";
+var firstCell = "_1s4anja5";
 var fullHeight = "_1s4anja1";
-var preventScroll = "_1s4anja3";
-var scrollableBody = "_1s4anja2";
-var tableRow = "_1s4anja5";
+var preventScroll = "_1s4anja4";
+var scrollableBody = "_1s4anja3";
+var tableHeader = "_1s4anja2";
+var tableRow = "_1s4anja6";
 var tableWrapper = "_1s4anja0";
 export {
   firstCell,
   fullHeight,
   preventScroll,
   scrollableBody,
+  tableHeader,
   tableRow,
   tableWrapper
 };

--- a/frontend/src/components/Modal/ModalV2.tsx
+++ b/frontend/src/components/Modal/ModalV2.tsx
@@ -52,7 +52,7 @@ export const Modal: React.FC<
 			style={{
 				top: 0,
 				left: 0,
-				zIndex: '90',
+				zIndex: '20001', // +1 more than the header z-index
 				overflow: 'hidden',
 				backgroundColor: '#6F6E777A',
 			}}

--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -298,7 +298,7 @@ const EditorBackground = () => {
 					height="14"
 					patternUnits="userSpaceOnUse"
 				>
-					<circle fill="#c8c7cb" cx="7" cy="7" r="1" />
+					<circle fill="#e4e2e4" cx="7" cy="7" r="1" />
 				</pattern>
 			</defs>
 

--- a/frontend/src/pages/Graphing/components/Graph.css.ts
+++ b/frontend/src/pages/Graphing/components/Graph.css.ts
@@ -15,6 +15,7 @@ export const loadingText = style({
 
 export const legendWrapper = style({
 	left: -6,
+	flexShrink: 0,
 	maxHeight: 40,
 	paddingTop: 2,
 	paddingBottom: 2,

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -235,46 +235,42 @@ export const getTickFormatter = (metric: string, data?: any[] | undefined) => {
 
 export const getCustomTooltip =
 	(xAxisMetric: any, yAxisMetric: any) =>
-	({ active, payload, label }: any) => {
-		if (active && payload && payload.length) {
-			return (
-				<Box cssClass={style.tooltipWrapper}>
-					<Text
-						size="xxSmall"
-						weight="medium"
-						color="default"
-						cssClass={style.tooltipText}
+	({ payload, label }: any) => {
+		return (
+			<Box cssClass={style.tooltipWrapper}>
+				<Text
+					size="xxSmall"
+					weight="medium"
+					color="default"
+					cssClass={style.tooltipText}
+				>
+					{getTickFormatter(xAxisMetric)(label)}
+				</Text>
+				{payload.map((p: any, idx: number) => (
+					<Box
+						display="flex"
+						flexDirection="row"
+						alignItems="center"
+						key={idx}
 					>
-						{getTickFormatter(xAxisMetric)(label)}
-					</Text>
-					{payload.map((p: any, idx: number) => (
 						<Box
-							display="flex"
-							flexDirection="row"
-							alignItems="center"
-							key={idx}
+							style={{
+								backgroundColor: p.color,
+							}}
+							cssClass={style.tooltipDot}
+						></Box>
+						<Text
+							size="xxSmall"
+							weight="medium"
+							color="default"
+							cssClass={style.tooltipText}
 						>
-							<Box
-								style={{
-									backgroundColor: p.color,
-								}}
-								cssClass={style.tooltipDot}
-							></Box>
-							<Text
-								size="xxSmall"
-								weight="medium"
-								color="default"
-								cssClass={style.tooltipText}
-							>
-								{getTickFormatter(yAxisMetric)(p.value)}
-							</Text>
-						</Box>
-					))}
-				</Box>
-			)
-		}
-
-		return null
+							{getTickFormatter(yAxisMetric)(p.value)}
+						</Text>
+					</Box>
+				))}
+			</Box>
+		)
 	}
 
 export const CustomYAxisTick = ({

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -8,6 +8,7 @@ import {
 	IconSolidChartSquareLine,
 	IconSolidDocumentReport,
 	IconSolidDotsHorizontal,
+	IconSolidDuplicate,
 	IconSolidLoading,
 	IconSolidPencil,
 	IconSolidTable,
@@ -97,6 +98,7 @@ export interface ChartProps<TConfig> {
 	limitMetric?: string
 	viewConfig: TConfig
 	disabled?: boolean
+	onClone?: () => void
 	onDelete?: () => void
 	onExpand?: () => void
 	onEdit?: () => void
@@ -382,6 +384,7 @@ const Graph = ({
 	title,
 	viewConfig,
 	disabled,
+	onClone,
 	onDelete,
 	onExpand,
 	onEdit,
@@ -722,7 +725,7 @@ const Graph = ({
 								onClick={onEdit}
 							/>
 						)}
-						{onDelete !== undefined && (
+						{(onDelete || onClone) && (
 							<Menu>
 								<Menu.Button
 									size="medium"
@@ -734,21 +737,40 @@ const Graph = ({
 									}}
 								/>
 								<Menu.List>
-									<Menu.Item
-										onClick={(e) => {
-											e.stopPropagation()
-											onDelete()
-										}}
-									>
-										<Box
-											display="flex"
-											alignItems="center"
-											gap="4"
+									{onClone && (
+										<Menu.Item
+											onClick={(e) => {
+												e.stopPropagation()
+												onClone()
+											}}
 										>
-											<IconSolidTrash />
-											Delete metric view
-										</Box>
-									</Menu.Item>
+											<Box
+												display="flex"
+												alignItems="center"
+												gap="4"
+											>
+												<IconSolidDuplicate />
+												Clone metric view
+											</Box>
+										</Menu.Item>
+									)}
+									{onDelete && (
+										<Menu.Item
+											onClick={(e) => {
+												e.stopPropagation()
+												onDelete()
+											}}
+										>
+											<Box
+												display="flex"
+												alignItems="center"
+												gap="4"
+											>
+												<IconSolidTrash />
+												Delete metric view
+											</Box>
+										</Menu.Item>
+									)}
 								</Menu.List>
 							</Menu>
 						)}

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -685,7 +685,7 @@ const Graph = ({
 			height="full"
 			display="flex"
 			flexDirection="column"
-			gap="4"
+			gap="8"
 			justifyContent="space-between"
 			onMouseEnter={() => {
 				setGraphHover(true)
@@ -694,138 +694,68 @@ const Graph = ({
 				setGraphHover(false)
 			}}
 		>
-			<Box display="flex" flexDirection="column">
-				<Box
-					display="flex"
-					flexDirection="row"
-					justifyContent="space-between"
-				>
-					<Text
-						size="small"
-						color="default"
-						cssClass={style.titleText}
-					>
-						{title || 'Untitled metric view'}
-					</Text>
-					{showMenu && graphHover && !disabled && called && (
-						<Box
-							cssClass={clsx(style.titleText, {
-								[style.hiddenMenu]: !graphHover,
-							})}
-						>
-							{onExpand !== undefined && (
-								<Button
-									size="xSmall"
-									emphasis="low"
-									kind="secondary"
-									iconLeft={<IconSolidArrowsExpand />}
-									onClick={onExpand}
-								/>
-							)}
-							{onEdit !== undefined && (
-								<Button
-									size="xSmall"
-									emphasis="low"
-									kind="secondary"
-									iconLeft={<IconSolidPencil />}
-									onClick={onEdit}
-								/>
-							)}
-							{onDelete !== undefined && (
-								<Menu>
-									<Menu.Button
-										size="medium"
-										emphasis="low"
-										kind="secondary"
-										iconLeft={<IconSolidDotsHorizontal />}
-										onClick={(e: any) => {
-											e.stopPropagation()
-										}}
-									/>
-									<Menu.List>
-										<Menu.Item
-											onClick={(e) => {
-												e.stopPropagation()
-												onDelete()
-											}}
-										>
-											<Box
-												display="flex"
-												alignItems="center"
-												gap="4"
-											>
-												<IconSolidTrash />
-												Delete metric view
-											</Box>
-										</Menu.Item>
-									</Menu.List>
-								</Menu>
-							)}
-						</Box>
-					)}
-				</Box>
-				{showLegend && (
-					<Box position="relative" cssClass={style.legendWrapper}>
-						{series.map((key, idx) => {
-							return (
-								<Button
-									kind="secondary"
-									emphasis="low"
-									size="xSmall"
-									key={key}
-									onClick={() => {
-										if (spotlight === idx) {
-											setSpotlight(undefined)
-										} else {
-											setSpotlight(idx)
-										}
-									}}
-									cssClass={style.legendTextButton}
-								>
-									<Tooltip
-										delayed
-										trigger={
-											<>
-												<Box
-													style={{
-														backgroundColor:
-															isActive(
-																spotlight,
-																idx,
-															)
-																? getColor(idx)
-																: undefined,
-													}}
-													cssClass={style.legendDot}
-												></Box>
-												<Box
-													cssClass={
-														style.legendTextWrapper
-													}
-												>
-													<Text
-														lines="1"
-														color={
-															isActive(
-																spotlight,
-																idx,
-															)
-																? undefined
-																: 'n8'
-														}
-														align="left"
-													>
-														{key || '<empty>'}
-													</Text>
-												</Box>
-											</>
-										}
-									>
-										{key || '<empty>'}
-									</Tooltip>
-								</Button>
-							)
+			<Box
+				display="flex"
+				flexDirection="row"
+				justifyContent="space-between"
+			>
+				<Text size="small" color="default" cssClass={style.titleText}>
+					{title || 'Untitled metric view'}
+				</Text>
+				{showMenu && graphHover && !disabled && called && (
+					<Box
+						cssClass={clsx(style.titleText, {
+							[style.hiddenMenu]: !graphHover,
 						})}
+					>
+						{onExpand !== undefined && (
+							<Button
+								size="xSmall"
+								emphasis="low"
+								kind="secondary"
+								iconLeft={<IconSolidArrowsExpand />}
+								onClick={onExpand}
+							/>
+						)}
+						{onEdit !== undefined && (
+							<Button
+								size="xSmall"
+								emphasis="low"
+								kind="secondary"
+								iconLeft={<IconSolidPencil />}
+								onClick={onEdit}
+							/>
+						)}
+						{onDelete !== undefined && (
+							<Menu>
+								<Menu.Button
+									size="medium"
+									emphasis="low"
+									kind="secondary"
+									iconLeft={<IconSolidDotsHorizontal />}
+									onClick={(e: any) => {
+										e.stopPropagation()
+									}}
+								/>
+								<Menu.List>
+									<Menu.Item
+										onClick={(e) => {
+											e.stopPropagation()
+											onDelete()
+										}}
+									>
+										<Box
+											display="flex"
+											alignItems="center"
+											gap="4"
+										>
+											<IconSolidTrash />
+											Delete metric view
+										</Box>
+									</Menu.Item>
+								</Menu.List>
+							</Menu>
+						)}
 					</Box>
 				)}
 			</Box>
@@ -861,6 +791,66 @@ const Graph = ({
 						</Stack>
 					)}
 					{innerChart}
+				</Box>
+			)}
+			{showLegend && (
+				<Box position="relative" cssClass={style.legendWrapper}>
+					{series.map((key, idx) => {
+						return (
+							<Button
+								kind="secondary"
+								emphasis="low"
+								size="xSmall"
+								key={key}
+								onClick={() => {
+									if (spotlight === idx) {
+										setSpotlight(undefined)
+									} else {
+										setSpotlight(idx)
+									}
+								}}
+								cssClass={style.legendTextButton}
+							>
+								<Tooltip
+									delayed
+									trigger={
+										<>
+											<Box
+												style={{
+													backgroundColor: isActive(
+														spotlight,
+														idx,
+													)
+														? getColor(idx)
+														: undefined,
+												}}
+												cssClass={style.legendDot}
+											></Box>
+											<Box
+												cssClass={
+													style.legendTextWrapper
+												}
+											>
+												<Text
+													lines="1"
+													color={
+														isActive(spotlight, idx)
+															? undefined
+															: 'n8'
+													}
+													align="left"
+												>
+													{key || '<empty>'}
+												</Text>
+											</Box>
+										</>
+									}
+								>
+									{key || '<empty>'}
+								</Tooltip>
+							</Button>
+						)
+					})}
 				</Box>
 			)}
 		</Box>

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -201,10 +201,12 @@ export const getTickFormatter = (metric: string, data?: any[] | undefined) => {
 				timeMetrics[metric as keyof typeof timeMetrics] ?? 'ns'
 			let lastUnit = startUnit
 			for (const entry of durationUnitMap) {
-				if (startUnit !== '' && startUnit !== entry[1]) {
+				if (startUnit !== '') {
+					if (startUnit === entry[1]) {
+						startUnit = ''
+					}
 					continue
 				}
-				startUnit = ''
 				if (value / entry[0] < 1) {
 					break
 				}

--- a/frontend/src/pages/Graphing/components/Table.css.ts
+++ b/frontend/src/pages/Graphing/components/Table.css.ts
@@ -9,13 +9,14 @@ export const fullHeight = style({
 	height: 'calc(100% - 50px)',
 })
 
+export const tableHeader = style({
+	overflowY: 'hidden',
+	scrollbarGutter: 'stable',
+})
+
 export const scrollableBody = style({
-	overflowY: 'scroll',
-	selectors: {
-		'&::-webkit-scrollbar': {
-			display: 'none',
-		},
-	},
+	overflowY: 'auto',
+	scrollbarGutter: 'stable',
 })
 
 export const preventScroll = style({

--- a/frontend/src/pages/Graphing/components/Table.tsx
+++ b/frontend/src/pages/Graphing/components/Table.tsx
@@ -50,7 +50,7 @@ export const MetricTable = ({
 	return (
 		<Box height="full" cssClass={style.tableWrapper}>
 			<Table noBorder className={style.fullHeight}>
-				<Table.Head>
+				<Table.Head className={style.tableHeader}>
 					<Table.Row className={style.tableRow}>
 						{showXAxisColumn && (
 							<Table.Header>


### PR DESCRIPTION
## Summary
- [HIG-4650] active_length already set up, but a small issue was causing tick markers to show the previous unit
- [HIG-4554] move legend below graphs
- [HIG-4546] make table scrollbar visible, add gutter to header and body
- [HIG-4490] use static-divider-weak color for editor background
- [HIG-4659] update modal z-index so it's on top of the header
- [HIG-4637] stop tooltip flickering in top left
- [SUP-12] add clone metric view option under graph menu
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested w/ active_length, length, Jank
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
