### PR TITLE
fix error enhancement for versioned sourcemaps

### DIFF
--- a/backend/stacktraces/enhancer.go
+++ b/backend/stacktraces/enhancer.go
@@ -415,6 +415,9 @@ func processStackFrame(ctx context.Context, projectId int, version *string, stac
 		} else {
 			sourceMapURL, sourceMapFileBytes, err = getURLSourcemap(ctx, projectId, v, stackTraceFileURL, stackTraceFilePath, stackFileNameIndex, storageClient, &stackTraceError)
 		}
+		if err == nil {
+			break
+		}
 	}
 	if err != nil {
 		return nil, err, stackTraceError

--- a/backend/stacktraces/test-files/1/version-a1b2c3/main.8344d167.chunk.js.map
+++ b/backend/stacktraces/test-files/1/version-a1b2c3/main.8344d167.chunk.js.map
@@ -1,0 +1,1 @@
+../../main.8344d167.chunk.js.map


### PR DESCRIPTION
## Summary

* Fixes an issue in the versioned sourcemap processing version fallback logic that would not use the versioned sourcemap even if one was found in S3.

## How did you test this change?

manual prod testing, new unit test

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no