### PR TITLE
support arbitrary structured json logs ingestion

### DIFF
--- a/backend/http/logging_test.go
+++ b/backend/http/logging_test.go
@@ -22,6 +22,8 @@ const FlyNDJson = `{"event":{"provider":"app"},"fly":{"app":{"instance":"4d891d7
 {"event":{"provider":"app"},"fly":{"app":{"instance":"6e82d4e6a37548","name":"fly-builder-autumn-violet-9735"},"region":"lax"},"host":"971e","log":{"level":"info"},"message":"time=\"2023-06-27T01:19:12.541516209Z\" level=debug msg=\"checking docker activity\"","timestamp":"2023-06-27T01:19:12.541906845Z"}
 {"event":{"provider":"app"},"fly":{"app":{"instance":"6e82d4e6a37548","name":"fly-builder-autumn-violet-9735"},"region":"lax"},"host":"971e","log":{"level":"info"},"message":"time=\"2023-06-27T01:19:12.541802849Z\" level=debug msg=\"Calling GET /v1.41/containers/json?filters=%7B%22status%22%3A%7B%22running%22%3Atrue%7D%7D&limit=0\"","timestamp":"2023-06-27T01:19:12.542083756Z"}`
 
+const GCPJson = `{"insertId":"o9knqgrvve37m18j","jsonPayload":{"job":"work.email.recurring_queue_new_review_notifications","job-id":"ff0bfe05-d764-4885-adbf-be5c3fd6fa57","job-queue":"qa:kvasir","level":"info","max-retry":5,"msg":"processing task","retry":0,"worker":"asynq"},"labels":{"compute.googleapis.com/resource_name":"gke-staging-spot-pool-4741f477-ts57","k8s-pod/app":"worker","k8s-pod/app_kubernetes_io/managed-by":"shelob","k8s-pod/pod-template-hash":"6cc89b447c","k8s-pod/security_istio_io/tlsMode":"istio","k8s-pod/service_istio_io/canonical-name":"worker","k8s-pod/service_istio_io/canonical-revision":"latest"},"logName":"projects/precisely-staging/logs/stdout","receiveTimestamp":"2024-04-18T11:15:04.985600039Z","resource":{"labels":{"cluster_name":"staging","container_name":"worker","location":"europe-west3-a","namespace_name":"qa","pod_name":"worker-deployment-6cc89b447c-wbksh","project_id":"precisely-staging"},"type":"k8s_container"},"severity":"INFO","timestamp":"2024-04-18T11:15:00Z"}`
+
 type MockResponseWriter struct {
 	statusCode int
 }
@@ -83,6 +85,14 @@ func TestHandleFlyJSONGZIPLog(t *testing.T) {
 	r.Header.Set("Content-Encoding", "gzip")
 	r.Header.Set(LogDrainProjectHeader, "1")
 	r.Header.Set(LogDrainServiceHeader, "foo")
+	w := &MockResponseWriter{}
+	HandleJSONLog(w, r)
+	assert.Equal(t, 200, w.statusCode)
+}
+
+func TestHandleGCPJson(t *testing.T) {
+	r, _ := http.NewRequest("POST", "/v1/logs/json?project=1", strings.NewReader(GCPJson))
+	r.Header.Set("Content-Type", "application/json")
 	w := &MockResponseWriter{}
 	HandleJSONLog(w, r)
 	assert.Equal(t, 200, w.statusCode)

--- a/backend/http/logging_test.go
+++ b/backend/http/logging_test.go
@@ -105,8 +105,7 @@ func TestHandleGCPJson(t *testing.T) {
 	assert.Equal(t, 200, w.statusCode)
 
 	spans := spanRecorder.Ended()
-	assert.Equal(t, 1, len(spans))
-	span := spans[0]
+	span := spans[len(spans)-1]
 	event := span.Events()[0]
 	assert.Equal(t, "highlight.log", span.Name())
 	assert.Equal(t, "log", event.Name)

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -261,11 +261,6 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 							projectSessionErrors[fields.projectID][fields.sessionID] = append(projectSessionErrors[fields.projectID][fields.sessionID], backendError)
 						}
 					} else if event.Name() == highlight.LogEvent {
-						if fields.logMessage == "" {
-							lg(ctx, fields).Warn("otel received log with no message")
-							continue
-						}
-
 						if fields.logSeverity == "" {
 							fields.logSeverity = "unknown"
 						}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -3288,7 +3288,7 @@ func (r *Resolver) submitFrontendConsoleMessages(ctx context.Context, sessionObj
 			semconv.ServiceNameKey.String(sessionObj.ServiceName),
 			semconv.ServiceVersionKey.String(ptr.ToString(sessionObj.AppVersion)),
 		}
-		span, _ := highlight.StartTraceWithoutResourceAttributes(ctx, r.Tracer, highlight.UtilitySpanName, []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)}, attributes...)
+		span, _ := highlight.StartTraceWithoutResourceAttributes(ctx, r.Tracer, highlight.LogSpanName, []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)}, attributes...)
 		message := strings.Join(row.Value, " ")
 		attrs := []attribute.KeyValue{
 			hlog.LogSeverityKey.String(row.Type),

--- a/backend/vercel/vercel_test.go
+++ b/backend/vercel/vercel_test.go
@@ -127,7 +127,7 @@ func TestHandleLog(t *testing.T) {
 	assert.Equal(t, 1, len(spans))
 	span := spans[0]
 	event := span.Events()[0]
-	assert.Equal(t, "highlight-ctx", span.Name())
+	assert.Equal(t, "highlight.log", span.Name())
 	assert.Equal(t, "log", event.Name)
 
 	msg, found := lo.Find(event.Attributes, func(attr attribute.KeyValue) bool {

--- a/docs-content/getting-started/5_backend-logging/07_hosting/gcp.md
+++ b/docs-content/getting-started/5_backend-logging/07_hosting/gcp.md
@@ -19,7 +19,7 @@ Check out the following examples of setting up logs streaming in these services:
 3. Setup a [Log Router Sink](https://console.cloud.google.com/logs/router) in Google Cloud Logging
 ![](/images/gcp/step2.png)
 
-4. Setup a Pub/Sub Subscription to export to highlight.io over HTTPS. Set the delivery to Push on endpoint URL  https://pub.highlight.io/v1/logs/raw?project=YOUR_PROJECT_ID&service=backend-service
+4. Setup a Pub/Sub Subscription to export to highlight.io over HTTPS. Set the delivery type to `Push`. Set the endpoint URL depending on the structure of your logs. If your logs are structured as `JSON`, set the endpoint to https://pub.highlight.io/v1/logs/json?project=YOUR_PROJECT_ID&service=backend-service. Otherwise, for unstructured text logs, set the endpoint to  https://pub.highlight.io/v1/logs/raw?project=YOUR_PROJECT_ID&service=backend-service
 ![](/images/gcp/step3.png)
 
 At this point, your infrastructure / service logs should show up in [highlight](https://app.highlight.io/logs)!

--- a/sdk/highlight-go/log/util.go
+++ b/sdk/highlight-go/log/util.go
@@ -84,7 +84,7 @@ func submitVercelLog(ctx context.Context, tracer trace.Tracer, projectID int, se
 	ctx = context.WithValue(ctx, highlight.ContextKeys.SessionSecureID, log.RequestId)
 	ctx = context.WithValue(ctx, highlight.ContextKeys.RequestID, log.RequestId)
 	span, _ := highlight.StartTraceWithoutResourceAttributes(
-		ctx, tracer, highlight.UtilitySpanName, []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)},
+		ctx, tracer, highlight.LogSpanName, []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)},
 		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)), semconv.ServiceNameKey.String(serviceName),
 	)
 	defer highlight.EndTrace(span)
@@ -151,7 +151,7 @@ func SubmitVercelLogs(ctx context.Context, tracer trace.Tracer, projectID int, s
 
 func SubmitHTTPLog(ctx context.Context, tracer trace.Tracer, projectID int, lg Log) error {
 	span, _ := highlight.StartTraceWithoutResourceAttributes(
-		ctx, tracer, highlight.UtilitySpanName, []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)},
+		ctx, tracer, highlight.LogSpanName, []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)},
 		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)),
 	)
 	defer highlight.EndTrace(span)

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -50,7 +50,8 @@ const MetricSpanName = "highlight-metric"
 const MetricEventName = "metric.name"
 const MetricEventValue = "metric.value"
 
-const UtilitySpanName = "highlight-ctx"
+const ErrorSpanName = "highlight.error"
+const LogSpanName = "highlight.log"
 
 type TraceType string
 
@@ -257,7 +258,7 @@ func RecordMetric(ctx context.Context, name string, value float64, tags ...attri
 // Highlight session and trace are inferred from the context.
 // If no sessionID is set, then the error is associated with the project without a session context.
 func RecordError(ctx context.Context, err error, tags ...attribute.KeyValue) context.Context {
-	span, ctx := StartTraceWithTimestamp(ctx, UtilitySpanName, time.Now(), []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)}, tags...)
+	span, ctx := StartTraceWithTimestamp(ctx, ErrorSpanName, time.Now(), []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)}, tags...)
 	defer EndTrace(span)
 	RecordSpanError(span, err)
 	return ctx


### PR DESCRIPTION
## Summary

* support arbitrary structured json logs ingestion from `/v1/logs/json`
* support ingesting log messages with no body but with attributes
* update gcp pub/sub example docs

## How did you test this change?

new unit testing
![Screenshot from 2024-05-15 12-34-10](https://github.com/highlight/highlight/assets/1351531/2b16892e-0eee-4f87-84cc-5f5bf3880e72)



## Are there any deployment considerations?

no

## Does this work require review from our design team?

no