### PR TITLE
add calendly modal to main app

### DIFF
--- a/backend/email/email.go
+++ b/backend/email/email.go
@@ -133,8 +133,8 @@ func getExceededLimitMessage(productType string, workspaceId int) string {
 }
 
 func getOverageMessage(productType string, workspaceId int) string {
-	return fmt.Sprintf(`Your %s usage has exceeded the included amount - extra %s are now incurring a charge for the rest of the month.<br>
-		If you'd like to check the exact charge for the month',
+	return fmt.Sprintf(`Your %s usage has exceeded the included amount - extra %s are now incurring a charge.<br>
+		If you'd like to check the exact charge for the month,
 		please visit the subscription details page <a href="%s/w/%d/current-plan">here</a>.`,
 		productType, productType, frontendUri, workspaceId)
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
 		"react": "^18.2.0",
 		"react-autosize-textarea": "^7.1.0",
 		"react-awesome-query-builder": "^4.8.0",
+		"react-calendly": "^4.3.0",
 		"react-collapsible": "^2.8.1",
 		"react-command-palette": "0.16.0",
 		"react-copy-to-clipboard": "^5.0.2",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -123,7 +123,6 @@ input[name='option-input'] {
 }
 
 iframe {
-	background-color: var(--color-primary-background);
 	border: 0;
 	z-index: -10;
 }

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -5908,11 +5908,21 @@ body {
 ._141pqa00 {
   margin: auto;
   overflow: clip;
-  width: 90vw;
-  height: 90vh;
+  min-width: 320px;
+  min-height: 700px;
+  width: 1000px;
+  height: 900px;
   display: flex;
   justify-content: center;
   align-items: center;
+  position: relative;
+  pointer-events: auto;
+  transition: all;
+}
+._141pqa01 {
+  position: absolute;
+  top: 32px;
+  right: 32px;
 }
 .bsyaa20 {
   text-decoration: none;

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -5871,11 +5871,6 @@ body {
 .u25ybo0 {
   width: 100%;
 }
-._1ozlps90 {
-  margin-top: auto;
-  margin-bottom: auto;
-  max-width: 1080px;
-}
 ._14ud0dc0::-webkit-scrollbar {
   width: 9px;
   height: 9px;
@@ -5909,6 +5904,15 @@ body {
   border: 1px solid transparent;
   border-radius: 30px;
   border-left-width: 2px;
+}
+._141pqa00 {
+  margin: auto;
+  overflow: clip;
+  width: 90vw;
+  height: 90vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 .bsyaa20 {
   text-decoration: none;
@@ -6070,6 +6074,11 @@ body {
 }
 ._1gpgayid:focus {
   background-color: var(--_1pyqka91m);
+}
+._1ozlps90 {
+  margin-top: auto;
+  margin-bottom: auto;
+  max-width: 1080px;
 }
 ._10xh0c20 {
   position: absolute;

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -5871,6 +5871,45 @@ body {
 .u25ybo0 {
   width: 100%;
 }
+._1ozlps90 {
+  margin-top: auto;
+  margin-bottom: auto;
+  max-width: 1080px;
+}
+._14ud0dc0::-webkit-scrollbar {
+  width: 9px;
+  height: 9px;
+}
+:hover._14ud0dc0::-webkit-scrollbar-thumb {
+  background-color: var(--_1pyqka91p);
+}
+:hover._14ud0dc0::-webkit-scrollbar:horizontal {
+  border-top: var(--_1pyqka9k) solid 1px;
+}
+._14ud0dc0::-webkit-scrollbar-thumb:horizontal {
+  background-clip: padding-box;
+  background-color: var(--_1pyqka91o);
+  border: 1px solid transparent;
+  border-radius: 30px;
+  border-top-width: 2px;
+}
+._14ud0dc1::-webkit-scrollbar {
+  width: 9px;
+  height: 9px;
+}
+:hover._14ud0dc1::-webkit-scrollbar-thumb {
+  background-color: var(--_1pyqka91p);
+}
+:hover._14ud0dc1::-webkit-scrollbar:vertical {
+  border-left: var(--_1pyqka9k) solid 1px;
+}
+._14ud0dc1::-webkit-scrollbar-thumb:vertical {
+  background-clip: padding-box;
+  background-color: var(--_1pyqka91o);
+  border: 1px solid transparent;
+  border-radius: 30px;
+  border-left-width: 2px;
+}
 .bsyaa20 {
   text-decoration: none;
   color: var(--_1pyqka9y);
@@ -6031,45 +6070,6 @@ body {
 }
 ._1gpgayid:focus {
   background-color: var(--_1pyqka91m);
-}
-._14ud0dc0::-webkit-scrollbar {
-  width: 9px;
-  height: 9px;
-}
-:hover._14ud0dc0::-webkit-scrollbar-thumb {
-  background-color: var(--_1pyqka91p);
-}
-:hover._14ud0dc0::-webkit-scrollbar:horizontal {
-  border-top: var(--_1pyqka9k) solid 1px;
-}
-._14ud0dc0::-webkit-scrollbar-thumb:horizontal {
-  background-clip: padding-box;
-  background-color: var(--_1pyqka91o);
-  border: 1px solid transparent;
-  border-radius: 30px;
-  border-top-width: 2px;
-}
-._14ud0dc1::-webkit-scrollbar {
-  width: 9px;
-  height: 9px;
-}
-:hover._14ud0dc1::-webkit-scrollbar-thumb {
-  background-color: var(--_1pyqka91p);
-}
-:hover._14ud0dc1::-webkit-scrollbar:vertical {
-  border-left: var(--_1pyqka9k) solid 1px;
-}
-._14ud0dc1::-webkit-scrollbar-thumb:vertical {
-  background-clip: padding-box;
-  background-color: var(--_1pyqka91o);
-  border: 1px solid transparent;
-  border-radius: 30px;
-  border-left-width: 2px;
-}
-._1ozlps90 {
-  margin-top: auto;
-  margin-bottom: auto;
-  max-width: 1080px;
 }
 ._10xh0c20 {
   position: absolute;

--- a/frontend/src/__generated/ve/components/CalendlyModal/styles.css.js
+++ b/frontend/src/__generated/ve/components/CalendlyModal/styles.css.js
@@ -1,5 +1,7 @@
 // src/components/CalendlyModal/styles.css.ts
+var closeIcon = "_141pqa01";
 var modalInner = "_141pqa00";
 export {
+  closeIcon,
   modalInner
 };

--- a/frontend/src/__generated/ve/components/CalendlyModal/styles.css.js
+++ b/frontend/src/__generated/ve/components/CalendlyModal/styles.css.js
@@ -1,0 +1,5 @@
+// src/components/CalendlyModal/styles.css.ts
+var modalInner = "_141pqa00";
+export {
+  modalInner
+};

--- a/frontend/src/components/CalendlyModal/CalendlyModal.tsx
+++ b/frontend/src/components/CalendlyModal/CalendlyModal.tsx
@@ -1,0 +1,158 @@
+import { Button } from '@components/Button'
+import * as style from '@components/Modal/ModalV2.css'
+import { Box, Stack } from '@highlight-run/ui/components'
+import { getAttributionData } from '@util/attribution'
+import clsx from 'clsx'
+import React, { useState } from 'react'
+import { InlineWidget } from 'react-calendly'
+import { useHotkeys } from 'react-hotkeys-hook'
+
+import { styledVerticalScrollbar } from '@/style/common.css'
+
+export function Calendly() {
+	const { referral } = getAttributionData()
+	const utm = JSON.parse(referral)
+	console.log({ utm })
+	return (
+		<InlineWidget
+			url="https://calendly.com/highlight-io/discussion"
+			styles={{ width: 1080, height: 720 }}
+			utm={utm}
+		/>
+	)
+}
+
+export function CalendlyModal() {
+	const [calendlyOpen, setCalendlyOpen] = useState(false)
+	useHotkeys(
+		'escape',
+		() => {
+			setCalendlyOpen(false)
+		},
+		[],
+	)
+
+	return (
+		<>
+			<Button
+				kind="primary"
+				size="small"
+				emphasis="medium"
+				onClick={() => setCalendlyOpen(true)}
+				trackingId="ClickCalendlyOpen"
+			>
+				Book a call with Highlight
+			</Button>
+			{calendlyOpen ? (
+				<Box
+					display="flex"
+					height="screen"
+					width="screen"
+					position="fixed"
+					alignItems="flex-start"
+					justifyContent="center"
+					style={{
+						top: 0,
+						left: 0,
+						zIndex: '90',
+						overflow: 'hidden',
+						backgroundColor: '#6F6E777A',
+					}}
+					onClick={() => setCalendlyOpen(false)}
+				>
+					<Stack
+						cssClass={clsx(
+							styledVerticalScrollbar,
+							style.modalInner,
+						)}
+					>
+						<Calendly />
+					</Stack>
+				</Box>
+			) : null}
+		</>
+	)
+}
+
+/*
+
+export function CalendlyModal({
+								  className,
+								  children,
+							  }: React.PropsWithChildren<{ className?: string }>) {
+	const [calendlyOpen, setCalendlyOpen] = useState(false)
+
+	return (
+		<div>
+			<button
+				type="button"
+				onClick={() => setCalendlyOpen(true)}
+				className={classNames(
+					'flex items-center gap-1 px-3 transition-colors rounded active:brightness-50',
+					className,
+					calendlyOpen
+						? 'bg-blue-cta text-dark-background'
+						: 'hover:bg-white/10',
+				)}
+			>
+				{children ?? (
+					<div className={'flex items-center gap-1'}>
+						<Typography type="copy2" emphasis>
+							Request a Demo Call
+						</Typography>
+						<ArrowRightCircleIcon className="w-5 h-5" />
+					</div>
+				)}
+			</button>
+
+			<Transition appear show={calendlyOpen} as={Fragment}>
+				<Dialog
+					as="div"
+					className="relative z-[999] w-screen h-screen"
+					onClose={() => setCalendlyOpen(false)}
+				>
+					<Transition.Child
+						as={Fragment}
+						enter="ease-out duration-300"
+						enterFrom="opacity-0"
+						enterTo="opacity-100"
+						leave="ease-in duration-200"
+						leaveFrom="opacity-100"
+						leaveTo="opacity-0"
+					>
+						<div className="fixed inset-0 bg-black/25" />
+					</Transition.Child>
+
+					<div className="fixed inset-0 overflow-y-auto">
+						<div className="flex min-h-full items-center justify-center p-4 text-center">
+							<Transition.Child
+								as={Fragment}
+								enter="ease-out duration-300"
+								enterFrom="opacity-0 scale-95"
+								enterTo="opacity-100 scale-100"
+								leave="ease-in duration-200"
+								leaveFrom="opacity-100 scale-100"
+								leaveTo="opacity-0 scale-95"
+							>
+								<Dialog.Panel className="fixed grid place-items-center inset-0 z-50 w-screen h-screen pointer-events-none">
+									<div className="relative flex min-w-[320px] w-screen max-w-5xl min-[1000px]:h-[700px] h-[900px] transition-opacity max-[652px]:pt-14 pointer-events-auto">
+										<Calendly />
+
+										<button
+											className="absolute grid w-10 h-10 rounded-full place-content-center bg-divider-on-dark max-[652px]:right-2 max-[652px]:top-2 right-10 top-16 hover:brightness-150 transition-all pointer-events-auto"
+											onClick={() =>
+												setCalendlyOpen(false)
+											}
+										>
+											<XMarkIcon className="w-5 h-5" />
+										</button>
+									</div>
+								</Dialog.Panel>
+							</Transition.Child>
+						</div>
+					</div>
+				</Dialog>
+			</Transition>
+		</div>
+	)
+}*/

--- a/frontend/src/components/CalendlyModal/CalendlyModal.tsx
+++ b/frontend/src/components/CalendlyModal/CalendlyModal.tsx
@@ -1,7 +1,9 @@
 import { Button } from '@components/Button'
-import * as style from '@components/Modal/ModalV2.css'
-import { Box, Stack } from '@highlight-run/ui/components'
+import { useGetBillingDetailsForProjectQuery } from '@graph/hooks'
+import { Box, IconSolidCalendar, Stack } from '@highlight-run/ui/components'
+import { useProjectId } from '@hooks/useProjectId'
 import { getAttributionData } from '@util/attribution'
+import { isProjectWithinTrial } from '@util/billing/billing'
 import clsx from 'clsx'
 import React, { useState } from 'react'
 import { InlineWidget } from 'react-calendly'
@@ -9,21 +11,34 @@ import { useHotkeys } from 'react-hotkeys-hook'
 
 import { styledVerticalScrollbar } from '@/style/common.css'
 
+import * as style from './styles.css'
+
 export function Calendly() {
 	const { referral } = getAttributionData()
-	const utm = JSON.parse(referral)
+	let utm = {}
+	try {
+		utm = JSON.parse(referral)
+	} catch (e) {}
 	console.log({ utm })
 	return (
 		<InlineWidget
 			url="https://calendly.com/highlight-io/discussion"
-			styles={{ width: 1080, height: 720 }}
+			styles={{ width: '100%', height: '100%' }}
 			utm={utm}
 		/>
 	)
 }
 
 export function CalendlyModal() {
+	const { projectId } = useProjectId()
+	const { data } = useGetBillingDetailsForProjectQuery({
+		variables: {
+			project_id: projectId,
+		},
+	})
 	const [calendlyOpen, setCalendlyOpen] = useState(false)
+	const hasTrial = isProjectWithinTrial(data?.workspace_for_project)
+
 	useHotkeys(
 		'escape',
 		() => {
@@ -35,13 +50,14 @@ export function CalendlyModal() {
 	return (
 		<>
 			<Button
-				kind="primary"
+				kind={hasTrial ? 'primary' : 'secondary'}
 				size="small"
-				emphasis="medium"
+				emphasis="high"
+				iconLeft={<IconSolidCalendar />}
 				onClick={() => setCalendlyOpen(true)}
 				trackingId="ClickCalendlyOpen"
 			>
-				Book a call with Highlight
+				Book a call
 			</Button>
 			{calendlyOpen ? (
 				<Box

--- a/frontend/src/components/CalendlyModal/CalendlyModal.tsx
+++ b/frontend/src/components/CalendlyModal/CalendlyModal.tsx
@@ -1,10 +1,17 @@
 import { Button } from '@components/Button'
 import { useGetBillingDetailsForProjectQuery } from '@graph/hooks'
-import { Box, IconSolidCalendar, Stack } from '@highlight-run/ui/components'
+import {
+	Box,
+	ButtonIcon,
+	IconSolidCalendar,
+	IconSolidXCircle,
+	Stack,
+} from '@highlight-run/ui/components'
 import { useProjectId } from '@hooks/useProjectId'
 import { getAttributionData } from '@util/attribution'
 import { isProjectWithinTrial } from '@util/billing/billing'
 import clsx from 'clsx'
+import { AnimatePresence, motion } from 'framer-motion'
 import React, { useState } from 'react'
 import { InlineWidget } from 'react-calendly'
 import { useHotkeys } from 'react-hotkeys-hook'
@@ -19,7 +26,6 @@ export function Calendly() {
 	try {
 		utm = JSON.parse(referral)
 	} catch (e) {}
-	console.log({ utm })
 	return (
 		<InlineWidget
 			url="https://calendly.com/highlight-io/discussion"
@@ -59,116 +65,54 @@ export function CalendlyModal() {
 			>
 				Book a call
 			</Button>
-			{calendlyOpen ? (
-				<Box
-					display="flex"
-					height="screen"
-					width="screen"
-					position="fixed"
-					alignItems="flex-start"
-					justifyContent="center"
-					style={{
-						top: 0,
-						left: 0,
-						zIndex: '90',
-						overflow: 'hidden',
-						backgroundColor: '#6F6E777A',
-					}}
-					onClick={() => setCalendlyOpen(false)}
-				>
-					<Stack
-						cssClass={clsx(
-							styledVerticalScrollbar,
-							style.modalInner,
-						)}
+			<AnimatePresence>
+				{calendlyOpen ? (
+					<motion.div
+						key="calendlyWrapper"
+						initial={{ opacity: 0 }}
+						animate={{ opacity: 1 }}
+						exit={{ opacity: 0, display: 'none' }}
+						transition={{
+							duration: 3,
+						}}
 					>
-						<Calendly />
-					</Stack>
-				</Box>
-			) : null}
+						<Box
+							display="flex"
+							height="screen"
+							width="screen"
+							position="fixed"
+							alignItems="flex-start"
+							justifyContent="center"
+							style={{
+								top: 0,
+								left: 0,
+								zIndex: '90',
+								overflow: 'hidden',
+								backgroundColor: '#6F6E777A',
+							}}
+							onClick={() => setCalendlyOpen(false)}
+						>
+							<Stack
+								cssClass={clsx(
+									styledVerticalScrollbar,
+									style.modalInner,
+								)}
+								onClick={() => setCalendlyOpen(false)}
+							>
+								<Calendly />
+								<ButtonIcon
+									shape="square"
+									emphasis="low"
+									kind="secondary"
+									onClick={() => setCalendlyOpen(false)}
+									icon={<IconSolidXCircle size="32" />}
+									cssClass={style.closeIcon}
+								/>
+							</Stack>
+						</Box>
+					</motion.div>
+				) : null}
+			</AnimatePresence>
 		</>
 	)
 }
-
-/*
-
-export function CalendlyModal({
-								  className,
-								  children,
-							  }: React.PropsWithChildren<{ className?: string }>) {
-	const [calendlyOpen, setCalendlyOpen] = useState(false)
-
-	return (
-		<div>
-			<button
-				type="button"
-				onClick={() => setCalendlyOpen(true)}
-				className={classNames(
-					'flex items-center gap-1 px-3 transition-colors rounded active:brightness-50',
-					className,
-					calendlyOpen
-						? 'bg-blue-cta text-dark-background'
-						: 'hover:bg-white/10',
-				)}
-			>
-				{children ?? (
-					<div className={'flex items-center gap-1'}>
-						<Typography type="copy2" emphasis>
-							Request a Demo Call
-						</Typography>
-						<ArrowRightCircleIcon className="w-5 h-5" />
-					</div>
-				)}
-			</button>
-
-			<Transition appear show={calendlyOpen} as={Fragment}>
-				<Dialog
-					as="div"
-					className="relative z-[999] w-screen h-screen"
-					onClose={() => setCalendlyOpen(false)}
-				>
-					<Transition.Child
-						as={Fragment}
-						enter="ease-out duration-300"
-						enterFrom="opacity-0"
-						enterTo="opacity-100"
-						leave="ease-in duration-200"
-						leaveFrom="opacity-100"
-						leaveTo="opacity-0"
-					>
-						<div className="fixed inset-0 bg-black/25" />
-					</Transition.Child>
-
-					<div className="fixed inset-0 overflow-y-auto">
-						<div className="flex min-h-full items-center justify-center p-4 text-center">
-							<Transition.Child
-								as={Fragment}
-								enter="ease-out duration-300"
-								enterFrom="opacity-0 scale-95"
-								enterTo="opacity-100 scale-100"
-								leave="ease-in duration-200"
-								leaveFrom="opacity-100 scale-100"
-								leaveTo="opacity-0 scale-95"
-							>
-								<Dialog.Panel className="fixed grid place-items-center inset-0 z-50 w-screen h-screen pointer-events-none">
-									<div className="relative flex min-w-[320px] w-screen max-w-5xl min-[1000px]:h-[700px] h-[900px] transition-opacity max-[652px]:pt-14 pointer-events-auto">
-										<Calendly />
-
-										<button
-											className="absolute grid w-10 h-10 rounded-full place-content-center bg-divider-on-dark max-[652px]:right-2 max-[652px]:top-2 right-10 top-16 hover:brightness-150 transition-all pointer-events-auto"
-											onClick={() =>
-												setCalendlyOpen(false)
-											}
-										>
-											<XMarkIcon className="w-5 h-5" />
-										</button>
-									</div>
-								</Dialog.Panel>
-							</Transition.Child>
-						</div>
-					</div>
-				</Dialog>
-			</Transition>
-		</div>
-	)
-}*/

--- a/frontend/src/components/CalendlyModal/styles.css.ts
+++ b/frontend/src/components/CalendlyModal/styles.css.ts
@@ -3,9 +3,20 @@ import { style } from '@vanilla-extract/css'
 export const modalInner = style({
 	margin: 'auto',
 	overflow: 'clip',
-	width: '90vw',
-	height: '90vh',
+	minWidth: 320,
+	minHeight: 700,
+	width: 1000,
+	height: 900,
 	display: 'flex',
 	justifyContent: 'center',
 	alignItems: 'center',
+	position: 'relative',
+	pointerEvents: 'auto',
+	transition: 'all',
+})
+
+export const closeIcon = style({
+	position: 'absolute',
+	top: 32,
+	right: 32,
 })

--- a/frontend/src/components/CalendlyModal/styles.css.ts
+++ b/frontend/src/components/CalendlyModal/styles.css.ts
@@ -1,0 +1,11 @@
+import { style } from '@vanilla-extract/css'
+
+export const modalInner = style({
+	margin: 'auto',
+	overflow: 'clip',
+	width: '90vw',
+	height: '90vh',
+	display: 'flex',
+	justifyContent: 'center',
+	alignItems: 'center',
+})

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -79,71 +79,71 @@ type Props = {
 }
 
 const useProjectRedirectLink = () => {
-    const location = useLocation()
-    const { projectId } = useProjectId()
-    const { projectId: localStorageProjectId } = useLocalStorageProjectId()
-    const { allProjects, currentWorkspace } = useApplicationContext()
-    const workspaceId = currentWorkspace?.id
-    const localStorageProject = allProjects?.find(
-        (p) => String(p?.id) === String(localStorageProjectId),
-    )
-    const verificationPaths = [
-        { path: '/:project_id/setup/*' },
-        { path: '/:project_id/setup/backend/*' },
-        { path: '/:project_id/setup/backend-logging/*' },
-        { path: '/:project_id/setup/traces/*' },
-        { path: '/:project_id/setup/alerts/*' },
-    ]
-    const updateBackToPath = (projectId: string | number) => {
-        const match = matchRoutes(verificationPaths, location)?.at(0)
-        const routePath = match?.route?.path
+	const location = useLocation()
+	const { projectId } = useProjectId()
+	const { projectId: localStorageProjectId } = useLocalStorageProjectId()
+	const { allProjects, currentWorkspace } = useApplicationContext()
+	const workspaceId = currentWorkspace?.id
+	const localStorageProject = allProjects?.find(
+		(p) => String(p?.id) === String(localStorageProjectId),
+	)
+	const verificationPaths = [
+		{ path: '/:project_id/setup/*' },
+		{ path: '/:project_id/setup/backend/*' },
+		{ path: '/:project_id/setup/backend-logging/*' },
+		{ path: '/:project_id/setup/traces/*' },
+		{ path: '/:project_id/setup/alerts/*' },
+	]
+	const updateBackToPath = (projectId: string | number) => {
+		const match = matchRoutes(verificationPaths, location)?.at(0)
+		const routePath = match?.route?.path
 
-        switch (routePath) {
-            case '/:project_id/setup/backend/*':
-                return `/${projectId}/errors`
-            case '/:project_id/setup/backend-logging/*':
-                return `/${projectId}/logs`
-            case '/:project_id/setup/traces/*':
-                return `/${projectId}/traces`
-            case '/:project_id/setup/alerts/*':
-                return `/${projectId}/alerts`
-            default:
-                return `/${projectId}/sessions`
-        }
-    }
+		switch (routePath) {
+			case '/:project_id/setup/backend/*':
+				return `/${projectId}/errors`
+			case '/:project_id/setup/backend-logging/*':
+				return `/${projectId}/logs`
+			case '/:project_id/setup/traces/*':
+				return `/${projectId}/traces`
+			case '/:project_id/setup/alerts/*':
+				return `/${projectId}/alerts`
+			default:
+				return `/${projectId}/sessions`
+		}
+	}
 
-    const getProjectRedirectLink = () => {
-        const isWorkspaceTab =
-            workspaceId &&
-            matchRoutes([{ path: '/w/:workspace_id/*' }], location)?.at(0)
-                ?.params?.workspace_id === workspaceId
+	const getProjectRedirectLink = () => {
+		const isWorkspaceTab =
+			workspaceId &&
+			matchRoutes([{ path: '/w/:workspace_id/*' }], location)?.at(0)
+				?.params?.workspace_id === workspaceId
 
-        if (!localStorageProject) {
-            if (allProjects && allProjects.length === 0 && isWorkspaceTab) {
-                return `/w/${workspaceId}/new`
-            }
-            if (isWorkspaceTab && allProjects) {
-                return `/${allProjects[0]?.id}/sessions`
-            }
+		if (!localStorageProject) {
+			if (allProjects && allProjects.length === 0 && isWorkspaceTab) {
+				return `/w/${workspaceId}/new`
+			}
+			if (isWorkspaceTab && allProjects) {
+				return `/${allProjects[0]?.id}/sessions`
+			}
 
-            if (projectId && projectId !== 'demo') {
-                return updateBackToPath(projectId)
-            }
-        }
-        //if user in workspace tab and have not slected any of the projects. setting default to first project.
-        //if user does not have any projects. ideally we need to force the user to create atleast one project if they are trying to click on go back to project.
-        if (
-            isWorkspaceTab &&
-            (!projectId || projectId == 'demo') &&
-            allProjects?.length
-        ) {
-            return `/${allProjects[0]?.id}/sessions`
-        }
-        return updateBackToPath(localStorageProjectId || projectId)
-    }
-    const goBackPath = getProjectRedirectLink()
+			if (projectId && projectId !== 'demo') {
+				return updateBackToPath(projectId)
+			}
+		}
+		//if user in workspace tab and have not slected any of the projects. setting default to first project.
+		//if user does not have any projects. ideally we need to force the user to create atleast one project if they are trying to click on go back to project.
+		if (
+			isWorkspaceTab &&
+			(!projectId || projectId == 'demo') &&
+			allProjects?.length
+		) {
+			return `/${allProjects[0]?.id}/sessions`
+		}
+		return updateBackToPath(localStorageProjectId || projectId)
+	}
+	const goBackPath = getProjectRedirectLink()
 
-    return goBackPath
+	return goBackPath
 }
 
 export const Header: React.FC<Props> = ({ fullyIntegrated }) => {

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,12 +1,12 @@
 import { useAuthContext } from '@authentication/AuthContext'
+import { CalendlyModal } from '@components/CalendlyModal/CalendlyModal'
 import { DEMO_WORKSPACE_PROXY_APPLICATION_ID } from '@components/DemoWorkspaceButton/DemoWorkspaceButton'
 import ProjectPicker from '@components/Header/components/ProjectPicker/ProjectPicker'
 import { betaTag, linkStyle } from '@components/Header/styles.css'
+import { useBillingHook } from '@components/Header/useBillingHook'
 import { LinkButton } from '@components/LinkButton'
 import {
 	useGetBillingDetailsForProjectQuery,
-	useGetProjectQuery,
-	useGetSubscriptionDetailsQuery,
 	useGetSystemConfigurationQuery,
 	useGetWorkspacesQuery,
 } from '@graph/hooks'
@@ -78,106 +78,72 @@ type Props = {
 	fullyIntegrated?: boolean
 }
 
-export const useBillingHook = ({
-	workspace_id,
-	project_id,
-}: {
-	workspace_id?: string
-	project_id?: string
-}) => {
-	const { isAuthLoading, isLoggedIn } = useAuthContext()
-	const { data: projectData } = useGetProjectQuery({
-		variables: { id: project_id || '' },
-		skip: !project_id?.length || !!workspace_id?.length,
-	})
-
-	const {
-		loading: subscriptionLoading,
-		data: subscriptionData,
-		refetch: refetchSubscription,
-	} = useGetSubscriptionDetailsQuery({
-		variables: {
-			workspace_id: workspace_id || projectData?.workspace?.id || '',
-		},
-		skip:
-			isAuthLoading ||
-			!isLoggedIn ||
-			(!workspace_id?.length && !projectData?.workspace?.id),
-	})
-
-	return {
-		loading: subscriptionLoading,
-		subscriptionData: subscriptionData,
-		refetchSubscription: refetchSubscription,
-	}
-}
-
 const useProjectRedirectLink = () => {
-	const location = useLocation()
-	const { projectId } = useProjectId()
-	const { projectId: localStorageProjectId } = useLocalStorageProjectId()
-	const { allProjects, currentWorkspace } = useApplicationContext()
-	const workspaceId = currentWorkspace?.id
-	const localStorageProject = allProjects?.find(
-		(p) => String(p?.id) === String(localStorageProjectId),
-	)
-	const verificationPaths = [
-		{ path: '/:project_id/setup/*' },
-		{ path: '/:project_id/setup/backend/*' },
-		{ path: '/:project_id/setup/backend-logging/*' },
-		{ path: '/:project_id/setup/traces/*' },
-		{ path: '/:project_id/setup/alerts/*' },
-	]
-	const updateBackToPath = (projectId: string | number) => {
-		const match = matchRoutes(verificationPaths, location)?.at(0)
-		const routePath = match?.route?.path
+    const location = useLocation()
+    const { projectId } = useProjectId()
+    const { projectId: localStorageProjectId } = useLocalStorageProjectId()
+    const { allProjects, currentWorkspace } = useApplicationContext()
+    const workspaceId = currentWorkspace?.id
+    const localStorageProject = allProjects?.find(
+        (p) => String(p?.id) === String(localStorageProjectId),
+    )
+    const verificationPaths = [
+        { path: '/:project_id/setup/*' },
+        { path: '/:project_id/setup/backend/*' },
+        { path: '/:project_id/setup/backend-logging/*' },
+        { path: '/:project_id/setup/traces/*' },
+        { path: '/:project_id/setup/alerts/*' },
+    ]
+    const updateBackToPath = (projectId: string | number) => {
+        const match = matchRoutes(verificationPaths, location)?.at(0)
+        const routePath = match?.route?.path
 
-		switch (routePath) {
-			case '/:project_id/setup/backend/*':
-				return `/${projectId}/errors`
-			case '/:project_id/setup/backend-logging/*':
-				return `/${projectId}/logs`
-			case '/:project_id/setup/traces/*':
-				return `/${projectId}/traces`
-			case '/:project_id/setup/alerts/*':
-				return `/${projectId}/alerts`
-			default:
-				return `/${projectId}/sessions`
-		}
-	}
+        switch (routePath) {
+            case '/:project_id/setup/backend/*':
+                return `/${projectId}/errors`
+            case '/:project_id/setup/backend-logging/*':
+                return `/${projectId}/logs`
+            case '/:project_id/setup/traces/*':
+                return `/${projectId}/traces`
+            case '/:project_id/setup/alerts/*':
+                return `/${projectId}/alerts`
+            default:
+                return `/${projectId}/sessions`
+        }
+    }
 
-	const getProjectRedirectLink = () => {
-		const isWorkspaceTab =
-			workspaceId &&
-			matchRoutes([{ path: '/w/:workspace_id/*' }], location)?.at(0)
-				?.params?.workspace_id === workspaceId
+    const getProjectRedirectLink = () => {
+        const isWorkspaceTab =
+            workspaceId &&
+            matchRoutes([{ path: '/w/:workspace_id/*' }], location)?.at(0)
+                ?.params?.workspace_id === workspaceId
 
-		if (!localStorageProject) {
-			if (allProjects && allProjects.length === 0 && isWorkspaceTab) {
-				return `/w/${workspaceId}/new`
-			}
-			if (isWorkspaceTab && allProjects) {
-				return `/${allProjects[0]?.id}/sessions`
-			}
+        if (!localStorageProject) {
+            if (allProjects && allProjects.length === 0 && isWorkspaceTab) {
+                return `/w/${workspaceId}/new`
+            }
+            if (isWorkspaceTab && allProjects) {
+                return `/${allProjects[0]?.id}/sessions`
+            }
 
-			if (projectId && projectId !== 'demo') {
-				return updateBackToPath(projectId)
-			}
-		}
-		//if user in workspace tab and have not slected any of the projects. setting default to first project.
-		//if user does not have any projects. ideally we need to force the user to create atleast one project if they are trying to click on go back to project.
-		if (
-			isWorkspaceTab &&
-			(!projectId || projectId == 'demo') &&
-			allProjects?.length
-		) {
-			return `/${allProjects[0]?.id}/sessions`
-		}
-		return updateBackToPath(localStorageProjectId || projectId)
-	}
-	const goBackPath = getProjectRedirectLink()
+            if (projectId && projectId !== 'demo') {
+                return updateBackToPath(projectId)
+            }
+        }
+        //if user in workspace tab and have not slected any of the projects. setting default to first project.
+        //if user does not have any projects. ideally we need to force the user to create atleast one project if they are trying to click on go back to project.
+        if (
+            isWorkspaceTab &&
+            (!projectId || projectId == 'demo') &&
+            allProjects?.length
+        ) {
+            return `/${allProjects[0]?.id}/sessions`
+        }
+        return updateBackToPath(localStorageProjectId || projectId)
+    }
+    const goBackPath = getProjectRedirectLink()
 
-	return goBackPath
+    return goBackPath
 }
 
 export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
@@ -552,6 +518,7 @@ export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 								)}
 							{!isSetup && !isSettings && (
 								<Box display="flex" alignItems="center" gap="4">
+									<CalendlyModal />
 									<Box>
 										<ButtonIcon
 											cssClass={styles.button}

--- a/frontend/src/components/Header/useBillingHook.tsx
+++ b/frontend/src/components/Header/useBillingHook.tsx
@@ -1,0 +1,39 @@
+import { useAuthContext } from '@authentication/AuthContext'
+import {
+	useGetProjectQuery,
+	useGetSubscriptionDetailsQuery,
+} from '@graph/hooks'
+
+export const useBillingHook = ({
+	workspace_id,
+	project_id,
+}: {
+	workspace_id?: string
+	project_id?: string
+}) => {
+	const { isAuthLoading, isLoggedIn } = useAuthContext()
+	const { data: projectData } = useGetProjectQuery({
+		variables: { id: project_id || '' },
+		skip: !project_id?.length || !!workspace_id?.length,
+	})
+
+	const {
+		loading: subscriptionLoading,
+		data: subscriptionData,
+		refetch: refetchSubscription,
+	} = useGetSubscriptionDetailsQuery({
+		variables: {
+			workspace_id: workspace_id || projectData?.workspace?.id || '',
+		},
+		skip:
+			isAuthLoading ||
+			!isLoggedIn ||
+			(!workspace_id?.length && !projectData?.workspace?.id),
+	})
+
+	return {
+		loading: subscriptionLoading,
+		subscriptionData: subscriptionData,
+		refetchSubscription: refetchSubscription,
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14472,6 +14472,7 @@ __metadata:
     react: "npm:^18.2.0"
     react-autosize-textarea: "npm:^7.1.0"
     react-awesome-query-builder: "npm:^4.8.0"
+    react-calendly: "npm:^4.3.0"
     react-collapsible: "npm:^2.8.1"
     react-command-palette: "npm:0.16.0"
     react-copy-to-clipboard: "npm:^5.0.2"


### PR DESCRIPTION
## Summary

Adds a `Book a call` button (primary for trial customers, secondary for others) that displays the calendly modal.
![Screenshot from 2024-05-28 15-01-10](https://github.com/highlight/highlight/assets/1351531/73e6a5b0-519c-4ca5-a233-809b9f7a33db)

Closes HIG-4699

## How did you test this change?

[reflame](https://app.highlight.io/1/sessions?%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201HXZFPY7SMRRDHXVM7QRFZA80%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22vadim%2Fenterprise-call%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D)

## Are there any deployment considerations?

no

## Does this work require review from our design team?

yes
