### PR TITLE
use github code build runners

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -9,7 +9,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
     code-setup:
-        runs-on: ubuntu-latest
+        runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -21,7 +21,7 @@ jobs:
 
     code-quality-check:
         needs: code-setup
-        runs-on: ubuntu-latest
+        runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
 
     make-check:
         needs: [code-setup]
-        runs-on: ubuntu-latest
+        runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
 
     build:
         needs: code-quality-check
-        runs-on: ubuntu-latest
+        runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -88,7 +88,7 @@ jobs:
 
     test:
         needs: code-quality-check
-        runs-on: ubuntu-latest
+        runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}
         services:
             postgres:
                 image: ankane/pgvector

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,11 @@ jobs:
                   zip deleteSessionBatchFromS3.zip deleteSessionBatchFromS3
                   CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/sendEmail
                   zip sendEmail.zip sendEmail
+            - name: Configure AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  aws-region: us-east-2
+                  role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
@@ -126,6 +131,11 @@ jobs:
                   zip saveSessionExport.zip saveSessionExport
                   CGO_ENABLED=0 go build ./lambda-functions/sessionExport/sendEmail
                   zip sendEmail.zip sendEmail
+            - name: Configure AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  aws-region: us-east-2
+                  role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
@@ -170,6 +180,11 @@ jobs:
                   zip getDigestData.zip getDigestData
                   CGO_ENABLED=0 go build ./lambda-functions/digests/sendDigestEmails
                   zip sendDigestEmails.zip sendDigestEmails
+            - name: Configure AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  aws-region: us-east-2
+                  role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
@@ -220,6 +235,11 @@ jobs:
                   zip getSessionInsightsData.zip getSessionInsightsData
                   CGO_ENABLED=0 go build ./lambda-functions/sessionInsights/sendSessionInsightsEmails
                   zip sendSessionInsightsEmails.zip sendSessionInsightsEmails
+            - name: Configure AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  aws-region: us-east-2
+                  role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
@@ -260,6 +280,11 @@ jobs:
                   cd backend/
                   GOARCH=arm64 GOOS=linux CGO_ENABLED=0 go build -o bootstrap ./lambda-functions/metering/awsMarketplaceListener
                   zip awsMarketplaceListener.zip bootstrap
+            - name: Configure AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  aws-region: us-east-2
+                  role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
@@ -292,6 +317,11 @@ jobs:
                   cd backend/
                   CGO_ENABLED=0 go build ./lambda-functions/journeys/updateNormalnessScores
                   zip updateNormalnessScores.zip updateNormalnessScores
+            - name: Configure AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  aws-region: us-east-2
+                  role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
@@ -319,6 +349,11 @@ jobs:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+            - name: Configure AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  aws-region: us-east-2
+                  role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
             - name: Login to Amazon ECR
               id: login-ecr
               uses: aws-actions/amazon-ecr-login@v2
@@ -462,6 +497,11 @@ jobs:
     deploy_opentelemetry_collector:
         runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large
         steps:
+            - name: Configure AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  aws-region: us-east-2
+                  role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
             - name: Login to Amazon ECR
               id: login-ecr
               uses: aws-actions/amazon-ecr-login@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -308,7 +308,7 @@ jobs:
 
     deploy_backend:
         needs: migrate-database
-        runs-on: buildjet-2vcpu-ubuntu-2204-arm
+        runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}
         steps:
             - name: Check out the repo
               uses: actions/checkout@v4
@@ -460,7 +460,7 @@ jobs:
                   cluster: highlight-ec2-prod
 
     deploy_opentelemetry_collector:
-        runs-on: buildjet-2vcpu-ubuntu-2204-arm
+        runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}
         steps:
             - name: Login to Amazon ECR
               id: login-ecr

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,12 +60,6 @@ jobs:
                   zip deleteSessionBatchFromS3.zip deleteSessionBatchFromS3
                   CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/sendEmail
                   zip sendEmail.zip sendEmail
-            - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-2
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
@@ -84,40 +78,30 @@ jobs:
             - name: Deploy getSessionIdsByQuery
               uses: appleboy/lambda-action@v0.1.9
               with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   aws_region: us-east-2
                   function_name: getSessionIdsByQuery
                   zip_file: backend/getSessionIdsByQuery.zip
             - name: Deploy deleteSessionBatchFromPostgres
               uses: appleboy/lambda-action@v0.1.9
               with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   aws_region: us-east-2
                   function_name: deleteSessionBatchFromPostgres
                   zip_file: backend/deleteSessionBatchFromPostgres.zip
             - name: Deploy deleteSessionBatchFromOpenSearch
               uses: appleboy/lambda-action@v0.1.9
               with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   aws_region: us-east-2
                   function_name: deleteSessionBatchFromOpenSearch
                   zip_file: backend/deleteSessionBatchFromOpenSearch.zip
             - name: Deploy deleteSessionBatchFromS3
               uses: appleboy/lambda-action@v0.1.9
               with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   aws_region: us-east-2
                   function_name: deleteSessionBatchFromS3
                   zip_file: backend/deleteSessionBatchFromS3.zip
             - name: Deploy sendEmail
               uses: appleboy/lambda-action@v0.1.9
               with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   aws_region: us-east-2
                   function_name: sendEmail
                   zip_file: backend/sendEmail.zip
@@ -142,12 +126,6 @@ jobs:
                   zip saveSessionExport.zip saveSessionExport
                   CGO_ENABLED=0 go build ./lambda-functions/sessionExport/sendEmail
                   zip sendEmail.zip sendEmail
-            - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-2
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
@@ -160,16 +138,12 @@ jobs:
             - name: Deploy saveSessionExport
               uses: appleboy/lambda-action@v0.1.9
               with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   aws_region: us-east-2
                   function_name: saveSessionExport
                   zip_file: backend/saveSessionExport.zip
             - name: Deploy sendSessionExportEmail
               uses: appleboy/lambda-action@v0.1.9
               with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   aws_region: us-east-2
                   function_name: sendSessionExportEmail
                   zip_file: backend/sendEmail.zip
@@ -196,12 +170,6 @@ jobs:
                   zip getDigestData.zip getDigestData
                   CGO_ENABLED=0 go build ./lambda-functions/digests/sendDigestEmails
                   zip sendDigestEmails.zip sendDigestEmails
-            - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-2
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
@@ -216,24 +184,18 @@ jobs:
             - name: Deploy getProjectIds
               uses: appleboy/lambda-action@v0.1.9
               with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   aws_region: us-east-2
                   function_name: getProjectIds
                   zip_file: backend/getProjectIds.zip
             - name: Deploy getDigestData
               uses: appleboy/lambda-action@v0.1.9
               with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   aws_region: us-east-2
                   function_name: getDigestData
                   zip_file: backend/getDigestData.zip
             - name: Deploy sendDigestEmails
               uses: appleboy/lambda-action@v0.1.9
               with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   aws_region: us-east-2
                   function_name: sendDigestEmails
                   zip_file: backend/sendDigestEmails.zip
@@ -258,12 +220,6 @@ jobs:
                   zip getSessionInsightsData.zip getSessionInsightsData
                   CGO_ENABLED=0 go build ./lambda-functions/sessionInsights/sendSessionInsightsEmails
                   zip sendSessionInsightsEmails.zip sendSessionInsightsEmails
-            - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-2
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
@@ -276,16 +232,12 @@ jobs:
             - name: Deploy getSessionInsightsData
               uses: appleboy/lambda-action@v0.1.9
               with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   aws_region: us-east-2
                   function_name: getSessionInsightsData
                   zip_file: backend/getSessionInsightsData.zip
             - name: Deploy sendSessionInsightsEmails
               uses: appleboy/lambda-action@v0.1.9
               with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   aws_region: us-east-2
                   function_name: sendSessionInsightsEmails
                   zip_file: backend/sendSessionInsightsEmails.zip
@@ -308,12 +260,6 @@ jobs:
                   cd backend/
                   GOARCH=arm64 GOOS=linux CGO_ENABLED=0 go build -o bootstrap ./lambda-functions/metering/awsMarketplaceListener
                   zip awsMarketplaceListener.zip bootstrap
-            - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-2
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
@@ -324,8 +270,6 @@ jobs:
             - name: Deploy awsMarketplaceListener
               uses: appleboy/lambda-action@v0.1.9
               with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   aws_region: us-east-2
                   function_name: awsMarketplaceListener
                   zip_file: backend/awsMarketplaceListener.zip
@@ -348,12 +292,6 @@ jobs:
                   cd backend/
                   CGO_ENABLED=0 go build ./lambda-functions/journeys/updateNormalnessScores
                   zip updateNormalnessScores.zip updateNormalnessScores
-            - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-2
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
@@ -364,8 +302,6 @@ jobs:
             - name: Deploy updateNormalnessScores
               uses: appleboy/lambda-action@v0.1.9
               with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   aws_region: us-east-2
                   function_name: updateNormalnessScores
                   zip_file: backend/updateNormalnessScores.zip
@@ -376,13 +312,6 @@ jobs:
         steps:
             - name: Check out the repo
               uses: actions/checkout@v4
-
-            - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-2
 
             - name: Login to Docker Hub
               uses: docker/login-action@v3
@@ -533,12 +462,6 @@ jobs:
     deploy_opentelemetry_collector:
         runs-on: buildjet-2vcpu-ubuntu-2204-arm
         steps:
-            - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-2
             - name: Login to Amazon ECR
               id: login-ecr
               uses: aws-actions/amazon-ecr-login@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -473,6 +473,7 @@ jobs:
               with:
                   filters: |
                       otel-changed:
+                        - '.github/workflows/deploy.yml'
                         - 'deploy/opentelemetry-collector.Dockerfile'
                         - 'deploy/otel-collector.yaml'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -308,7 +308,7 @@ jobs:
 
     deploy_backend:
         needs: migrate-database
-        runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large
         steps:
             - name: Check out the repo
               uses: actions/checkout@v4
@@ -460,7 +460,7 @@ jobs:
                   cluster: highlight-ec2-prod
 
     deploy_opentelemetry_collector:
-        runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large
         steps:
             - name: Login to Amazon ECR
               id: login-ecr

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
     migrate-database:
-        runs-on: ubuntu-latest
+        runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -27,17 +27,6 @@ jobs:
                   cache-dependency-path: 'backend/go.sum'
             - name: Install Doppler CLI
               uses: dopplerhq/cli-action@v3
-            - name: Add public IP to AWS security group
-              uses: sohelamin/aws-security-group-add-ip-action@master
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: 'us-east-2'
-                  aws-security-group-id: ${{ secrets.AWS_RDS_SECURITY_GROUP_ID }}
-                  port: '5432'
-                  to-port: ''
-                  protocol: 'tcp'
-                  description: 'GitHub Action for migrate-database'
             - name: Migrate database
               run: |
                   cd backend/
@@ -47,7 +36,7 @@ jobs:
 
     deploy-session-delete-lambdas:
         needs: migrate-database
-        runs-on: ubuntu-latest
+        runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -135,7 +124,7 @@ jobs:
 
     deploy-session-export-lambdas:
         needs: migrate-database
-        runs-on: ubuntu-latest
+        runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -187,7 +176,7 @@ jobs:
 
     deploy-digest-lambdas:
         needs: migrate-database
-        runs-on: ubuntu-latest
+        runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -251,7 +240,7 @@ jobs:
 
     deploy-session-insights-lambdas:
         needs: migrate-database
-        runs-on: ubuntu-latest
+        runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -303,7 +292,7 @@ jobs:
 
     deploy-metering-lambdas:
         needs: migrate-database
-        runs-on: ubuntu-latest
+        runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -343,7 +332,7 @@ jobs:
 
     deploy-user-journey-lambdas:
         needs: migrate-database
-        runs-on: ubuntu-latest
+        runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,31 +81,31 @@ jobs:
                   aws lambda update-function-configuration --function-name sendEmail \
                     --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')" 2>&1 >/dev/null
             - name: Deploy getSessionIdsByQuery
-              uses: appleboy/lambda-action@v0.1.9
+              uses: appleboy/lambda-action@v0.2.0
               with:
                   aws_region: us-east-2
                   function_name: getSessionIdsByQuery
                   zip_file: backend/getSessionIdsByQuery.zip
             - name: Deploy deleteSessionBatchFromPostgres
-              uses: appleboy/lambda-action@v0.1.9
+              uses: appleboy/lambda-action@v0.2.0
               with:
                   aws_region: us-east-2
                   function_name: deleteSessionBatchFromPostgres
                   zip_file: backend/deleteSessionBatchFromPostgres.zip
             - name: Deploy deleteSessionBatchFromOpenSearch
-              uses: appleboy/lambda-action@v0.1.9
+              uses: appleboy/lambda-action@v0.2.0
               with:
                   aws_region: us-east-2
                   function_name: deleteSessionBatchFromOpenSearch
                   zip_file: backend/deleteSessionBatchFromOpenSearch.zip
             - name: Deploy deleteSessionBatchFromS3
-              uses: appleboy/lambda-action@v0.1.9
+              uses: appleboy/lambda-action@v0.2.0
               with:
                   aws_region: us-east-2
                   function_name: deleteSessionBatchFromS3
                   zip_file: backend/deleteSessionBatchFromS3.zip
             - name: Deploy sendEmail
-              uses: appleboy/lambda-action@v0.1.9
+              uses: appleboy/lambda-action@v0.2.0
               with:
                   aws_region: us-east-2
                   function_name: sendEmail
@@ -146,13 +146,13 @@ jobs:
                   aws lambda update-function-configuration --function-name sendSessionExportEmail \
                     --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')" 2>&1 >/dev/null
             - name: Deploy saveSessionExport
-              uses: appleboy/lambda-action@v0.1.9
+              uses: appleboy/lambda-action@v0.2.0
               with:
                   aws_region: us-east-2
                   function_name: saveSessionExport
                   zip_file: backend/saveSessionExport.zip
             - name: Deploy sendSessionExportEmail
-              uses: appleboy/lambda-action@v0.1.9
+              uses: appleboy/lambda-action@v0.2.0
               with:
                   aws_region: us-east-2
                   function_name: sendSessionExportEmail
@@ -197,19 +197,19 @@ jobs:
                   aws lambda update-function-configuration --function-name sendDigestEmails \
                     --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')" 2>&1 >/dev/null
             - name: Deploy getProjectIds
-              uses: appleboy/lambda-action@v0.1.9
+              uses: appleboy/lambda-action@v0.2.0
               with:
                   aws_region: us-east-2
                   function_name: getProjectIds
                   zip_file: backend/getProjectIds.zip
             - name: Deploy getDigestData
-              uses: appleboy/lambda-action@v0.1.9
+              uses: appleboy/lambda-action@v0.2.0
               with:
                   aws_region: us-east-2
                   function_name: getDigestData
                   zip_file: backend/getDigestData.zip
             - name: Deploy sendDigestEmails
-              uses: appleboy/lambda-action@v0.1.9
+              uses: appleboy/lambda-action@v0.2.0
               with:
                   aws_region: us-east-2
                   function_name: sendDigestEmails
@@ -250,13 +250,13 @@ jobs:
                   aws lambda update-function-configuration --function-name sendSessionInsightsEmails \
                     --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')" 2>&1 >/dev/null
             - name: Deploy getSessionInsightsData
-              uses: appleboy/lambda-action@v0.1.9
+              uses: appleboy/lambda-action@v0.2.0
               with:
                   aws_region: us-east-2
                   function_name: getSessionInsightsData
                   zip_file: backend/getSessionInsightsData.zip
             - name: Deploy sendSessionInsightsEmails
-              uses: appleboy/lambda-action@v0.1.9
+              uses: appleboy/lambda-action@v0.2.0
               with:
                   aws_region: us-east-2
                   function_name: sendSessionInsightsEmails
@@ -293,7 +293,7 @@ jobs:
                   aws lambda update-function-configuration --function-name awsMarketplaceListener \
                     --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')" 2>&1 >/dev/null
             - name: Deploy awsMarketplaceListener
-              uses: appleboy/lambda-action@v0.1.9
+              uses: appleboy/lambda-action@v0.2.0
               with:
                   aws_region: us-east-2
                   function_name: awsMarketplaceListener
@@ -330,7 +330,7 @@ jobs:
                   aws lambda update-function-configuration --function-name updateNormalnessScores \
                     --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')" 2>&1 >/dev/null
             - name: Deploy updateNormalnessScores
-              uses: appleboy/lambda-action@v0.1.9
+              uses: appleboy/lambda-action@v0.2.0
               with:
                   aws_region: us-east-2
                   function_name: updateNormalnessScores

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,35 +81,15 @@ jobs:
                   aws lambda update-function-configuration --function-name sendEmail \
                     --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')" 2>&1 >/dev/null
             - name: Deploy getSessionIdsByQuery
-              uses: appleboy/lambda-action@v0.2.0
-              with:
-                  aws_region: us-east-2
-                  function_name: getSessionIdsByQuery
-                  zip_file: backend/getSessionIdsByQuery.zip
+              run: aws lambda update-function-code --function-name getSessionIdsByQuery --zip-file fileb://backend/getSessionIdsByQuery.zip
             - name: Deploy deleteSessionBatchFromPostgres
-              uses: appleboy/lambda-action@v0.2.0
-              with:
-                  aws_region: us-east-2
-                  function_name: deleteSessionBatchFromPostgres
-                  zip_file: backend/deleteSessionBatchFromPostgres.zip
+              run: aws lambda update-function-code --function-name deleteSessionBatchFromPostgres --zip-file fileb://backend/deleteSessionBatchFromPostgres.zip
             - name: Deploy deleteSessionBatchFromOpenSearch
-              uses: appleboy/lambda-action@v0.2.0
-              with:
-                  aws_region: us-east-2
-                  function_name: deleteSessionBatchFromOpenSearch
-                  zip_file: backend/deleteSessionBatchFromOpenSearch.zip
+              run: aws lambda update-function-code --function-name deleteSessionBatchFromOpenSearch --zip-file fileb://backend/deleteSessionBatchFromOpenSearch.zip
             - name: Deploy deleteSessionBatchFromS3
-              uses: appleboy/lambda-action@v0.2.0
-              with:
-                  aws_region: us-east-2
-                  function_name: deleteSessionBatchFromS3
-                  zip_file: backend/deleteSessionBatchFromS3.zip
+              run: aws lambda update-function-code --function-name deleteSessionBatchFromS3 --zip-file fileb://backend/deleteSessionBatchFromS3.zip
             - name: Deploy sendEmail
-              uses: appleboy/lambda-action@v0.2.0
-              with:
-                  aws_region: us-east-2
-                  function_name: sendEmail
-                  zip_file: backend/sendEmail.zip
+              run: aws lambda update-function-code --function-name sendEmail --zip-file fileb://backend/sendEmail.zip
 
     deploy-session-export-lambdas:
         needs: migrate-database
@@ -146,17 +126,9 @@ jobs:
                   aws lambda update-function-configuration --function-name sendSessionExportEmail \
                     --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')" 2>&1 >/dev/null
             - name: Deploy saveSessionExport
-              uses: appleboy/lambda-action@v0.2.0
-              with:
-                  aws_region: us-east-2
-                  function_name: saveSessionExport
-                  zip_file: backend/saveSessionExport.zip
+              run: aws lambda update-function-code --function-name saveSessionExport --zip-file fileb://backend/saveSessionExport.zip
             - name: Deploy sendSessionExportEmail
-              uses: appleboy/lambda-action@v0.2.0
-              with:
-                  aws_region: us-east-2
-                  function_name: sendSessionExportEmail
-                  zip_file: backend/sendEmail.zip
+              run: aws lambda update-function-code --function-name sendSessionExportEmail --zip-file fileb://backend/sendEmail.zip
 
     deploy-digest-lambdas:
         needs: migrate-database
@@ -197,23 +169,11 @@ jobs:
                   aws lambda update-function-configuration --function-name sendDigestEmails \
                     --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')" 2>&1 >/dev/null
             - name: Deploy getProjectIds
-              uses: appleboy/lambda-action@v0.2.0
-              with:
-                  aws_region: us-east-2
-                  function_name: getProjectIds
-                  zip_file: backend/getProjectIds.zip
+              run: aws lambda update-function-code --function-name getProjectIds --zip-file fileb://backend/getProjectIds.zip
             - name: Deploy getDigestData
-              uses: appleboy/lambda-action@v0.2.0
-              with:
-                  aws_region: us-east-2
-                  function_name: getDigestData
-                  zip_file: backend/getDigestData.zip
+              run: aws lambda update-function-code --function-name getDigestData --zip-file fileb://backend/getDigestData.zip
             - name: Deploy sendDigestEmails
-              uses: appleboy/lambda-action@v0.2.0
-              with:
-                  aws_region: us-east-2
-                  function_name: sendDigestEmails
-                  zip_file: backend/sendDigestEmails.zip
+              run: aws lambda update-function-code --function-name sendDigestEmails --zip-file fileb://backend/sendDigestEmails.zip
 
     deploy-session-insights-lambdas:
         needs: migrate-database
@@ -250,17 +210,9 @@ jobs:
                   aws lambda update-function-configuration --function-name sendSessionInsightsEmails \
                     --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')" 2>&1 >/dev/null
             - name: Deploy getSessionInsightsData
-              uses: appleboy/lambda-action@v0.2.0
-              with:
-                  aws_region: us-east-2
-                  function_name: getSessionInsightsData
-                  zip_file: backend/getSessionInsightsData.zip
+              run: aws lambda update-function-code --function-name getSessionInsightsData --zip-file fileb://backend/getSessionInsightsData.zip
             - name: Deploy sendSessionInsightsEmails
-              uses: appleboy/lambda-action@v0.2.0
-              with:
-                  aws_region: us-east-2
-                  function_name: sendSessionInsightsEmails
-                  zip_file: backend/sendSessionInsightsEmails.zip
+              run: aws lambda update-function-code --function-name sendSessionInsightsEmails --zip-file fileb://backend/sendSessionInsightsEmails.zip
 
     deploy-metering-lambdas:
         needs: migrate-database
@@ -293,11 +245,7 @@ jobs:
                   aws lambda update-function-configuration --function-name awsMarketplaceListener \
                     --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')" 2>&1 >/dev/null
             - name: Deploy awsMarketplaceListener
-              uses: appleboy/lambda-action@v0.2.0
-              with:
-                  aws_region: us-east-2
-                  function_name: awsMarketplaceListener
-                  zip_file: backend/awsMarketplaceListener.zip
+              run: aws lambda update-function-code --function-name awsMarketplaceListener --zip-file fileb://backend/awsMarketplaceListener.zip
 
     deploy-user-journey-lambdas:
         needs: migrate-database
@@ -330,11 +278,7 @@ jobs:
                   aws lambda update-function-configuration --function-name updateNormalnessScores \
                     --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')" 2>&1 >/dev/null
             - name: Deploy updateNormalnessScores
-              uses: appleboy/lambda-action@v0.2.0
-              with:
-                  aws_region: us-east-2
-                  function_name: updateNormalnessScores
-                  zip_file: backend/updateNormalnessScores.zip
+              run: aws lambda update-function-code --function-name updateNormalnessScores --zip-file fileb://backend/updateNormalnessScores.zip
 
     deploy_backend:
         needs: migrate-database

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,15 +81,15 @@ jobs:
                   aws lambda update-function-configuration --function-name sendEmail \
                     --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')" 2>&1 >/dev/null
             - name: Deploy getSessionIdsByQuery
-              run: aws lambda update-function-code --function-name getSessionIdsByQuery --zip-file fileb://backend/getSessionIdsByQuery.zip
+              run: aws lambda update-function-code --function-name getSessionIdsByQuery --zip-file fileb://backend/getSessionIdsByQuery.zip 2>&1 >/dev/null
             - name: Deploy deleteSessionBatchFromPostgres
-              run: aws lambda update-function-code --function-name deleteSessionBatchFromPostgres --zip-file fileb://backend/deleteSessionBatchFromPostgres.zip
+              run: aws lambda update-function-code --function-name deleteSessionBatchFromPostgres --zip-file fileb://backend/deleteSessionBatchFromPostgres.zip 2>&1 >/dev/null
             - name: Deploy deleteSessionBatchFromOpenSearch
-              run: aws lambda update-function-code --function-name deleteSessionBatchFromOpenSearch --zip-file fileb://backend/deleteSessionBatchFromOpenSearch.zip
+              run: aws lambda update-function-code --function-name deleteSessionBatchFromOpenSearch --zip-file fileb://backend/deleteSessionBatchFromOpenSearch.zip 2>&1 >/dev/null
             - name: Deploy deleteSessionBatchFromS3
-              run: aws lambda update-function-code --function-name deleteSessionBatchFromS3 --zip-file fileb://backend/deleteSessionBatchFromS3.zip
+              run: aws lambda update-function-code --function-name deleteSessionBatchFromS3 --zip-file fileb://backend/deleteSessionBatchFromS3.zip 2>&1 >/dev/null
             - name: Deploy sendEmail
-              run: aws lambda update-function-code --function-name sendEmail --zip-file fileb://backend/sendEmail.zip
+              run: aws lambda update-function-code --function-name sendEmail --zip-file fileb://backend/sendEmail.zip 2>&1 >/dev/null
 
     deploy-session-export-lambdas:
         needs: migrate-database
@@ -126,9 +126,9 @@ jobs:
                   aws lambda update-function-configuration --function-name sendSessionExportEmail \
                     --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')" 2>&1 >/dev/null
             - name: Deploy saveSessionExport
-              run: aws lambda update-function-code --function-name saveSessionExport --zip-file fileb://backend/saveSessionExport.zip
+              run: aws lambda update-function-code --function-name saveSessionExport --zip-file fileb://backend/saveSessionExport.zip 2>&1 >/dev/null
             - name: Deploy sendSessionExportEmail
-              run: aws lambda update-function-code --function-name sendSessionExportEmail --zip-file fileb://backend/sendEmail.zip
+              run: aws lambda update-function-code --function-name sendSessionExportEmail --zip-file fileb://backend/sendEmail.zip 2>&1 >/dev/null
 
     deploy-digest-lambdas:
         needs: migrate-database
@@ -169,11 +169,11 @@ jobs:
                   aws lambda update-function-configuration --function-name sendDigestEmails \
                     --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')" 2>&1 >/dev/null
             - name: Deploy getProjectIds
-              run: aws lambda update-function-code --function-name getProjectIds --zip-file fileb://backend/getProjectIds.zip
+              run: aws lambda update-function-code --function-name getProjectIds --zip-file fileb://backend/getProjectIds.zip 2>&1 >/dev/null
             - name: Deploy getDigestData
-              run: aws lambda update-function-code --function-name getDigestData --zip-file fileb://backend/getDigestData.zip
+              run: aws lambda update-function-code --function-name getDigestData --zip-file fileb://backend/getDigestData.zip 2>&1 >/dev/null
             - name: Deploy sendDigestEmails
-              run: aws lambda update-function-code --function-name sendDigestEmails --zip-file fileb://backend/sendDigestEmails.zip
+              run: aws lambda update-function-code --function-name sendDigestEmails --zip-file fileb://backend/sendDigestEmails.zip 2>&1 >/dev/null
 
     deploy-session-insights-lambdas:
         needs: migrate-database
@@ -210,9 +210,9 @@ jobs:
                   aws lambda update-function-configuration --function-name sendSessionInsightsEmails \
                     --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')" 2>&1 >/dev/null
             - name: Deploy getSessionInsightsData
-              run: aws lambda update-function-code --function-name getSessionInsightsData --zip-file fileb://backend/getSessionInsightsData.zip
+              run: aws lambda update-function-code --function-name getSessionInsightsData --zip-file fileb://backend/getSessionInsightsData.zip 2>&1 >/dev/null
             - name: Deploy sendSessionInsightsEmails
-              run: aws lambda update-function-code --function-name sendSessionInsightsEmails --zip-file fileb://backend/sendSessionInsightsEmails.zip
+              run: aws lambda update-function-code --function-name sendSessionInsightsEmails --zip-file fileb://backend/sendSessionInsightsEmails.zip 2>&1 >/dev/null
 
     deploy-metering-lambdas:
         needs: migrate-database
@@ -245,7 +245,7 @@ jobs:
                   aws lambda update-function-configuration --function-name awsMarketplaceListener \
                     --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')" 2>&1 >/dev/null
             - name: Deploy awsMarketplaceListener
-              run: aws lambda update-function-code --function-name awsMarketplaceListener --zip-file fileb://backend/awsMarketplaceListener.zip
+              run: aws lambda update-function-code --function-name awsMarketplaceListener --zip-file fileb://backend/awsMarketplaceListener.zip 2>&1 >/dev/null
 
     deploy-user-journey-lambdas:
         needs: migrate-database
@@ -278,7 +278,7 @@ jobs:
                   aws lambda update-function-configuration --function-name updateNormalnessScores \
                     --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')" 2>&1 >/dev/null
             - name: Deploy updateNormalnessScores
-              run: aws lambda update-function-code --function-name updateNormalnessScores --zip-file fileb://backend/updateNormalnessScores.zip
+              run: aws lambda update-function-code --function-name updateNormalnessScores --zip-file fileb://backend/updateNormalnessScores.zip 2>&1 >/dev/null
 
     deploy_backend:
         needs: migrate-database

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,12 +28,14 @@ jobs:
                   submodules: recursive
 
             - name: Login to Docker Hub
+              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'
               uses: docker/login-action@v3
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
             - name: Login to GitHub Docker
+              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'
               uses: docker/login-action@v3
               with:
                   registry: ghcr.io

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -56,14 +56,6 @@ jobs:
             - name: Check formatting
               run: yarn format-check
 
-            - name: Configure AWS credentials
-              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-2
-
             - name: Install Doppler CLI
               uses: dopplerhq/cli-action@v3
 
@@ -164,14 +156,6 @@ jobs:
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-            - name: Configure AWS credentials
-              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-2
 
             - name: Start docker containers & run cypress
               env:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -67,37 +67,12 @@ jobs:
             - name: Install Doppler CLI
               uses: dopplerhq/cli-action@v3
 
-            # setting REACT_APP_COMMIT_SHA to a dummy value in CI to allow consistent turborepo remote caching
-
-            - name: Build & test (with render environment)
-              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'
-              run: doppler run -- bash -c 'RENDER_PREVIEW=false yarn test:all'
-              env:
-                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_RENDER_SECRET }}
-                  GRAPHCMS_TOKEN: ${{ secrets.GRAPHCMS_TOKEN }}
-                  NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
-                  REACT_APP_COMMIT_SHA: abcdef1234567890a1b2c3d4e5f6fedcba098765
-
             - name: Build & test (in a fork without doppler)
-              if: github.event.pull_request.head.repo.full_name != 'highlight/highlight' && github.ref != 'refs/heads/main'
               run: yarn test:all
               env:
                   GRAPHCMS_TOKEN: ${{ secrets.GRAPHCMS_TOKEN }}
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
-                  REACT_APP_COMMIT_SHA: abcdef1234567890a1b2c3d4e5f6fedcba098765
-
-            - name: Add public IP to AWS security group
-              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'
-              uses: sohelamin/aws-security-group-add-ip-action@master
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: 'us-east-2'
-                  aws-security-group-id: ${{ secrets.AWS_RDS_SECURITY_GROUP_ID }}
-                  port: '5432'
-                  to-port: ''
-                  protocol: 'tcp'
-                  description: 'GitHub Action for Monorepo'
+                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
 
             - name: Test session screenshot lambda
               if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -294,6 +294,11 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 					}
 				}
 
+				// skip logrus spans
+				if span.Name() == highlight.LogrusSpanName {
+					continue
+				}
+
 				timestamp := graph.ClampTime(span.StartTimestamp().AsTime(), curTime)
 				traceRow := clickhouse.NewTraceRow(timestamp, fields.projectIDInt).
 					WithSecureSessionId(fields.sessionID).

--- a/docker/backup_disk.xml
+++ b/docker/backup_disk.xml
@@ -1,5 +1,0 @@
-<clickhouse>
-    <backups>
-        <allowed_path>/backups/</allowed_path>
-    </backups>
-</clickhouse>

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -83,7 +83,8 @@ services:
             - '0.0.0.0:8123:8123'
             - '0.0.0.0:9000:9000'
         volumes:
-            - ./backup_disk.xml:/etc/clickhouse-server/config.d/backup_disk.xml
+            - ./config.xml:/etc/clickhouse-server/config.d/highlight.xml
+            - ./users.xml:/etc/clickhouse-server/users.d/highlight.xml
             - clickhouse-data:/var/lib/clickhouse
             - clickhouse-logs:/var/log/clickhouse-server
 

--- a/docker/config.xml
+++ b/docker/config.xml
@@ -1,0 +1,8 @@
+<clickhouse>
+    <backups>
+        <allowed_path>/backups/</allowed_path>
+        <remove_backup_files_after_failure>true</remove_backup_files_after_failure>
+    </backups>
+    <global_profiler_cpu_time_period_ns>1000000000</global_profiler_cpu_time_period_ns>
+    <global_profiler_real_time_period_ns>1000000000</global_profiler_real_time_period_ns>
+</clickhouse>

--- a/docker/users.xml
+++ b/docker/users.xml
@@ -1,0 +1,13 @@
+<clickhouse>
+    <users>
+        <default>
+            <profile>default</profile>
+        </default>
+    </users>
+    <profiles>
+        <default>
+            <query_profiler_real_time_period_ns>1000000000</query_profiler_real_time_period_ns>
+            <query_profiler_cpu_time_period_ns>1000000000</query_profiler_cpu_time_period_ns>
+        </default>
+    </profiles>
+</clickhouse>

--- a/e2e/tests/src/conftest.py
+++ b/e2e/tests/src/conftest.py
@@ -34,7 +34,7 @@ def run_and_poll(
         pre()
     proc = run(node_bin, args, cwd=cwd)
     try:
-        for _ in range(15):
+        for _ in range(60):
             try:
                 r = request()
                 if r.ok:

--- a/highlight.io/pages/customers/index.tsx
+++ b/highlight.io/pages/customers/index.tsx
@@ -37,7 +37,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
 	const QUERY = gql`
       query GetCustomers() {
-          customers(where: { hidden: false }) {
+          customers(where: { hidden: false }, orderBy: createdAt_DESC) {
               slug
               image {
                   url

--- a/sdk/highlight-go/log/logrus.go
+++ b/sdk/highlight-go/log/logrus.go
@@ -59,7 +59,7 @@ func (hook *Hook) Fire(entry *logrus.Entry) error {
 		ctx = context.TODO()
 	}
 
-	span, _ := highlight.StartTraceWithTimestamp(ctx, "highlight.go.log", entry.Time, []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)})
+	span, _ := highlight.StartTraceWithTimestamp(ctx, highlight.LogrusSpanName, entry.Time, []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)})
 	defer highlight.EndTrace(span)
 
 	msg := entry.Message

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -52,6 +52,7 @@ const MetricEventValue = "metric.value"
 
 const ErrorSpanName = "highlight.error"
 const LogSpanName = "highlight.log"
+const LogrusSpanName = "highlight.go.log"
 
 type TraceType string
 


### PR DESCRIPTION
## Summary

Switch to github code build runners to avoid using AWS secrets to set up credentials.
Skip `highlight.go.log` spans from ingest to avoid recursive highlight app trace ingest.
Fix highlight.io customer testimonial sorting.

Closes SUP-33

## How did you test this change?

https://github.com/highlight/highlight/actions/runs/9121209141/job/25079992204

## Are there any deployment considerations?

will monitor main merge / deploy

## Does this work require review from our design team?

no
