### PR TITLE
fix:default title of the chart should be updated to the graphed value…

### DIFF
--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -25,7 +25,7 @@ import { vars } from '@highlight-run/ui/vars'
 import { useParams } from '@util/react-router/useParams'
 import { Divider, message } from 'antd'
 import moment from 'moment'
-import React, { PropsWithChildren, useId, useMemo, useState } from 'react'
+import React, { PropsWithChildren, useId, useMemo, useRef, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { useNavigate } from 'react-router-dom'
 import { useDebounce } from 'react-use'
@@ -457,7 +457,7 @@ export const GraphingEditor = () => {
 			nullHandling,
 			productType,
 			query: debouncedQuery,
-			title: metricViewTitle,
+			title: metricViewTitle || tempMetricViewTitle?.current,
 			type: viewType,
 		}
 
@@ -577,6 +577,7 @@ export const GraphingEditor = () => {
 
 	const [metric, setMetric] = useState('')
 	const [metricViewTitle, setMetricViewTitle] = useState('')
+	const tempMetricViewTitle = useRef<string>('');
 	const [groupByEnabled, setGroupByEnabled] = useState(false)
 	const [groupByKey, setGroupByKey] = useState('')
 
@@ -627,6 +628,16 @@ export const GraphingEditor = () => {
 		}
 		return baseArray.concat(numericKeys).slice(0, 8)
 	}, [numericKeys, keysQuery])
+
+	tempMetricViewTitle.current = useMemo(()=>{
+		let newValue = ''
+		const stringifiedFunctionType = functionType?.toString() ?? ''; 
+		newValue =  (metricViewTitle || stringifiedFunctionType || '');
+		if(newValue === stringifiedFunctionType && stringifiedFunctionType) {
+			newValue+= metric ? `(${metric})` : '';
+		}
+		return newValue;	
+	}, [functionType, metric, metricViewTitle])
 
 	let display: string | undefined
 	let nullHandling: string | undefined
@@ -747,7 +758,7 @@ export const GraphingEditor = () => {
 									borderRadius="8"
 								>
 									<Graph
-										title={metricViewTitle}
+										title={metricViewTitle || tempMetricViewTitle?.current}
 										viewConfig={viewConfig}
 										productType={productType}
 										projectId={projectId}
@@ -807,7 +818,7 @@ export const GraphingEditor = () => {
 										<Input
 											type="text"
 											name="title"
-											placeholder="Untitled metric view"
+											placeholder={ tempMetricViewTitle?.current || "Untitled metric view" }
 											value={metricViewTitle}
 											onChange={(e) => {
 												setMetricViewTitle(

--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -25,7 +25,13 @@ import { vars } from '@highlight-run/ui/vars'
 import { useParams } from '@util/react-router/useParams'
 import { Divider, message } from 'antd'
 import moment from 'moment'
-import React, { PropsWithChildren, useId, useMemo, useRef, useState } from 'react'
+import React, {
+	PropsWithChildren,
+	useId,
+	useMemo,
+	useRef,
+	useState,
+} from 'react'
 import { Helmet } from 'react-helmet'
 import { useNavigate } from 'react-router-dom'
 import { useDebounce } from 'react-use'
@@ -577,7 +583,7 @@ export const GraphingEditor = () => {
 
 	const [metric, setMetric] = useState('')
 	const [metricViewTitle, setMetricViewTitle] = useState('')
-	const tempMetricViewTitle = useRef<string>('');
+	const tempMetricViewTitle = useRef<string>('')
 	const [groupByEnabled, setGroupByEnabled] = useState(false)
 	const [groupByKey, setGroupByKey] = useState('')
 
@@ -629,15 +635,20 @@ export const GraphingEditor = () => {
 		return baseArray.concat(numericKeys).slice(0, 8)
 	}, [numericKeys, keysQuery])
 
-	tempMetricViewTitle.current = useMemo(()=>{
+	tempMetricViewTitle.current = useMemo(() => {
 		let newViewTitle = ''
-		const stringifiedFunctionType = functionType?.toString() ?? ''; 
-		newViewTitle =  (metricViewTitle || stringifiedFunctionType || '');
-		if(newViewTitle === stringifiedFunctionType && stringifiedFunctionType) {
-			newViewTitle+= metric ? `(${metric})` : '';
+		const stringifiedFunctionType = functionType?.toString() ?? ''
+		newViewTitle = metricViewTitle || stringifiedFunctionType || ''
+		if (
+			newViewTitle === stringifiedFunctionType &&
+			stringifiedFunctionType
+		) {
+			newViewTitle += metric ? `(${metric})` : ''
 		}
-		newViewTitle = newViewTitle ? `${newViewTitle} Of ${productType?.toString() ?? ''}` : newViewTitle;
-		return newViewTitle;	
+		newViewTitle = newViewTitle
+			? `${newViewTitle} Of ${productType?.toString() ?? ''}`
+			: newViewTitle
+		return newViewTitle
 	}, [functionType, metric, metricViewTitle, productType])
 
 	let display: string | undefined
@@ -759,7 +770,10 @@ export const GraphingEditor = () => {
 									borderRadius="8"
 								>
 									<Graph
-										title={metricViewTitle || tempMetricViewTitle?.current}
+										title={
+											metricViewTitle ||
+											tempMetricViewTitle?.current
+										}
 										viewConfig={viewConfig}
 										productType={productType}
 										projectId={projectId}
@@ -819,7 +833,10 @@ export const GraphingEditor = () => {
 										<Input
 											type="text"
 											name="title"
-											placeholder={ tempMetricViewTitle?.current || "Untitled metric view" }
+											placeholder={
+												tempMetricViewTitle?.current ||
+												'Untitled metric view'
+											}
 											value={metricViewTitle}
 											onChange={(e) => {
 												setMetricViewTitle(

--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -630,14 +630,15 @@ export const GraphingEditor = () => {
 	}, [numericKeys, keysQuery])
 
 	tempMetricViewTitle.current = useMemo(()=>{
-		let newValue = ''
+		let newViewTitle = ''
 		const stringifiedFunctionType = functionType?.toString() ?? ''; 
-		newValue =  (metricViewTitle || stringifiedFunctionType || '');
-		if(newValue === stringifiedFunctionType && stringifiedFunctionType) {
-			newValue+= metric ? `(${metric})` : '';
+		newViewTitle =  (metricViewTitle || stringifiedFunctionType || '');
+		if(newViewTitle === stringifiedFunctionType && stringifiedFunctionType) {
+			newViewTitle+= metric ? `(${metric})` : '';
 		}
-		return newValue;	
-	}, [functionType, metric, metricViewTitle])
+		newViewTitle = newViewTitle ? `${newViewTitle} Of ${productType?.toString() ?? ''}` : newViewTitle;
+		return newViewTitle;	
+	}, [functionType, metric, metricViewTitle, productType])
 
 	let display: string | undefined
 	let nullHandling: string | undefined


### PR DESCRIPTION
fixes: #8579
/claim #8579 

## Summary
case 1: If the graph is created/edited without any title it will pick from function type and metric. [functionType(metric)]
case 2: If the user wants to give a proper name to it, they can fill in the title of their choice. The user's title will be given a higher priority irrespective of the updation of function and metric.

note: If the user wants the system to pick the title. Make the title empty. It will automatically pick the title based on function type and metric.
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
https://www.loom.com/share/9fd9a1e000d84c5098afe7330f0dc6e5

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
No

## Does this work require review from our design team?
No

<!--
 Request review from julian-highlight / our design team 
-->

