### PR TITLE
fix: Formatted network request payload has weird formatting

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -448,5 +448,17 @@ strong {
 
 /* override antd4 global anchor transition */
 a {
-	 transition: none !important;
- }
+	transition: none !important;
+}
+
+
+span.token.atom-input {
+	font-size: unset;
+	border-radius: unset;
+	border: unset;
+	width: unset;
+	padding: unset;
+	outline: unset;
+	background-color: unset;
+	caret-color: unset;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -451,7 +451,6 @@ a {
 	transition: none !important;
 }
 
-
 span.token.atom-input {
 	font-size: unset;
 	border-radius: unset;


### PR DESCRIPTION
fixes #8560 
/claim #8560

## Summary
There was a class name conflict between two third party components 
1. react-command-pallette
2. react-syntax-highlighter

The react-command-pallete library comes with a default theme called "atom" that has a declaration for "atom-input"
This theme is imported whenever the react-command-pallete is used and was thus globally available.

Our graphql variable "Type" also has the class name atom-input and therefore inherits the global styling for the default
atom theme from the react-command-pallete component.

My proposed solution just overrides those styles by introducing a global declaration with higher specificity that
unsets the css declaration. I';ve seen similar done for the atom-overlay class.

## Default atom style from the command-pallete library. 
This is imported as a global css by the library.
<img width="713" alt="Screenshot 2024-05-17 at 12 03 49 PM" src="https://github.com/highlight/highlight/assets/119384208/7ea16ae4-f8c6-443e-b1c4-2ad83591f493">


## Fixed output
<img width="524" alt="Screenshot 2024-05-17 at 1 00 52 PM" src="https://github.com/highlight/highlight/assets/119384208/22d43ee8-05f8-4a27-a907-4eaa96ff3894">




<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
Click testing
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
No
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
No
<!--
 Request review from julian-highlight / our design team 
-->
