### PR TITLE
stop polling for more resources after 15 mins

### DIFF
--- a/frontend/src/components/FeedResults/FeedResults.tsx
+++ b/frontend/src/components/FeedResults/FeedResults.tsx
@@ -11,6 +11,7 @@ import * as style from './FeedResults.css'
 interface Props {
 	maxResults: number
 	more: number
+	pollingExpired: boolean
 	type: 'sessions' | 'errors' | 'logs' | 'traces'
 	onClick: () => void
 }
@@ -19,8 +20,10 @@ export const AdditionalFeedResults = function ({
 	maxResults,
 	more,
 	type,
+	pollingExpired,
 	onClick,
 }: Props) {
+	console.log('pollingExpired', pollingExpired)
 	const rounded = ['sessions', 'errors'].includes(type)
 
 	const countText = more >= maxResults ? `${maxResults}+` : more
@@ -28,7 +31,7 @@ export const AdditionalFeedResults = function ({
 
 	return (
 		<AnimatePresence>
-			{more > 0 ? (
+			{more > 0 || pollingExpired ? (
 				<motion.div
 					key="AdditionalFeedResultsWrapper"
 					initial={{ opacity: 0 }}
@@ -57,7 +60,9 @@ export const AdditionalFeedResults = function ({
 							<Box display="flex" alignItems="center" gap="8">
 								<IconOutlineArrowNarrowUp />
 								<Text>
-									{countText} new {resourceText}
+									{pollingExpired
+										? 'Load new results'
+										: `${countText} new ${resourceText}`}
 								</Text>
 							</Box>
 						</Button>

--- a/frontend/src/components/FeedResults/FeedResults.tsx
+++ b/frontend/src/components/FeedResults/FeedResults.tsx
@@ -23,7 +23,6 @@ export const AdditionalFeedResults = function ({
 	pollingExpired,
 	onClick,
 }: Props) {
-	console.log('pollingExpired', pollingExpired)
 	const rounded = ['sessions', 'errors'].includes(type)
 
 	const countText = more >= maxResults ? `${maxResults}+` : more

--- a/frontend/src/components/Search/SearchContext.tsx
+++ b/frontend/src/components/Search/SearchContext.tsx
@@ -31,6 +31,7 @@ interface SearchContext extends Partial<ReturnType<typeof useSearchTime>> {
 	moreResults: number
 	resetMoreResults: () => void
 	histogramBucketSize?: DateHistogramBucketSize
+	pollingExpired: boolean
 }
 
 export const [useSearchContext, SearchContextProvider] =
@@ -49,6 +50,7 @@ interface Props extends Partial<ReturnType<typeof useSearchTime>> {
 	histogramBucketSize?: SearchContext['histogramBucketSize']
 	moreResults?: SearchContext['moreResults']
 	resetMoreResults?: SearchContext['resetMoreResults']
+	pollingExpired?: SearchContext['pollingExpired']
 }
 
 export const SearchContext: React.FC<Props> = ({
@@ -64,6 +66,7 @@ export const SearchContext: React.FC<Props> = ({
 	onSubmit,
 	resetMoreResults = () => null,
 	setPage = () => null,
+	pollingExpired = false,
 	...searchTimeContext
 }) => {
 	const [queryParam] = useQueryParam('query', StringParam)
@@ -89,6 +92,7 @@ export const SearchContext: React.FC<Props> = ({
 				onSubmit,
 				setPage,
 				resetMoreResults,
+				pollingExpired,
 				...searchTimeContext,
 			}}
 		>

--- a/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
@@ -241,6 +241,7 @@ export default function ErrorsV2() {
 			histogramBucketSize={getErrorsData.histogramBucketSize}
 			page={page}
 			setPage={setPage}
+			pollingExpired={getErrorsData.pollingExpired}
 			{...searchTimeContext}
 		>
 			<Helmet>

--- a/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
+++ b/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
@@ -32,6 +32,7 @@ export const SearchPanel = () => {
 		totalCount,
 		moreResults: moreErrors,
 		resetMoreResults: resetMoreErrors,
+		pollingExpired,
 		loading,
 		page,
 		setPage,
@@ -118,6 +119,7 @@ export const SearchPanel = () => {
 					setPage(1)
 					rebaseSearchTime!()
 				}}
+				pollingExpired={pollingExpired}
 			/>
 			<Box
 				padding="8"

--- a/frontend/src/pages/ErrorsV2/useGetErrors.ts
+++ b/frontend/src/pages/ErrorsV2/useGetErrors.ts
@@ -49,10 +49,11 @@ export const useGetErrors = ({
 		fetchPolicy: 'network-only',
 	})
 
-	const { numMore: moreErrors, reset: resetMoreErrors } = usePollQuery<
-		GetErrorGroupsQuery,
-		GetErrorGroupsQueryVariables
-	>({
+	const {
+		numMore: moreErrors,
+		pollingExpired,
+		reset: resetMoreErrors,
+	} = usePollQuery<GetErrorGroupsQuery, GetErrorGroupsQueryVariables>({
 		variableFn: useCallback(() => {
 			return {
 				params: {
@@ -81,6 +82,7 @@ export const useGetErrors = ({
 		errorGroupSecureIds:
 			data?.error_groups?.error_groups.map((eg) => eg.secure_id) || [],
 		moreErrors,
+		pollingExpired,
 		resetMoreErrors,
 		loading,
 		error,

--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -91,6 +91,7 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 	const {
 		logEdges,
 		moreLogs,
+		pollingExpired,
 		clearMoreLogs,
 		loading,
 		error,
@@ -227,6 +228,7 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 							bodyHeight={`calc(100vh - ${otherElementsHeight}px)`}
 							selectedColumns={selectedColumns}
 							setSelectedColumns={setSelectedColumns}
+							pollingExpired={pollingExpired}
 						/>
 					</Box>
 				</Box>

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -336,7 +336,7 @@ const LogsTableInner = ({
 						<Box width="full">
 							<AdditionalFeedResults
 								maxResults={MAX_LOGS}
-								more={moreLogs}
+								more={moreLogs ?? 0}
 								type="logs"
 								onClick={() => {
 									clearMoreLogs()

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -128,6 +128,7 @@ type LogsTableInnerProps = {
 	handleAdditionalLogsDateChange?: () => void
 	selectedColumns?: LogCustomColumn[]
 	setSelectedColumns?: (columns: LogCustomColumn[]) => void
+	pollingExpired?: boolean
 }
 
 const LOADING_AFTER_HEIGHT = 28
@@ -139,6 +140,7 @@ const LogsTableInner = ({
 	query,
 	queryParts,
 	moreLogs,
+	pollingExpired,
 	bodyHeight,
 	clearMoreLogs,
 	handleAdditionalLogsDateChange,
@@ -148,7 +150,9 @@ const LogsTableInner = ({
 }: LogsTableInnerProps) => {
 	const bodyRef = useRef<HTMLDivElement>(null)
 	const enableFetchMoreLogs =
-		!!moreLogs && !!clearMoreLogs && !!handleAdditionalLogsDateChange
+		(!!moreLogs || pollingExpired) &&
+		!!clearMoreLogs &&
+		!!handleAdditionalLogsDateChange
 
 	const [expanded, setExpanded] = useState<ExpandedState>({})
 
@@ -338,6 +342,7 @@ const LogsTableInner = ({
 									clearMoreLogs()
 									handleAdditionalLogsDateChange()
 								}}
+								pollingExpired={pollingExpired ?? false}
 							/>
 						</Box>
 					</Table.Row>

--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -112,7 +112,7 @@ export const useGetLogs = ({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [data?.logs.edges])
 
-	const { numMore, reset } = usePollQuery<
+	const { numMore, pollingExpired, reset } = usePollQuery<
 		GetLogsQuery,
 		GetLogsQueryVariables
 	>({
@@ -250,6 +250,7 @@ export const useGetLogs = ({
 		logEdges: logEdgesWithResources,
 		moreLogs: numMore,
 		clearMoreLogs: reset,
+		pollingExpired,
 		loading,
 		loadingAfter,
 		loadingBefore,

--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -276,6 +276,7 @@ export const PlayerPage = () => {
 						}
 						page={page}
 						setPage={setPage}
+						pollingExpired={getSessionsData.pollingExpired}
 						{...searchTimeContext}
 					>
 						<Helmet>

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
@@ -138,6 +138,7 @@ export const SessionFeedV3 = React.memo(() => {
 		setPage,
 		rebaseSearchTime,
 		updateSearchTime,
+		pollingExpired,
 	} = useSearchContext()
 
 	const { showBanner } = useGlobalContext()
@@ -219,6 +220,7 @@ export const SessionFeedV3 = React.memo(() => {
 						resetMoreResults()
 						rebaseSearchTime!()
 					}}
+					pollingExpired={pollingExpired}
 				/>
 				<Box
 					padding="8"

--- a/frontend/src/pages/Sessions/useGetSessions.ts
+++ b/frontend/src/pages/Sessions/useGetSessions.ts
@@ -49,10 +49,11 @@ export const useGetSessions = ({
 		fetchPolicy: 'network-only',
 	})
 
-	const { numMore: moreSessions, reset: resetMoreSessions } = usePollQuery<
-		GetSessionsQuery,
-		GetSessionsQueryVariables
-	>({
+	const {
+		numMore: moreSessions,
+		reset: resetMoreSessions,
+		pollingExpired,
+	} = usePollQuery<GetSessionsQuery, GetSessionsQueryVariables>({
 		variableFn: useCallback(() => {
 			return {
 				params: {
@@ -87,6 +88,7 @@ export const useGetSessions = ({
 		refetch,
 		totalCount: data?.sessions?.totalCount || 0,
 		histogramBucketSize: determineHistogramBucketSize(startDate, endDate),
+		pollingExpired,
 	}
 }
 

--- a/frontend/src/pages/Traces/TracesList.tsx
+++ b/frontend/src/pages/Traces/TracesList.tsx
@@ -53,6 +53,7 @@ type Props = {
 	fetchMoreWhenScrolled: (target: HTMLDivElement) => void
 	loadingAfter: boolean
 	textAreaRef: React.RefObject<HTMLTextAreaElement>
+	pollingExpired: boolean
 }
 
 const LOADING_AFTER_HEIGHT = 28
@@ -62,6 +63,7 @@ const LOAD_BEFORE_HEIGHT = 28
 export const TracesList: React.FC<Props> = ({
 	loading,
 	numMoreTraces,
+	pollingExpired,
 	traceEdges,
 	handleAdditionalTracesDateChange,
 	resetMoreTraces,
@@ -108,7 +110,7 @@ export const TracesList: React.FC<Props> = ({
 
 	const bodyRef = useRef<HTMLDivElement>(null)
 	const enableFetchMoreTraces =
-		!!numMoreTraces &&
+		(!!numMoreTraces || pollingExpired) &&
 		!!resetMoreTraces &&
 		!!handleAdditionalTracesDateChange
 
@@ -330,6 +332,7 @@ export const TracesList: React.FC<Props> = ({
 									resetMoreTraces()
 									handleAdditionalTracesDateChange()
 								}}
+								pollingExpired={pollingExpired}
 							/>
 						</Box>
 					</Table.Row>

--- a/frontend/src/pages/Traces/TracesList.tsx
+++ b/frontend/src/pages/Traces/TracesList.tsx
@@ -326,7 +326,7 @@ export const TracesList: React.FC<Props> = ({
 						<Box width="full">
 							<AdditionalFeedResults
 								maxResults={MAX_TRACES}
-								more={numMoreTraces}
+								more={numMoreTraces ?? 0}
 								type="traces"
 								onClick={() => {
 									resetMoreTraces()

--- a/frontend/src/pages/Traces/TracesPage.tsx
+++ b/frontend/src/pages/Traces/TracesPage.tsx
@@ -83,6 +83,7 @@ export const TracesPage: React.FC = () => {
 	const {
 		traceEdges,
 		moreTraces,
+		pollingExpired,
 		clearMoreTraces,
 		loading,
 		loadingAfter,
@@ -371,6 +372,7 @@ export const TracesPage: React.FC = () => {
 						fetchMoreWhenScrolled={fetchMoreWhenScrolled}
 						loadingAfter={loadingAfter}
 						textAreaRef={textAreaRef}
+						pollingExpired={pollingExpired}
 					/>
 				</Box>
 			</Box>

--- a/frontend/src/pages/Traces/useGetTraces.ts
+++ b/frontend/src/pages/Traces/useGetTraces.ts
@@ -108,7 +108,7 @@ export const useGetTraces = ({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [data?.traces.edges])
 
-	const { numMore, reset } = usePollQuery<
+	const { numMore, pollingExpired, reset } = usePollQuery<
 		GetTracesQuery,
 		GetTracesQueryVariables
 	>({
@@ -222,6 +222,7 @@ export const useGetTraces = ({
 	return {
 		traceEdges: (data?.traces.edges || []) as TraceEdge[],
 		moreTraces: numMore,
+		pollingExpired,
 		clearMoreTraces: reset,
 		loading,
 		loadingAfter,

--- a/frontend/src/util/search.ts
+++ b/frontend/src/util/search.ts
@@ -3,7 +3,7 @@ import log from '@util/log'
 import moment from 'moment'
 import { useEffect, useRef, useState } from 'react'
 
-import { ClickhouseQuery, QueryInput } from '@/graph/generated/schemas'
+import { QueryInput } from '@/graph/generated/schemas'
 
 export const POLL_INTERVAL = 5000
 const POLL_EXPIRY_MINUTES = 15
@@ -11,13 +11,9 @@ const POLL_EXPIRY_MINUTES = 15
 // usePollQuery polls a lazy query function and returns a 'more' count
 export function usePollQuery<
 	T,
-	U extends
-		| {
-				params: QueryInput
-		  }
-		| {
-				query: ClickhouseQuery
-		  },
+	U extends {
+		params: QueryInput
+	},
 >({
 	variableFn,
 	moreDataQuery,
@@ -59,15 +55,8 @@ export function usePollQuery<
 				return
 			}
 
-			let startDate: string
-			let endDate: string
-			if ('params' in variables) {
-				startDate = variables.params.date_range.start_date
-				endDate = variables.params.date_range.end_date
-			} else {
-				startDate = variables.query.dateRange.start_date
-				endDate = variables.query.dateRange.end_date
-			}
+			const startDate = variables.params.date_range.start_date
+			const endDate = variables.params.date_range.end_date
 
 			const isExpired =
 				moment(endDate).diff(startDate, 'minutes') >=

--- a/frontend/src/util/search.ts
+++ b/frontend/src/util/search.ts
@@ -1,11 +1,24 @@
 import { LazyQueryExecFunction, QueryResult } from '@apollo/client'
 import log from '@util/log'
+import moment from 'moment'
 import { useEffect, useRef, useState } from 'react'
 
+import { ClickhouseQuery, QueryInput } from '@/graph/generated/schemas'
+
 export const POLL_INTERVAL = 5000
+const POLL_EXPIRY_MINUTES = 15
 
 // usePollQuery polls a lazy query function and returns a 'more' count
-export function usePollQuery<T, U>({
+export function usePollQuery<
+	T,
+	U extends
+		| {
+				params: QueryInput
+		  }
+		| {
+				query: ClickhouseQuery
+		  },
+>({
 	variableFn,
 	moreDataQuery,
 	getResultCount,
@@ -20,6 +33,7 @@ export function usePollQuery<T, U>({
 }) {
 	const pollTimeout = useRef<number>()
 	const [numMore, setNumMore] = useState<number>(0)
+	const [pollingExpired, setPollingExpired] = useState<boolean>(false)
 
 	useEffect(() => {
 		if (numMore >= maxResults) {
@@ -44,6 +58,26 @@ export function usePollQuery<T, U>({
 				) as unknown as number
 				return
 			}
+
+			let startDate: string
+			let endDate: string
+			if ('params' in variables) {
+				startDate = variables.params.date_range.start_date
+				endDate = variables.params.date_range.end_date
+			} else {
+				startDate = variables.query.dateRange.start_date
+				endDate = variables.query.dateRange.end_date
+			}
+
+			const isExpired =
+				moment(endDate).diff(startDate, 'minutes') >=
+				POLL_EXPIRY_MINUTES
+			if (isExpired) {
+				setPollingExpired(true)
+				pollTimeout.current = undefined
+				return
+			}
+
 			const currentTimeout = pollTimeout.current
 			const result = await moreDataQuery({ variables })
 			if (pollTimeout.current === currentTimeout) {
@@ -57,22 +91,26 @@ export function usePollQuery<T, U>({
 				) as unknown as number
 			}
 		}
+
 		pollTimeout.current = setTimeout(
 			poll,
 			POLL_INTERVAL,
 		) as unknown as number
 		return () => {
 			setNumMore(0)
+			setPollingExpired(false)
 			clearTimeout(pollTimeout.current)
 			pollTimeout.current = undefined
 		}
 	}, [getResultCount, moreDataQuery, variableFn, skip])
 	return {
 		numMore,
+		pollingExpired,
 		reset: () => {
+			setNumMore(0)
+			setPollingExpired(false)
 			clearTimeout(pollTimeout.current)
 			pollTimeout.current = undefined
-			setNumMore(0)
 		},
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14644,8 +14644,8 @@ __metadata:
     diary: "npm:^0.4.3"
     lodash-es: "npm:^4.17.21"
     long: "npm:^5.2.1"
-    protobufjs: "npm:^7.2.1"
-    protobufjs-cli: "npm:^1.1.1"
+    protobufjs: "npm:^7.2.6"
+    protobufjs-cli: "npm:^1.1.2"
     tsup: "npm:^7.2.0"
   languageName: unknown
   linkType: soft
@@ -55987,7 +55987,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs-cli@npm:^1.1.1":
+"protobufjs-cli@npm:^1.1.2":
   version: 1.1.2
   resolution: "protobufjs-cli@npm:1.1.2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -14644,8 +14644,8 @@ __metadata:
     diary: "npm:^0.4.3"
     lodash-es: "npm:^4.17.21"
     long: "npm:^5.2.1"
-    protobufjs: "npm:^7.2.6"
-    protobufjs-cli: "npm:^1.1.2"
+    protobufjs: "npm:^7.2.1"
+    protobufjs-cli: "npm:^1.1.1"
     tsup: "npm:^7.2.0"
   languageName: unknown
   linkType: soft
@@ -55987,7 +55987,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs-cli@npm:^1.1.2":
+"protobufjs-cli@npm:^1.1.1":
   version: 1.1.2
   resolution: "protobufjs-cli@npm:1.1.2"
   dependencies:


### PR DESCRIPTION
## Summary
- stop polling after 15 mins
- set a `pollingExpired` variable, show "load more results" after this time has passed
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally w/ shorter polling expiry time
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
