### PR TITLE
[SUP-27] cors config updates

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/highlight-run/highlight/backend/assets"
 	"html/template"
 	"io"
 	"math/rand"
@@ -14,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/highlight-run/highlight/backend/assets"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/marketplacemetering"
@@ -195,7 +196,7 @@ var PRIVATE_GRAPH_CORS_OPTIONS = cors.Options{
 	AllowedHeaders:         []string{"*"},
 }
 
-func validateOrigin(r *http.Request, origin string) bool {
+func validateOrigin(_ *http.Request, origin string) bool {
 	// From the highlight frontend, only the url is whitelisted.
 	isRenderPreviewEnv := strings.HasPrefix(origin, "https://frontend-pr-") && strings.HasSuffix(origin, ".onrender.com")
 	// Is this an AWS Amplify environment?

--- a/backend/main.go
+++ b/backend/main.go
@@ -183,20 +183,29 @@ func enhancedHealthCheck(ctx context.Context, db *gorm.DB, rClient *redis.Client
 	}
 }
 
-func validateOrigin(_ *http.Request, origin string) bool {
-	if runtimeParsed == util.PrivateGraph {
-		// From the highlight frontend, only the url is whitelisted.
-		isRenderPreviewEnv := strings.HasPrefix(origin, "https://frontend-pr-") && strings.HasSuffix(origin, ".onrender.com")
-		// Is this an AWS Amplify environment?
-		isAWSEnv := strings.HasPrefix(origin, "https://pr-") && strings.HasSuffix(origin, ".d25bj3loqvp3nx.amplifyapp.com")
-		isReflamePreview := origin == "https://preview.highlight.io"
+var PUBLIC_GRAPH_CORS_OPTIONS = cors.Options{
+	AllowedOrigins:   []string{"*"},
+	AllowCredentials: false,
+	AllowedHeaders:   []string{"*"},
+}
 
-		if origin == frontendURL || origin == "https://app.highlight.run" || origin == "https://app.highlight.io" || origin == landingStagingURL || isRenderPreviewEnv || isAWSEnv || isReflamePreview {
-			return true
-		}
-	} else if runtimeParsed == util.PublicGraph || runtimeParsed == util.All {
+var PRIVATE_GRAPH_CORS_OPTIONS = cors.Options{
+	AllowOriginRequestFunc: validateOrigin,
+	AllowCredentials:       true,
+	AllowedHeaders:         []string{"*"},
+}
+
+func validateOrigin(r *http.Request, origin string) bool {
+	// From the highlight frontend, only the url is whitelisted.
+	isRenderPreviewEnv := strings.HasPrefix(origin, "https://frontend-pr-") && strings.HasSuffix(origin, ".onrender.com")
+	// Is this an AWS Amplify environment?
+	isAWSEnv := strings.HasPrefix(origin, "https://pr-") && strings.HasSuffix(origin, ".d25bj3loqvp3nx.amplifyapp.com")
+	isReflamePreview := origin == "https://preview.highlight.io"
+
+	if origin == frontendURL || origin == "https://app.highlight.run" || origin == "https://app.highlight.io" || origin == landingStagingURL || isRenderPreviewEnv || isAWSEnv || isReflamePreview {
 		return true
 	}
+
 	return false
 }
 
@@ -390,11 +399,6 @@ func main() {
 		return brotli.NewWriterLevel(w, level)
 	})
 	r.Use(compressor.Handler)
-	r.Use(cors.New(cors.Options{
-		AllowOriginRequestFunc: validateOrigin,
-		AllowCredentials:       true,
-		AllowedHeaders:         []string{"*"},
-	}).Handler)
 	r.HandleFunc("/health", healthRouter(runtimeParsed, db, redisClient, clickhouseClient, kafkaProducer, kafkaBatchedProducer))
 
 	zapierStore := zapier.ZapierResthookStore{
@@ -435,6 +439,7 @@ func main() {
 		r.Post(fmt.Sprintf("%s/%s", privateEndpoint, "login"), privateResolver.Login)
 
 		r.Route(privateEndpoint, func(r chi.Router) {
+			r.Use(cors.New(PRIVATE_GRAPH_CORS_OPTIONS).Handler)
 			r.Use(highlightChi.Middleware)
 			r.Use(private.PrivateMiddleware)
 			if fsClient, ok := storageClient.(*storage.FilesystemClient); ok {
@@ -510,6 +515,7 @@ func main() {
 			publicEndpoint = "/"
 		}
 		r.Route(publicEndpoint, func(r chi.Router) {
+			r.Use(cors.New(PUBLIC_GRAPH_CORS_OPTIONS).Handler)
 			r.Use(highlightChi.Middleware)
 			r.Use(public.PublicMiddleware)
 


### PR DESCRIPTION
## Summary
- Highlight doesn't use credentials for public graph requests, but we should not allow credentials in case this changes in future
- move cors configs within the public and private routers only - I don't think it's necessary to use cors on other routes (`/health`, `/otel`) and we should probably have separate public/private configs for hobby deploys too rather than using a single one for the `All` runtime - @Vadman97 can you confirm this last bullet point?
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally to confirm functionality was working properly, tested cross-origin requests
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
