### PR TITLE
Require re-authentication after removing 2FA

### DIFF
--- a/frontend/src/pages/UserSettings/Auth/Auth.tsx
+++ b/frontend/src/pages/UserSettings/Auth/Auth.tsx
@@ -295,6 +295,8 @@ export const VerifyPhone: React.FC<VerifyPhoneProps> = ({
 }
 
 const Enrolled: React.FC<Props> = ({ setError, setStatus }) => {
+	const { signOut } = useAuthContext()
+
 	return (
 		<Space direction="vertical" size="medium">
 			<p>
@@ -319,8 +321,11 @@ const Enrolled: React.FC<Props> = ({ setError, setStatus }) => {
 								currentFactor,
 							)
 
-							setStatus(AuthState.Enroll)
-							message.success('2FA removed successfully')
+							signOut()
+
+							message.success(
+								'2FA removed successfully. Please re-authenticate.',
+							)
 						} catch (e: any) {
 							if (e.code === 'auth/requires-recent-login') {
 								setStatus(AuthState.Login)


### PR DESCRIPTION
## Summary

As a security measure, we should be requiring users to sign in again after removing 2FA from their account.

## How did you test this change?

* Enroll in 2FA
* Remove 2FA
* Ensure you are signed out and that the notification message makes sense

## Are there any deployment considerations?

N/A - minor client-side change.

## Does this work require review from our design team?

N/A - text-only change in the UI.
