### PR TITLE
Disable polling if traces are sorted

### DIFF
--- a/frontend/src/pages/Traces/TracesPage.tsx
+++ b/frontend/src/pages/Traces/TracesPage.tsx
@@ -79,6 +79,7 @@ export const TracesPage: React.FC = () => {
 	})
 	const minDate = presetStartDate(DEFAULT_TIME_PRESETS[5])
 	const timeMode: TIME_MODE = 'fixed-range' // TODO: Support permalink mode
+	const skipPolling = !selectedPreset || !!sortColumn
 
 	const {
 		traceEdges,
@@ -94,7 +95,7 @@ export const TracesPage: React.FC = () => {
 		traceCursor,
 		startDate,
 		endDate,
-		skipPolling: !selectedPreset,
+		skipPolling,
 		sortColumn,
 		sortDirection: sortDirection as SortDirection,
 	})


### PR DESCRIPTION
## Summary

It doesn't make sense to fetch additional results when we are sorting traces by anything other than the default (timestamp desc), so disable it when a user is sorting on a column.

## How did you test this change?

* View `GetTraces` queries happening in the background after loading the traces page
* Sort traces by clicking one of the column headers
* Confirm there are no additional `GetTraces` queries after the initial one

## Are there any deployment considerations?

N/A - should only reduce the number of queries we are sending to fetch traces.

## Does this work require review from our design team?

N/A