### PR TITLE
fix dashboard crash for tooltip for invalid point

### DIFF
--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -237,7 +237,8 @@ export const getTickFormatter = (metric: string, data?: any[] | undefined) => {
 
 export const getCustomTooltip =
 	(xAxisMetric: any, yAxisMetric: any) =>
-	({ payload, label }: any) => {
+	({ active, payload, label }: any) => {
+		const isValid = active && payload && payload.length
 		return (
 			<Box cssClass={style.tooltipWrapper}>
 				<Text
@@ -246,7 +247,7 @@ export const getCustomTooltip =
 					color="default"
 					cssClass={style.tooltipText}
 				>
-					{getTickFormatter(xAxisMetric)(label)}
+					{isValid && getTickFormatter(xAxisMetric)(label)}
 				</Text>
 				{payload.map((p: any, idx: number) => (
 					<Box
@@ -267,7 +268,7 @@ export const getCustomTooltip =
 							color="default"
 							cssClass={style.tooltipText}
 						>
-							{getTickFormatter(yAxisMetric)(p.value)}
+							{isValid && getTickFormatter(yAxisMetric)(p.value)}
 						</Text>
 					</Box>
 				))}
@@ -593,7 +594,7 @@ const Graph = ({
 		  }
 		: undefined
 
-	let isEmpty = data !== undefined
+	let isEmpty = true
 	for (const d of data ?? []) {
 		for (const v of Object.values(d)) {
 			if (!!v) {


### PR DESCRIPTION
## Summary
- Previously, tooltips returned null if there was no data at a point. This was changed to fix a flickering issue, but certain inputs started crashing. Don't call getTickFormatter for these points as the `value` to format may be undefined.
- also fix `isEmpty` check so loading state doesn't have grey lines displayed
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally with crash scenario
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
