### PR TITLE
rewrite log_attributes mvs to write directly to log_key_values table

### DIFF
--- a/backend/clickhouse/migrations/000104_rewrite_log_attributes_mv.down.sql
+++ b/backend/clickhouse/migrations/000104_rewrite_log_attributes_mv.down.sql
@@ -1,0 +1,102 @@
+DROP VIEW IF EXISTS log_attributes_mv;
+CREATE MATERIALIZED VIEW log_attributes_mv TO log_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `LogTimestamp` DateTime,
+    `LogUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    arrayJoin(LogAttributes).1 AS Key,
+    Timestamp AS LogTimestamp,
+    UUID AS LogUUID,
+    arrayJoin(LogAttributes).2 AS Value
+FROM logs
+WHERE (
+        Key NOT IN (
+            'level',
+            'secure_session_id',
+            'service_name',
+            'service_version',
+            'source',
+            'span_id',
+            'trace_id',
+            'message'
+        )
+    )
+    AND (Value != '');
+DROP VIEW IF EXISTS log_service_name_mv;
+CREATE MATERIALIZED VIEW log_service_name_mv TO log_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `LogTimestamp` DateTime,
+    `LogUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    'service_name' AS Key,
+    Timestamp AS LogTimestamp,
+    UUID AS LogUUID,
+    ServiceName AS Value
+FROM logs
+WHERE (ServiceName != '');
+DROP VIEW IF EXISTS log_service_version_mv;
+CREATE MATERIALIZED VIEW log_service_version_mv TO log_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `LogTimestamp` DateTime,
+    `LogUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    'service_version' AS Key,
+    Timestamp AS LogTimestamp,
+    UUID AS LogUUID,
+    ServiceVersion AS Value
+FROM logs
+WHERE (ServiceVersion != '');
+DROP VIEW IF EXISTS log_source_mv;
+CREATE MATERIALIZED VIEW log_source_mv TO log_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `LogTimestamp` DateTime,
+    `LogUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    'source' AS Key,
+    Timestamp AS LogTimestamp,
+    UUID AS LogUUID,
+    Source AS Value
+FROM logs
+WHERE (Source != '');
+DROP VIEW IF EXISTS log_severity_text_mv;
+CREATE MATERIALIZED VIEW log_severity_text_mv TO log_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `LogTimestamp` DateTime,
+    `LogUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    'level' AS Key,
+    Timestamp AS LogTimestamp,
+    UUID AS LogUUID,
+    SeverityText AS Value
+FROM logs
+WHERE (SeverityText != '');
+DROP VIEW IF EXISTS log_environment_mv;
+CREATE MATERIALIZED VIEW log_environment_mv TO log_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `LogTimestamp` DateTime,
+    `LogUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    'environment' AS Key,
+    Timestamp AS LogTimestamp,
+    UUID AS LogUUID,
+    Environment AS Value
+FROM logs
+WHERE (Environment != '');

--- a/backend/clickhouse/migrations/000104_rewrite_log_attributes_mv.up.sql
+++ b/backend/clickhouse/migrations/000104_rewrite_log_attributes_mv.up.sql
@@ -1,0 +1,126 @@
+DROP VIEW IF EXISTS log_attributes_mv;
+CREATE MATERIALIZED VIEW log_attributes_mv TO log_key_values (
+    `ProjectId` Int32,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) AS
+SELECT ProjectId,
+    arrayJoin(LogAttributes).1 AS Key,
+    toStartOfDay(Timestamp) AS Day,
+    arrayJoin(LogAttributes).2 AS Value,
+    count() AS Count
+FROM logs
+WHERE (
+        Key NOT IN (
+            'level',
+            'secure_session_id',
+            'service_name',
+            'service_version',
+            'source',
+            'span_id',
+            'trace_id',
+            'message'
+        )
+    )
+    AND (Value != '')
+GROUP BY ProjectId,
+    Key,
+    Day,
+    Value;
+DROP VIEW IF EXISTS log_service_name_mv;
+CREATE MATERIALIZED VIEW log_service_name_mv TO log_key_values (
+    `ProjectId` Int32,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) AS
+SELECT ProjectId AS ProjectId,
+    'service_name' AS Key,
+    toStartOfDay(Timestamp) AS Day,
+    ServiceName AS Value,
+    count() AS Count
+FROM logs
+WHERE (ServiceName != '')
+GROUP BY ProjectId,
+    Key,
+    Day,
+    Value;
+DROP VIEW IF EXISTS log_service_version_mv;
+CREATE MATERIALIZED VIEW log_service_version_mv TO log_key_values (
+    `ProjectId` Int32,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) AS
+SELECT ProjectId AS ProjectId,
+    'service_version' AS Key,
+    toStartOfDay(Timestamp) AS Day,
+    ServiceVersion AS Value,
+    count() AS Count
+FROM logs
+WHERE (ServiceVersion != '')
+GROUP BY ProjectId,
+    Key,
+    Day,
+    Value;
+DROP VIEW IF EXISTS log_source_mv;
+CREATE MATERIALIZED VIEW log_source_mv TO log_key_values (
+    `ProjectId` Int32,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) AS
+SELECT ProjectId AS ProjectId,
+    'source' AS Key,
+    toStartOfDay(Timestamp) AS Day,
+    Source AS Value,
+    count() AS Count
+FROM logs
+WHERE (Source != '')
+GROUP BY ProjectId,
+    Key,
+    Day,
+    Value;
+DROP VIEW IF EXISTS log_severity_text_mv;
+CREATE MATERIALIZED VIEW log_severity_text_mv TO log_key_values (
+    `ProjectId` Int32,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) AS
+SELECT ProjectId AS ProjectId,
+    'level' AS Key,
+    toStartOfDay(Timestamp) AS Day,
+    SeverityText AS Value,
+    count() AS Count
+FROM logs
+WHERE (SeverityText != '')
+GROUP BY ProjectId,
+    Key,
+    Day,
+    Value;
+DROP VIEW IF EXISTS log_environment_mv;
+CREATE MATERIALIZED VIEW log_environment_mv TO log_key_values (
+    `ProjectId` Int32,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) AS
+SELECT ProjectId AS ProjectId,
+    'environment' AS Key,
+    toStartOfDay(Timestamp) AS Day,
+    Environment AS Value,
+    count() AS Count
+FROM logs
+WHERE (Environment != '')
+GROUP BY ProjectId,
+    Key,
+    Day,
+    Value;


### PR DESCRIPTION
## Summary
- saw `log_attributes` merges accounting for ~10% of total merge time, we can write directly to `log_key_values` instead like we've done for `trace_key_values` previously
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran migrations locally, validated that new entries were added to `log_key_values`
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, will follow up by deleting `log_attributes` to reclaim some storage
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
