### PR TITLE
send billing notifications on new overage charges

### DIFF
--- a/backend/email/email.go
+++ b/backend/email/email.go
@@ -39,12 +39,16 @@ const (
 	BillingStripeTrial3Days       EmailType = "BillingStripeTrial3Days"
 	BillingSessionUsage80Percent  EmailType = "BillingSessionUsage80Percent"
 	BillingSessionUsage100Percent EmailType = "BillingSessionUsage100Percent"
+	BillingSessionOverage         EmailType = "BillingSessionOverage"
 	BillingErrorsUsage80Percent   EmailType = "BillingErrorsUsage80Percent"
 	BillingErrorsUsage100Percent  EmailType = "BillingErrorsUsage100Percent"
+	BillingErrorsOverage          EmailType = "BillingErrorsOverage"
 	BillingLogsUsage80Percent     EmailType = "BillingLogsUsage80Percent"
 	BillingLogsUsage100Percent    EmailType = "BillingLogsUsage100Percent"
+	BillingLogsOverage            EmailType = "BillingLogsOverage"
 	BillingTracesUsage80Percent   EmailType = "BillingTracesUsage80Percent"
 	BillingTracesUsage100Percent  EmailType = "BillingTracesUsage100Percent"
+	BillingTracesOverage          EmailType = "BillingTracesOverage"
 	BillingInvalidPayment         EmailType = "BillingInvalidPayment"
 )
 
@@ -128,6 +132,13 @@ func getExceededLimitMessage(productType string, workspaceId int) string {
 		productType, productType, frontendUri, workspaceId)
 }
 
+func getOverageMessage(productType string, workspaceId int) string {
+	return fmt.Sprintf(`Your %s usage has exceeded the included amount - extra %s are now incurring a charge for the rest of the month.<br>
+		If you'd like to check the exact charge for the month',
+		please visit the subscription details page <a href="%s/w/%d/current-plan">here</a>.`,
+		productType, productType, frontendUri, workspaceId)
+}
+
 func getBillingNotificationSubject(emailType EmailType) string {
 	switch emailType {
 	case BillingHighlightTrial7Days:
@@ -142,18 +153,26 @@ func getBillingNotificationSubject(emailType EmailType) string {
 		return "[Highlight] billing limits - 80% of your session usage"
 	case BillingSessionUsage100Percent:
 		return "[Highlight] billing limits - 100% of your session usage"
+	case BillingSessionOverage:
+		return "[Highlight] overages charges - sessions over your included amount"
 	case BillingErrorsUsage80Percent:
 		return "[Highlight] billing limits - 80% of your errors usage"
 	case BillingErrorsUsage100Percent:
 		return "[Highlight] billing limits - 100% of your errors usage"
+	case BillingErrorsOverage:
+		return "[Highlight] overages charges - errors over your included amount"
 	case BillingLogsUsage80Percent:
 		return "[Highlight] billing limits - 80% of your logs usage"
 	case BillingLogsUsage100Percent:
 		return "[Highlight] billing limits - 100% of your logs usage"
+	case BillingLogsOverage:
+		return "[Highlight] overages charges - logs over your included amount"
 	case BillingTracesUsage80Percent:
 		return "[Highlight] billing limits - 80% of your traces usage"
 	case BillingTracesUsage100Percent:
 		return "[Highlight] billing limits - 100% of your traces usage"
+	case BillingTracesOverage:
+		return "[Highlight] overages charges - traces over your included amount"
 	case BillingInvalidPayment:
 		return "[Highlight] invalid billing - issues with your payment method"
 	default:
@@ -192,18 +211,26 @@ func getBillingNotificationMessage(workspaceId int, emailType EmailType) string 
 		return getApproachingLimitMessage("sessions", workspaceId)
 	case BillingSessionUsage100Percent:
 		return getExceededLimitMessage("sessions", workspaceId)
+	case BillingSessionOverage:
+		return getOverageMessage("sessions", workspaceId)
 	case BillingErrorsUsage80Percent:
 		return getApproachingLimitMessage("errors", workspaceId)
 	case BillingErrorsUsage100Percent:
 		return getExceededLimitMessage("errors", workspaceId)
+	case BillingErrorsOverage:
+		return getOverageMessage("errors", workspaceId)
 	case BillingLogsUsage80Percent:
 		return getApproachingLimitMessage("logs", workspaceId)
 	case BillingLogsUsage100Percent:
 		return getExceededLimitMessage("logs", workspaceId)
+	case BillingLogsOverage:
+		return getOverageMessage("logs", workspaceId)
 	case BillingTracesUsage80Percent:
 		return getApproachingLimitMessage("traces", workspaceId)
 	case BillingTracesUsage100Percent:
 		return getExceededLimitMessage("traces", workspaceId)
+	case BillingTracesOverage:
+		return getOverageMessage("traces", workspaceId)
 	case BillingInvalidPayment:
 		return fmt.Sprintf(`
 			We're having issues validating your payment details!<br>

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1985,13 +1985,11 @@ func SendBillingNotifications(ctx context.Context, db *gorm.DB, mailClient *send
 		Active:      true,
 	}
 	if err := db.Create(&history).Error; err != nil {
-		if err != nil {
-			var pgErr *pgconn.PgError
-			// An active BillingEmailHistory may already exist -
-			// in this case, don't send users another email.
-			if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
-				return nil
-			}
+		var pgErr *pgconn.PgError
+		// An active BillingEmailHistory may already exist -
+		// in this case, don't send users another email.
+		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
+			return nil
 		}
 		return e.Wrap(err, "error creating BillingEmailHistory")
 	}

--- a/backend/worker/worker_test.go
+++ b/backend/worker/worker_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"github.com/sendgrid/sendgrid-go"
 	"io"
 	"os"
 	"testing"
@@ -884,7 +885,7 @@ func TestCalculateOverages(t *testing.T) {
 
 	ctx := context.TODO()
 	s := store.NewStore(DB, redisClient, nil, nil, nil, chClient)
-	pWorker := pricing.NewWorker(DB, redisClient, s, chClient, nil, nil, nil)
+	pWorker := pricing.NewWorker(DB, redisClient, s, chClient, nil, nil, sendgrid.NewSendClient(""))
 	worker := Worker{
 		Resolver: &graph.Resolver{
 			DB:               DB,


### PR DESCRIPTION
## Summary

Send billing notifications per product for overage charges. 
For example, when `sessions` hit a monthly overage for the first time for a workspace,
notify the workspace admins about upcoming charges.

## How did you test this change?

TODO

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no