### PR TITLE
Fix autoplay redirect

### DIFF
--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -928,9 +928,10 @@ export const usePlayer = (): ReplayerContextInterface => {
 			if (nextSessionInList) {
 				pause(state.time).then(() => {
 					resetPlayer()
-					navigate(
-						`/${projectId}/sessions/${nextSessionInList.secure_id}`,
-					)
+					navigate({
+						pathname: `/${projectId}/sessions/${nextSessionInList.secure_id}`,
+						search: location.search,
+					})
 				})
 			}
 		}


### PR DESCRIPTION
## Summary
When autoplay moves to the next session, it clears the search params. Redirect to the correct url with the search params.

https://www.loom.com/share/fb1a8752396e407ea7465b1c2963e2ce?sid=cbd6ec84-4cf9-4969-86b9-ebd4687d22fc

## How did you test this change?
1) View the sessions page
2) Add a filter
3) Make sure autoplay sessions is on
4) Play a session
- [ ] When the session is over, the next session starts
- [ ] The search results do not change

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
