### PR TITLE
cleanup billing history graphs ranges and tooltips

### DIFF
--- a/frontend/src/pages/Billing/BillingPageV2.tsx
+++ b/frontend/src/pages/Billing/BillingPageV2.tsx
@@ -80,6 +80,8 @@ type UsageCardProps = {
 	billingPeriodEnd?: moment.Moment
 }
 
+const UsageRangeOptions = ['Monthly', 'Weekly', 'Daily'] as const
+
 const UsageCard = ({
 	productIcon,
 	productType,
@@ -104,13 +106,20 @@ const UsageCard = ({
 		start: moment.Moment
 		end: moment.Moment
 	}>({
-		start: (billingPeriodEnd ?? moment()).subtract(3, 'months'),
-		end: billingPeriodEnd ?? moment(),
+		start: (moment(billingPeriodEnd) ?? moment()).subtract(3, 'months'),
+		end: moment(billingPeriodEnd) ?? moment(),
 	})
 
-	const setUsageRange = (option: 'Monthly' | 'Weekly') => {
+	const setUsageRange = (option: 'Monthly' | 'Weekly' | 'Daily') => {
 		setRange({
-			start: moment().subtract(option === 'Monthly' ? 12 : 3, 'months'),
+			start: moment().subtract(
+				option === 'Monthly'
+					? 4 * 12 * 7
+					: option === 'Weekly'
+					? 12 * 7
+					: 12,
+				'days',
+			),
 			end: moment(),
 		})
 	}
@@ -232,6 +241,7 @@ const UsageCard = ({
 					</Tooltip>
 					{enableBillingLimits ? (
 						<Tooltip
+							maxWidth={177}
 							delayed
 							trigger={
 								<Badge
@@ -244,11 +254,15 @@ const UsageCard = ({
 									iconEnd={
 										<IconSolidInformationCircle size={12} />
 									}
-								></Badge>
+								/>
 							}
 						>
-							{productType} will not be recorded once this billing
-							limit is reached.
+							<Box padding="4">
+								<Text size="xSmall" color="moderate">
+									<b>{productType}</b> will not be recorded
+									once this billing limit is reached.
+								</Text>
+							</Box>
 						</Tooltip>
 					) : null}
 					{billingLimitCents === 0 ? (
@@ -293,9 +307,18 @@ const UsageCard = ({
 							</Text>
 						)}
 						{isOverage && (
-							<Tooltip delayed trigger={<IconSolidExclamation />}>
-								{productType} have exceeded your billing limit
-								and are not being recorded.
+							<Tooltip
+								maxWidth={177}
+								delayed
+								trigger={<IconSolidExclamation size={12} />}
+							>
+								<Box padding="4">
+									<Text size="xSmall" color="moderate">
+										<b>{productType}</b> have exceeded your
+										billing limit and are not being
+										recorded.
+									</Text>
+								</Box>
 							</Tooltip>
 						)}
 					</Box>
@@ -353,18 +376,19 @@ const UsageCard = ({
 								{usageRange.end.diff(usageRange.start, 'day') >
 								100
 									? 'Monthly'
-									: 'Weekly'}
+									: usageRange.end.diff(
+											usageRange.start,
+											'day',
+									  ) > 40
+									? 'Weekly'
+									: 'Daily'}
 							</Text>
 						</Menu.Button>
 						<Menu.List>
-							{['Monthly', 'Weekly'].map((option) => (
+							{UsageRangeOptions.map((option) => (
 								<Menu.Item
 									key={option}
-									onClick={() =>
-										setUsageRange(
-											option as 'Monthly' | 'Weekly',
-										)
-									}
+									onClick={() => setUsageRange(option)}
 								>
 									<Box display="flex" alignItems="center">
 										<Text size="xSmall" color="moderate">
@@ -799,7 +823,7 @@ const BillingPageV2 = ({}: BillingPageProps) => {
 													?.next_invoice_date ??
 													data?.workspace
 														?.billing_period_end,
-										  ).add(-1, 'month')
+										  )
 										: undefined
 								}
 								{...product}
@@ -897,6 +921,7 @@ const BillingPageV2 = ({}: BillingPageProps) => {
 									>
 										{hasExtras && (
 											<Tooltip
+												maxWidth={177}
 												delayed
 												trigger={
 													<IconSolidInformationCircle
@@ -904,20 +929,28 @@ const BillingPageV2 = ({}: BillingPageProps) => {
 													/>
 												}
 											>
-												Includes a{' '}
-												{data?.billingDetails.plan
-													.interval === 'Annual'
-													? 'yearly'
-													: 'monthly'}{' '}
-												base charge of{' '}
-												{baseAmountFormatted}
-												{discountPercent
-													? ` with a ${discountPercent}% discount`
-													: ''}
-												{discountAmount
-													? ` with a ${discountAmountFormatted} discount`
-													: ''}
-												.
+												<Box padding="4">
+													<Text
+														size="xSmall"
+														color="moderate"
+													>
+														Includes a{' '}
+														{data?.billingDetails
+															.plan.interval ===
+														'Annual'
+															? 'yearly'
+															: 'monthly'}{' '}
+														base charge of{' '}
+														{baseAmountFormatted}
+														{discountPercent
+															? ` with a ${discountPercent}% discount`
+															: ''}
+														{discountAmount
+															? ` with a ${discountAmountFormatted} discount`
+															: ''}
+														.
+													</Text>
+												</Box>
 											</Tooltip>
 										)}
 										<Text color="p11" weight="bold">

--- a/frontend/src/pages/Billing/BillingPageV2.tsx
+++ b/frontend/src/pages/Billing/BillingPageV2.tsx
@@ -82,6 +82,10 @@ type UsageCardProps = {
 
 const UsageRangeOptions = ['Monthly', 'Weekly', 'Daily'] as const
 
+const BucketCount = 12
+const DaysInWeek = 7
+const WeeksInMonth = 4
+
 const UsageCard = ({
 	productIcon,
 	productType,
@@ -114,10 +118,10 @@ const UsageCard = ({
 		setRange({
 			start: moment().subtract(
 				option === 'Monthly'
-					? 4 * 12 * 7
+					? BucketCount * DaysInWeek * WeeksInMonth
 					: option === 'Weekly'
-					? 12 * 7
-					: 12,
+					? BucketCount * DaysInWeek
+					: BucketCount,
 				'days',
 			),
 			end: moment(),

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedCard/SessionFeedCard.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedCard/SessionFeedCard.tsx
@@ -193,11 +193,11 @@ export const SessionFeedCard = React.memo(
 												/>
 											}
 										>
-											<Box
-												style={{ maxWidth: 250 }}
-												p="8"
-											>
-												<Text>
+											<Box padding="4">
+												<Text
+													size="xSmall"
+													color="moderate"
+												>
 													Filter by sessions with
 													errors
 												</Text>
@@ -224,11 +224,11 @@ export const SessionFeedCard = React.memo(
 												/>
 											}
 										>
-											<Box
-												style={{ maxWidth: 250 }}
-												p="8"
-											>
-												<Text>
+											<Box padding="4">
+												<Text
+													size="xSmall"
+													color="moderate"
+												>
 													Filter by first time users
 												</Text>
 											</Box>
@@ -254,11 +254,11 @@ export const SessionFeedCard = React.memo(
 												/>
 											}
 										>
-											<Box
-												style={{ maxWidth: 250 }}
-												p="8"
-											>
-												<Text>
+											<Box padding="4">
+												<Text
+													size="xSmall"
+													color="moderate"
+												>
 													Filter by sessions with rage
 													clicks
 												</Text>
@@ -267,6 +267,8 @@ export const SessionFeedCard = React.memo(
 									)}
 									{!viewed && (
 										<Tooltip
+											maxWidth={177}
+											delayed
 											trigger={
 												<Tag
 													shape="basic"
@@ -285,11 +287,11 @@ export const SessionFeedCard = React.memo(
 												/>
 											}
 										>
-											<Box
-												style={{ maxWidth: 250 }}
-												p="8"
-											>
-												<Text>
+											<Box padding="4">
+												<Text
+													size="xSmall"
+													color="moderate"
+												>
 													Filter by unviewed sessions
 												</Text>
 											</Box>
@@ -326,11 +328,11 @@ export const SessionFeedCard = React.memo(
 												</Tag>
 											}
 										>
-											<Box
-												style={{ maxWidth: 250 }}
-												p="8"
-											>
-												<Text>
+											<Box padding="4">
+												<Text
+													size="xSmall"
+													color="moderate"
+												>
 													Filter by live sessions
 												</Text>
 											</Box>


### PR DESCRIPTION
## Summary

* fixes billing history graphs not loading for active subscriptions
* fixes date ranges for each par on the billing history graphs
* adds a `daily` option to the billing history graphs
* fixes tooltip styling on sessions feed and on billing page

## How did you test this change?

reflame billing page, session feed

![Screenshot from 2024-05-29 11-39-18](https://github.com/highlight/highlight/assets/1351531/f3b4c739-1fc9-4a89-ac8c-d39239efdfda)
![Screenshot from 2024-05-29 11-39-50](https://github.com/highlight/highlight/assets/1351531/d39875ec-61d7-465d-ba26-2265f16c22e2)

## Are there any deployment considerations?

no

## Does this work require review from our design team?

yes
