### PR TITLE
Fix search input alignment

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -249,7 +249,7 @@ const DevToolsWindowV2: React.FC<
 											>
 												<Box
 													display="flex"
-													justifyContent="space-between"
+													justifyContent="flex-start"
 													align="center"
 													width="full"
 													gap="4"
@@ -272,14 +272,7 @@ const DevToolsWindowV2: React.FC<
 														placeholder="Search"
 														size="xSmall"
 														outline={false}
-														onKeyDown={(e: any) => {
-															if (
-																e.code ===
-																'Escape'
-															) {
-																e.target?.blur()
-															}
-														}}
+														width="100%"
 													/>
 												</Box>
 											</Form>


### PR DESCRIPTION
## Summary
The search input should be aligned with the magnifying glass

![Screenshot 2024-05-29 at 2 50 37 PM](https://github.com/highlight/highlight/assets/17744174/02ae4c9a-83ca-4b4c-bee9-4b376f33e46c)

## How did you test this change?
1) View a session
2) Open the dev console and view the logs
- [ ] Search is aligned with magnifying glass
- [ ] Search is extended the full length

![Screenshot 2024-05-29 at 2 52 16 PM](https://github.com/highlight/highlight/assets/17744174/408c3cdc-916d-4e9e-bffc-887534b22484)

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
