### PR TITLE
Grafana improvements

### DIFF
--- a/scripts/migrations/init.sql
+++ b/scripts/migrations/init.sql
@@ -104,3 +104,7 @@ INSERT INTO o_auth_operations (created_at, client_id, authorized_graph_ql_operat
 VALUES (now(), 'abc123', 'logs');
 INSERT INTO o_auth_operations (created_at, client_id, authorized_graph_ql_operation)
 VALUES (now(), 'abc123', 'traces');
+INSERT INTO o_auth_operations (created_at, client_id, authorized_graph_ql_operation)
+VALUES (now(), 'abc123', 'metrics');
+INSERT INTO o_auth_operations (created_at, client_id, authorized_graph_ql_operation)
+VALUES (now(), 'abc123', 'traces_metrics');

--- a/sdk/highlightinc-highlight-datasource/docker-compose.yaml
+++ b/sdk/highlightinc-highlight-datasource/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   grafana:
     container_name: 'highlightinc-highlight-datasource'
     extra_hosts:
-            - 'host.docker.internal:host-gateway'
+      - 'host.docker.internal:host-gateway'
     platform: 'linux/amd64'
     build:
       context: ./.config

--- a/sdk/highlightinc-highlight-datasource/docker-compose.yaml
+++ b/sdk/highlightinc-highlight-datasource/docker-compose.yaml
@@ -3,6 +3,8 @@ version: '3.0'
 services:
   grafana:
     container_name: 'highlightinc-highlight-datasource'
+    extra_hosts:
+            - 'host.docker.internal:host-gateway'
     platform: 'linux/amd64'
     build:
       context: ./.config

--- a/sdk/highlightinc-highlight-datasource/pkg/plugin/datasource.go
+++ b/sdk/highlightinc-highlight-datasource/pkg/plugin/datasource.go
@@ -314,7 +314,7 @@ const (
 	TableSessions Table = "sessions"
 )
 
-func (d *Datasource) queryLogLines(ctx context.Context, productType ProductType, from time.Time, to time.Time, input queryInput, dataSourceSettings DataSourceSettings) backend.DataResponse {
+func (d *Datasource) queryLogLines(ctx context.Context, productType ProductType, from time.Time, to time.Time, refId string, input queryInput, dataSourceSettings DataSourceSettings) backend.DataResponse {
 	var result struct {
 		LogLines []LogLine `graphql:"log_lines(product_type: $product_type, project_id: $project_id, params: $params)"`
 	}
@@ -345,7 +345,7 @@ func (d *Datasource) queryLogLines(ctx context.Context, productType ProductType,
 	}
 
 	frame := data.NewFrame(
-		"response",
+		refId,
 		data.NewField("timestamp", nil, timestamps),
 		data.NewField("body", nil, bodies),
 		data.NewField("severity", nil, severities),
@@ -364,7 +364,7 @@ func (d *Datasource) queryLogLines(ctx context.Context, productType ProductType,
 	return response
 }
 
-func (d *Datasource) queryMetrics(ctx context.Context, productType ProductType, from time.Time, to time.Time, input queryInput, dataSourceSettings DataSourceSettings) backend.DataResponse {
+func (d *Datasource) queryMetrics(ctx context.Context, productType ProductType, from time.Time, to time.Time, refId string, input queryInput, dataSourceSettings DataSourceSettings) backend.DataResponse {
 	var result struct {
 		MetricsBuckets MetricsBuckets `graphql:"metrics(product_type: $product_type, project_id: $project_id, params: $params, column: $column, metric_types: $metric_types, group_by: $group_by, bucket_by: $bucket_by, bucket_count: $bucket_count, limit: $limit, limit_aggregator: $limit_aggregator, limit_column: $limit_column)"`
 	}
@@ -411,7 +411,7 @@ func (d *Datasource) queryMetrics(ctx context.Context, productType ProductType, 
 		bucketMaxs[bucket.BucketID] = pointy.Float64(bucket.BucketMax)
 	}
 
-	frame := data.NewFrame("response")
+	frame := data.NewFrame(refId)
 
 	if input.BucketBy == "Timestamp" {
 		timeValues := lo.Map(bucketIds, func(i uint64, _ int) time.Time {
@@ -458,6 +458,7 @@ func (d *Datasource) queryMetrics(ctx context.Context, productType ProductType, 
 func (d *Datasource) query(ctx context.Context, pCtx backend.PluginContext, query backend.DataQuery) backend.DataResponse {
 	from := query.TimeRange.From
 	to := query.TimeRange.To
+	refId := query.RefID
 
 	var input queryInput
 	err := json.Unmarshal(query.JSON, &input)
@@ -484,9 +485,9 @@ func (d *Datasource) query(ctx context.Context, pCtx backend.PluginContext, quer
 	}
 
 	if input.Metric == "None" {
-		return d.queryLogLines(ctx, productType, from, to, input, dataSourceSettings)
+		return d.queryLogLines(ctx, productType, from, to, refId, input, dataSourceSettings)
 	} else {
-		return d.queryMetrics(ctx, productType, from, to, input, dataSourceSettings)
+		return d.queryMetrics(ctx, productType, from, to, refId, input, dataSourceSettings)
 	}
 }
 

--- a/sdk/highlightinc-highlight-datasource/src/datasource.ts
+++ b/sdk/highlightinc-highlight-datasource/src/datasource.ts
@@ -31,6 +31,21 @@ export const metricOptions: { value: string; label: string; tables: Table[] }[] 
   { value: 'None', label: 'None', tables: ['traces', 'logs', 'errors', 'sessions'] },
 ];
 
+const variableFormatter = (value: string | string[]): string => {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value.length < 2) {
+    return value[0];
+  }
+
+  const values = value.reduce((acc, v) => {
+    return acc + (acc.length > 0 ? ' OR ' : '') + v;
+  }, '');
+  return `(${values})`;
+};
+
 export class DataSource extends DataSourceWithBackend<HighlightQuery, HighlightDataSourceOptions> {
   url?: string;
   projectID?: number;
@@ -44,7 +59,7 @@ export class DataSource extends DataSourceWithBackend<HighlightQuery, HighlightD
   applyTemplateVariables(query: HighlightQuery, scopedVars: ScopedVars): HighlightQuery {
     const interpolatedQuery: HighlightQuery = {
       ...query,
-      queryText: getTemplateSrv().replace(query.queryText, scopedVars),
+      queryText: getTemplateSrv().replace(query.queryText, scopedVars, variableFormatter),
     };
 
     return interpolatedQuery;


### PR DESCRIPTION
## Summary
Make the following grafana improvements:
- easier to start locally
- use refId for frame name to allow multiple frames
- support IN clauses with variables

https://www.loom.com/share/7a6112555c824b72a9762e05a24f3aa6?sid=f4207067-548d-44e2-b89b-3083cf550993

## How did you test this change?
1) Go to an edit graph view
2) Open the query inspector and refresh the query
- [ ] The frame name in `response.results.[ref_id].frames[0].schema.name` should be the `refId`
3) Add a multiple value variable
4) Add that value to a query i.e. `email=$foo`
- [ ] Variable is correctly replaced with multiple values
- [ ] Variable is correctly replaced with single value

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
