### PR TITLE
remove unnecessary apollo caching policies

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -608,7 +608,7 @@ func (r *Resolver) loadErrorGroupFrequenciesClickhouse(ctx context.Context, eg *
 	if eg.FirstOccurrence, eg.LastOccurrence, err = r.ClickhouseClient.QueryErrorGroupOccurrences(ctx, eg.ProjectID, eg.ID); err != nil {
 		return e.Wrap(err, "error querying error group occurrences")
 	}
-	if err := r.SetErrorFrequenciesClickhouse(ctx, eg.ProjectID, []*model.ErrorGroup{eg}, 30); err != nil {
+	if err := r.SetErrorFrequenciesClickhouse(ctx, eg.ProjectID, []*model.ErrorGroup{eg}, 7); err != nil {
 		return e.Wrap(err, "error querying error group frequencies")
 	}
 	return nil

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5209,15 +5209,15 @@ func (r *queryResolver) ErrorGroup(ctx context.Context, secureID string, useClic
 	if err != nil {
 		return nil, err
 	}
-	if err := r.loadErrorGroupFrequenciesClickhouse(ctx, eg); err != nil {
-		return nil, err
-	}
 	retentionDate, err := r.GetProjectRetentionDate(eg.ProjectID)
 	if err != nil {
 		return nil, err
 	}
 	if eg.UpdatedAt.Before(retentionDate) {
 		return nil, e.New("no new error instances after the workspace's retention date")
+	}
+	if err := r.SetErrorFrequenciesClickhouse(ctx, eg.ProjectID, []*model.ErrorGroup{eg}, ErrorGroupLookbackDays); err != nil {
+		return nil, err
 	}
 	return eg, err
 }

--- a/frontend/src/util/graph.tsx
+++ b/frontend/src/util/graph.tsx
@@ -80,31 +80,6 @@ const authLink = setContext((_, { headers }) => {
 
 const cache = new InMemoryCache({
 	typePolicies: {
-		Session: {
-			keyFields: ['secure_id'],
-		},
-		ErrorGroup: {
-			// avoid caching error groups because they can change as new error objects match
-			keyFields: false,
-			merge: false,
-		},
-		ErrorObject: {
-			keyFields: ['id'],
-		},
-		DashboardPayload: {
-			fields: {
-				metrics_histogram: {
-					keyArgs: ['project_id', 'metric_name', 'params'],
-				},
-			},
-		},
-		HistogramPayload: {
-			fields: {
-				metrics_histogram: {
-					keyArgs: ['project_id', 'metric_name', 'params'],
-				},
-			},
-		},
 		Query: {
 			fields: {
 				logs: relayStylePagination([
@@ -114,9 +89,13 @@ const cache = new InMemoryCache({
 					'params',
 					['query', 'date_range', ['start_date', 'end_date']],
 				]),
-				error_groups_clickhouse: {
-					keyArgs: ['project_id', 'count', 'query', 'page'],
-				},
+				traces: relayStylePagination([
+					'project_id',
+					'at',
+					'direction',
+					'params',
+					['query', 'date_range', ['start_date', 'end_date']],
+				]),
 				visualization: {
 					read(_, { args, toReference }) {
 						return toReference({


### PR DESCRIPTION
## Summary

Cleans up old cache policies that cause flicker on feeds.

## How did you test this change?

Reflame

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no