### PR TITLE
Console logs table backend

### DIFF
--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -183,9 +183,7 @@ func TestReadSessionLogs(t *testing.T) {
 	assert.Equal(t, edges[0].Node.Message, "Body")
 	assert.Equal(t, edges[0].Node.Level, modelInputs.LogLevelInfo)
 
-	// assert we aren't loading log attributes which is a large column
-	// see: https://github.com/ClickHouse/ClickHouse/issues/7187
-	assert.Empty(t, edges[0].Node.LogAttributes)
+	assert.Equal(t, edges[0].Node.LogAttributes["service"], "foo")
 }
 
 func TestReadLogsTotalCount(t *testing.T) {


### PR DESCRIPTION
## Summary
Update the backend to fetch have all the log columns available for graph - this is needed to replace the console log table with the logs table in https://github.com/highlight/highlight/pull/8696

Want to get this in separately to test frontend performance 

## How did you test this change?
1. Load a session
- [ ] Able to fetch console logs appropriately in the dev tools

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
