### PR TITLE
move ADMIN_PASSWORD auth handler inside route

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -437,7 +437,6 @@ func main() {
 		})
 		r.HandleFunc("/slack-events", privateResolver.SlackEventsWebhook(ctx, slackSigningSecret))
 		r.Post(fmt.Sprintf("%s/%s", privateEndpoint, "microsoft-teams/bot"), privateResolver.MicrosoftTeamsBotEndpoint)
-		r.Post(fmt.Sprintf("%s/%s", privateEndpoint, "login"), privateResolver.Login)
 
 		r.Route(privateEndpoint, func(r chi.Router) {
 			r.Use(cors.New(PRIVATE_GRAPH_CORS_OPTIONS).Handler)
@@ -450,6 +449,7 @@ func main() {
 			r.Get("/project-token/{project_id}", privateResolver.ProjectJWTHandler)
 
 			r.Get("/validate-token", privateResolver.ValidateAuthToken)
+			r.Post("/login", privateResolver.Login)
 
 			privateServer := ghandler.New(privategen.NewExecutableSchema(
 				privategen.Config{


### PR DESCRIPTION
## Summary
- CORS was breaking for `ADMIN_PASSWORD` auth because the handler was defined outside the `r.Route` function that applied the CORS config
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested locally w/ `ADMIN_PASSWORD` auth enabled, validated problem before, fix after. will confirm cypress test passes
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
