### PR TITLE
update private graph CORS origins

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -197,13 +197,8 @@ var PRIVATE_GRAPH_CORS_OPTIONS = cors.Options{
 }
 
 func validateOrigin(_ *http.Request, origin string) bool {
-	// From the highlight frontend, only the url is whitelisted.
-	isRenderPreviewEnv := strings.HasPrefix(origin, "https://frontend-pr-") && strings.HasSuffix(origin, ".onrender.com")
-	// Is this an AWS Amplify environment?
-	isAWSEnv := strings.HasPrefix(origin, "https://pr-") && strings.HasSuffix(origin, ".d25bj3loqvp3nx.amplifyapp.com")
-	isReflamePreview := origin == "https://preview.highlight.io"
-
-	if origin == frontendURL || origin == "https://app.highlight.run" || origin == "https://app.highlight.io" || origin == landingStagingURL || isRenderPreviewEnv || isAWSEnv || isReflamePreview {
+	isHighlight := strings.HasSuffix(origin, "highlight.io")
+	if origin == frontendURL || origin == landingStagingURL || isHighlight {
 		return true
 	}
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -197,8 +197,8 @@ var PRIVATE_GRAPH_CORS_OPTIONS = cors.Options{
 }
 
 func validateOrigin(_ *http.Request, origin string) bool {
-	isHighlight := strings.HasSuffix(origin, "highlight.io")
-	if origin == frontendURL || origin == landingStagingURL || isHighlight {
+	isHighlightSubdomain := strings.HasSuffix(origin, ".highlight.io")
+	if origin == frontendURL || origin == landingStagingURL || isHighlightSubdomain {
 		return true
 	}
 

--- a/deploy/private-graph-task.json
+++ b/deploy/private-graph-task.json
@@ -91,7 +91,7 @@
 	"compatibilities": ["EC2"],
 	"requiresCompatibilities": ["EC2"],
 	"cpu": "4096",
-	"memory": "8192",
+	"memory": "16384",
 	"runtimePlatform": {
 		"cpuArchitecture": "ARM64",
 		"operatingSystemFamily": "LINUX"


### PR DESCRIPTION
## Summary

Update private graph cors to allow all highlight.io subdomains.

## How did you test this change?

CI
local deploy
![Screenshot from 2024-06-05 14-28-00](https://github.com/highlight/highlight/assets/1351531/be1ac3cf-7aa3-438c-a336-f7b35f235d7e)

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no