### PR TITLE
update session_intervals to bigint

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1224,6 +1224,7 @@ type CommentSlackThread struct {
 
 type SessionInterval struct {
 	Model
+	ID              int64  `gorm:"primary_key;type:bigint;autoIncrement" json:"id" deep:"-"`
 	SessionSecureID string `gorm:"index" json:"secure_id"`
 	StartTime       time.Time
 	EndTime         time.Time


### PR DESCRIPTION
## Summary

Updates session_intervals model to `bigint` now that the `id` column is migrated in prod.

## How did you test this change?

N/A

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
