### PR TITLE
Fix search input length

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6338,6 +6338,7 @@ body {
   font-size: 36px;
   font-weight: 700 !important;
   color: var(--_1pyqka9b);
+  width: 100%;
 }
 ._9wfl880:focus {
   outline: 0;

--- a/frontend/src/pages/Alerts/components/AlertTitleField/AlertTitleField.tsx
+++ b/frontend/src/pages/Alerts/components/AlertTitleField/AlertTitleField.tsx
@@ -1,4 +1,4 @@
-import { Form, FormState } from '@highlight-run/ui/components'
+import { Box, Form, FormState } from '@highlight-run/ui/components'
 
 import { AlertForm } from '@/pages/Alerts/utils/AlertsUtils'
 
@@ -9,16 +9,18 @@ const AlertTitleField = () => {
 	const errors = formStore.useState('errors')
 
 	return (
-		<Form.Input
-			name={formStore.names.name}
-			placeholder="Type name..."
-			style={{
-				borderColor: errors.name
-					? 'var(--color-red-500)'
-					: 'transparent',
-			}}
-			className={styles.formTitle}
-		/>
+		<Box width="full">
+			<Form.Input
+				name={formStore.names.name}
+				placeholder="Type name..."
+				style={{
+					borderColor: errors.name
+						? 'var(--color-red-500)'
+						: 'transparent',
+				}}
+				className={styles.formTitle}
+			/>
+		</Box>
 	)
 }
 

--- a/frontend/src/pages/Alerts/components/AlertTitleField/styles.css.ts
+++ b/frontend/src/pages/Alerts/components/AlertTitleField/styles.css.ts
@@ -5,6 +5,7 @@ export const formTitle = style({
 	fontSize: 36,
 	fontWeight: '700 !important',
 	color: vars.theme.static.content.default,
+	width: '100%',
 	selectors: {
 		'&:focus': {
 			outline: 0,

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -264,16 +264,18 @@ const DevToolsWindowV2: React.FC<
 															size={16}
 														/>
 													</Box>
-													<Form.Input
-														name={
-															formStore.names
-																.search
-														}
-														placeholder="Search"
-														size="xSmall"
-														outline={false}
-														width="100%"
-													/>
+													<Box width="full">
+														<Form.Input
+															name={
+																formStore.names
+																	.search
+															}
+															placeholder="Search"
+															size="xSmall"
+															outline={false}
+															width="100%"
+														/>
+													</Box>
 												</Box>
 											</Form>
 										</Box>

--- a/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
+++ b/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
@@ -149,12 +149,14 @@ const EventStreamV2 = function () {
 								color="secondaryContentText"
 							>
 								<IconSolidSearch size={16} />
-								<Form.Input
-									name={formStore.names.search}
-									placeholder="Search"
-									size="xSmall"
-									outline={false}
-								/>
+								<Box width="full">
+									<Form.Input
+										name={formStore.names.search}
+										placeholder="Search"
+										size="xSmall"
+										outline={false}
+									/>
+								</Box>
 							</Box>
 						</Form>
 					</Box>


### PR DESCRIPTION
## Summary
Fix the following inputs to be full length and aligned to the left
- search bar in dev tools
- search bar in session events
- alert titles

## How did you test this change?
1) View a session
- [ ] Search bar in dev tools is full length
- [ ] Search bar in session events left panel is full length
2) Create a new alert
- [ ] Alert title is full length

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
