### PR TITLE
update docs

### DIFF
--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/content-security-policy.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/content-security-policy.md
@@ -28,6 +28,10 @@ Your [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) definition may
 />
 ```
 
+Alternatively, Content Security Policy may be set by the HTML document response header `Content-Security-Policy`.
+Check your initial app HTML document load for the header to make sure you are setting it to the desired value.
+
+
 ```hint
 highlight.run version 8.11 changes how we bundle the client so that we no longer require a `script-src` definition. Make sure you are using the latest version of the SDK to use the above CSP policy.
 ```

--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/content-security-policy.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/content-security-policy.md
@@ -14,17 +14,20 @@ You should keep reading this if your application runs in an environment that enf
 Here are the policies you'll need to set to use Highlight:
 
 #### `connect-src`: `https://pub.highlight.io`
-This policy is to allow connecting with Highlight servers to send recorded session data.
+This policy allows connecting with Highlight servers to send recorded session data.
+
+#### `worker-src`: `data:`
+This policy allows creating an inlined web worker initialized by our npm package `highlight.run`.
 
 Your [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) definition may look something like this:
 
 ```html
 <meta
   http-equiv="Content-Security-Policy"
-  content="default-src 'self'; connect-src https://pub.highlight.io;"
+  content="default-src 'self'; worker-src 'data:'; connect-src https://pub.highlight.io;"
 />
 ```
 
 ```hint
-highlight.run version 8.11 changes how we bundle the client so that we no longer require a `script-src` or `worker-src` definition. Make sure you are using the latest version of the SDK to use the above CSP policy.
+highlight.run version 8.11 changes how we bundle the client so that we no longer require a `script-src` definition. Make sure you are using the latest version of the SDK to use the above CSP policy.
 ```

--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/content-security-policy.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/content-security-policy.md
@@ -16,7 +16,7 @@ Here are the policies you'll need to set to use Highlight:
 #### `connect-src`: `https://pub.highlight.io`
 This policy allows connecting with Highlight servers to send recorded session data.
 
-#### `worker-src`: `data:`
+#### `worker-src`: `data: blob:`
 This policy allows creating an inlined web worker initialized by our npm package `highlight.run`.
 
 Your [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) definition may look something like this:
@@ -24,7 +24,7 @@ Your [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) definition may
 ```html
 <meta
   http-equiv="Content-Security-Policy"
-  content="default-src 'self'; worker-src 'data:'; connect-src https://pub.highlight.io;"
+  content="connect-src https://pub.highlight.io; worker-src data: blob:;"
 />
 ```
 

--- a/docs-content/sdk/client.md
+++ b/docs-content/sdk/client.md
@@ -109,7 +109,7 @@ slug: client
         </aside>
         <aside className="parameter">
           <h5>inlineStylesheet <code>boolean</code> <code>optional</code></h5>
-          <p>Specifies whether to inline CSS style tags into the recording. When not set, defaults to `true` which will inline stylesheets to make sure apps recorded from `localhost` or other non-public network endpoints can be replayed. Setting to `false` may help with CORS issues caused by fetching the stylesheet contents, as well as with performance issues caused by the inlining process.</p>
+          <p>Specifies whether to inline CSS style tags into the recording. When not set, defaults to true which will inline stylesheets to make sure apps recorded from localhost or other non-public network endpoints can be replayed. Setting to false may help with CORS issues caused by fetching the stylesheet contents, as well as with performance issues caused by the inlining process.</p>
         </aside>
       </article>
     </aside>

--- a/docs-content/sdk/client.md
+++ b/docs-content/sdk/client.md
@@ -107,6 +107,10 @@ slug: client
           <h5>inlineImages <code>boolean</code> <code>optional</code></h5>
           <p>Specifies whether to record image content. We default inlineImages to true on localhost and false on other domains. Inlined images that are otherwise only available on localhost can be sent to Highlight's servers and used in session replay; however, this can cause CORS errors. Explicitly set inlineImages to false to resolve CORS errors.</p>
         </aside>
+        <aside className="parameter">
+          <h5>inlineStylesheet <code>boolean</code> <code>optional</code></h5>
+          <p>Specifies whether to inline CSS style tags into the recording. When not set, defaults to `true` which will inline stylesheets to make sure apps recorded from `localhost` or other non-public network endpoints can be replayed. Setting to `false` may help with CORS issues caused by fetching the stylesheet contents, as well as with performance issues caused by the inlining process.</p>
+        </aside>
       </article>
     </aside>
   </div>


### PR DESCRIPTION
## Summary

* update CSP values to correct for web worker loading
* document inlineStylesheet flag

## How did you test this change?

[vercel](https://highlight-landing-13nafcrc1-highlight-run.vercel.app/docs/getting-started/client-sdk/replay-configuration/content-security-policy)
https://highlight-landing-git-vadim-docs-updates-highlight-run.vercel.app/docs/sdk/client

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
