### PR TITLE
[HIG-4723] return all projects in workspace for super users

### DIFF
--- a/backend/private-graph/graph/resolver_test.go
+++ b/backend/private-graph/graph/resolver_test.go
@@ -726,6 +726,10 @@ func TestResolver_AccessLevels(t *testing.T) {
 	}
 	for _, v := range tests {
 		util.RunTestWithDBWipe(t, DB, func(t *testing.T) {
+			if err := os.Setenv("DEMO_PROJECT_ID", "0"); err != nil {
+				t.Fatal(e.Wrap(err, "error resetting demo project id"))
+			}
+
 			r.Resolver = &Resolver{DB: DB}
 			if err := DB.Create(&model.Workspace{Model: model.Model{ID: 1}}).Error; err != nil {
 				t.Fatal(e.Wrap(err, "error creating workspace 1"))

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7859,6 +7859,15 @@ func (r *queryResolver) Workspace(ctx context.Context, id int) (*model.Workspace
 		return nil, nil
 	}
 
+	if r.isWhitelistedAccount(ctx) {
+		projects := []model.Project{}
+		if err := r.DB.WithContext(ctx).Order("name ASC").Model(&workspace).Association("Projects").Find(&projects); err != nil {
+			return nil, nil
+		}
+		workspace.Projects = projects
+		return workspace, nil
+	}
+
 	workspace.Projects = lo.FilterMap(projects, func(p *model.Project, _ int) (model.Project, bool) {
 		if p == nil {
 			return model.Project{}, false


### PR DESCRIPTION
## Summary
- fix issue where the project dropdown for other workspaces was empty for super users
- attempted fix for test flakiness https://github.com/highlight/highlight/actions/runs/9407237601/job/25912686105?pr=8722#step:5:836 
  - only the tests involving the demo project were failing - there's another test which can set a different project id so I think if that test runs first it was causing this test to fail. explicitly set `DEMO_PROJECT_ID = 0` to avoid that
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
