### PR TITLE
[SUP-52] ensure unauthed users don't get a NPE, fix join workflow

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -8129,8 +8129,13 @@ func (r *queryResolver) AdminRoleByProject(ctx context.Context, projectID int) (
 		}
 	}
 
+	var workspaceId int
+	if project != nil {
+		workspaceId = project.WorkspaceID
+	}
+
 	return &model.WorkspaceAdminRole{
-		WorkspaceId: project.WorkspaceID,
+		WorkspaceId: workspaceId,
 		Admin:       admin,
 		Role:        role,
 		ProjectIds:  projectIds,

--- a/frontend/src/routers/ProjectRouter/ProjectRouter.tsx
+++ b/frontend/src/routers/ProjectRouter/ProjectRouter.tsx
@@ -55,6 +55,7 @@ export const ProjectRouter = () => {
 
 	const { data, error } = useGetProjectDropdownOptionsQuery({
 		variables: { project_id: projectId! },
+		errorPolicy: 'all',
 		skip: !isLoggedIn || !projectId, // Higher level routers decide when guests are allowed to hit this router
 	})
 


### PR DESCRIPTION
## Summary
- return a default workspace id when the user is unauthenticated or not in the project
- use `errorPolicy: 'all'` so `joinable_workspaces` is available even though other resolvers (`project` and `workspace`) throw an authentication error
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested unauthenticated and auto-join use cases locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
