### PR TITLE
fix session attribute search

### DIFF
--- a/backend/clickhouse/migrations/000104_update_session_attributes.down.sql
+++ b/backend/clickhouse/migrations/000104_update_session_attributes.down.sql
@@ -1,0 +1,13 @@
+DROP VIEW IF EXISTS sessions_joined_vw;
+CREATE VIEW IF NOT EXISTS sessions_joined_vw AS
+select ProjectID as ProjectId,
+       CreatedAt as Timestamp,
+       mapFromArrays(
+               arrayMap(x->splitByChar('_', x, 2) [2], FieldKeys),
+               arrayMap(
+                       (k, kv)->substring(kv, length(k) + 2),
+                       arrayZip(FieldKeys, FieldKeyValues)
+               )
+       ) as SessionAttributes,
+       *
+from sessions FINAL SETTINGS splitby_max_substrings_includes_remaining_string = 1;

--- a/backend/clickhouse/migrations/000104_update_session_attributes.up.sql
+++ b/backend/clickhouse/migrations/000104_update_session_attributes.up.sql
@@ -1,0 +1,17 @@
+DROP VIEW IF EXISTS sessions_joined_vw;
+CREATE VIEW IF NOT EXISTS sessions_joined_vw AS
+select ProjectID as ProjectId,
+       CreatedAt as Timestamp,
+       mapFromArrays(
+               arrayMap(x->splitByChar('_', x, 2) [2], FieldKeys),
+               arrayMap(
+                       (k, kv)->substring(kv, length(k) + 2),
+                       arrayZip(FieldKeys, FieldKeyValues)
+               )
+       ) as SessionAttributes,
+       arrayMap((kv) -> (
+                     arrayStringConcat(arraySlice(splitByChar('_', kv), 2, length(splitByChar('_', kv)) - 2), '_'),
+                     splitByChar('_', kv)[length(splitByChar('_', kv))]
+       ), FieldKeyValues) as SessionAttributePairs,
+       *
+from sessions FINAL SETTINGS splitby_max_substrings_includes_remaining_string = 1;

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -492,8 +492,9 @@ func SessionMatchesQuery(session *model.Session, filters listener.Filters) bool 
 
 var SessionsJoinedTableConfig = model.TableConfig[modelInputs.ReservedSessionKey]{
 	TableName:        SessionsJoinedTable,
-	AttributesColumn: "SessionAttributes",
-	BodyColumn:       `concat(coalesce(nullif(SessionAttributes['email'],''), nullif(Identifier, ''), nullif(toString(Fingerprint), ''), 'unidentified'), ': ', City, if(City != '', ', ', ''), Country)`,
+	AttributesColumn: "SessionAttributePairs",
+	AttributesList:   true,
+	BodyColumn:       `concat(coalesce(nullif(arrayFilter((k, v) -> k = 'email', SessionAttributePairs) [1].2,''), nullif(Identifier, ''), nullif(toString(Fingerprint), ''), 'unidentified'), ': ', City, if(City != '', ', ', ''), Country)`,
 	KeysToColumns: map[modelInputs.ReservedSessionKey]string{
 		modelInputs.ReservedSessionKeyActiveLength:       "ActiveLength",
 		modelInputs.ReservedSessionKeyServiceVersion:     "AppVersion",

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -2427,9 +2427,11 @@ type TableConfig[TReservedKey ~string] struct {
 	BodyColumn       string
 	SeverityColumn   string
 	AttributesColumn string
-	KeysToColumns    map[TReservedKey]string
-	ReservedKeys     []TReservedKey
-	SelectColumns    []string
-	DefaultFilter    string
-	IgnoredFilters   map[string]bool
+	// AttributesList set when AttributesColumn is an array of k,v pairs of attributes
+	AttributesList bool
+	KeysToColumns  map[TReservedKey]string
+	ReservedKeys   []TReservedKey
+	SelectColumns  []string
+	DefaultFilter  string
+	IgnoredFilters map[string]bool
 }


### PR DESCRIPTION
## Summary

We're received recent report that our session search is not returning all attributes.
This was also visible from experimentation with new metric graphs where sessions
were not being returned.

The issue was that multiple values for a single attribute would not be shown (we would
build a map with only one of the values, picking one arbitrarily).

Converts the approach to using an array of attribute KV pairs, and searching across that
array for possible matches.

## How did you test this change?

https://www.loom.com/share/b97f3ed97ca74b1da708bd20f5e185e2

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
