### PR TITLE
Improve logs table performance

### DIFF
--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -21,7 +21,10 @@ import { Helmet } from 'react-helmet'
 import { useQueryParam } from 'use-query-params'
 
 import { DEFAULT_COLUMN_SIZE } from '@/components/CustomColumnPopover'
-import { SearchContext } from '@/components/Search/SearchContext'
+import {
+	SearchContext,
+	useSearchContext,
+} from '@/components/Search/SearchContext'
 import {
 	TIME_FORMAT,
 	TIME_MODE,
@@ -33,7 +36,6 @@ import {
 	QueryParam,
 	SearchForm,
 } from '@/components/Search/SearchForm/SearchForm'
-import { parseSearch } from '@/components/Search/utils'
 import { useGetMetricsQuery } from '@/graph/generated/hooks'
 import { useNumericProjectId } from '@/hooks/useProjectId'
 import { useSearchTime } from '@/hooks/useSearchTime'
@@ -54,13 +56,16 @@ const LogsPage = () => {
 	const timeMode = log_cursor !== undefined ? 'permalink' : 'fixed-range'
 	const presetDefault =
 		timeMode === 'permalink' ? PermalinkPreset : FixedRangePreset
+	const [query, setQuery] = useQueryParam('query', QueryParam)
 
 	return (
-		<LogsPageInner
-			logCursor={log_cursor}
-			timeMode={timeMode}
-			presetDefault={presetDefault}
-		/>
+		<SearchContext initialQuery={query} onSubmit={setQuery}>
+			<LogsPageInner
+				logCursor={log_cursor}
+				timeMode={timeMode}
+				presetDefault={presetDefault}
+			/>
+		</SearchContext>
 	)
 }
 
@@ -77,8 +82,7 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 	const { project_id } = useParams<{
 		project_id: string
 	}>()
-	const [query, setQuery] = useQueryParam('query', QueryParam)
-	const { queryParts } = parseSearch(query)
+	const { query, queryParts } = useSearchContext()
 	const textAreaRef = useRef<HTMLTextAreaElement | null>(null)
 
 	const [selectedColumns, setSelectedColumns] = useLocalStorage(
@@ -212,7 +216,7 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 	}, [])
 
 	return (
-		<SearchContext initialQuery={query} onSubmit={setQuery}>
+		<>
 			<Helmet>
 				<title>Logs</title>
 			</Helmet>
@@ -282,7 +286,7 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 					</Box>
 				</Box>
 			</Box>
-		</SearchContext>
+		</>
 	)
 }
 

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -234,7 +234,8 @@ const LogsTableInner = ({
 			columnHeaders,
 			columns,
 		}
-	}, [columnHelper, queryParts, selectedColumns, setSelectedColumns])
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [queryParts, selectedColumns, setSelectedColumns])
 
 	const table = useReactTable({
 		data: logEdges,

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -416,19 +416,6 @@ const LogsTableRow: React.FC<LogsTableRowProps> = ({
 		const log = row.original.node
 		const rowExpanded = row.getIsExpanded()
 
-		const matchedAttributes = findMatchingAttributes(queryParts, {
-			...log.logAttributes,
-			environment: log.environment,
-			level: log.level,
-			message: log.message,
-			secure_session_id: log.secureSessionID,
-			service_name: log.serviceName,
-			service_version: log.serviceVersion,
-			source: log.source,
-			span_id: log.spanID,
-			trace_id: log.traceID,
-		})
-
 		return (
 			<Table.Row
 				selected={expanded}
@@ -440,7 +427,21 @@ const LogsTableRow: React.FC<LogsTableRowProps> = ({
 						<Table.Cell py="4" />
 						<Table.Cell py="4" borderTop="dividerWeak">
 							<LogDetails
-								matchedAttributes={matchedAttributes}
+								matchedAttributes={findMatchingAttributes(
+									queryParts,
+									{
+										...log.logAttributes,
+										environment: log.environment,
+										level: log.level,
+										message: log.message,
+										secure_session_id: log.secureSessionID,
+										service_name: log.serviceName,
+										service_version: log.serviceVersion,
+										source: log.source,
+										span_id: log.spanID,
+										trace_id: log.traceID,
+									},
+								)}
 								row={row}
 								queryParts={queryParts}
 							/>


### PR DESCRIPTION
## Summary
Improve performance of logs table by:
- conditionally matchedAttributes attributes
- limit rerenders by reducing changes in `columnData`'s dependency array

## How did you test this change?
1) View the logs table
2) Open the dev tools and start recording the performance
3) Scroll down a few pages
4) Open a logs row
5) Scroll down a few pages

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A