### PR TITLE
disable introspection for public graph

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -514,10 +514,23 @@ func main() {
 			r.Use(highlightChi.Middleware)
 			r.Use(public.PublicMiddleware)
 
-			publicServer := ghandler.NewDefaultServer(publicgen.NewExecutableSchema(
+			publicServer := ghandler.New(publicgen.NewExecutableSchema(
 				publicgen.Config{
 					Resolvers: publicResolver,
 				}))
+
+			publicServer.AddTransport(transport.Websocket{
+				KeepAlivePingInterval: 10 * time.Second,
+			})
+			publicServer.AddTransport(transport.Options{})
+			publicServer.AddTransport(transport.GET{})
+			publicServer.AddTransport(transport.POST{})
+			publicServer.AddTransport(transport.MultipartForm{})
+			publicServer.SetQueryCache(lru.New(1000))
+			publicServer.Use(extension.AutomaticPersistedQuery{
+				Cache: lru.New(100),
+			})
+
 			publicServer.Use(htrace.NewGraphqlTracer(string(util.PublicGraph)))
 			publicServer.SetErrorPresenter(htrace.GraphQLErrorPresenter(string(util.PublicGraph)))
 			publicServer.SetRecoverFunc(htrace.GraphQLRecoverFunc())


### PR DESCRIPTION
## Summary
- public graph used `NewDefaultServer` which configured introspection by default
- use `New` instead and configure it the same, minus introspection
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- sent introspection gql request to public graph locally, got `introspection disabled` response
![Screen Shot 2024-06-17 at 9 23 04 AM](https://github.com/highlight/highlight/assets/86132398/c42f502f-6662-4e62-bc76-a6701cdef528)

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, can revert if issues
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
