### PR TITLE
[HIG-4714] longer rounding for longer time intervals for better caching

### DIFF
--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -497,7 +497,7 @@ const Graph = ({
 
 		const newStartFetch = presetStartDate(selectedPreset)
 		const newPollInterval =
-			moment().diff(newStartFetch, 'hours') > 5
+			moment().diff(newStartFetch, 'hours') >= 4
 				? LONGER_POLL_INTERVAL_VALUE
 				: POLL_INTERVAL_VALUE
 
@@ -517,18 +517,25 @@ const Graph = ({
 			return
 		}
 
+		const useLongerRounding =
+			moment(fetchEnd).diff(fetchStart, 'hours') >= 4
+
+		const overage = useLongerRounding ? moment(fetchStart).minute() % 5 : 0
+		const start = moment(fetchStart)
+			.startOf('minute')
+			.subtract(overage, 'minute')
+		const end = moment(fetchEnd)
+			.startOf('minute')
+			.subtract(overage, 'minute')
+
 		getMetrics({
 			variables: {
 				product_type: productType,
 				project_id: projectId,
 				params: {
 					date_range: {
-						start_date: moment(fetchStart)
-							.startOf('minute')
-							.format(TIME_FORMAT),
-						end_date: moment(fetchEnd)
-							.startOf('minute')
-							.format(TIME_FORMAT),
+						start_date: start.format(TIME_FORMAT),
+						end_date: end.format(TIME_FORMAT),
 					},
 					query: query,
 				},


### PR DESCRIPTION
## Summary
- round to nearest 5 minutes when time range >= 4 hours to limit refetching when time range is likely a fraction of a bucket and improve the experience when navigating between pages as data doesn't have to be reloaded 
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- testing in preview
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
