### PR TITLE
Create new metric alert tables

### DIFF
--- a/backend/alerts/logalerts.go
+++ b/backend/alerts/logalerts.go
@@ -26,7 +26,7 @@ func BuildLogAlert(project *model.Project, workspace *model.Workspace, admin *mo
 	}
 
 	return &model.LogAlert{
-		Alert: model.Alert{
+		AlertDeprecated: model.AlertDeprecated{
 			ProjectID:         input.ProjectID,
 			CountThreshold:    input.CountThreshold,
 			ThresholdWindow:   &input.ThresholdWindow,

--- a/backend/alerts/sessionalerts.go
+++ b/backend/alerts/sessionalerts.go
@@ -91,7 +91,7 @@ func BuildSessionAlert(project *model.Project, workspace *model.Workspace, admin
 	}
 
 	return &model.SessionAlert{
-		Alert: model.Alert{
+		AlertDeprecated: model.AlertDeprecated{
 			ProjectID:            input.ProjectID,
 			ExcludedEnvironments: envString,
 			CountThreshold:       input.CountThreshold,

--- a/backend/clickhouse/migrations/000105_create_alert_state_changes_table.down.sql
+++ b/backend/clickhouse/migrations/000105_create_alert_state_changes_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS alert_state_changes

--- a/backend/clickhouse/migrations/000105_create_alert_state_changes_table.up.sql
+++ b/backend/clickhouse/migrations/000105_create_alert_state_changes_table.up.sql
@@ -7,11 +7,9 @@ CREATE TABLE IF NOT EXISTS alert_state_changes
     PreviousState LowCardinality(String),
     Title String,
     GroupByKey String,
-    INDEX idx_alert_id          AlertID TYPE bloom_filter(0.001) GRANULARITY 1,
 )   ENGINE = MergeTree
-PARTITION BY toDate(Timestamp)
 ORDER BY (
     ProjectID,
+    AlertID,
     toUnixTimestamp(Timestamp),
-    AlertID
 )

--- a/backend/clickhouse/migrations/000105_create_alert_state_changes_table.up.sql
+++ b/backend/clickhouse/migrations/000105_create_alert_state_changes_table.up.sql
@@ -7,11 +7,11 @@ CREATE TABLE IF NOT EXISTS alert_state_changes
     PreviousState LowCardinality(String),
     Title String,
     GroupByKey String,
-    INDEX idx_alert_id          AlertId TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_alert_id          AlertID TYPE bloom_filter(0.001) GRANULARITY 1,
 )   ENGINE = MergeTree
 PARTITION BY toDate(Timestamp)
 ORDER BY (
-    ProjectId,
+    ProjectID,
     toUnixTimestamp(Timestamp),
-    AlertId
+    AlertID
 )

--- a/backend/clickhouse/migrations/000105_create_alert_state_changes_table.up.sql
+++ b/backend/clickhouse/migrations/000105_create_alert_state_changes_table.up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS alert_state_changes
+(
+    Timestamp DateTime64(6),
+    ProjectID UInt32,
+    AlertID UInt32,
+    State LowCardinality(String),
+    PreviousState LowCardinality(String),
+    Title String,
+    GroupByKey String,
+    INDEX idx_alert_id          AlertId TYPE bloom_filter(0.001) GRANULARITY 1,
+)   ENGINE = MergeTree
+PARTITION BY toDate(Timestamp)
+ORDER BY (
+    ProjectId,
+    toUnixTimestamp(Timestamp),
+    AlertId
+)

--- a/backend/migrations/cmd/alert-ids/main.go
+++ b/backend/migrations/cmd/alert-ids/main.go
@@ -40,7 +40,7 @@ func main() {
 		log.WithContext(ctx).Fatalf("error setting up db: %+v", err)
 	}
 	var sessionAlerts []model.SessionAlert
-	db.Model(model.SessionAlert{}).Where(&model.SessionAlert{Alert: model.AlertDeprecated{Type: &model.AlertType.USER_PROPERTIES}}).Or(&model.SessionAlert{Alert: model.AlertDeprecated{Type: &model.AlertType.TRACK_PROPERTIES}}).Scan(&sessionAlerts)
+	db.Model(model.SessionAlert{}).Where(&model.SessionAlert{AlertDeprecated: model.AlertDeprecated{Type: &model.AlertType.USER_PROPERTIES}}).Or(&model.SessionAlert{AlertDeprecated: model.AlertDeprecated{Type: &model.AlertType.TRACK_PROPERTIES}}).Scan(&sessionAlerts)
 	for _, alert := range sessionAlerts {
 		if alert.TrackProperties != nil {
 			trackProperties, err := GetPropertiesOld(&alert)

--- a/backend/migrations/cmd/alert-ids/main.go
+++ b/backend/migrations/cmd/alert-ids/main.go
@@ -40,7 +40,7 @@ func main() {
 		log.WithContext(ctx).Fatalf("error setting up db: %+v", err)
 	}
 	var sessionAlerts []model.SessionAlert
-	db.Model(model.SessionAlert{}).Where(&model.SessionAlert{Alert: model.Alert{Type: &model.AlertType.USER_PROPERTIES}}).Or(&model.SessionAlert{Alert: model.Alert{Type: &model.AlertType.TRACK_PROPERTIES}}).Scan(&sessionAlerts)
+	db.Model(model.SessionAlert{}).Where(&model.SessionAlert{Alert: model.AlertDeprecated{Type: &model.AlertType.USER_PROPERTIES}}).Or(&model.SessionAlert{Alert: model.AlertDeprecated{Type: &model.AlertType.TRACK_PROPERTIES}}).Scan(&sessionAlerts)
 	for _, alert := range sessionAlerts {
 		if alert.TrackProperties != nil {
 			trackProperties, err := GetPropertiesOld(&alert)

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1963,9 +1963,7 @@ type Alert struct {
 	Query             *string
 	GroupByKey        *string
 	Disabled          bool `gorm:"default:false"`
-	Default           bool `gorm:"default:false"` // alert created during setup flow
 	LastAdminToEditID int  `gorm:"last_admin_to_edit_id"`
-	State             modelInputs.AlertState
 
 	// fields for threshold alert
 	BelowThreshold    *bool

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -202,6 +202,8 @@ var Models = []interface{}{
 	&ErrorTag{},
 	&Graph{},
 	&Visualization{},
+	&Alert{},
+	&AlertDestination{},
 }
 
 func init() {
@@ -1951,6 +1953,34 @@ func (s *Session) GetUserProperties() (map[string]string, error) {
 		return nil, e.Wrapf(err, "[project_id: %d] error unmarshalling user properties map into bytes", s.ProjectID)
 	}
 	return userProperties, nil
+}
+
+type Alert struct {
+	Model
+	Name              string
+	ProductType       modelInputs.ProductType
+	FunctionType      modelInputs.MetricAggregator
+	Query             *string
+	GroupByKey        *string
+	Disabled          bool `gorm:"default:false"`
+	Default           bool `gorm:"default:false"` // alert created during setup flow
+	LastAdminToEditID int  `gorm:"last_admin_to_edit_id"`
+	State             modelInputs.AlertState
+
+	// fields for threshold alert
+	BelowThreshold    *bool
+	ThresholdCount    *int
+	ThresholdWindow   *int
+	ThresholdCooldown *int
+}
+
+type AlertDestination struct {
+	Model
+	AlertID         int
+	DestinationType modelInputs.AlertDestinationType
+	TypeID          string
+	TypeName        string
+	Authorization   *string // webhooks may have this
 }
 
 type AlertDeprecated struct {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1953,7 +1953,7 @@ func (s *Session) GetUserProperties() (map[string]string, error) {
 	return userProperties, nil
 }
 
-type Alert struct {
+type AlertDeprecated struct {
 	ProjectID            int
 	ExcludedEnvironments *string
 	CountThreshold       int
@@ -1970,7 +1970,7 @@ type Alert struct {
 
 type ErrorAlert struct {
 	Model
-	Alert
+	AlertDeprecated
 	RegexGroups *string
 	Query       string
 	AlertIntegrations
@@ -2041,7 +2041,7 @@ func (obj *ErrorAlert) GetRegexGroups() ([]*string, error) {
 
 type SessionAlert struct {
 	Model
-	Alert
+	AlertDeprecated
 	TrackProperties *string
 	UserProperties  *string
 	ExcludeRules    *string
@@ -2071,7 +2071,7 @@ type Service struct {
 
 type LogAlert struct {
 	Model
-	Alert
+	AlertDeprecated
 	Query          string
 	BelowThreshold bool
 	AlertIntegrations
@@ -2094,7 +2094,7 @@ type SavedSegment struct {
 	ProjectID  int                                `gorm:"index:idx_saved_segment,priority:1" json:"project_id"`
 }
 
-func (obj *Alert) GetExcludedEnvironments() ([]*string, error) {
+func (obj *AlertDeprecated) GetExcludedEnvironments() ([]*string, error) {
 	if obj == nil {
 		return nil, e.New("empty session alert object for excluded environments")
 	}
@@ -2109,7 +2109,7 @@ func (obj *Alert) GetExcludedEnvironments() ([]*string, error) {
 	return sanitizedExcludedEnvironments, nil
 }
 
-func (obj *Alert) GetChannelsToNotify() ([]*modelInputs.SanitizedSlackChannel, error) {
+func (obj *AlertDeprecated) GetChannelsToNotify() ([]*modelInputs.SanitizedSlackChannel, error) {
 	if obj == nil {
 		return nil, e.New("empty session alert object for channels to notify")
 	}
@@ -2124,11 +2124,11 @@ func (obj *Alert) GetChannelsToNotify() ([]*modelInputs.SanitizedSlackChannel, e
 	return sanitizedChannels, nil
 }
 
-func (obj *Alert) GetName() string {
+func (obj *AlertDeprecated) GetName() string {
 	return obj.Name
 }
 
-func (obj *Alert) GetEmailsToNotify() ([]*string, error) {
+func (obj *AlertDeprecated) GetEmailsToNotify() ([]*string, error) {
 	if obj == nil {
 		return nil, e.New("empty session alert object for emails to notify")
 	}
@@ -2138,7 +2138,7 @@ func (obj *Alert) GetEmailsToNotify() ([]*string, error) {
 	return emailsToNotify, err
 }
 
-func (obj *Alert) GetDailyErrorEventFrequency(db *gorm.DB, id int) ([]*int64, error) {
+func (obj *AlertDeprecated) GetDailyErrorEventFrequency(db *gorm.DB, id int) ([]*int64, error) {
 	var dailyAlerts []*int64
 	if err := db.Raw(`
 		SELECT COUNT(e.id)
@@ -2159,7 +2159,7 @@ func (obj *Alert) GetDailyErrorEventFrequency(db *gorm.DB, id int) ([]*int64, er
 	return dailyAlerts, nil
 }
 
-func (obj *Alert) GetDailySessionEventFrequency(db *gorm.DB, id int) ([]*int64, error) {
+func (obj *AlertDeprecated) GetDailySessionEventFrequency(db *gorm.DB, id int) ([]*int64, error) {
 	var dailyAlerts []*int64
 	if err := db.Raw(`
 		SELECT COUNT(e.id)
@@ -2180,7 +2180,7 @@ func (obj *Alert) GetDailySessionEventFrequency(db *gorm.DB, id int) ([]*int64, 
 	return dailyAlerts, nil
 }
 
-func (obj *Alert) GetDailyLogEventFrequency(db *gorm.DB, id int) ([]*int64, error) {
+func (obj *AlertDeprecated) GetDailyLogEventFrequency(db *gorm.DB, id int) ([]*int64, error) {
 	var dailyAlerts []*int64
 	if err := db.Raw(`
 		SELECT COUNT(e.id)

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -12686,9 +12686,11 @@ type Dashboard {
 }
 
 enum AlertState {
-	Normal # no alerts are pending or firing
-	Pending # at least one alert is pending
-	Firing # at least one alert is firing
+	Normal
+	Pending
+	Alerting
+	NoData
+	Error
 }
 
 enum AlertDestinationType {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -12685,6 +12685,20 @@ type Dashboard {
 	last_admin_to_edit_id: ID!
 }
 
+enum AlertState {
+	Normal # no alerts are pending or firing
+	Pending # at least one alert is pending
+	Firing # at least one alert is firing
+}
+
+enum AlertDestinationType {
+	Slack
+	Discord
+	MicrosoftTeams
+	Webhook
+	Email
+}
+
 type SanitizedSlackChannel {
 	webhook_channel: String
 	webhook_channel_id: String

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -1036,6 +1036,96 @@ type WorkspaceForInviteLink struct {
 	ProjectID       int        `json:"project_id"`
 }
 
+type AlertDestinationType string
+
+const (
+	AlertDestinationTypeSlack          AlertDestinationType = "Slack"
+	AlertDestinationTypeDiscord        AlertDestinationType = "Discord"
+	AlertDestinationTypeMicrosoftTeams AlertDestinationType = "MicrosoftTeams"
+	AlertDestinationTypeWebhook        AlertDestinationType = "Webhook"
+	AlertDestinationTypeEmail          AlertDestinationType = "Email"
+)
+
+var AllAlertDestinationType = []AlertDestinationType{
+	AlertDestinationTypeSlack,
+	AlertDestinationTypeDiscord,
+	AlertDestinationTypeMicrosoftTeams,
+	AlertDestinationTypeWebhook,
+	AlertDestinationTypeEmail,
+}
+
+func (e AlertDestinationType) IsValid() bool {
+	switch e {
+	case AlertDestinationTypeSlack, AlertDestinationTypeDiscord, AlertDestinationTypeMicrosoftTeams, AlertDestinationTypeWebhook, AlertDestinationTypeEmail:
+		return true
+	}
+	return false
+}
+
+func (e AlertDestinationType) String() string {
+	return string(e)
+}
+
+func (e *AlertDestinationType) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = AlertDestinationType(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid AlertDestinationType", str)
+	}
+	return nil
+}
+
+func (e AlertDestinationType) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type AlertState string
+
+const (
+	AlertStateNormal  AlertState = "Normal"
+	AlertStatePending AlertState = "Pending"
+	AlertStateFiring  AlertState = "Firing"
+)
+
+var AllAlertState = []AlertState{
+	AlertStateNormal,
+	AlertStatePending,
+	AlertStateFiring,
+}
+
+func (e AlertState) IsValid() bool {
+	switch e {
+	case AlertStateNormal, AlertStatePending, AlertStateFiring:
+		return true
+	}
+	return false
+}
+
+func (e AlertState) String() string {
+	return string(e)
+}
+
+func (e *AlertState) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = AlertState(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid AlertState", str)
+	}
+	return nil
+}
+
+func (e AlertState) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 type DashboardChartType string
 
 const (

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -1086,20 +1086,24 @@ func (e AlertDestinationType) MarshalGQL(w io.Writer) {
 type AlertState string
 
 const (
-	AlertStateNormal  AlertState = "Normal"
-	AlertStatePending AlertState = "Pending"
-	AlertStateFiring  AlertState = "Firing"
+	AlertStateNormal   AlertState = "Normal"
+	AlertStatePending  AlertState = "Pending"
+	AlertStateAlerting AlertState = "Alerting"
+	AlertStateNoData   AlertState = "NoData"
+	AlertStateError    AlertState = "Error"
 )
 
 var AllAlertState = []AlertState{
 	AlertStateNormal,
 	AlertStatePending,
-	AlertStateFiring,
+	AlertStateAlerting,
+	AlertStateNoData,
+	AlertStateError,
 }
 
 func (e AlertState) IsValid() bool {
 	switch e {
-	case AlertStateNormal, AlertStatePending, AlertStateFiring:
+	case AlertStateNormal, AlertStatePending, AlertStateAlerting, AlertStateNoData, AlertStateError:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -2096,7 +2096,7 @@ func (r *Resolver) RemoveMicrosoftTeamsFromWorkspace(ctx context.Context, worksp
 
 		microsoftTeamsChannelsToNotify := make(model.MicrosoftTeamsChannels, 0)
 
-		projectAlert := model.Alert{ProjectID: projectID}
+		projectAlert := model.AlertDeprecated{ProjectID: projectID}
 		emptyMicrosoftTeamsChannels := model.AlertIntegrations{
 			MicrosoftTeamsChannelsToNotify: microsoftTeamsChannelsToNotify,
 		}
@@ -2105,7 +2105,7 @@ func (r *Resolver) RemoveMicrosoftTeamsFromWorkspace(ctx context.Context, worksp
 			return e.Wrap(err, "error removing microsoft_teams channels from created SessionAlert's")
 		}
 
-		if err := tx.Where(&model.ErrorAlert{Alert: projectAlert}).Updates(model.ErrorAlert{AlertIntegrations: emptyMicrosoftTeamsChannels}).Error; err != nil {
+		if err := tx.Where(&model.ErrorAlert{AlertDeprecated: projectAlert}).Updates(model.ErrorAlert{AlertIntegrations: emptyMicrosoftTeamsChannels}).Error; err != nil {
 			return e.Wrap(err, "error removing microsoft_teams channels from created ErrorAlert's")
 		}
 
@@ -2114,7 +2114,7 @@ func (r *Resolver) RemoveMicrosoftTeamsFromWorkspace(ctx context.Context, worksp
 			return e.Wrap(err, "error removing microsoft_teams channels from created MetricMonitor's")
 		}
 
-		if err := tx.Where(&model.LogAlert{Alert: projectAlert}).Updates(model.LogAlert{AlertIntegrations: emptyMicrosoftTeamsChannels}).Error; err != nil {
+		if err := tx.Where(&model.LogAlert{AlertDeprecated: projectAlert}).Updates(model.LogAlert{AlertIntegrations: emptyMicrosoftTeamsChannels}).Error; err != nil {
 			return e.Wrap(err, "error removing microsoft_teams channels from created LogAlert's")
 		}
 
@@ -2134,15 +2134,15 @@ func (r *Resolver) RemoveSlackFromWorkspace(ctx context.Context, workspace *mode
 		}
 
 		empty := "[]"
-		projectAlert := model.Alert{ProjectID: projectID}
-		clearedChannelsAlert := model.Alert{ChannelsToNotify: &empty}
+		projectAlert := model.AlertDeprecated{ProjectID: projectID}
+		clearedChannelsAlert := model.AlertDeprecated{ChannelsToNotify: &empty}
 
 		// set existing alerts to have empty slack channels to notify
-		if err := tx.Where(&model.SessionAlert{Alert: projectAlert}).Updates(model.SessionAlert{Alert: clearedChannelsAlert}).Error; err != nil {
+		if err := tx.Where(&model.SessionAlert{AlertDeprecated: projectAlert}).Updates(model.SessionAlert{AlertDeprecated: clearedChannelsAlert}).Error; err != nil {
 			return e.Wrap(err, "error removing slack channels from created SessionAlert's")
 		}
 
-		if err := tx.Where(&model.ErrorAlert{Alert: projectAlert}).Updates(model.ErrorAlert{Alert: clearedChannelsAlert}).Error; err != nil {
+		if err := tx.Where(&model.ErrorAlert{AlertDeprecated: projectAlert}).Updates(model.ErrorAlert{AlertDeprecated: clearedChannelsAlert}).Error; err != nil {
 			return e.Wrap(err, "error removing slack channels from created ErrorAlert's")
 		}
 
@@ -2151,7 +2151,7 @@ func (r *Resolver) RemoveSlackFromWorkspace(ctx context.Context, workspace *mode
 			return e.Wrap(err, "error removing slack channels from created MetricMonitor's")
 		}
 
-		if err := tx.Where(&model.LogAlert{Alert: projectAlert}).Updates(model.LogAlert{Alert: clearedChannelsAlert}).Error; err != nil {
+		if err := tx.Where(&model.LogAlert{AlertDeprecated: projectAlert}).Updates(model.LogAlert{AlertDeprecated: clearedChannelsAlert}).Error; err != nil {
 			return e.Wrap(err, "error removing slack channels from created LogAlert's")
 		}
 

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1552,9 +1552,11 @@ type Dashboard {
 }
 
 enum AlertState {
-	Normal # no alerts are pending or firing
-	Pending # at least one alert is pending
-	Firing # at least one alert is firing
+	Normal
+	Pending
+	Alerting
+	NoData
+	Error
 }
 
 enum AlertDestinationType {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1551,6 +1551,20 @@ type Dashboard {
 	last_admin_to_edit_id: ID!
 }
 
+enum AlertState {
+	Normal # no alerts are pending or firing
+	Pending # at least one alert is pending
+	Firing # at least one alert is firing
+}
+
+enum AlertDestinationType {
+	Slack
+	Discord
+	MicrosoftTeams
+	Webhook
+	Email
+}
+
 type SanitizedSlackChannel {
 	webhook_channel: String
 	webhook_channel_id: String

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3336,7 +3336,7 @@ func (r *mutationResolver) CreateErrorAlert(ctx context.Context, projectID int, 
 	}
 
 	newAlert := &model.ErrorAlert{
-		Alert: model.Alert{
+		AlertDeprecated: model.AlertDeprecated{
 			ProjectID:         projectID,
 			CountThreshold:    countThreshold,
 			ThresholdWindow:   &thresholdWindow,
@@ -3477,7 +3477,7 @@ func (r *mutationResolver) DeleteErrorAlert(ctx context.Context, projectID int, 
 	}
 
 	projectAlert := &model.ErrorAlert{}
-	if err := r.DB.WithContext(ctx).Where(&model.ErrorAlert{Model: model.Model{ID: errorAlertID}, Alert: model.Alert{ProjectID: projectID}}).Find(&projectAlert).Error; err != nil {
+	if err := r.DB.WithContext(ctx).Where(&model.ErrorAlert{Model: model.Model{ID: errorAlertID}, AlertDeprecated: model.AlertDeprecated{ProjectID: projectID}}).Find(&projectAlert).Error; err != nil {
 		return nil, e.Wrap(err, "this error alert does not exist in this project.")
 	}
 
@@ -3543,7 +3543,7 @@ func (r *mutationResolver) UpdateSessionAlertIsDisabled(ctx context.Context, id 
 	}
 
 	sessionAlert := &model.SessionAlert{
-		Alert: model.Alert{
+		AlertDeprecated: model.AlertDeprecated{
 			Disabled: &disabled,
 		},
 	}
@@ -3567,7 +3567,7 @@ func (r *mutationResolver) UpdateErrorAlertIsDisabled(ctx context.Context, id in
 	}
 
 	errorAlert := &model.ErrorAlert{
-		Alert: model.Alert{
+		AlertDeprecated: model.AlertDeprecated{
 			Disabled: &disabled,
 		},
 	}
@@ -3687,7 +3687,7 @@ func (r *mutationResolver) DeleteSessionAlert(ctx context.Context, projectID int
 	}
 
 	projectAlert := &model.SessionAlert{}
-	if err := r.DB.WithContext(ctx).Where(&model.ErrorAlert{Model: model.Model{ID: sessionAlertID}, Alert: model.Alert{ProjectID: projectID}}).Find(&projectAlert).Error; err != nil {
+	if err := r.DB.WithContext(ctx).Where(&model.ErrorAlert{Model: model.Model{ID: sessionAlertID}, AlertDeprecated: model.AlertDeprecated{ProjectID: projectID}}).Find(&projectAlert).Error; err != nil {
 		return nil, e.Wrap(err, "this session alert does not exist in this project.")
 	}
 
@@ -3855,7 +3855,7 @@ func (r *mutationResolver) UpdateLogAlertIsDisabled(ctx context.Context, id int,
 	}
 
 	alert := &model.LogAlert{
-		Alert: model.Alert{
+		AlertDeprecated: model.AlertDeprecated{
 			Disabled: &disabled,
 		},
 	}
@@ -7054,7 +7054,7 @@ func (r *queryResolver) TrackPropertiesAlerts(ctx context.Context, projectID int
 		return nil, err
 	}
 	var alerts []*model.SessionAlert
-	if err := r.DB.WithContext(ctx).Where(&model.SessionAlert{Alert: model.Alert{Type: &model.AlertType.TRACK_PROPERTIES}}).
+	if err := r.DB.WithContext(ctx).Where(&model.SessionAlert{AlertDeprecated: model.AlertDeprecated{Type: &model.AlertType.TRACK_PROPERTIES}}).
 		Where("project_id = ?", projectID).Find(&alerts).Error; err != nil {
 		return nil, e.Wrap(err, "error querying track properties alerts")
 	}
@@ -7068,7 +7068,7 @@ func (r *queryResolver) UserPropertiesAlerts(ctx context.Context, projectID int)
 		return nil, err
 	}
 	var alerts []*model.SessionAlert
-	if err := r.DB.WithContext(ctx).Where(&model.SessionAlert{Alert: model.Alert{Type: &model.AlertType.USER_PROPERTIES}}).
+	if err := r.DB.WithContext(ctx).Where(&model.SessionAlert{AlertDeprecated: model.AlertDeprecated{Type: &model.AlertType.USER_PROPERTIES}}).
 		Where("project_id = ?", projectID).Find(&alerts).Error; err != nil {
 		return nil, e.Wrap(err, "error querying user properties alerts")
 	}
@@ -7082,7 +7082,7 @@ func (r *queryResolver) NewSessionAlerts(ctx context.Context, projectID int) ([]
 		return nil, err
 	}
 	var alerts []*model.SessionAlert
-	if err := r.DB.WithContext(ctx).Where(&model.SessionAlert{Alert: model.Alert{Type: &model.AlertType.NEW_SESSION}}).
+	if err := r.DB.WithContext(ctx).Where(&model.SessionAlert{AlertDeprecated: model.AlertDeprecated{Type: &model.AlertType.NEW_SESSION}}).
 		Where("project_id = ?", projectID).Find(&alerts).Error; err != nil {
 		return nil, e.Wrap(err, "error querying new session alerts")
 	}
@@ -9845,3 +9845,76 @@ type sessionCommentResolver struct{ *Resolver }
 type subscriptionResolver struct{ *Resolver }
 type timelineIndicatorEventResolver struct{ *Resolver }
 type visualizationResolver struct{ *Resolver }
+
+// !!! WARNING !!!
+// The code below was going to be deleted when updating resolvers. It has been copied here so you have
+// one last chance to move it out of harms way if you want. There are two reasons this happens:
+//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
+//     it when you're done.
+//   - You have helper methods in this file. Move them out to keep these resolver files clean.
+func (r *errorAlertResolver) Name(ctx context.Context, obj *model.ErrorAlert) (*string, error) {
+	panic(fmt.Errorf("not implemented: Name - Name"))
+}
+func (r *errorAlertResolver) CountThreshold(ctx context.Context, obj *model.ErrorAlert) (int, error) {
+	panic(fmt.Errorf("not implemented: CountThreshold - CountThreshold"))
+}
+func (r *errorAlertResolver) ThresholdWindow(ctx context.Context, obj *model.ErrorAlert) (*int, error) {
+	panic(fmt.Errorf("not implemented: ThresholdWindow - ThresholdWindow"))
+}
+func (r *errorAlertResolver) LastAdminToEditID(ctx context.Context, obj *model.ErrorAlert) (*int, error) {
+	panic(fmt.Errorf("not implemented: LastAdminToEditID - LastAdminToEditID"))
+}
+func (r *errorAlertResolver) Type(ctx context.Context, obj *model.ErrorAlert) (string, error) {
+	panic(fmt.Errorf("not implemented: Type - Type"))
+}
+func (r *errorAlertResolver) Frequency(ctx context.Context, obj *model.ErrorAlert) (int, error) {
+	panic(fmt.Errorf("not implemented: Frequency - Frequency"))
+}
+func (r *errorAlertResolver) Disabled(ctx context.Context, obj *model.ErrorAlert) (bool, error) {
+	panic(fmt.Errorf("not implemented: Disabled - disabled"))
+}
+func (r *errorAlertResolver) Default(ctx context.Context, obj *model.ErrorAlert) (bool, error) {
+	panic(fmt.Errorf("not implemented: Default - default"))
+}
+func (r *logAlertResolver) Name(ctx context.Context, obj *model.LogAlert) (string, error) {
+	panic(fmt.Errorf("not implemented: Name - Name"))
+}
+func (r *logAlertResolver) CountThreshold(ctx context.Context, obj *model.LogAlert) (int, error) {
+	panic(fmt.Errorf("not implemented: CountThreshold - CountThreshold"))
+}
+func (r *logAlertResolver) ThresholdWindow(ctx context.Context, obj *model.LogAlert) (int, error) {
+	panic(fmt.Errorf("not implemented: ThresholdWindow - ThresholdWindow"))
+}
+func (r *logAlertResolver) LastAdminToEditID(ctx context.Context, obj *model.LogAlert) (*int, error) {
+	panic(fmt.Errorf("not implemented: LastAdminToEditID - LastAdminToEditID"))
+}
+func (r *logAlertResolver) Type(ctx context.Context, obj *model.LogAlert) (string, error) {
+	panic(fmt.Errorf("not implemented: Type - Type"))
+}
+func (r *logAlertResolver) Disabled(ctx context.Context, obj *model.LogAlert) (bool, error) {
+	panic(fmt.Errorf("not implemented: Disabled - disabled"))
+}
+func (r *logAlertResolver) Default(ctx context.Context, obj *model.LogAlert) (bool, error) {
+	panic(fmt.Errorf("not implemented: Default - default"))
+}
+func (r *sessionAlertResolver) Name(ctx context.Context, obj *model.SessionAlert) (*string, error) {
+	panic(fmt.Errorf("not implemented: Name - Name"))
+}
+func (r *sessionAlertResolver) CountThreshold(ctx context.Context, obj *model.SessionAlert) (int, error) {
+	panic(fmt.Errorf("not implemented: CountThreshold - CountThreshold"))
+}
+func (r *sessionAlertResolver) ThresholdWindow(ctx context.Context, obj *model.SessionAlert) (*int, error) {
+	panic(fmt.Errorf("not implemented: ThresholdWindow - ThresholdWindow"))
+}
+func (r *sessionAlertResolver) LastAdminToEditID(ctx context.Context, obj *model.SessionAlert) (*int, error) {
+	panic(fmt.Errorf("not implemented: LastAdminToEditID - LastAdminToEditID"))
+}
+func (r *sessionAlertResolver) Type(ctx context.Context, obj *model.SessionAlert) (string, error) {
+	panic(fmt.Errorf("not implemented: Type - Type"))
+}
+func (r *sessionAlertResolver) Disabled(ctx context.Context, obj *model.SessionAlert) (bool, error) {
+	panic(fmt.Errorf("not implemented: Disabled - disabled"))
+}
+func (r *sessionAlertResolver) Default(ctx context.Context, obj *model.SessionAlert) (bool, error) {
+	panic(fmt.Errorf("not implemented: Default - default"))
+}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1348,7 +1348,7 @@ func (r *Resolver) AddSessionFeedbackImpl(ctx context.Context, input *kafka_queu
 	}
 
 	var errorAlerts []*model.ErrorAlert
-	if err := r.DB.WithContext(ctx).Model(&model.ErrorAlert{}).Where(&model.ErrorAlert{Alert: model.Alert{ProjectID: session.ProjectID, Disabled: &model.F}}).Find(&errorAlerts).Error; err != nil {
+	if err := r.DB.WithContext(ctx).Model(&model.ErrorAlert{}).Where(&model.ErrorAlert{AlertDeprecated: model.AlertDeprecated{ProjectID: session.ProjectID, Disabled: &model.F}}).Find(&errorAlerts).Error; err != nil {
 		return e.Wrapf(err, "[project_id: %d] error fetching session feedback alerts", session.ProjectID)
 	}
 
@@ -1676,7 +1676,7 @@ type AlertCountsGroupedByRecent struct {
 func (r *Resolver) sendErrorAlert(ctx context.Context, projectID int, sessionObj *model.Session, group *model.ErrorGroup, errorObject *model.ErrorObject, visitedUrl string) {
 	func() {
 		var errorAlerts []*model.ErrorAlert
-		if err := r.DB.WithContext(ctx).Model(&model.ErrorAlert{}).Where(&model.ErrorAlert{Alert: model.Alert{ProjectID: projectID, Disabled: &model.F}}).Find(&errorAlerts).Error; err != nil {
+		if err := r.DB.WithContext(ctx).Model(&model.ErrorAlert{}).Where(&model.ErrorAlert{AlertDeprecated: model.AlertDeprecated{ProjectID: projectID, Disabled: &model.F}}).Find(&errorAlerts).Error; err != nil {
 			log.WithContext(ctx).Error(e.Wrap(err, "error fetching ErrorAlerts object"))
 			return
 		}
@@ -3006,7 +3006,7 @@ func (r *Resolver) HandleSessionViewable(ctx context.Context, projectID int, ses
 func (r *Resolver) SendSessionInitAlert(ctx context.Context, workspace *model.Workspace, project *model.Project, sessionID int) error {
 	// Sending session init alert
 	var sessionAlerts []*model.SessionAlert
-	if err := r.DB.WithContext(ctx).Model(&model.SessionAlert{}).Where(&model.SessionAlert{Alert: model.Alert{ProjectID: project.ID, Disabled: &model.F}}).
+	if err := r.DB.WithContext(ctx).Model(&model.SessionAlert{}).Where(&model.SessionAlert{AlertDeprecated: model.AlertDeprecated{ProjectID: project.ID, Disabled: &model.F}}).
 		Where("type=?", model.AlertType.NEW_SESSION).Find(&sessionAlerts).Error; err != nil {
 		log.WithContext(ctx).Error(e.Wrapf(err, "[project_id: %d] error fetching new session alert", project.ID))
 		return err
@@ -3329,7 +3329,7 @@ func (r *Resolver) SendSessionTrackPropertiesAlert(ctx context.Context, workspac
 	defer alertWorkerSpan.Finish()
 	// Sending Track Properties Alert
 	var sessionAlerts []*model.SessionAlert
-	if err := r.DB.WithContext(ctx).Model(&model.SessionAlert{}).Where(&model.SessionAlert{Alert: model.Alert{ProjectID: session.ProjectID, Disabled: &model.F}}).Where("type=?", model.AlertType.TRACK_PROPERTIES).Find(&sessionAlerts).Error; err != nil {
+	if err := r.DB.WithContext(ctx).Model(&model.SessionAlert{}).Where(&model.SessionAlert{AlertDeprecated: model.AlertDeprecated{ProjectID: session.ProjectID, Disabled: &model.F}}).Where("type=?", model.AlertType.TRACK_PROPERTIES).Find(&sessionAlerts).Error; err != nil {
 		log.WithContext(ctx).Error(e.Wrapf(err, "[project_id: %d] error fetching track properties alert", session.ProjectID))
 		return err
 	}
@@ -3439,7 +3439,7 @@ func (r *Resolver) SendSessionTrackPropertiesAlert(ctx context.Context, workspac
 func (r *Resolver) SendSessionIdentifiedAlert(ctx context.Context, workspace *model.Workspace, project *model.Project, session *model.Session) error {
 	// Sending New User Alert
 	var sessionAlerts []*model.SessionAlert
-	if err := r.DB.WithContext(ctx).Model(&model.SessionAlert{}).Where(&model.SessionAlert{Alert: model.Alert{ProjectID: session.ProjectID, Disabled: &model.F}}).Where("type=?", model.AlertType.NEW_USER).Find(&sessionAlerts).Error; err != nil {
+	if err := r.DB.WithContext(ctx).Model(&model.SessionAlert{}).Where(&model.SessionAlert{AlertDeprecated: model.AlertDeprecated{ProjectID: session.ProjectID, Disabled: &model.F}}).Where("type=?", model.AlertType.NEW_USER).Find(&sessionAlerts).Error; err != nil {
 		log.WithContext(ctx).Error(e.Wrapf(err, "[project_id: %d] error fetching new user alert", session.ProjectID))
 		return err
 	}
@@ -3519,7 +3519,7 @@ func (r *Resolver) SendSessionUserPropertiesAlert(ctx context.Context, workspace
 	defer alertSpan.Finish()
 	// Sending User Properties Alert
 	var sessionAlerts []*model.SessionAlert
-	if err := r.DB.WithContext(ctx).Model(&model.SessionAlert{}).Where(&model.SessionAlert{Alert: model.Alert{ProjectID: session.ProjectID, Disabled: &model.F}}).Where("type=?", model.AlertType.USER_PROPERTIES).Find(&sessionAlerts).Error; err != nil {
+	if err := r.DB.WithContext(ctx).Model(&model.SessionAlert{}).Where(&model.SessionAlert{AlertDeprecated: model.AlertDeprecated{ProjectID: session.ProjectID, Disabled: &model.F}}).Where("type=?", model.AlertType.USER_PROPERTIES).Find(&sessionAlerts).Error; err != nil {
 		log.WithContext(ctx).Error(e.Wrapf(err, "[project_id: %d] error fetching user properties alert", session.ProjectID))
 		return err
 	}

--- a/backend/temp-alerts/temp-alerts.go
+++ b/backend/temp-alerts/temp-alerts.go
@@ -78,7 +78,7 @@ type SendSlackAlertInput struct {
 
 func SendAlertFeedback(ctx context.Context, db *gorm.DB, mailClient *sendgrid.Client, obj *model.ErrorAlert, input *SendSlackAlertInput) {
 	obj.Type = ptr.String(model.AlertType.ERROR_FEEDBACK)
-	if err := sendSlackAlert(ctx, db, &obj.Alert, input); err != nil {
+	if err := sendSlackAlert(ctx, db, &obj.AlertDeprecated, input); err != nil {
 		log.WithContext(ctx).Error(err)
 	}
 }
@@ -92,7 +92,7 @@ func SendErrorAlerts(ctx context.Context, db *gorm.DB, mailClient *sendgrid.Clie
 		})
 	}()
 
-	if err := sendSlackAlert(ctx, db, &obj.Alert, input); err != nil {
+	if err := sendSlackAlert(ctx, db, &obj.AlertDeprecated, input); err != nil {
 		log.WithContext(ctx).Error(err)
 	}
 	emailsToNotify, err := model.GetEmailsToNotify(obj.EmailsToNotify)
@@ -149,7 +149,7 @@ func SendSessionAlerts(ctx context.Context, db *gorm.DB, mailClient *sendgrid.Cl
 		})
 	}()
 
-	if err := sendSlackAlert(ctx, db, &obj.Alert, input); err != nil {
+	if err := sendSlackAlert(ctx, db, &obj.AlertDeprecated, input); err != nil {
 		log.WithContext(ctx).Error(err)
 	}
 
@@ -300,7 +300,7 @@ func getPreviewText(alertType string) string {
 	}
 }
 
-func sendSlackAlert(ctx context.Context, db *gorm.DB, obj *model.Alert, input *SendSlackAlertInput) error {
+func sendSlackAlert(ctx context.Context, db *gorm.DB, obj *model.AlertDeprecated, input *SendSlackAlertInput) error {
 	// TODO: combine `error_alerts` and `session_alerts` tables and create composite index on (project_id, type)
 	if obj == nil {
 		return errors.New("alert is nil")

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -871,7 +871,7 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 		}
 		// Sending Rage Click Alert
 		var sessionAlerts []*model.SessionAlert
-		if err := w.Resolver.DB.WithContext(ctx).Model(&model.SessionAlert{}).Where(&model.SessionAlert{Alert: model.Alert{ProjectID: projectID, Disabled: &model.F}}).Where("type=?", model.AlertType.RAGE_CLICK).Find(&sessionAlerts).Error; err != nil {
+		if err := w.Resolver.DB.WithContext(ctx).Model(&model.SessionAlert{}).Where(&model.SessionAlert{Alert: model.AlertDeprecated{ProjectID: projectID, Disabled: &model.F}}).Where("type=?", model.AlertType.RAGE_CLICK).Find(&sessionAlerts).Error; err != nil {
 			return e.Wrapf(err, "[project_id: %d] error fetching rage click alert", projectID)
 		}
 

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -871,7 +871,7 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 		}
 		// Sending Rage Click Alert
 		var sessionAlerts []*model.SessionAlert
-		if err := w.Resolver.DB.WithContext(ctx).Model(&model.SessionAlert{}).Where(&model.SessionAlert{Alert: model.AlertDeprecated{ProjectID: projectID, Disabled: &model.F}}).Where("type=?", model.AlertType.RAGE_CLICK).Find(&sessionAlerts).Error; err != nil {
+		if err := w.Resolver.DB.WithContext(ctx).Model(&model.SessionAlert{}).Where(&model.SessionAlert{AlertDeprecated: model.AlertDeprecated{ProjectID: projectID, Disabled: &model.F}}).Where("type=?", model.AlertType.RAGE_CLICK).Find(&sessionAlerts).Error; err != nil {
 			return e.Wrapf(err, "[project_id: %d] error fetching rage click alert", projectID)
 		}
 

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -137,7 +137,9 @@ export enum AlertDestinationType {
 }
 
 export enum AlertState {
-	Firing = 'Firing',
+	Alerting = 'Alerting',
+	Error = 'Error',
+	NoData = 'NoData',
 	Normal = 'Normal',
 	Pending = 'Pending',
 }

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -128,6 +128,20 @@ export enum AdminRole {
 	Member = 'MEMBER',
 }
 
+export enum AlertDestinationType {
+	Discord = 'Discord',
+	Email = 'Email',
+	MicrosoftTeams = 'MicrosoftTeams',
+	Slack = 'Slack',
+	Webhook = 'Webhook',
+}
+
+export enum AlertState {
+	Firing = 'Firing',
+	Normal = 'Normal',
+	Pending = 'Pending',
+}
+
 export type AllProjectSettings = {
 	__typename?: 'AllProjectSettings'
 	autoResolveStaleErrorsDayInterval: Scalars['Int']


### PR DESCRIPTION
## Summary
Add the following tables to production:
- Alert (Postgres)
- AlertDestination (Postgres)
- AlertStateChange (Clickhouse)

More info: https://www.notion.so/runhighlight/Metric-Alerts-7b3080a13d8347c296cc263ad30e0b8c

## How did you test this change?
1) Able to build backend
2) Can create/edit/delete/fire alert

## Are there any deployment considerations?
Not used in production

## Does this work require review from our design team?
N/A
