### PR TITLE
fix public graph deployment issue

### DIFF
--- a/sdk/highlight-go/log/console_messages_parser.go
+++ b/sdk/highlight-go/log/console_messages_parser.go
@@ -2,9 +2,10 @@ package hlog
 
 import (
 	"encoding/json"
+	"strconv"
+
 	e "github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"strconv"
 )
 
 type MessageTrace struct {
@@ -46,11 +47,11 @@ func ParseConsoleMessages(messages string) ([]*Message, error) {
 		if attrString, ok := message.AttributesRaw.(string); ok && attrString != "" {
 			if err := json.Unmarshal([]byte(attrString), &msg.Attributes); err != nil {
 				log.WithField("attributes.raw", message.AttributesRaw).WithError(err).Warn("error decoding message attributes")
-				message.Attributes["attributes.raw"] = message.AttributesRaw
+				msg.Attributes["attributes.raw"] = message.AttributesRaw
 			}
 		} else {
 			log.WithField("attributes.raw", message.AttributesRaw).Warn("unknown console message attribute format")
-			message.Attributes["attributes.raw"] = message.AttributesRaw
+			msg.Attributes["attributes.raw"] = message.AttributesRaw
 		}
 		var messageValue []string
 		for _, v := range message.Value {


### PR DESCRIPTION
## Summary
- public graph deployment error since Friday - from the logs it appears to be caused by a nil map reference here:
![Screen Shot 2024-06-17 at 11 15 16 AM](https://github.com/highlight/highlight/assets/86132398/20298272-051a-40c0-b07c-719c3d23c302)

https://github.com/highlight/highlight/commit/072137b69b7dfee81aca288cdaed5c4d621f8aac#diff-1e34df331d996d37ce29f5f628641b29174beec6e2e2a4a3b84bf21fa39598d2R53
- I think this code is supposed to use `msg` instead of `message`
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ensured logs / traces were still working locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, will monitor public graph deploy
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
