### PR TITLE
correctly process SessionAtrributes array in metrics

### DIFF
--- a/backend/parser/listener/listener.go
+++ b/backend/parser/listener/listener.go
@@ -79,7 +79,7 @@ func (s *SearchListener[T]) getAttributeFilterExpr(op Operator, value any) sqlbu
 		postfix = ")"
 	}
 	if s.attributesList {
-		return sqlbuilder.Buildf(fmt.Sprintf("notEmpty(arrayFilter((k, v) -> k = %%s AND %sv%s %s %%s, SessionAttributePairs))", prefix, postfix, op), s.currentKey, value)
+		return sqlbuilder.Buildf(fmt.Sprintf("notEmpty(arrayFilter((k, v) -> k = %%s AND %sv%s %s %%s, %s))", prefix, postfix, op, s.attributesColumn), s.currentKey, value)
 	}
 	return sqlbuilder.Buildf(prefix+s.attributesColumn+fmt.Sprintf("[%%s]%s %s %%s", postfix, op), s.currentKey, value)
 }


### PR DESCRIPTION
## Summary

`SessionAttributePairs` was not being used correctly for session metrics graphs, breaking the
`visited-url` chart in the default dashboard as well as other session attributes charts.

## How did you test this change?

A consideration is still how we should process attributes with multiple values.

<img width="1230" alt="Screenshot 2024-06-17 at 16 56 25" src="https://github.com/highlight/highlight/assets/1351531/1e263d2d-4fac-41b3-a63b-404cc1300881">

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
