### PR TITLE
Add new alert queries and mutations

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1958,13 +1958,15 @@ func (s *Session) GetUserProperties() (map[string]string, error) {
 
 type Alert struct {
 	Model
+	ProjectID         int
 	Name              string
 	ProductType       modelInputs.ProductType
 	FunctionType      modelInputs.MetricAggregator
 	Query             *string
 	GroupByKey        *string
-	Disabled          bool `gorm:"default:false"`
-	LastAdminToEditID int  `gorm:"last_admin_to_edit_id"`
+	Disabled          bool                `gorm:"default:false"`
+	LastAdminToEditID int                 `gorm:"last_admin_to_edit_id"`
+	Destinations      []*AlertDestination `gorm:"foreignKey:AlertID"`
 
 	// fields for threshold alert
 	BelowThreshold    *bool

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -2401,35 +2401,35 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Admin.UserDefinedTeamSize(childComplexity), true
 
-	case "Alert.BelowThreshold":
+	case "Alert.below_threshold":
 		if e.complexity.Alert.BelowThreshold == nil {
 			break
 		}
 
 		return e.complexity.Alert.BelowThreshold(childComplexity), true
 
-	case "Alert.Destinations":
+	case "Alert.destinations":
 		if e.complexity.Alert.Destinations == nil {
 			break
 		}
 
 		return e.complexity.Alert.Destinations(childComplexity), true
 
-	case "Alert.Disabled":
+	case "Alert.disabled":
 		if e.complexity.Alert.Disabled == nil {
 			break
 		}
 
 		return e.complexity.Alert.Disabled(childComplexity), true
 
-	case "Alert.FunctionType":
+	case "Alert.function_type":
 		if e.complexity.Alert.FunctionType == nil {
 			break
 		}
 
 		return e.complexity.Alert.FunctionType(childComplexity), true
 
-	case "Alert.GroupByKey":
+	case "Alert.group_by_key":
 		if e.complexity.Alert.GroupByKey == nil {
 			break
 		}
@@ -2443,49 +2443,49 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Alert.ID(childComplexity), true
 
-	case "Alert.LastAdminToEditID":
+	case "Alert.last_admin_to_edit_id":
 		if e.complexity.Alert.LastAdminToEditID == nil {
 			break
 		}
 
 		return e.complexity.Alert.LastAdminToEditID(childComplexity), true
 
-	case "Alert.Name":
+	case "Alert.name":
 		if e.complexity.Alert.Name == nil {
 			break
 		}
 
 		return e.complexity.Alert.Name(childComplexity), true
 
-	case "Alert.ProductType":
+	case "Alert.product_type":
 		if e.complexity.Alert.ProductType == nil {
 			break
 		}
 
 		return e.complexity.Alert.ProductType(childComplexity), true
 
-	case "Alert.Query":
+	case "Alert.query":
 		if e.complexity.Alert.Query == nil {
 			break
 		}
 
 		return e.complexity.Alert.Query(childComplexity), true
 
-	case "Alert.ThresholdCooldown":
+	case "Alert.threshold_cooldown":
 		if e.complexity.Alert.ThresholdCooldown == nil {
 			break
 		}
 
 		return e.complexity.Alert.ThresholdCooldown(childComplexity), true
 
-	case "Alert.ThresholdCount":
+	case "Alert.threshold_count":
 		if e.complexity.Alert.ThresholdCount == nil {
 			break
 		}
 
 		return e.complexity.Alert.ThresholdCount(childComplexity), true
 
-	case "Alert.ThresholdWindow":
+	case "Alert.threshold_window":
 		if e.complexity.Alert.ThresholdWindow == nil {
 			break
 		}
@@ -2499,14 +2499,14 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Alert.UpdatedAt(childComplexity), true
 
-	case "AlertDestination.AlertID":
+	case "AlertDestination.alert_id":
 		if e.complexity.AlertDestination.AlertID == nil {
 			break
 		}
 
 		return e.complexity.AlertDestination.AlertID(childComplexity), true
 
-	case "AlertDestination.DestinationType":
+	case "AlertDestination.destination_type":
 		if e.complexity.AlertDestination.DestinationType == nil {
 			break
 		}
@@ -2520,14 +2520,14 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.AlertDestination.ID(childComplexity), true
 
-	case "AlertDestination.TypeID":
+	case "AlertDestination.type_id":
 		if e.complexity.AlertDestination.TypeID == nil {
 			break
 		}
 
 		return e.complexity.AlertDestination.TypeID(childComplexity), true
 
-	case "AlertDestination.TypeName":
+	case "AlertDestination.type_name":
 		if e.complexity.AlertDestination.TypeName == nil {
 			break
 		}
@@ -13042,29 +13042,29 @@ enum AlertDestinationType {
 
 type AlertDestination {
 	id: ID!
-	AlertID: ID!
-	DestinationType: AlertDestinationType!
-	TypeID: String!
-	TypeName: String!
+	alert_id: ID!
+	destination_type: AlertDestinationType!
+	type_id: String!
+	type_name: String!
 }
 
 type Alert {
 	id: ID!
 	updated_at: Timestamp!
-	Name: String!
-	ProductType: ProductType!
-	FunctionType: MetricAggregator!
-	Query: String
-	GroupByKey: String
-	Disabled: Boolean!
-	LastAdminToEditID: ID
-	Destinations: [AlertDestination]!
+	name: String!
+	product_type: ProductType!
+	function_type: MetricAggregator!
+	query: String
+	group_by_key: String
+	disabled: Boolean!
+	last_admin_to_edit_id: ID
+	destinations: [AlertDestination]!
 
 	# threshold alerts
-	BelowThreshold: Boolean
-	ThresholdCount: Int
-	ThresholdWindow: Int
-	ThresholdCooldown: Int
+	below_threshold: Boolean
+	threshold_count: Int
+	threshold_window: Int
+	threshold_cooldown: Int
 }
 
 type AlertStateChange {
@@ -24714,8 +24714,8 @@ func (ec *executionContext) fieldContext_Alert_updated_at(ctx context.Context, f
 	return fc, nil
 }
 
-func (ec *executionContext) _Alert_Name(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Alert_Name(ctx, field)
+func (ec *executionContext) _Alert_name(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_name(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -24745,7 +24745,7 @@ func (ec *executionContext) _Alert_Name(ctx context.Context, field graphql.Colle
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Alert_Name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Alert_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Alert",
 		Field:      field,
@@ -24758,8 +24758,8 @@ func (ec *executionContext) fieldContext_Alert_Name(ctx context.Context, field g
 	return fc, nil
 }
 
-func (ec *executionContext) _Alert_ProductType(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Alert_ProductType(ctx, field)
+func (ec *executionContext) _Alert_product_type(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_product_type(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -24789,7 +24789,7 @@ func (ec *executionContext) _Alert_ProductType(ctx context.Context, field graphq
 	return ec.marshalNProductType2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐProductType(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Alert_ProductType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Alert_product_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Alert",
 		Field:      field,
@@ -24802,8 +24802,8 @@ func (ec *executionContext) fieldContext_Alert_ProductType(ctx context.Context, 
 	return fc, nil
 }
 
-func (ec *executionContext) _Alert_FunctionType(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Alert_FunctionType(ctx, field)
+func (ec *executionContext) _Alert_function_type(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_function_type(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -24833,7 +24833,7 @@ func (ec *executionContext) _Alert_FunctionType(ctx context.Context, field graph
 	return ec.marshalNMetricAggregator2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐMetricAggregator(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Alert_FunctionType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Alert_function_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Alert",
 		Field:      field,
@@ -24846,8 +24846,8 @@ func (ec *executionContext) fieldContext_Alert_FunctionType(ctx context.Context,
 	return fc, nil
 }
 
-func (ec *executionContext) _Alert_Query(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Alert_Query(ctx, field)
+func (ec *executionContext) _Alert_query(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_query(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -24874,7 +24874,7 @@ func (ec *executionContext) _Alert_Query(ctx context.Context, field graphql.Coll
 	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Alert_Query(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Alert_query(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Alert",
 		Field:      field,
@@ -24887,8 +24887,8 @@ func (ec *executionContext) fieldContext_Alert_Query(ctx context.Context, field 
 	return fc, nil
 }
 
-func (ec *executionContext) _Alert_GroupByKey(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Alert_GroupByKey(ctx, field)
+func (ec *executionContext) _Alert_group_by_key(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_group_by_key(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -24915,7 +24915,7 @@ func (ec *executionContext) _Alert_GroupByKey(ctx context.Context, field graphql
 	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Alert_GroupByKey(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Alert_group_by_key(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Alert",
 		Field:      field,
@@ -24928,8 +24928,8 @@ func (ec *executionContext) fieldContext_Alert_GroupByKey(ctx context.Context, f
 	return fc, nil
 }
 
-func (ec *executionContext) _Alert_Disabled(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Alert_Disabled(ctx, field)
+func (ec *executionContext) _Alert_disabled(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_disabled(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -24959,7 +24959,7 @@ func (ec *executionContext) _Alert_Disabled(ctx context.Context, field graphql.C
 	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Alert_Disabled(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Alert_disabled(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Alert",
 		Field:      field,
@@ -24972,8 +24972,8 @@ func (ec *executionContext) fieldContext_Alert_Disabled(ctx context.Context, fie
 	return fc, nil
 }
 
-func (ec *executionContext) _Alert_LastAdminToEditID(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Alert_LastAdminToEditID(ctx, field)
+func (ec *executionContext) _Alert_last_admin_to_edit_id(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_last_admin_to_edit_id(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -25000,7 +25000,7 @@ func (ec *executionContext) _Alert_LastAdminToEditID(ctx context.Context, field 
 	return ec.marshalOID2int(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Alert_LastAdminToEditID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Alert_last_admin_to_edit_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Alert",
 		Field:      field,
@@ -25013,8 +25013,8 @@ func (ec *executionContext) fieldContext_Alert_LastAdminToEditID(ctx context.Con
 	return fc, nil
 }
 
-func (ec *executionContext) _Alert_Destinations(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Alert_Destinations(ctx, field)
+func (ec *executionContext) _Alert_destinations(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_destinations(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -25044,7 +25044,7 @@ func (ec *executionContext) _Alert_Destinations(ctx context.Context, field graph
 	return ec.marshalNAlertDestination2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐAlertDestination(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Alert_Destinations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Alert_destinations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Alert",
 		Field:      field,
@@ -25054,14 +25054,14 @@ func (ec *executionContext) fieldContext_Alert_Destinations(ctx context.Context,
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_AlertDestination_id(ctx, field)
-			case "AlertID":
-				return ec.fieldContext_AlertDestination_AlertID(ctx, field)
-			case "DestinationType":
-				return ec.fieldContext_AlertDestination_DestinationType(ctx, field)
-			case "TypeID":
-				return ec.fieldContext_AlertDestination_TypeID(ctx, field)
-			case "TypeName":
-				return ec.fieldContext_AlertDestination_TypeName(ctx, field)
+			case "alert_id":
+				return ec.fieldContext_AlertDestination_alert_id(ctx, field)
+			case "destination_type":
+				return ec.fieldContext_AlertDestination_destination_type(ctx, field)
+			case "type_id":
+				return ec.fieldContext_AlertDestination_type_id(ctx, field)
+			case "type_name":
+				return ec.fieldContext_AlertDestination_type_name(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type AlertDestination", field.Name)
 		},
@@ -25069,8 +25069,8 @@ func (ec *executionContext) fieldContext_Alert_Destinations(ctx context.Context,
 	return fc, nil
 }
 
-func (ec *executionContext) _Alert_BelowThreshold(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Alert_BelowThreshold(ctx, field)
+func (ec *executionContext) _Alert_below_threshold(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_below_threshold(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -25097,7 +25097,7 @@ func (ec *executionContext) _Alert_BelowThreshold(ctx context.Context, field gra
 	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Alert_BelowThreshold(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Alert_below_threshold(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Alert",
 		Field:      field,
@@ -25110,8 +25110,8 @@ func (ec *executionContext) fieldContext_Alert_BelowThreshold(ctx context.Contex
 	return fc, nil
 }
 
-func (ec *executionContext) _Alert_ThresholdCount(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Alert_ThresholdCount(ctx, field)
+func (ec *executionContext) _Alert_threshold_count(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_threshold_count(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -25138,7 +25138,7 @@ func (ec *executionContext) _Alert_ThresholdCount(ctx context.Context, field gra
 	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Alert_ThresholdCount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Alert_threshold_count(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Alert",
 		Field:      field,
@@ -25151,8 +25151,8 @@ func (ec *executionContext) fieldContext_Alert_ThresholdCount(ctx context.Contex
 	return fc, nil
 }
 
-func (ec *executionContext) _Alert_ThresholdWindow(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Alert_ThresholdWindow(ctx, field)
+func (ec *executionContext) _Alert_threshold_window(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_threshold_window(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -25179,7 +25179,7 @@ func (ec *executionContext) _Alert_ThresholdWindow(ctx context.Context, field gr
 	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Alert_ThresholdWindow(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Alert_threshold_window(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Alert",
 		Field:      field,
@@ -25192,8 +25192,8 @@ func (ec *executionContext) fieldContext_Alert_ThresholdWindow(ctx context.Conte
 	return fc, nil
 }
 
-func (ec *executionContext) _Alert_ThresholdCooldown(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Alert_ThresholdCooldown(ctx, field)
+func (ec *executionContext) _Alert_threshold_cooldown(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_threshold_cooldown(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -25220,7 +25220,7 @@ func (ec *executionContext) _Alert_ThresholdCooldown(ctx context.Context, field 
 	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Alert_ThresholdCooldown(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Alert_threshold_cooldown(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Alert",
 		Field:      field,
@@ -25277,8 +25277,8 @@ func (ec *executionContext) fieldContext_AlertDestination_id(ctx context.Context
 	return fc, nil
 }
 
-func (ec *executionContext) _AlertDestination_AlertID(ctx context.Context, field graphql.CollectedField, obj *model1.AlertDestination) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_AlertDestination_AlertID(ctx, field)
+func (ec *executionContext) _AlertDestination_alert_id(ctx context.Context, field graphql.CollectedField, obj *model1.AlertDestination) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AlertDestination_alert_id(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -25308,7 +25308,7 @@ func (ec *executionContext) _AlertDestination_AlertID(ctx context.Context, field
 	return ec.marshalNID2int(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_AlertDestination_AlertID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_AlertDestination_alert_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "AlertDestination",
 		Field:      field,
@@ -25321,8 +25321,8 @@ func (ec *executionContext) fieldContext_AlertDestination_AlertID(ctx context.Co
 	return fc, nil
 }
 
-func (ec *executionContext) _AlertDestination_DestinationType(ctx context.Context, field graphql.CollectedField, obj *model1.AlertDestination) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_AlertDestination_DestinationType(ctx, field)
+func (ec *executionContext) _AlertDestination_destination_type(ctx context.Context, field graphql.CollectedField, obj *model1.AlertDestination) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AlertDestination_destination_type(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -25352,7 +25352,7 @@ func (ec *executionContext) _AlertDestination_DestinationType(ctx context.Contex
 	return ec.marshalNAlertDestinationType2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐAlertDestinationType(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_AlertDestination_DestinationType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_AlertDestination_destination_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "AlertDestination",
 		Field:      field,
@@ -25365,8 +25365,8 @@ func (ec *executionContext) fieldContext_AlertDestination_DestinationType(ctx co
 	return fc, nil
 }
 
-func (ec *executionContext) _AlertDestination_TypeID(ctx context.Context, field graphql.CollectedField, obj *model1.AlertDestination) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_AlertDestination_TypeID(ctx, field)
+func (ec *executionContext) _AlertDestination_type_id(ctx context.Context, field graphql.CollectedField, obj *model1.AlertDestination) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AlertDestination_type_id(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -25396,7 +25396,7 @@ func (ec *executionContext) _AlertDestination_TypeID(ctx context.Context, field 
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_AlertDestination_TypeID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_AlertDestination_type_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "AlertDestination",
 		Field:      field,
@@ -25409,8 +25409,8 @@ func (ec *executionContext) fieldContext_AlertDestination_TypeID(ctx context.Con
 	return fc, nil
 }
 
-func (ec *executionContext) _AlertDestination_TypeName(ctx context.Context, field graphql.CollectedField, obj *model1.AlertDestination) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_AlertDestination_TypeName(ctx, field)
+func (ec *executionContext) _AlertDestination_type_name(ctx context.Context, field graphql.CollectedField, obj *model1.AlertDestination) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AlertDestination_type_name(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -25440,7 +25440,7 @@ func (ec *executionContext) _AlertDestination_TypeName(ctx context.Context, fiel
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_AlertDestination_TypeName(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_AlertDestination_type_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "AlertDestination",
 		Field:      field,
@@ -48359,30 +48359,30 @@ func (ec *executionContext) fieldContext_Mutation_createAlert(ctx context.Contex
 				return ec.fieldContext_Alert_id(ctx, field)
 			case "updated_at":
 				return ec.fieldContext_Alert_updated_at(ctx, field)
-			case "Name":
-				return ec.fieldContext_Alert_Name(ctx, field)
-			case "ProductType":
-				return ec.fieldContext_Alert_ProductType(ctx, field)
-			case "FunctionType":
-				return ec.fieldContext_Alert_FunctionType(ctx, field)
-			case "Query":
-				return ec.fieldContext_Alert_Query(ctx, field)
-			case "GroupByKey":
-				return ec.fieldContext_Alert_GroupByKey(ctx, field)
-			case "Disabled":
-				return ec.fieldContext_Alert_Disabled(ctx, field)
-			case "LastAdminToEditID":
-				return ec.fieldContext_Alert_LastAdminToEditID(ctx, field)
-			case "Destinations":
-				return ec.fieldContext_Alert_Destinations(ctx, field)
-			case "BelowThreshold":
-				return ec.fieldContext_Alert_BelowThreshold(ctx, field)
-			case "ThresholdCount":
-				return ec.fieldContext_Alert_ThresholdCount(ctx, field)
-			case "ThresholdWindow":
-				return ec.fieldContext_Alert_ThresholdWindow(ctx, field)
-			case "ThresholdCooldown":
-				return ec.fieldContext_Alert_ThresholdCooldown(ctx, field)
+			case "name":
+				return ec.fieldContext_Alert_name(ctx, field)
+			case "product_type":
+				return ec.fieldContext_Alert_product_type(ctx, field)
+			case "function_type":
+				return ec.fieldContext_Alert_function_type(ctx, field)
+			case "query":
+				return ec.fieldContext_Alert_query(ctx, field)
+			case "group_by_key":
+				return ec.fieldContext_Alert_group_by_key(ctx, field)
+			case "disabled":
+				return ec.fieldContext_Alert_disabled(ctx, field)
+			case "last_admin_to_edit_id":
+				return ec.fieldContext_Alert_last_admin_to_edit_id(ctx, field)
+			case "destinations":
+				return ec.fieldContext_Alert_destinations(ctx, field)
+			case "below_threshold":
+				return ec.fieldContext_Alert_below_threshold(ctx, field)
+			case "threshold_count":
+				return ec.fieldContext_Alert_threshold_count(ctx, field)
+			case "threshold_window":
+				return ec.fieldContext_Alert_threshold_window(ctx, field)
+			case "threshold_cooldown":
+				return ec.fieldContext_Alert_threshold_cooldown(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Alert", field.Name)
 		},
@@ -48441,30 +48441,30 @@ func (ec *executionContext) fieldContext_Mutation_updateAlert(ctx context.Contex
 				return ec.fieldContext_Alert_id(ctx, field)
 			case "updated_at":
 				return ec.fieldContext_Alert_updated_at(ctx, field)
-			case "Name":
-				return ec.fieldContext_Alert_Name(ctx, field)
-			case "ProductType":
-				return ec.fieldContext_Alert_ProductType(ctx, field)
-			case "FunctionType":
-				return ec.fieldContext_Alert_FunctionType(ctx, field)
-			case "Query":
-				return ec.fieldContext_Alert_Query(ctx, field)
-			case "GroupByKey":
-				return ec.fieldContext_Alert_GroupByKey(ctx, field)
-			case "Disabled":
-				return ec.fieldContext_Alert_Disabled(ctx, field)
-			case "LastAdminToEditID":
-				return ec.fieldContext_Alert_LastAdminToEditID(ctx, field)
-			case "Destinations":
-				return ec.fieldContext_Alert_Destinations(ctx, field)
-			case "BelowThreshold":
-				return ec.fieldContext_Alert_BelowThreshold(ctx, field)
-			case "ThresholdCount":
-				return ec.fieldContext_Alert_ThresholdCount(ctx, field)
-			case "ThresholdWindow":
-				return ec.fieldContext_Alert_ThresholdWindow(ctx, field)
-			case "ThresholdCooldown":
-				return ec.fieldContext_Alert_ThresholdCooldown(ctx, field)
+			case "name":
+				return ec.fieldContext_Alert_name(ctx, field)
+			case "product_type":
+				return ec.fieldContext_Alert_product_type(ctx, field)
+			case "function_type":
+				return ec.fieldContext_Alert_function_type(ctx, field)
+			case "query":
+				return ec.fieldContext_Alert_query(ctx, field)
+			case "group_by_key":
+				return ec.fieldContext_Alert_group_by_key(ctx, field)
+			case "disabled":
+				return ec.fieldContext_Alert_disabled(ctx, field)
+			case "last_admin_to_edit_id":
+				return ec.fieldContext_Alert_last_admin_to_edit_id(ctx, field)
+			case "destinations":
+				return ec.fieldContext_Alert_destinations(ctx, field)
+			case "below_threshold":
+				return ec.fieldContext_Alert_below_threshold(ctx, field)
+			case "threshold_count":
+				return ec.fieldContext_Alert_threshold_count(ctx, field)
+			case "threshold_window":
+				return ec.fieldContext_Alert_threshold_window(ctx, field)
+			case "threshold_cooldown":
+				return ec.fieldContext_Alert_threshold_cooldown(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Alert", field.Name)
 		},
@@ -57764,30 +57764,30 @@ func (ec *executionContext) fieldContext_Query_alerts(ctx context.Context, field
 				return ec.fieldContext_Alert_id(ctx, field)
 			case "updated_at":
 				return ec.fieldContext_Alert_updated_at(ctx, field)
-			case "Name":
-				return ec.fieldContext_Alert_Name(ctx, field)
-			case "ProductType":
-				return ec.fieldContext_Alert_ProductType(ctx, field)
-			case "FunctionType":
-				return ec.fieldContext_Alert_FunctionType(ctx, field)
-			case "Query":
-				return ec.fieldContext_Alert_Query(ctx, field)
-			case "GroupByKey":
-				return ec.fieldContext_Alert_GroupByKey(ctx, field)
-			case "Disabled":
-				return ec.fieldContext_Alert_Disabled(ctx, field)
-			case "LastAdminToEditID":
-				return ec.fieldContext_Alert_LastAdminToEditID(ctx, field)
-			case "Destinations":
-				return ec.fieldContext_Alert_Destinations(ctx, field)
-			case "BelowThreshold":
-				return ec.fieldContext_Alert_BelowThreshold(ctx, field)
-			case "ThresholdCount":
-				return ec.fieldContext_Alert_ThresholdCount(ctx, field)
-			case "ThresholdWindow":
-				return ec.fieldContext_Alert_ThresholdWindow(ctx, field)
-			case "ThresholdCooldown":
-				return ec.fieldContext_Alert_ThresholdCooldown(ctx, field)
+			case "name":
+				return ec.fieldContext_Alert_name(ctx, field)
+			case "product_type":
+				return ec.fieldContext_Alert_product_type(ctx, field)
+			case "function_type":
+				return ec.fieldContext_Alert_function_type(ctx, field)
+			case "query":
+				return ec.fieldContext_Alert_query(ctx, field)
+			case "group_by_key":
+				return ec.fieldContext_Alert_group_by_key(ctx, field)
+			case "disabled":
+				return ec.fieldContext_Alert_disabled(ctx, field)
+			case "last_admin_to_edit_id":
+				return ec.fieldContext_Alert_last_admin_to_edit_id(ctx, field)
+			case "destinations":
+				return ec.fieldContext_Alert_destinations(ctx, field)
+			case "below_threshold":
+				return ec.fieldContext_Alert_below_threshold(ctx, field)
+			case "threshold_count":
+				return ec.fieldContext_Alert_threshold_count(ctx, field)
+			case "threshold_window":
+				return ec.fieldContext_Alert_threshold_window(ctx, field)
+			case "threshold_cooldown":
+				return ec.fieldContext_Alert_threshold_cooldown(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Alert", field.Name)
 		},
@@ -57849,30 +57849,30 @@ func (ec *executionContext) fieldContext_Query_alert(ctx context.Context, field 
 				return ec.fieldContext_Alert_id(ctx, field)
 			case "updated_at":
 				return ec.fieldContext_Alert_updated_at(ctx, field)
-			case "Name":
-				return ec.fieldContext_Alert_Name(ctx, field)
-			case "ProductType":
-				return ec.fieldContext_Alert_ProductType(ctx, field)
-			case "FunctionType":
-				return ec.fieldContext_Alert_FunctionType(ctx, field)
-			case "Query":
-				return ec.fieldContext_Alert_Query(ctx, field)
-			case "GroupByKey":
-				return ec.fieldContext_Alert_GroupByKey(ctx, field)
-			case "Disabled":
-				return ec.fieldContext_Alert_Disabled(ctx, field)
-			case "LastAdminToEditID":
-				return ec.fieldContext_Alert_LastAdminToEditID(ctx, field)
-			case "Destinations":
-				return ec.fieldContext_Alert_Destinations(ctx, field)
-			case "BelowThreshold":
-				return ec.fieldContext_Alert_BelowThreshold(ctx, field)
-			case "ThresholdCount":
-				return ec.fieldContext_Alert_ThresholdCount(ctx, field)
-			case "ThresholdWindow":
-				return ec.fieldContext_Alert_ThresholdWindow(ctx, field)
-			case "ThresholdCooldown":
-				return ec.fieldContext_Alert_ThresholdCooldown(ctx, field)
+			case "name":
+				return ec.fieldContext_Alert_name(ctx, field)
+			case "product_type":
+				return ec.fieldContext_Alert_product_type(ctx, field)
+			case "function_type":
+				return ec.fieldContext_Alert_function_type(ctx, field)
+			case "query":
+				return ec.fieldContext_Alert_query(ctx, field)
+			case "group_by_key":
+				return ec.fieldContext_Alert_group_by_key(ctx, field)
+			case "disabled":
+				return ec.fieldContext_Alert_disabled(ctx, field)
+			case "last_admin_to_edit_id":
+				return ec.fieldContext_Alert_last_admin_to_edit_id(ctx, field)
+			case "destinations":
+				return ec.fieldContext_Alert_destinations(ctx, field)
+			case "below_threshold":
+				return ec.fieldContext_Alert_below_threshold(ctx, field)
+			case "threshold_count":
+				return ec.fieldContext_Alert_threshold_count(ctx, field)
+			case "threshold_window":
+				return ec.fieldContext_Alert_threshold_window(ctx, field)
+			case "threshold_cooldown":
+				return ec.fieldContext_Alert_threshold_cooldown(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Alert", field.Name)
 		},
@@ -84097,45 +84097,45 @@ func (ec *executionContext) _Alert(ctx context.Context, sel ast.SelectionSet, ob
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "Name":
-			out.Values[i] = ec._Alert_Name(ctx, field, obj)
+		case "name":
+			out.Values[i] = ec._Alert_name(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "ProductType":
-			out.Values[i] = ec._Alert_ProductType(ctx, field, obj)
+		case "product_type":
+			out.Values[i] = ec._Alert_product_type(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "FunctionType":
-			out.Values[i] = ec._Alert_FunctionType(ctx, field, obj)
+		case "function_type":
+			out.Values[i] = ec._Alert_function_type(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "Query":
-			out.Values[i] = ec._Alert_Query(ctx, field, obj)
-		case "GroupByKey":
-			out.Values[i] = ec._Alert_GroupByKey(ctx, field, obj)
-		case "Disabled":
-			out.Values[i] = ec._Alert_Disabled(ctx, field, obj)
+		case "query":
+			out.Values[i] = ec._Alert_query(ctx, field, obj)
+		case "group_by_key":
+			out.Values[i] = ec._Alert_group_by_key(ctx, field, obj)
+		case "disabled":
+			out.Values[i] = ec._Alert_disabled(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "LastAdminToEditID":
-			out.Values[i] = ec._Alert_LastAdminToEditID(ctx, field, obj)
-		case "Destinations":
-			out.Values[i] = ec._Alert_Destinations(ctx, field, obj)
+		case "last_admin_to_edit_id":
+			out.Values[i] = ec._Alert_last_admin_to_edit_id(ctx, field, obj)
+		case "destinations":
+			out.Values[i] = ec._Alert_destinations(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "BelowThreshold":
-			out.Values[i] = ec._Alert_BelowThreshold(ctx, field, obj)
-		case "ThresholdCount":
-			out.Values[i] = ec._Alert_ThresholdCount(ctx, field, obj)
-		case "ThresholdWindow":
-			out.Values[i] = ec._Alert_ThresholdWindow(ctx, field, obj)
-		case "ThresholdCooldown":
-			out.Values[i] = ec._Alert_ThresholdCooldown(ctx, field, obj)
+		case "below_threshold":
+			out.Values[i] = ec._Alert_below_threshold(ctx, field, obj)
+		case "threshold_count":
+			out.Values[i] = ec._Alert_threshold_count(ctx, field, obj)
+		case "threshold_window":
+			out.Values[i] = ec._Alert_threshold_window(ctx, field, obj)
+		case "threshold_cooldown":
+			out.Values[i] = ec._Alert_threshold_cooldown(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -84175,23 +84175,23 @@ func (ec *executionContext) _AlertDestination(ctx context.Context, sel ast.Selec
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "AlertID":
-			out.Values[i] = ec._AlertDestination_AlertID(ctx, field, obj)
+		case "alert_id":
+			out.Values[i] = ec._AlertDestination_alert_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "DestinationType":
-			out.Values[i] = ec._AlertDestination_DestinationType(ctx, field, obj)
+		case "destination_type":
+			out.Values[i] = ec._AlertDestination_destination_type(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "TypeID":
-			out.Values[i] = ec._AlertDestination_TypeID(ctx, field, obj)
+		case "type_id":
+			out.Values[i] = ec._AlertDestination_type_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "TypeName":
-			out.Values[i] = ec._AlertDestination_TypeName(ctx, field, obj)
+		case "type_name":
+			out.Values[i] = ec._AlertDestination_type_name(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -133,6 +133,41 @@ type ComplexityRoot struct {
 		UserDefinedTeamSize   func(childComplexity int) int
 	}
 
+	Alert struct {
+		BelowThreshold    func(childComplexity int) int
+		Destinations      func(childComplexity int) int
+		Disabled          func(childComplexity int) int
+		FunctionType      func(childComplexity int) int
+		GroupByKey        func(childComplexity int) int
+		ID                func(childComplexity int) int
+		LastAdminToEditID func(childComplexity int) int
+		Name              func(childComplexity int) int
+		ProductType       func(childComplexity int) int
+		Query             func(childComplexity int) int
+		ThresholdCooldown func(childComplexity int) int
+		ThresholdCount    func(childComplexity int) int
+		ThresholdWindow   func(childComplexity int) int
+		UpdatedAt         func(childComplexity int) int
+	}
+
+	AlertDestination struct {
+		AlertID         func(childComplexity int) int
+		DestinationType func(childComplexity int) int
+		ID              func(childComplexity int) int
+		TypeID          func(childComplexity int) int
+		TypeName        func(childComplexity int) int
+	}
+
+	AlertStateChange struct {
+		AlertID       func(childComplexity int) int
+		GroupByKey    func(childComplexity int) int
+		ID            func(childComplexity int) int
+		PreviousState func(childComplexity int) int
+		State         func(childComplexity int) int
+		Timestamp     func(childComplexity int) int
+		Title         func(childComplexity int) int
+	}
+
 	AllProjectSettings struct {
 		AutoResolveStaleErrorsDayInterval func(childComplexity int) int
 		BillingEmail                      func(childComplexity int) int
@@ -799,6 +834,7 @@ type ComplexityRoot struct {
 		ChangeAdminRole                       func(childComplexity int, workspaceID int, adminID int, newRole string) int
 		ChangeProjectMembership               func(childComplexity int, workspaceID int, adminID int, projectIds []int) int
 		CreateAdmin                           func(childComplexity int) int
+		CreateAlert                           func(childComplexity int, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) int
 		CreateCloudflareProxy                 func(childComplexity int, workspaceID int, proxySubdomain string) int
 		CreateErrorAlert                      func(childComplexity int, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, query string, regexGroups []*string, frequency int, defaultArg *bool) int
 		CreateErrorComment                    func(childComplexity int, projectID int, errorGroupSecureID string, text string, textForEmail string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, errorURL string, authorName string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
@@ -816,6 +852,7 @@ type ComplexityRoot struct {
 		CreateSessionCommentWithExistingIssue func(childComplexity int, projectID int, sessionSecureID string, sessionTimestamp int, text string, textForEmail string, xCoordinate float64, yCoordinate float64, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, sessionURL string, time float64, authorName string, sessionImage *string, tags []*model.SessionCommentTagInput, integrations []*model.IntegrationType, issueTitle *string, issueURL string, issueID string, additionalContext *string) int
 		CreateWorkspace                       func(childComplexity int, name string, promoCode *string) int
 		DeleteAdminFromWorkspace              func(childComplexity int, workspaceID int, adminID int) int
+		DeleteAlert                           func(childComplexity int, projectID int, alertID int) int
 		DeleteDashboard                       func(childComplexity int, id int) int
 		DeleteErrorAlert                      func(childComplexity int, projectID int, errorAlertID int) int
 		DeleteErrorComment                    func(childComplexity int, id int) int
@@ -859,6 +896,8 @@ type ComplexityRoot struct {
 		TestErrorEnhancement                  func(childComplexity int, errorObjectID int, githubRepoPath string, githubPrefix *string, buildPrefix *string, saveError *bool) int
 		UpdateAdminAboutYouDetails            func(childComplexity int, adminDetails model.AdminAboutYouDetails) int
 		UpdateAdminAndCreateWorkspace         func(childComplexity int, adminAndWorkspaceDetails model.AdminAndWorkspaceDetails) int
+		UpdateAlert                           func(childComplexity int, projectID int, alertID int, name *string, productType *model.ProductType, functionType *model.MetricAggregator, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) int
+		UpdateAlertDisabled                   func(childComplexity int, projectID int, alertID int, disabled bool) int
 		UpdateAllowMeterOverage               func(childComplexity int, workspaceID int, allowMeterOverage bool) int
 		UpdateAllowedEmailOrigins             func(childComplexity int, workspaceID int, allowedAutoJoinEmailOrigins string) int
 		UpdateBillingDetails                  func(childComplexity int, workspaceID int) int
@@ -948,6 +987,9 @@ type ComplexityRoot struct {
 		AdminRole                        func(childComplexity int, workspaceID int) int
 		AdminRoleByProject               func(childComplexity int, projectID int) int
 		AiQuerySuggestion                func(childComplexity int, timeZone string, projectID int, productType model.ProductType, query string) int
+		Alert                            func(childComplexity int, id int) int
+		AlertStateChanges                func(childComplexity int, alertID int) int
+		Alerts                           func(childComplexity int, projectID int) int
 		AverageSessionLength             func(childComplexity int, projectID int, lookbackDays float64) int
 		BillingDetails                   func(childComplexity int, workspaceID int) int
 		BillingDetailsForProject         func(childComplexity int, projectID int) int
@@ -1737,6 +1779,10 @@ type MutationResolver interface {
 	SyncSlackIntegration(ctx context.Context, projectID int) (*model.SlackSyncResponse, error)
 	CreateMetricMonitor(ctx context.Context, projectID int, name string, aggregator model.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
 	UpdateMetricMonitor(ctx context.Context, metricMonitorID int, projectID int, name *string, aggregator *model.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, disabled *bool, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
+	CreateAlert(ctx context.Context, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) (*model1.Alert, error)
+	UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *model.ProductType, functionType *model.MetricAggregator, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) (*model1.Alert, error)
+	UpdateAlertDisabled(ctx context.Context, projectID int, alertID int, disabled bool) (bool, error)
+	DeleteAlert(ctx context.Context, projectID int, alertID int) (bool, error)
 	CreateErrorAlert(ctx context.Context, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, query string, regexGroups []*string, frequency int, defaultArg *bool) (*model1.ErrorAlert, error)
 	UpdateErrorAlert(ctx context.Context, projectID int, name *string, errorAlertID int, countThreshold *int, thresholdWindow *int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, query string, regexGroups []*string, frequency *int, disabled *bool) (*model1.ErrorAlert, error)
 	DeleteErrorAlert(ctx context.Context, projectID int, errorAlertID int) (*model1.ErrorAlert, error)
@@ -1844,6 +1890,9 @@ type QueryResolver interface {
 	Workspaces(ctx context.Context) ([]*model1.Workspace, error)
 	WorkspacesCount(ctx context.Context) (int64, error)
 	JoinableWorkspaces(ctx context.Context) ([]*model1.Workspace, error)
+	Alerts(ctx context.Context, projectID int) ([]*model1.Alert, error)
+	Alert(ctx context.Context, id int) (*model1.Alert, error)
+	AlertStateChanges(ctx context.Context, alertID int) ([]*model.AlertStateChange, error)
 	ErrorAlerts(ctx context.Context, projectID int) ([]*model1.ErrorAlert, error)
 	NewUserAlerts(ctx context.Context, projectID int) ([]*model1.SessionAlert, error)
 	TrackPropertiesAlerts(ctx context.Context, projectID int) ([]*model1.SessionAlert, error)
@@ -2351,6 +2400,188 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Admin.UserDefinedTeamSize(childComplexity), true
+
+	case "Alert.BelowThreshold":
+		if e.complexity.Alert.BelowThreshold == nil {
+			break
+		}
+
+		return e.complexity.Alert.BelowThreshold(childComplexity), true
+
+	case "Alert.Destinations":
+		if e.complexity.Alert.Destinations == nil {
+			break
+		}
+
+		return e.complexity.Alert.Destinations(childComplexity), true
+
+	case "Alert.Disabled":
+		if e.complexity.Alert.Disabled == nil {
+			break
+		}
+
+		return e.complexity.Alert.Disabled(childComplexity), true
+
+	case "Alert.FunctionType":
+		if e.complexity.Alert.FunctionType == nil {
+			break
+		}
+
+		return e.complexity.Alert.FunctionType(childComplexity), true
+
+	case "Alert.GroupByKey":
+		if e.complexity.Alert.GroupByKey == nil {
+			break
+		}
+
+		return e.complexity.Alert.GroupByKey(childComplexity), true
+
+	case "Alert.id":
+		if e.complexity.Alert.ID == nil {
+			break
+		}
+
+		return e.complexity.Alert.ID(childComplexity), true
+
+	case "Alert.LastAdminToEditID":
+		if e.complexity.Alert.LastAdminToEditID == nil {
+			break
+		}
+
+		return e.complexity.Alert.LastAdminToEditID(childComplexity), true
+
+	case "Alert.Name":
+		if e.complexity.Alert.Name == nil {
+			break
+		}
+
+		return e.complexity.Alert.Name(childComplexity), true
+
+	case "Alert.ProductType":
+		if e.complexity.Alert.ProductType == nil {
+			break
+		}
+
+		return e.complexity.Alert.ProductType(childComplexity), true
+
+	case "Alert.Query":
+		if e.complexity.Alert.Query == nil {
+			break
+		}
+
+		return e.complexity.Alert.Query(childComplexity), true
+
+	case "Alert.ThresholdCooldown":
+		if e.complexity.Alert.ThresholdCooldown == nil {
+			break
+		}
+
+		return e.complexity.Alert.ThresholdCooldown(childComplexity), true
+
+	case "Alert.ThresholdCount":
+		if e.complexity.Alert.ThresholdCount == nil {
+			break
+		}
+
+		return e.complexity.Alert.ThresholdCount(childComplexity), true
+
+	case "Alert.ThresholdWindow":
+		if e.complexity.Alert.ThresholdWindow == nil {
+			break
+		}
+
+		return e.complexity.Alert.ThresholdWindow(childComplexity), true
+
+	case "Alert.updated_at":
+		if e.complexity.Alert.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.Alert.UpdatedAt(childComplexity), true
+
+	case "AlertDestination.AlertID":
+		if e.complexity.AlertDestination.AlertID == nil {
+			break
+		}
+
+		return e.complexity.AlertDestination.AlertID(childComplexity), true
+
+	case "AlertDestination.DestinationType":
+		if e.complexity.AlertDestination.DestinationType == nil {
+			break
+		}
+
+		return e.complexity.AlertDestination.DestinationType(childComplexity), true
+
+	case "AlertDestination.id":
+		if e.complexity.AlertDestination.ID == nil {
+			break
+		}
+
+		return e.complexity.AlertDestination.ID(childComplexity), true
+
+	case "AlertDestination.TypeID":
+		if e.complexity.AlertDestination.TypeID == nil {
+			break
+		}
+
+		return e.complexity.AlertDestination.TypeID(childComplexity), true
+
+	case "AlertDestination.TypeName":
+		if e.complexity.AlertDestination.TypeName == nil {
+			break
+		}
+
+		return e.complexity.AlertDestination.TypeName(childComplexity), true
+
+	case "AlertStateChange.AlertID":
+		if e.complexity.AlertStateChange.AlertID == nil {
+			break
+		}
+
+		return e.complexity.AlertStateChange.AlertID(childComplexity), true
+
+	case "AlertStateChange.GroupByKey":
+		if e.complexity.AlertStateChange.GroupByKey == nil {
+			break
+		}
+
+		return e.complexity.AlertStateChange.GroupByKey(childComplexity), true
+
+	case "AlertStateChange.id":
+		if e.complexity.AlertStateChange.ID == nil {
+			break
+		}
+
+		return e.complexity.AlertStateChange.ID(childComplexity), true
+
+	case "AlertStateChange.PreviousState":
+		if e.complexity.AlertStateChange.PreviousState == nil {
+			break
+		}
+
+		return e.complexity.AlertStateChange.PreviousState(childComplexity), true
+
+	case "AlertStateChange.State":
+		if e.complexity.AlertStateChange.State == nil {
+			break
+		}
+
+		return e.complexity.AlertStateChange.State(childComplexity), true
+
+	case "AlertStateChange.timestamp":
+		if e.complexity.AlertStateChange.Timestamp == nil {
+			break
+		}
+
+		return e.complexity.AlertStateChange.Timestamp(childComplexity), true
+
+	case "AlertStateChange.Title":
+		if e.complexity.AlertStateChange.Title == nil {
+			break
+		}
+
+		return e.complexity.AlertStateChange.Title(childComplexity), true
 
 	case "AllProjectSettings.autoResolveStaleErrorsDayInterval":
 		if e.complexity.AllProjectSettings.AutoResolveStaleErrorsDayInterval == nil {
@@ -5394,6 +5625,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.CreateAdmin(childComplexity), true
 
+	case "Mutation.createAlert":
+		if e.complexity.Mutation.CreateAlert == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createAlert_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateAlert(childComplexity, args["project_id"].(int), args["name"].(string), args["product_type"].(model.ProductType), args["function_type"].(model.MetricAggregator), args["query"].(*string), args["group_by_key"].(*string), args["disabled"].(*bool), args["below_threshold"].(*bool), args["threshold_count"].(*int), args["threshold_window"].(*int), args["threshold_cooldown"].(*int)), true
+
 	case "Mutation.createCloudflareProxy":
 		if e.complexity.Mutation.CreateCloudflareProxy == nil {
 			break
@@ -5597,6 +5840,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.DeleteAdminFromWorkspace(childComplexity, args["workspace_id"].(int), args["admin_id"].(int)), true
+
+	case "Mutation.deleteAlert":
+		if e.complexity.Mutation.DeleteAlert == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteAlert_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteAlert(childComplexity, args["project_id"].(int), args["alert_id"].(int)), true
 
 	case "Mutation.deleteDashboard":
 		if e.complexity.Mutation.DeleteDashboard == nil {
@@ -6113,6 +6368,30 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.UpdateAdminAndCreateWorkspace(childComplexity, args["admin_and_workspace_details"].(model.AdminAndWorkspaceDetails)), true
+
+	case "Mutation.updateAlert":
+		if e.complexity.Mutation.UpdateAlert == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateAlert_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateAlert(childComplexity, args["project_id"].(int), args["alert_id"].(int), args["name"].(*string), args["product_type"].(*model.ProductType), args["function_type"].(*model.MetricAggregator), args["query"].(*string), args["group_by_key"].(*string), args["disabled"].(*bool), args["below_threshold"].(*bool), args["threshold_count"].(*int), args["threshold_window"].(*int), args["threshold_cooldown"].(*int)), true
+
+	case "Mutation.updateAlertDisabled":
+		if e.complexity.Mutation.UpdateAlertDisabled == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateAlertDisabled_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateAlertDisabled(childComplexity, args["project_id"].(int), args["alert_id"].(int), args["disabled"].(bool)), true
 
 	case "Mutation.updateAllowMeterOverage":
 		if e.complexity.Mutation.UpdateAllowMeterOverage == nil {
@@ -6734,6 +7013,42 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.AiQuerySuggestion(childComplexity, args["time_zone"].(string), args["project_id"].(int), args["product_type"].(model.ProductType), args["query"].(string)), true
+
+	case "Query.alert":
+		if e.complexity.Query.Alert == nil {
+			break
+		}
+
+		args, err := ec.field_Query_alert_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Alert(childComplexity, args["id"].(int)), true
+
+	case "Query.alert_state_changes":
+		if e.complexity.Query.AlertStateChanges == nil {
+			break
+		}
+
+		args, err := ec.field_Query_alert_state_changes_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.AlertStateChanges(childComplexity, args["alert_id"].(int)), true
+
+	case "Query.alerts":
+		if e.complexity.Query.Alerts == nil {
+			break
+		}
+
+		args, err := ec.field_Query_alerts_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Alerts(childComplexity, args["project_id"].(int)), true
 
 	case "Query.averageSessionLength":
 		if e.complexity.Query.AverageSessionLength == nil {
@@ -12725,6 +13040,43 @@ enum AlertDestinationType {
 	Email
 }
 
+type AlertDestination {
+	id: ID!
+	AlertID: ID!
+	DestinationType: AlertDestinationType!
+	TypeID: String!
+	TypeName: String!
+}
+
+type Alert {
+	id: ID!
+	updated_at: Timestamp!
+	Name: String!
+	ProductType: ProductType!
+	FunctionType: MetricAggregator!
+	Query: String
+	GroupByKey: String
+	Disabled: Boolean!
+	LastAdminToEditID: ID
+	Destinations: [AlertDestination]!
+
+	# threshold alerts
+	BelowThreshold: Boolean
+	ThresholdCount: Int
+	ThresholdWindow: Int
+	ThresholdCooldown: Int
+}
+
+type AlertStateChange {
+	id: ID!
+	timestamp: Timestamp!
+	AlertID: ID!
+	State: AlertState!
+	PreviousState: AlertState!
+	Title: String!
+	GroupByKey: String
+}
+
 type SanitizedSlackChannel {
 	webhook_channel: String
 	webhook_channel_id: String
@@ -13291,6 +13643,9 @@ type Query {
 	workspaces: [Workspace]
 	workspaces_count: Int64!
 	joinable_workspaces: [Workspace]
+	alerts(project_id: ID!): [Alert]!
+	alert(id: ID!): Alert!
+	alert_state_changes(alert_id: ID!): [AlertStateChange]!
 	error_alerts(project_id: ID!): [ErrorAlert]!
 	new_user_alerts(project_id: ID!): [SessionAlert]
 	track_properties_alerts(project_id: ID!): [SessionAlert]!
@@ -13874,6 +14229,39 @@ type Mutation {
 		disabled: Boolean
 		filters: [MetricTagFilterInput!]
 	): MetricMonitor
+	createAlert(
+		project_id: ID!
+		name: String!
+		product_type: ProductType!
+		function_type: MetricAggregator!
+		query: String
+		group_by_key: String
+		disabled: Boolean
+		below_threshold: Boolean
+		threshold_count: Int
+		threshold_window: Int
+		threshold_cooldown: Int # TODO(spenny): add destinations
+	): Alert
+	updateAlert(
+		project_id: ID!
+		alert_id: ID!
+		name: String
+		product_type: ProductType
+		function_type: MetricAggregator
+		query: String
+		group_by_key: String
+		disabled: Boolean
+		below_threshold: Boolean
+		threshold_count: Int
+		threshold_window: Int
+		threshold_cooldown: Int # TODO(spenny): add destinations
+	): Alert
+	updateAlertDisabled(
+		project_id: ID!
+		alert_id: ID!
+		disabled: Boolean!
+	): Boolean!
+	deleteAlert(project_id: ID!, alert_id: ID!): Boolean!
 	createErrorAlert(
 		project_id: ID!
 		name: String!
@@ -14183,6 +14571,111 @@ func (ec *executionContext) field_Mutation_changeProjectMembership_args(ctx cont
 		}
 	}
 	args["project_ids"] = arg2
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_createAlert_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["project_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["name"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+		arg1, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["name"] = arg1
+	var arg2 model.ProductType
+	if tmp, ok := rawArgs["product_type"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("product_type"))
+		arg2, err = ec.unmarshalNProductType2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐProductType(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["product_type"] = arg2
+	var arg3 model.MetricAggregator
+	if tmp, ok := rawArgs["function_type"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("function_type"))
+		arg3, err = ec.unmarshalNMetricAggregator2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐMetricAggregator(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["function_type"] = arg3
+	var arg4 *string
+	if tmp, ok := rawArgs["query"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
+		arg4, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["query"] = arg4
+	var arg5 *string
+	if tmp, ok := rawArgs["group_by_key"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("group_by_key"))
+		arg5, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["group_by_key"] = arg5
+	var arg6 *bool
+	if tmp, ok := rawArgs["disabled"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("disabled"))
+		arg6, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["disabled"] = arg6
+	var arg7 *bool
+	if tmp, ok := rawArgs["below_threshold"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("below_threshold"))
+		arg7, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["below_threshold"] = arg7
+	var arg8 *int
+	if tmp, ok := rawArgs["threshold_count"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_count"))
+		arg8, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["threshold_count"] = arg8
+	var arg9 *int
+	if tmp, ok := rawArgs["threshold_window"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_window"))
+		arg9, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["threshold_window"] = arg9
+	var arg10 *int
+	if tmp, ok := rawArgs["threshold_cooldown"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_cooldown"))
+		arg10, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["threshold_cooldown"] = arg10
 	return args, nil
 }
 
@@ -15428,6 +15921,30 @@ func (ec *executionContext) field_Mutation_deleteAdminFromWorkspace_args(ctx con
 		}
 	}
 	args["admin_id"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteAlert_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["project_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg0
+	var arg1 int
+	if tmp, ok := rawArgs["alert_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("alert_id"))
+		arg1, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["alert_id"] = arg1
 	return args, nil
 }
 
@@ -16940,6 +17457,153 @@ func (ec *executionContext) field_Mutation_updateAdminAndCreateWorkspace_args(ct
 	return args, nil
 }
 
+func (ec *executionContext) field_Mutation_updateAlertDisabled_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["project_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg0
+	var arg1 int
+	if tmp, ok := rawArgs["alert_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("alert_id"))
+		arg1, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["alert_id"] = arg1
+	var arg2 bool
+	if tmp, ok := rawArgs["disabled"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("disabled"))
+		arg2, err = ec.unmarshalNBoolean2bool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["disabled"] = arg2
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_updateAlert_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["project_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg0
+	var arg1 int
+	if tmp, ok := rawArgs["alert_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("alert_id"))
+		arg1, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["alert_id"] = arg1
+	var arg2 *string
+	if tmp, ok := rawArgs["name"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+		arg2, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["name"] = arg2
+	var arg3 *model.ProductType
+	if tmp, ok := rawArgs["product_type"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("product_type"))
+		arg3, err = ec.unmarshalOProductType2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐProductType(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["product_type"] = arg3
+	var arg4 *model.MetricAggregator
+	if tmp, ok := rawArgs["function_type"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("function_type"))
+		arg4, err = ec.unmarshalOMetricAggregator2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐMetricAggregator(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["function_type"] = arg4
+	var arg5 *string
+	if tmp, ok := rawArgs["query"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
+		arg5, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["query"] = arg5
+	var arg6 *string
+	if tmp, ok := rawArgs["group_by_key"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("group_by_key"))
+		arg6, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["group_by_key"] = arg6
+	var arg7 *bool
+	if tmp, ok := rawArgs["disabled"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("disabled"))
+		arg7, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["disabled"] = arg7
+	var arg8 *bool
+	if tmp, ok := rawArgs["below_threshold"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("below_threshold"))
+		arg8, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["below_threshold"] = arg8
+	var arg9 *int
+	if tmp, ok := rawArgs["threshold_count"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_count"))
+		arg9, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["threshold_count"] = arg9
+	var arg10 *int
+	if tmp, ok := rawArgs["threshold_window"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_window"))
+		arg10, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["threshold_window"] = arg10
+	var arg11 *int
+	if tmp, ok := rawArgs["threshold_cooldown"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_cooldown"))
+		arg11, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["threshold_cooldown"] = arg11
+	return args, nil
+}
+
 func (ec *executionContext) field_Mutation_updateAllowMeterOverage_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -17912,6 +18576,51 @@ func (ec *executionContext) field_Query_ai_query_suggestion_args(ctx context.Con
 		}
 	}
 	args["query"] = arg3
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_alert_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_alert_state_changes_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["alert_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("alert_id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["alert_id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_alerts_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["project_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg0
 	return args, nil
 }
 
@@ -23907,6 +24616,1138 @@ func (ec *executionContext) _Admin_user_defined_persona(ctx context.Context, fie
 func (ec *executionContext) fieldContext_Admin_user_defined_persona(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Admin",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Alert_id(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNID2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Alert_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Alert",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Alert_updated_at(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_updated_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTimestamp2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Alert_updated_at(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Alert",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Timestamp does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Alert_Name(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_Name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Alert_Name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Alert",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Alert_ProductType(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_ProductType(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ProductType, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.ProductType)
+	fc.Result = res
+	return ec.marshalNProductType2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐProductType(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Alert_ProductType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Alert",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ProductType does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Alert_FunctionType(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_FunctionType(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FunctionType, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.MetricAggregator)
+	fc.Result = res
+	return ec.marshalNMetricAggregator2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐMetricAggregator(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Alert_FunctionType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Alert",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type MetricAggregator does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Alert_Query(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_Query(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Query, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Alert_Query(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Alert",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Alert_GroupByKey(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_GroupByKey(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.GroupByKey, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Alert_GroupByKey(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Alert",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Alert_Disabled(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_Disabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Disabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Alert_Disabled(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Alert",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Alert_LastAdminToEditID(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_LastAdminToEditID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LastAdminToEditID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalOID2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Alert_LastAdminToEditID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Alert",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Alert_Destinations(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_Destinations(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Destinations, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model1.AlertDestination)
+	fc.Result = res
+	return ec.marshalNAlertDestination2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐAlertDestination(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Alert_Destinations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Alert",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_AlertDestination_id(ctx, field)
+			case "AlertID":
+				return ec.fieldContext_AlertDestination_AlertID(ctx, field)
+			case "DestinationType":
+				return ec.fieldContext_AlertDestination_DestinationType(ctx, field)
+			case "TypeID":
+				return ec.fieldContext_AlertDestination_TypeID(ctx, field)
+			case "TypeName":
+				return ec.fieldContext_AlertDestination_TypeName(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AlertDestination", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Alert_BelowThreshold(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_BelowThreshold(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BelowThreshold, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Alert_BelowThreshold(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Alert",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Alert_ThresholdCount(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_ThresholdCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ThresholdCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Alert_ThresholdCount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Alert",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Alert_ThresholdWindow(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_ThresholdWindow(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ThresholdWindow, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Alert_ThresholdWindow(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Alert",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Alert_ThresholdCooldown(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_ThresholdCooldown(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ThresholdCooldown, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Alert_ThresholdCooldown(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Alert",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AlertDestination_id(ctx context.Context, field graphql.CollectedField, obj *model1.AlertDestination) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AlertDestination_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNID2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AlertDestination_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AlertDestination",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AlertDestination_AlertID(ctx context.Context, field graphql.CollectedField, obj *model1.AlertDestination) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AlertDestination_AlertID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AlertID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNID2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AlertDestination_AlertID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AlertDestination",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AlertDestination_DestinationType(ctx context.Context, field graphql.CollectedField, obj *model1.AlertDestination) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AlertDestination_DestinationType(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DestinationType, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.AlertDestinationType)
+	fc.Result = res
+	return ec.marshalNAlertDestinationType2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐAlertDestinationType(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AlertDestination_DestinationType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AlertDestination",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type AlertDestinationType does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AlertDestination_TypeID(ctx context.Context, field graphql.CollectedField, obj *model1.AlertDestination) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AlertDestination_TypeID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TypeID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AlertDestination_TypeID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AlertDestination",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AlertDestination_TypeName(ctx context.Context, field graphql.CollectedField, obj *model1.AlertDestination) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AlertDestination_TypeName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TypeName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AlertDestination_TypeName(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AlertDestination",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AlertStateChange_id(ctx context.Context, field graphql.CollectedField, obj *model.AlertStateChange) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AlertStateChange_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNID2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AlertStateChange_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AlertStateChange",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AlertStateChange_timestamp(ctx context.Context, field graphql.CollectedField, obj *model.AlertStateChange) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AlertStateChange_timestamp(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Timestamp, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTimestamp2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AlertStateChange_timestamp(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AlertStateChange",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Timestamp does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AlertStateChange_AlertID(ctx context.Context, field graphql.CollectedField, obj *model.AlertStateChange) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AlertStateChange_AlertID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AlertID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNID2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AlertStateChange_AlertID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AlertStateChange",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AlertStateChange_State(ctx context.Context, field graphql.CollectedField, obj *model.AlertStateChange) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AlertStateChange_State(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.State, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.AlertState)
+	fc.Result = res
+	return ec.marshalNAlertState2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐAlertState(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AlertStateChange_State(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AlertStateChange",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type AlertState does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AlertStateChange_PreviousState(ctx context.Context, field graphql.CollectedField, obj *model.AlertStateChange) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AlertStateChange_PreviousState(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PreviousState, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.AlertState)
+	fc.Result = res
+	return ec.marshalNAlertState2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐAlertState(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AlertStateChange_PreviousState(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AlertStateChange",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type AlertState does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AlertStateChange_Title(ctx context.Context, field graphql.CollectedField, obj *model.AlertStateChange) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AlertStateChange_Title(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Title, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AlertStateChange_Title(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AlertStateChange",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AlertStateChange_GroupByKey(ctx context.Context, field graphql.CollectedField, obj *model.AlertStateChange) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AlertStateChange_GroupByKey(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.GroupByKey, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AlertStateChange_GroupByKey(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AlertStateChange",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -46478,6 +48319,280 @@ func (ec *executionContext) fieldContext_Mutation_updateMetricMonitor(ctx contex
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_createAlert(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_createAlert(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["product_type"].(model.ProductType), fc.Args["function_type"].(model.MetricAggregator), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["disabled"].(*bool), fc.Args["below_threshold"].(*bool), fc.Args["threshold_count"].(*int), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model1.Alert)
+	fc.Result = res
+	return ec.marshalOAlert2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐAlert(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_createAlert(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Alert_id(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Alert_updated_at(ctx, field)
+			case "Name":
+				return ec.fieldContext_Alert_Name(ctx, field)
+			case "ProductType":
+				return ec.fieldContext_Alert_ProductType(ctx, field)
+			case "FunctionType":
+				return ec.fieldContext_Alert_FunctionType(ctx, field)
+			case "Query":
+				return ec.fieldContext_Alert_Query(ctx, field)
+			case "GroupByKey":
+				return ec.fieldContext_Alert_GroupByKey(ctx, field)
+			case "Disabled":
+				return ec.fieldContext_Alert_Disabled(ctx, field)
+			case "LastAdminToEditID":
+				return ec.fieldContext_Alert_LastAdminToEditID(ctx, field)
+			case "Destinations":
+				return ec.fieldContext_Alert_Destinations(ctx, field)
+			case "BelowThreshold":
+				return ec.fieldContext_Alert_BelowThreshold(ctx, field)
+			case "ThresholdCount":
+				return ec.fieldContext_Alert_ThresholdCount(ctx, field)
+			case "ThresholdWindow":
+				return ec.fieldContext_Alert_ThresholdWindow(ctx, field)
+			case "ThresholdCooldown":
+				return ec.fieldContext_Alert_ThresholdCooldown(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Alert", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_createAlert_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_updateAlert(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_updateAlert(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateAlert(rctx, fc.Args["project_id"].(int), fc.Args["alert_id"].(int), fc.Args["name"].(*string), fc.Args["product_type"].(*model.ProductType), fc.Args["function_type"].(*model.MetricAggregator), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["disabled"].(*bool), fc.Args["below_threshold"].(*bool), fc.Args["threshold_count"].(*int), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model1.Alert)
+	fc.Result = res
+	return ec.marshalOAlert2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐAlert(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_updateAlert(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Alert_id(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Alert_updated_at(ctx, field)
+			case "Name":
+				return ec.fieldContext_Alert_Name(ctx, field)
+			case "ProductType":
+				return ec.fieldContext_Alert_ProductType(ctx, field)
+			case "FunctionType":
+				return ec.fieldContext_Alert_FunctionType(ctx, field)
+			case "Query":
+				return ec.fieldContext_Alert_Query(ctx, field)
+			case "GroupByKey":
+				return ec.fieldContext_Alert_GroupByKey(ctx, field)
+			case "Disabled":
+				return ec.fieldContext_Alert_Disabled(ctx, field)
+			case "LastAdminToEditID":
+				return ec.fieldContext_Alert_LastAdminToEditID(ctx, field)
+			case "Destinations":
+				return ec.fieldContext_Alert_Destinations(ctx, field)
+			case "BelowThreshold":
+				return ec.fieldContext_Alert_BelowThreshold(ctx, field)
+			case "ThresholdCount":
+				return ec.fieldContext_Alert_ThresholdCount(ctx, field)
+			case "ThresholdWindow":
+				return ec.fieldContext_Alert_ThresholdWindow(ctx, field)
+			case "ThresholdCooldown":
+				return ec.fieldContext_Alert_ThresholdCooldown(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Alert", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_updateAlert_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_updateAlertDisabled(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_updateAlertDisabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateAlertDisabled(rctx, fc.Args["project_id"].(int), fc.Args["alert_id"].(int), fc.Args["disabled"].(bool))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_updateAlertDisabled(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_updateAlertDisabled_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteAlert(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_deleteAlert(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteAlert(rctx, fc.Args["project_id"].(int), fc.Args["alert_id"].(int))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteAlert(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteAlert_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_createErrorAlert(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_createErrorAlert(ctx, field)
 	if err != nil {
@@ -55602,6 +57717,247 @@ func (ec *executionContext) fieldContext_Query_joinable_workspaces(ctx context.C
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Workspace", field.Name)
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_alerts(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_alerts(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Alerts(rctx, fc.Args["project_id"].(int))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model1.Alert)
+	fc.Result = res
+	return ec.marshalNAlert2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐAlert(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_alerts(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Alert_id(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Alert_updated_at(ctx, field)
+			case "Name":
+				return ec.fieldContext_Alert_Name(ctx, field)
+			case "ProductType":
+				return ec.fieldContext_Alert_ProductType(ctx, field)
+			case "FunctionType":
+				return ec.fieldContext_Alert_FunctionType(ctx, field)
+			case "Query":
+				return ec.fieldContext_Alert_Query(ctx, field)
+			case "GroupByKey":
+				return ec.fieldContext_Alert_GroupByKey(ctx, field)
+			case "Disabled":
+				return ec.fieldContext_Alert_Disabled(ctx, field)
+			case "LastAdminToEditID":
+				return ec.fieldContext_Alert_LastAdminToEditID(ctx, field)
+			case "Destinations":
+				return ec.fieldContext_Alert_Destinations(ctx, field)
+			case "BelowThreshold":
+				return ec.fieldContext_Alert_BelowThreshold(ctx, field)
+			case "ThresholdCount":
+				return ec.fieldContext_Alert_ThresholdCount(ctx, field)
+			case "ThresholdWindow":
+				return ec.fieldContext_Alert_ThresholdWindow(ctx, field)
+			case "ThresholdCooldown":
+				return ec.fieldContext_Alert_ThresholdCooldown(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Alert", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_alerts_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_alert(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_alert(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Alert(rctx, fc.Args["id"].(int))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model1.Alert)
+	fc.Result = res
+	return ec.marshalNAlert2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐAlert(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_alert(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Alert_id(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Alert_updated_at(ctx, field)
+			case "Name":
+				return ec.fieldContext_Alert_Name(ctx, field)
+			case "ProductType":
+				return ec.fieldContext_Alert_ProductType(ctx, field)
+			case "FunctionType":
+				return ec.fieldContext_Alert_FunctionType(ctx, field)
+			case "Query":
+				return ec.fieldContext_Alert_Query(ctx, field)
+			case "GroupByKey":
+				return ec.fieldContext_Alert_GroupByKey(ctx, field)
+			case "Disabled":
+				return ec.fieldContext_Alert_Disabled(ctx, field)
+			case "LastAdminToEditID":
+				return ec.fieldContext_Alert_LastAdminToEditID(ctx, field)
+			case "Destinations":
+				return ec.fieldContext_Alert_Destinations(ctx, field)
+			case "BelowThreshold":
+				return ec.fieldContext_Alert_BelowThreshold(ctx, field)
+			case "ThresholdCount":
+				return ec.fieldContext_Alert_ThresholdCount(ctx, field)
+			case "ThresholdWindow":
+				return ec.fieldContext_Alert_ThresholdWindow(ctx, field)
+			case "ThresholdCooldown":
+				return ec.fieldContext_Alert_ThresholdCooldown(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Alert", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_alert_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_alert_state_changes(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_alert_state_changes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().AlertStateChanges(rctx, fc.Args["alert_id"].(int))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.AlertStateChange)
+	fc.Result = res
+	return ec.marshalNAlertStateChange2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐAlertStateChange(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_alert_state_changes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_AlertStateChange_id(ctx, field)
+			case "timestamp":
+				return ec.fieldContext_AlertStateChange_timestamp(ctx, field)
+			case "AlertID":
+				return ec.fieldContext_AlertStateChange_AlertID(ctx, field)
+			case "State":
+				return ec.fieldContext_AlertStateChange_State(ctx, field)
+			case "PreviousState":
+				return ec.fieldContext_AlertStateChange_PreviousState(ctx, field)
+			case "Title":
+				return ec.fieldContext_AlertStateChange_Title(ctx, field)
+			case "GroupByKey":
+				return ec.fieldContext_AlertStateChange_GroupByKey(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AlertStateChange", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_alert_state_changes_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -81720,6 +84076,214 @@ func (ec *executionContext) _Admin(ctx context.Context, sel ast.SelectionSet, ob
 	return out
 }
 
+var alertImplementors = []string{"Alert"}
+
+func (ec *executionContext) _Alert(ctx context.Context, sel ast.SelectionSet, obj *model1.Alert) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, alertImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Alert")
+		case "id":
+			out.Values[i] = ec._Alert_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updated_at":
+			out.Values[i] = ec._Alert_updated_at(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "Name":
+			out.Values[i] = ec._Alert_Name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "ProductType":
+			out.Values[i] = ec._Alert_ProductType(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "FunctionType":
+			out.Values[i] = ec._Alert_FunctionType(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "Query":
+			out.Values[i] = ec._Alert_Query(ctx, field, obj)
+		case "GroupByKey":
+			out.Values[i] = ec._Alert_GroupByKey(ctx, field, obj)
+		case "Disabled":
+			out.Values[i] = ec._Alert_Disabled(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "LastAdminToEditID":
+			out.Values[i] = ec._Alert_LastAdminToEditID(ctx, field, obj)
+		case "Destinations":
+			out.Values[i] = ec._Alert_Destinations(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "BelowThreshold":
+			out.Values[i] = ec._Alert_BelowThreshold(ctx, field, obj)
+		case "ThresholdCount":
+			out.Values[i] = ec._Alert_ThresholdCount(ctx, field, obj)
+		case "ThresholdWindow":
+			out.Values[i] = ec._Alert_ThresholdWindow(ctx, field, obj)
+		case "ThresholdCooldown":
+			out.Values[i] = ec._Alert_ThresholdCooldown(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var alertDestinationImplementors = []string{"AlertDestination"}
+
+func (ec *executionContext) _AlertDestination(ctx context.Context, sel ast.SelectionSet, obj *model1.AlertDestination) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, alertDestinationImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AlertDestination")
+		case "id":
+			out.Values[i] = ec._AlertDestination_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "AlertID":
+			out.Values[i] = ec._AlertDestination_AlertID(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "DestinationType":
+			out.Values[i] = ec._AlertDestination_DestinationType(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "TypeID":
+			out.Values[i] = ec._AlertDestination_TypeID(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "TypeName":
+			out.Values[i] = ec._AlertDestination_TypeName(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var alertStateChangeImplementors = []string{"AlertStateChange"}
+
+func (ec *executionContext) _AlertStateChange(ctx context.Context, sel ast.SelectionSet, obj *model.AlertStateChange) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, alertStateChangeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AlertStateChange")
+		case "id":
+			out.Values[i] = ec._AlertStateChange_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "timestamp":
+			out.Values[i] = ec._AlertStateChange_timestamp(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "AlertID":
+			out.Values[i] = ec._AlertStateChange_AlertID(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "State":
+			out.Values[i] = ec._AlertStateChange_State(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "PreviousState":
+			out.Values[i] = ec._AlertStateChange_PreviousState(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "Title":
+			out.Values[i] = ec._AlertStateChange_Title(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "GroupByKey":
+			out.Values[i] = ec._AlertStateChange_GroupByKey(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var allProjectSettingsImplementors = []string{"AllProjectSettings"}
 
 func (ec *executionContext) _AllProjectSettings(ctx context.Context, sel ast.SelectionSet, obj *model.AllProjectSettings) graphql.Marshaler {
@@ -87226,6 +89790,28 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_updateMetricMonitor(ctx, field)
 			})
+		case "createAlert":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_createAlert(ctx, field)
+			})
+		case "updateAlert":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_updateAlert(ctx, field)
+			})
+		case "updateAlertDisabled":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_updateAlertDisabled(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deleteAlert":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteAlert(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "createErrorAlert":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_createErrorAlert(ctx, field)
@@ -89206,6 +91792,72 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_joinable_workspaces(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "alerts":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_alerts(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "alert":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_alert(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "alert_state_changes":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_alert_state_changes(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -95936,6 +98588,154 @@ func (ec *executionContext) unmarshalNAdminAndWorkspaceDetails2githubᚗcomᚋhi
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) marshalNAlert2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐAlert(ctx context.Context, sel ast.SelectionSet, v model1.Alert) graphql.Marshaler {
+	return ec._Alert(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNAlert2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐAlert(ctx context.Context, sel ast.SelectionSet, v []*model1.Alert) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalOAlert2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐAlert(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	return ret
+}
+
+func (ec *executionContext) marshalNAlert2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐAlert(ctx context.Context, sel ast.SelectionSet, v *model1.Alert) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Alert(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNAlertDestination2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐAlertDestination(ctx context.Context, sel ast.SelectionSet, v []*model1.AlertDestination) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalOAlertDestination2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐAlertDestination(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	return ret
+}
+
+func (ec *executionContext) unmarshalNAlertDestinationType2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐAlertDestinationType(ctx context.Context, v interface{}) (model.AlertDestinationType, error) {
+	var res model.AlertDestinationType
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNAlertDestinationType2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐAlertDestinationType(ctx context.Context, sel ast.SelectionSet, v model.AlertDestinationType) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) unmarshalNAlertState2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐAlertState(ctx context.Context, v interface{}) (model.AlertState, error) {
+	var res model.AlertState
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNAlertState2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐAlertState(ctx context.Context, sel ast.SelectionSet, v model.AlertState) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) marshalNAlertStateChange2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐAlertStateChange(ctx context.Context, sel ast.SelectionSet, v []*model.AlertStateChange) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalOAlertStateChange2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐAlertStateChange(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	return ret
+}
+
 func (ec *executionContext) unmarshalNAny2ᚕinterface(ctx context.Context, v interface{}) ([]interface{}, error) {
 	var vSlice []interface{}
 	if v != nil {
@@ -101481,6 +104281,27 @@ func (ec *executionContext) marshalOAdmin2ᚖgithubᚗcomᚋhighlightᚑrunᚋhi
 	return ec._Admin(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalOAlert2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐAlert(ctx context.Context, sel ast.SelectionSet, v *model1.Alert) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Alert(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOAlertDestination2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐAlertDestination(ctx context.Context, sel ast.SelectionSet, v *model1.AlertDestination) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._AlertDestination(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOAlertStateChange2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐAlertStateChange(ctx context.Context, sel ast.SelectionSet, v *model.AlertStateChange) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._AlertStateChange(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalOAllProjectSettings2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐAllProjectSettings(ctx context.Context, sel ast.SelectionSet, v *model.AllProjectSettings) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -102615,6 +105436,22 @@ func (ec *executionContext) marshalOOAuthClient2ᚖgithubᚗcomᚋhighlightᚑru
 		return graphql.Null
 	}
 	return ec._OAuthClient(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOProductType2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐProductType(ctx context.Context, v interface{}) (*model.ProductType, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var res = new(model.ProductType)
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOProductType2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐProductType(ctx context.Context, sel ast.SelectionSet, v *model.ProductType) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
 }
 
 func (ec *executionContext) marshalOProject2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐProject(ctx context.Context, sel ast.SelectionSet, v model1.Project) graphql.Marshaler {

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -96,6 +96,16 @@ type AdminAndWorkspaceDetails struct {
 	PromoCode                   *string `json:"promo_code,omitempty"`
 }
 
+type AlertStateChange struct {
+	ID            int        `json:"id"`
+	Timestamp     time.Time  `json:"timestamp"`
+	AlertID       int        `json:"AlertID"`
+	State         AlertState `json:"State"`
+	PreviousState AlertState `json:"PreviousState"`
+	Title         string     `json:"Title"`
+	GroupByKey    *string    `json:"GroupByKey,omitempty"`
+}
+
 type AllProjectSettings struct {
 	ID                                int            `json:"id"`
 	VerboseID                         string         `json:"verbose_id"`

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1571,29 +1571,29 @@ enum AlertDestinationType {
 
 type AlertDestination {
 	id: ID!
-	AlertID: ID!
-	DestinationType: AlertDestinationType!
-	TypeID: String!
-	TypeName: String!
+	alert_id: ID!
+	destination_type: AlertDestinationType!
+	type_id: String!
+	type_name: String!
 }
 
 type Alert {
 	id: ID!
 	updated_at: Timestamp!
-	Name: String!
-	ProductType: ProductType!
-	FunctionType: MetricAggregator!
-	Query: String
-	GroupByKey: String
-	Disabled: Boolean!
-	LastAdminToEditID: ID
-	Destinations: [AlertDestination]!
+	name: String!
+	product_type: ProductType!
+	function_type: MetricAggregator!
+	query: String
+	group_by_key: String
+	disabled: Boolean!
+	last_admin_to_edit_id: ID
+	destinations: [AlertDestination]!
 
 	# threshold alerts
-	BelowThreshold: Boolean
-	ThresholdCount: Int
-	ThresholdWindow: Int
-	ThresholdCooldown: Int
+	below_threshold: Boolean
+	threshold_count: Int
+	threshold_window: Int
+	threshold_cooldown: Int
 }
 
 type AlertStateChange {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1569,6 +1569,43 @@ enum AlertDestinationType {
 	Email
 }
 
+type AlertDestination {
+	id: ID!
+	AlertID: ID!
+	DestinationType: AlertDestinationType!
+	TypeID: String!
+	TypeName: String!
+}
+
+type Alert {
+	id: ID!
+	updated_at: Timestamp!
+	Name: String!
+	ProductType: ProductType!
+	FunctionType: MetricAggregator!
+	Query: String
+	GroupByKey: String
+	Disabled: Boolean!
+	LastAdminToEditID: ID
+	Destinations: [AlertDestination]!
+
+	# threshold alerts
+	BelowThreshold: Boolean
+	ThresholdCount: Int
+	ThresholdWindow: Int
+	ThresholdCooldown: Int
+}
+
+type AlertStateChange {
+	id: ID!
+	timestamp: Timestamp!
+	AlertID: ID!
+	State: AlertState!
+	PreviousState: AlertState!
+	Title: String!
+	GroupByKey: String
+}
+
 type SanitizedSlackChannel {
 	webhook_channel: String
 	webhook_channel_id: String
@@ -2135,6 +2172,9 @@ type Query {
 	workspaces: [Workspace]
 	workspaces_count: Int64!
 	joinable_workspaces: [Workspace]
+	alerts(project_id: ID!): [Alert]!
+	alert(id: ID!): Alert!
+	alert_state_changes(alert_id: ID!): [AlertStateChange]!
 	error_alerts(project_id: ID!): [ErrorAlert]!
 	new_user_alerts(project_id: ID!): [SessionAlert]
 	track_properties_alerts(project_id: ID!): [SessionAlert]!
@@ -2718,6 +2758,39 @@ type Mutation {
 		disabled: Boolean
 		filters: [MetricTagFilterInput!]
 	): MetricMonitor
+	createAlert(
+		project_id: ID!
+		name: String!
+		product_type: ProductType!
+		function_type: MetricAggregator!
+		query: String
+		group_by_key: String
+		disabled: Boolean
+		below_threshold: Boolean
+		threshold_count: Int
+		threshold_window: Int
+		threshold_cooldown: Int # TODO(spenny): add destinations
+	): Alert
+	updateAlert(
+		project_id: ID!
+		alert_id: ID!
+		name: String
+		product_type: ProductType
+		function_type: MetricAggregator
+		query: String
+		group_by_key: String
+		disabled: Boolean
+		below_threshold: Boolean
+		threshold_count: Int
+		threshold_window: Int
+		threshold_cooldown: Int # TODO(spenny): add destinations
+	): Alert
+	updateAlertDisabled(
+		project_id: ID!
+		alert_id: ID!
+		disabled: Boolean!
+	): Boolean!
+	deleteAlert(project_id: ID!, alert_id: ID!): Boolean!
 	createErrorAlert(
 		project_id: ID!
 		name: String!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3304,6 +3304,136 @@ func (r *mutationResolver) UpdateMetricMonitor(ctx context.Context, metricMonito
 	return metricMonitor, nil
 }
 
+// CreateAlert is the resolver for the createAlert field.
+func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name string, productType modelInputs.ProductType, functionType modelInputs.MetricAggregator, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) (*model.Alert, error) {
+	_, err := r.isUserInProject(ctx, projectID)
+	admin, _ := r.getCurrentAdmin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	disabledVar := disabled
+	if disabledVar == nil {
+		disabledVar = pointy.Bool(false)
+	}
+
+	newAlert := &model.Alert{
+		ProjectID:         projectID,
+		Name:              name,
+		ProductType:       productType,
+		FunctionType:      functionType,
+		Query:             query,
+		GroupByKey:        groupByKey,
+		Disabled:          *disabledVar,
+		BelowThreshold:    belowThreshold,
+		ThresholdCount:    thresholdCount,
+		ThresholdWindow:   thresholdWindow,
+		ThresholdCooldown: thresholdCooldown,
+		LastAdminToEditID: admin.ID,
+	}
+
+	if err := r.DB.WithContext(ctx).Create(newAlert).Error; err != nil {
+		return nil, err
+	}
+
+	// TODO(spenny): create destinations
+
+	// TODO(spenny): send new message to destinations
+
+	return newAlert, nil
+}
+
+// UpdateAlert is the resolver for the updateAlert field.
+func (r *mutationResolver) UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *modelInputs.ProductType, functionType *modelInputs.MetricAggregator, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) (*model.Alert, error) {
+	project, err := r.isUserInProject(ctx, projectID)
+	admin, _ := r.getCurrentAdmin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	alertUpdates := map[string]interface{}{
+		"LastAdminToEditID": admin.ID,
+	}
+
+	if name != nil {
+		alertUpdates["CountThreshold"] = *name
+	}
+	if productType != nil {
+		alertUpdates["ProductType"] = *productType
+	}
+	if functionType != nil {
+		alertUpdates["FunctionType"] = *functionType
+	}
+	if query != nil {
+		alertUpdates["Query"] = *query
+	}
+	if groupByKey != nil {
+		alertUpdates["GroupByKey"] = *groupByKey
+	}
+	if disabled != nil {
+		alertUpdates["Disabled"] = *disabled
+	}
+	if belowThreshold != nil {
+		alertUpdates["BelowThreshold"] = *belowThreshold
+	}
+	if thresholdCount != nil {
+		alertUpdates["ThresholdCount"] = *thresholdCount
+	}
+	if thresholdWindow != nil {
+		alertUpdates["ThresholdWindow"] = *thresholdWindow
+	}
+	if thresholdCooldown != nil {
+		alertUpdates["ThresholdCooldown"] = *thresholdCooldown
+	}
+
+	alert := &model.Alert{}
+	updateErr := store.AssertRecordFound(r.DB.WithContext(ctx).Where(&model.Alert{Model: model.Model{ID: alertID}, ProjectID: project.ID}).Model(&alert).Clauses(clause.Returning{}).Updates(&alertUpdates))
+	if updateErr != nil {
+		return nil, updateErr
+	}
+
+	// TODO(spenny): create/delete destinations
+
+	// TODO(spenny): send edit message to destinations
+
+	return alert, nil
+}
+
+// UpdateAlertDisabled is the resolver for the updateAlertDisabled field.
+func (r *mutationResolver) UpdateAlertDisabled(ctx context.Context, projectID int, alertID int, disabled bool) (bool, error) {
+	project, err := r.isUserInProject(ctx, projectID)
+	if err != nil {
+		return false, err
+	}
+
+	updateErr := store.AssertRecordFound(r.DB.WithContext(ctx).Where(&model.Alert{Model: model.Model{ID: alertID}, ProjectID: project.ID}).Updates(map[string]interface{}{"Disabled": disabled}))
+	if updateErr != nil {
+		return false, updateErr
+	}
+
+	return true, nil
+}
+
+// DeleteAlert is the resolver for the deleteAlert field.
+func (r *mutationResolver) DeleteAlert(ctx context.Context, projectID int, alertID int) (bool, error) {
+	project, err := r.isUserInProject(ctx, projectID)
+	if err != nil {
+		return false, err
+	}
+
+	if err := r.DB.Delete(&model.Alert{Model: model.Model{ID: alertID}, ProjectID: project.ID}).Error; err != nil {
+		return false, err
+	}
+
+	// TODO(spenny): send deletion message to destinations?
+
+	if err := r.DB.Delete(&model.AlertDestination{AlertID: alertID}).Error; err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
 // CreateErrorAlert is the resolver for the createErrorAlert field.
 func (r *mutationResolver) CreateErrorAlert(ctx context.Context, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*modelInputs.SanitizedSlackChannelInput, discordChannels []*modelInputs.DiscordChannelInput, microsoftTeamsChannels []*modelInputs.MicrosoftTeamsChannelInput, webhookDestinations []*modelInputs.WebhookDestinationInput, emails []*string, query string, regexGroups []*string, frequency int, defaultArg *bool) (*model.ErrorAlert, error) {
 	project, err := r.isUserInProject(ctx, projectID)
@@ -7048,6 +7178,40 @@ func (r *queryResolver) JoinableWorkspaces(ctx context.Context) ([]*model.Worksp
 	}
 
 	return joinableWorkspaces, nil
+}
+
+// Alerts is the resolver for the alerts field.
+func (r *queryResolver) Alerts(ctx context.Context, projectID int) ([]*model.Alert, error) {
+	_, err := r.isUserInProjectOrDemoProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	alerts := []*model.Alert{}
+	if err := r.DB.Order("created_at asc").Model(&model.Alert{}).Preload("Destinations").Where("project_id = ?", projectID).Find(&alerts).Error; err != nil {
+		return nil, err
+	}
+	return alerts, nil
+}
+
+// Alert is the resolver for the alert field.
+func (r *queryResolver) Alert(ctx context.Context, id int) (*model.Alert, error) {
+	var alert *model.Alert
+	if err := r.DB.WithContext(ctx).Model(&model.Alert{}).Preload("Destinations").Where("id = ?", id).Find(&alert).Error; err != nil {
+		return nil, err
+	}
+
+	_, err := r.isUserInProjectOrDemoProject(ctx, alert.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+
+	return alert, nil
+}
+
+// AlertStateChanges is the resolver for the alert_state_changes field.
+func (r *queryResolver) AlertStateChanges(ctx context.Context, alertID int) ([]*modelInputs.AlertStateChange, error) {
+	// TODO(spenny): fetch alert state changes from clickhouse
+	return []*modelInputs.AlertStateChange{}, nil
 }
 
 // ErrorAlerts is the resolver for the error_alerts field.

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3413,7 +3413,6 @@ func (r *mutationResolver) UpdateAlertDisabled(ctx context.Context, projectID in
 	}
 
 	return true, err
-
 }
 
 // DeleteAlert is the resolver for the deleteAlert field.

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -128,6 +128,33 @@ export enum AdminRole {
 	Member = 'MEMBER',
 }
 
+export type Alert = {
+	__typename?: 'Alert'
+	BelowThreshold?: Maybe<Scalars['Boolean']>
+	Destinations: Array<Maybe<AlertDestination>>
+	Disabled: Scalars['Boolean']
+	FunctionType: MetricAggregator
+	GroupByKey?: Maybe<Scalars['String']>
+	LastAdminToEditID?: Maybe<Scalars['ID']>
+	Name: Scalars['String']
+	ProductType: ProductType
+	Query?: Maybe<Scalars['String']>
+	ThresholdCooldown?: Maybe<Scalars['Int']>
+	ThresholdCount?: Maybe<Scalars['Int']>
+	ThresholdWindow?: Maybe<Scalars['Int']>
+	id: Scalars['ID']
+	updated_at: Scalars['Timestamp']
+}
+
+export type AlertDestination = {
+	__typename?: 'AlertDestination'
+	AlertID: Scalars['ID']
+	DestinationType: AlertDestinationType
+	TypeID: Scalars['String']
+	TypeName: Scalars['String']
+	id: Scalars['ID']
+}
+
 export enum AlertDestinationType {
 	Discord = 'Discord',
 	Email = 'Email',
@@ -142,6 +169,17 @@ export enum AlertState {
 	NoData = 'NoData',
 	Normal = 'Normal',
 	Pending = 'Pending',
+}
+
+export type AlertStateChange = {
+	__typename?: 'AlertStateChange'
+	AlertID: Scalars['ID']
+	GroupByKey?: Maybe<Scalars['String']>
+	PreviousState: AlertState
+	State: AlertState
+	Title: Scalars['String']
+	id: Scalars['ID']
+	timestamp: Scalars['Timestamp']
 }
 
 export type AllProjectSettings = {
@@ -1134,6 +1172,7 @@ export type Mutation = {
 	changeAdminRole: WorkspaceAdminRole
 	changeProjectMembership: WorkspaceAdminRole
 	createAdmin: Admin
+	createAlert?: Maybe<Alert>
 	createCloudflareProxy: Scalars['String']
 	createErrorAlert?: Maybe<ErrorAlert>
 	createErrorComment?: Maybe<ErrorComment>
@@ -1151,6 +1190,7 @@ export type Mutation = {
 	createSessionCommentWithExistingIssue?: Maybe<SessionComment>
 	createWorkspace?: Maybe<Workspace>
 	deleteAdminFromWorkspace?: Maybe<Scalars['ID']>
+	deleteAlert: Scalars['Boolean']
 	deleteDashboard: Scalars['Boolean']
 	deleteErrorAlert?: Maybe<ErrorAlert>
 	deleteErrorComment?: Maybe<Scalars['Boolean']>
@@ -1194,6 +1234,8 @@ export type Mutation = {
 	testErrorEnhancement?: Maybe<ErrorObject>
 	updateAdminAboutYouDetails: Scalars['Boolean']
 	updateAdminAndCreateWorkspace?: Maybe<Project>
+	updateAlert?: Maybe<Alert>
+	updateAlertDisabled: Scalars['Boolean']
 	updateAllowMeterOverage?: Maybe<Workspace>
 	updateAllowedEmailOrigins?: Maybe<Scalars['ID']>
 	updateBillingDetails?: Maybe<Scalars['Boolean']>
@@ -1247,6 +1289,20 @@ export type MutationChangeProjectMembershipArgs = {
 	admin_id: Scalars['ID']
 	project_ids: Array<Scalars['ID']>
 	workspace_id: Scalars['ID']
+}
+
+export type MutationCreateAlertArgs = {
+	below_threshold?: InputMaybe<Scalars['Boolean']>
+	disabled?: InputMaybe<Scalars['Boolean']>
+	function_type: MetricAggregator
+	group_by_key?: InputMaybe<Scalars['String']>
+	name: Scalars['String']
+	product_type: ProductType
+	project_id: Scalars['ID']
+	query?: InputMaybe<Scalars['String']>
+	threshold_cooldown?: InputMaybe<Scalars['Int']>
+	threshold_count?: InputMaybe<Scalars['Int']>
+	threshold_window?: InputMaybe<Scalars['Int']>
 }
 
 export type MutationCreateCloudflareProxyArgs = {
@@ -1425,6 +1481,11 @@ export type MutationCreateWorkspaceArgs = {
 export type MutationDeleteAdminFromWorkspaceArgs = {
 	admin_id: Scalars['ID']
 	workspace_id: Scalars['ID']
+}
+
+export type MutationDeleteAlertArgs = {
+	alert_id: Scalars['ID']
+	project_id: Scalars['ID']
 }
 
 export type MutationDeleteDashboardArgs = {
@@ -1695,6 +1756,27 @@ export type MutationUpdateAdminAndCreateWorkspaceArgs = {
 	admin_and_workspace_details: AdminAndWorkspaceDetails
 }
 
+export type MutationUpdateAlertArgs = {
+	alert_id: Scalars['ID']
+	below_threshold?: InputMaybe<Scalars['Boolean']>
+	disabled?: InputMaybe<Scalars['Boolean']>
+	function_type?: InputMaybe<MetricAggregator>
+	group_by_key?: InputMaybe<Scalars['String']>
+	name?: InputMaybe<Scalars['String']>
+	product_type?: InputMaybe<ProductType>
+	project_id: Scalars['ID']
+	query?: InputMaybe<Scalars['String']>
+	threshold_cooldown?: InputMaybe<Scalars['Int']>
+	threshold_count?: InputMaybe<Scalars['Int']>
+	threshold_window?: InputMaybe<Scalars['Int']>
+}
+
+export type MutationUpdateAlertDisabledArgs = {
+	alert_id: Scalars['ID']
+	disabled: Scalars['Boolean']
+	project_id: Scalars['ID']
+}
+
 export type MutationUpdateAllowMeterOverageArgs = {
 	allow_meter_overage: Scalars['Boolean']
 	workspace_id: Scalars['ID']
@@ -1961,6 +2043,9 @@ export type Query = {
 	admin_role?: Maybe<WorkspaceAdminRole>
 	admin_role_by_project?: Maybe<WorkspaceAdminRole>
 	ai_query_suggestion: QueryOutput
+	alert: Alert
+	alert_state_changes: Array<Maybe<AlertStateChange>>
+	alerts: Array<Maybe<Alert>>
 	api_key_to_org_id?: Maybe<Scalars['ID']>
 	averageSessionLength?: Maybe<AverageSessionLength>
 	billingDetails: BillingDetails
@@ -2141,6 +2226,18 @@ export type QueryAi_Query_SuggestionArgs = {
 	project_id: Scalars['ID']
 	query: Scalars['String']
 	time_zone: Scalars['String']
+}
+
+export type QueryAlertArgs = {
+	id: Scalars['ID']
+}
+
+export type QueryAlert_State_ChangesArgs = {
+	alert_id: Scalars['ID']
+}
+
+export type QueryAlertsArgs = {
+	project_id: Scalars['ID']
 }
 
 export type QueryApi_Key_To_Org_IdArgs = {

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -130,29 +130,29 @@ export enum AdminRole {
 
 export type Alert = {
 	__typename?: 'Alert'
-	BelowThreshold?: Maybe<Scalars['Boolean']>
-	Destinations: Array<Maybe<AlertDestination>>
-	Disabled: Scalars['Boolean']
-	FunctionType: MetricAggregator
-	GroupByKey?: Maybe<Scalars['String']>
-	LastAdminToEditID?: Maybe<Scalars['ID']>
-	Name: Scalars['String']
-	ProductType: ProductType
-	Query?: Maybe<Scalars['String']>
-	ThresholdCooldown?: Maybe<Scalars['Int']>
-	ThresholdCount?: Maybe<Scalars['Int']>
-	ThresholdWindow?: Maybe<Scalars['Int']>
+	below_threshold?: Maybe<Scalars['Boolean']>
+	destinations: Array<Maybe<AlertDestination>>
+	disabled: Scalars['Boolean']
+	function_type: MetricAggregator
+	group_by_key?: Maybe<Scalars['String']>
 	id: Scalars['ID']
+	last_admin_to_edit_id?: Maybe<Scalars['ID']>
+	name: Scalars['String']
+	product_type: ProductType
+	query?: Maybe<Scalars['String']>
+	threshold_cooldown?: Maybe<Scalars['Int']>
+	threshold_count?: Maybe<Scalars['Int']>
+	threshold_window?: Maybe<Scalars['Int']>
 	updated_at: Scalars['Timestamp']
 }
 
 export type AlertDestination = {
 	__typename?: 'AlertDestination'
-	AlertID: Scalars['ID']
-	DestinationType: AlertDestinationType
-	TypeID: Scalars['String']
-	TypeName: Scalars['String']
+	alert_id: Scalars['ID']
+	destination_type: AlertDestinationType
 	id: Scalars['ID']
+	type_id: Scalars['String']
+	type_name: Scalars['String']
 }
 
 export enum AlertDestinationType {


### PR DESCRIPTION
## Summary
Add the following graphql queries and mutations:
- `createAlert` - create an alert with params
- `updateAlert` - update an alert with provided params
- `updateAlertDisabled` - update the disabled field of the alert
- `deleteAlert` - delete alert and destinations
- `alerts` - fetch alerts by project
- `alert` - fetch alert by id
- `alert_state_changes` - fetch state changes of an alert by alert id

TODOs will be addressed in the following cards:
- [Add destination creation](https://linear.app/highlight/issue/HIG-4746/allow-adding-of-destinations)
- [Send destination messages](https://linear.app/highlight/issue/HIG-4747/send-destinations-message-when-destination-is-createddeleted)
- [Fetch alert state changes](https://linear.app/highlight/issue/HIG-4749/add-alert-state-changes-to-alert-detail-page)

https://www.loom.com/share/f97ff4bf04d940a9b21482295f16443f?sid=5ed6d278-7ef4-4f91-a077-31952385764b

## How did you test this change?
1) In postman upload the schema from [here](https://raw.githubusercontent.com/highlight/highlight/d2c8b2ee014a6ea7992596c7df35f37e07e9c6d4/backend/private-graph/graph/schema.graphqls)
2) Test the queries and mutation above

## Are there any deployment considerations?
N/A - not used in production

## Does this work require review from our design team?
N/A
