### PR TITLE
Fix error group first and last instance

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5290,7 +5290,7 @@ func (r *queryResolver) ErrorGroup(ctx context.Context, secureID string, useClic
 	if eg.UpdatedAt.Before(retentionDate) {
 		return nil, e.New("no new error instances after the workspace's retention date")
 	}
-	if err := r.SetErrorFrequenciesClickhouse(ctx, eg.ProjectID, []*model.ErrorGroup{eg}, ErrorGroupLookbackDays); err != nil {
+	if err := r.loadErrorGroupFrequenciesClickhouse(ctx, eg); err != nil {
 		return nil, err
 	}
 	return eg, err


### PR DESCRIPTION
## Summary
The first and last instance occurrence is missing, causing some UI misinformation

<img width="1560" alt="Screenshot 2024-06-18 at 5 53 57 PM" src="https://github.com/highlight/highlight/assets/17744174/fcd45626-7d1a-4c37-b7d0-c0a8b7dbd464">

## How did you test this change?
1) View an error on the error search page
- [ ] First/Last occurrence is correct

<img width="1516" alt="Screenshot 2024-06-18 at 5 56 58 PM" src="https://github.com/highlight/highlight/assets/17744174/79c48a41-877e-4512-8f68-b7e0f81f145e">

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
