### PR TITLE
Fix error group instances

### DIFF
--- a/backend/clickhouse/errors.go
+++ b/backend/clickhouse/errors.go
@@ -378,30 +378,53 @@ func (client *Client) QueryErrorGroupAggregateFrequency(ctx context.Context, pro
 	return items, err
 }
 
-func (client *Client) QueryErrorGroupOccurrences(ctx context.Context, projectId int, errorGroupId int) (*time.Time, *time.Time, error) {
+type ErrorGroupOccurence struct {
+	FirstOccurrence time.Time
+	LastOccurrence  time.Time
+}
+
+func (client *Client) QueryErrorGroupOccurrences(ctx context.Context, projectId int, errorGroupIds []int) (map[int]ErrorGroupOccurence, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 	sql, args := sb.Select(`
+		errorGroupID,
 		min(Timestamp) as firstOccurrence,
 		max(Timestamp) as lastOccurrence`).
 		From("error_objects FINAL").
 		Where(sb.Equal("ProjectID", projectId)).
-		Where(sb.Equal("ErrorGroupID", errorGroupId)).
+		Where(sb.In("ErrorGroupID", errorGroupIds)).
 		BuildWithFlavor(sqlbuilder.ClickHouse)
 
 	rows, err := client.conn.Query(ctx, sql, args...)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	var firstOccurrence time.Time
 	var lastOccurrence time.Time
 	for rows.Next() {
 		if err := rows.Scan(&firstOccurrence, &lastOccurrence); err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
-	return &firstOccurrence, &lastOccurrence, nil
+	occurancesByErrorGroup := map[int]ErrorGroupOccurence{}
+
+	for rows.Next() {
+		var errorGroupId int
+		var firstOccurrence time.Time
+		var lastOccurrence time.Time
+
+		if err := rows.Scan(&errorGroupId, &firstOccurrence, &lastOccurrence); err != nil {
+			return nil, err
+		}
+
+		occurancesByErrorGroup[errorGroupId] = ErrorGroupOccurence{
+			FirstOccurrence: firstOccurrence,
+			LastOccurrence:  lastOccurrence,
+		}
+	}
+
+	return occurancesByErrorGroup, nil
 }
 
 func (client *Client) QueryErrorGroupTags(ctx context.Context, projectId int, errorGroupId int) ([]*modelInputs.ErrorGroupTagAggregation, error) {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5220,7 +5220,7 @@ func (r *queryResolver) ErrorGroups(ctx context.Context, projectID int, count in
 	}
 
 	if len(results) > 0 {
-		if err := r.SetErrorFrequenciesClickhouse(ctx, project.ID, results, ErrorGroupLookbackDays); err != nil {
+		if err := r.loadErrorGroupFrequenciesClickhouse(ctx, project.ID, results); err != nil {
 			return nil, err
 		}
 	}
@@ -5290,7 +5290,7 @@ func (r *queryResolver) ErrorGroup(ctx context.Context, secureID string, useClic
 	if eg.UpdatedAt.Before(retentionDate) {
 		return nil, e.New("no new error instances after the workspace's retention date")
 	}
-	if err := r.SetErrorFrequenciesClickhouse(ctx, eg.ProjectID, []*model.ErrorGroup{eg}, ErrorGroupLookbackDays); err != nil {
+	if err := r.loadErrorGroupFrequenciesClickhouse(ctx, eg.ProjectID, []*model.ErrorGroup{eg}); err != nil {
 		return nil, err
 	}
 	return eg, err
@@ -6032,7 +6032,7 @@ func (r *queryResolver) DailyErrorFrequency(ctx context.Context, projectID int, 
 	if err != nil {
 		return nil, err
 	}
-	if err := r.loadErrorGroupFrequenciesClickhouse(ctx, errGroup); err != nil {
+	if err := r.loadErrorGroupFrequenciesClickhouse(ctx, projectID, []*model.ErrorGroup{errGroup}); err != nil {
 		return nil, err
 	}
 
@@ -6047,9 +6047,6 @@ func (r *queryResolver) DailyErrorFrequency(ctx context.Context, projectID int, 
 		return dists, nil
 	}
 
-	if err := r.SetErrorFrequenciesClickhouse(ctx, projectID, []*model.ErrorGroup{errGroup}, dateOffset); err != nil {
-		return nil, e.Wrap(err, "error setting error frequencies")
-	}
 	return errGroup.ErrorFrequency, nil
 }
 

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -7641,7 +7641,8 @@ export const GetErrorGroupsDocument = gql`
 				type
 				event
 				state
-				state
+				first_occurrence
+				last_occurrence
 				snoozed_until
 				environments
 				stack_trace

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -2518,6 +2518,8 @@ export type GetErrorGroupsQuery = { __typename?: 'Query' } & {
 					| 'type'
 					| 'event'
 					| 'state'
+					| 'first_occurrence'
+					| 'last_occurrence'
 					| 'snoozed_until'
 					| 'environments'
 					| 'stack_trace'

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -631,7 +631,8 @@ query GetErrorGroups(
 			type
 			event
 			state
-			state
+			first_occurrence
+			last_occurrence
 			snoozed_until
 			environments
 			stack_trace

--- a/frontend/src/pages/ErrorsV2/ErrorFeedCard/ErrorFeedCard.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorFeedCard/ErrorFeedCard.tsx
@@ -31,8 +31,12 @@ export const ErrorFeedCard = ({ errorGroup, onClick }: Props) => {
 		error_secure_id?: string
 	}>()
 	const body = getErrorBody(errorGroup?.event)
-	const createdDate = formatErrorGroupDate(errorGroup?.created_at)
-	const updatedDate = formatErrorGroupDate(errorGroup?.updated_at)
+	const firstInstance = formatErrorGroupDate(
+		errorGroup?.first_occurrence || errorGroup?.created_at,
+	)
+	const lastInstance = formatErrorGroupDate(
+		errorGroup?.last_occurrence || errorGroup?.updated_at,
+	)
 
 	const { totalCount, userCount } = getErrorGroupStats(errorGroup)
 	const snoozed =
@@ -172,14 +176,14 @@ export const ErrorFeedCard = ({ errorGroup, onClick }: Props) => {
 						</Box>
 						<Box display="flex" gap="4" alignItems="center">
 							<Tag shape="basic" kind="secondary">
-								{updatedDate}
+								{lastInstance}
 							</Tag>
 							<Tag
 								shape="basic"
 								kind="secondary"
 								iconLeft={<IconSolidSparkles size={12} />}
 							>
-								{createdDate}
+								{firstInstance}
 							</Tag>
 						</Box>
 					</Box>


### PR DESCRIPTION
## Summary
The error groups are not setting the correct first and last instances

On search:
- First instance: `ErrorGroup.CreatedAt` -> min `ErrorObject.Timestamp`
- Last instance:  `ErrorGroup.UpdatedAt` -> max `ErrorObject.Timestamp`

On detail page
- First instance: missing -> min `ErrorObject.Timestamp`
- Last instance: missing -> max `ErrorObject.Timestamp`

https://www.loom.com/share/ec0409905c224529b5a642ea3ea9f489?sid=91e0bd44-7c9f-4b34-947d-4328dae80203

## How did you test this change?
1) View the error search page
2) View the dates on the search card
- [ ] Confirm the dates are correct
3) Click into an error
- [ ] confirm the first/last occurrences are correct



## Are there any deployment considerations?
Watch performance of `ErrorGroups` graphql query

## Does this work require review from our design team?
N/A
