### PR TITLE
update kafka settings to prevent OOM

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -27,8 +27,8 @@ const ConsumerGroupName = "group-default"
 
 const (
 	TaskRetries           = 0
-	prefetchQueueCapacity = 10_000
-	MaxMessageSizeBytes   = 256 * 1024 * 1024 // MiB
+	prefetchQueueCapacity = 100
+	MaxMessageSizeBytes   = 128 * 1024 * 1024 // MiB
 )
 
 var (
@@ -187,9 +187,9 @@ func New(ctx context.Context, topic string, mode Mode, configOverride *ConfigOve
 			RequiredAcks: kafka.RequireOne,
 			Compression:  kafka.Zstd,
 			Async:        false,
-			BatchSize:    prefetchQueueCapacity,
+			BatchSize:    10_000,
 			BatchBytes:   MaxMessageSizeBytes,
-			BatchTimeout: 500 * time.Millisecond,
+			BatchTimeout: 100 * time.Millisecond,
 			ReadTimeout:  KafkaOperationTimeout,
 			WriteTimeout: KafkaOperationTimeout,
 			Logger:       getLogger("producer", topic, log.InfoLevel),

--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -27,8 +27,8 @@ const ConsumerGroupName = "group-default"
 
 const (
 	TaskRetries           = 0
-	prefetchQueueCapacity = 100
-	MaxMessageSizeBytes   = 128 * 1024 * 1024 // MiB
+	prefetchQueueCapacity = 1_000
+	MaxMessageSizeBytes   = 256 * 1024 * 1024 // MiB
 )
 
 var (

--- a/deploy/public-worker-main-service.json
+++ b/deploy/public-worker-main-service.json
@@ -5,8 +5,8 @@
 			"name": "highlight-backend",
 			"image": "173971919437.dkr.ecr.us-east-2.amazonaws.com/highlight-production-ecr-repo:9e93e3b2b90d93bbe4ceb059fb080bf00e66534c.arm64",
 			"cpu": 4096,
-			"memory": 16384,
-			"memoryReservation": 16384,
+			"memory": 32768,
+			"memoryReservation": 32768,
 			"portMappings": [],
 			"essential": true,
 			"command": [
@@ -80,7 +80,7 @@
 	"compatibilities": ["EXTERNAL", "EC2"],
 	"requiresCompatibilities": ["EC2"],
 	"cpu": "4096",
-	"memory": "16384",
+	"memory": "32768",
 	"runtimePlatform": {
 		"cpuArchitecture": "ARM64",
 		"operatingSystemFamily": "LINUX"


### PR DESCRIPTION
## Summary

Had some OOming earlier in the week due to the main worker prefetching a lot of large messages.
Recently switched to r7g ec2 boxes as they are cheaper with spot instances than m7g 
which also have more memory per CPU, so adjusting the worker memory allocation accordingly.

## How did you test this change?

deployed to prod manually which helped

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no