### PR TITLE
ensure retention set when super admin

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7922,6 +7922,8 @@ func (r *queryResolver) Workspace(ctx context.Context, id int) (*model.Workspace
 		return nil, nil
 	}
 
+	r.SetDefaultRetention(workspace)
+
 	if r.isWhitelistedAccount(ctx) {
 		projects := []model.Project{}
 		if err := r.DB.WithContext(ctx).Order("name ASC").Model(&workspace).Association("Projects").Find(&projects); err != nil {
@@ -7940,8 +7942,6 @@ func (r *queryResolver) Workspace(ctx context.Context, id int) (*model.Workspace
 
 		return *p, p.WorkspaceID == id
 	})
-
-	r.SetDefaultRetention(workspace)
 
 	return workspace, nil
 }


### PR DESCRIPTION
## Summary
- the superadmin branch returns early, make sure default retention is set before that returns (graphql schema now enforces non-null retention)
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktesting locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
