### PR TITLE
Ensure session feed query pulls in the latest sessions

### DIFF
--- a/frontend/src/pages/Sessions/useGetSessions.ts
+++ b/frontend/src/pages/Sessions/useGetSessions.ts
@@ -32,10 +32,14 @@ export const useGetSessions = ({
 	// query will still be sent and the data in the cache will be updated.
 	const roundedStartDate = moment(startDate)
 		.startOf('minute')
-		.subtract(moment(startDate).minute() % 15, 'minutes')
-	const roudnedEndDate = moment(endDate)
+		.subtract(moment(startDate).minute() % 10, 'minutes')
+	const endDateIsNearNow = moment().diff(moment(endDate), 'seconds') < 10
+	const momentEndDate = endDateIsNearNow
+		? moment(endDate).add(10, 'minutes')
+		: moment(endDate)
+	const roudnedEndDate = momentEndDate
 		.startOf('minute')
-		.subtract(moment(endDate).minute() % 15, 'minutes')
+		.subtract(moment(endDate).minute() % 10, 'minutes')
 
 	const { data, loading, error, refetch } = useGetSessionsQuery({
 		variables: {


### PR DESCRIPTION
## Summary

We are seeing an issue where new sessions aren't appearing in the feed because of some logic we added to help with showing cached results immediately on page load. This fixes the issue by extending the end date time into the future before subtracting from it for rounding. We only do this when the user is trying to show real time results.

## How did you test this change?

Click tested and checked the values using a debugger when using a fixed time and a relative time.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A