### PR TITLE
Fix comment link

### DIFF
--- a/frontend/src/components/Comment/utils/utils.ts
+++ b/frontend/src/components/Comment/utils/utils.ts
@@ -69,7 +69,7 @@ export const useNavigateToComment = (comment: ParsedSessionComment) => {
 	const { pause, sessionMetadata } = useReplayerContext()
 
 	return () => {
-		const urlSearchParams = new URLSearchParams()
+		const urlSearchParams = new URLSearchParams(window.location.search)
 		urlSearchParams.append(PlayerSearchParameters.commentId, comment?.id)
 
 		navigate(`${location.pathname}?${urlSearchParams.toString()}`, {


### PR DESCRIPTION
## Summary
When clicking on a comment in the session, the search params are wiped out. Fix this to append the search params

## How did you test this change?
1. Add a search param to the session search
2. Create a comment on a session
3. Click on the comment in the right panel
- [ ] Search remains intact
- [ ] Comment is open

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
