### PR TITLE
[HIG-4751] show <empty> for empty groups, fall back to metric name only when not grouped

### DIFF
--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -407,10 +407,14 @@ export const useGraphData = (
 					data.push({})
 				}
 
-				const seriesKeys = new Set<string>()
+				const hasGroups =
+					metrics.metrics.buckets.find((b) => b.group.length) !==
+					undefined
+
 				for (const b of metrics.metrics.buckets) {
-					const seriesKey = b.group.join(' ') || b.metric_type
-					seriesKeys.add(seriesKey)
+					const seriesKey = hasGroups
+						? b.group.join(' ') || '<empty>'
+						: b.metric_type
 					data[b.bucket_id][xAxisMetric] =
 						(b.bucket_min + b.bucket_max) / 2
 					data[b.bucket_id][seriesKey] = b.metric_value


### PR DESCRIPTION
## Summary
- fixes grouping key logic by showing `<empty>` tag when results are grouped but that group is the empty string
- falls back to metric name only when results are not grouped
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested in preview env
https://www.loom.com/share/4f2fb97b05d3411b959a0d7c393bb156
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
