### PR TITLE
Fix events autoscrolling jumping around

### DIFF
--- a/frontend/src/pages/Player/ReplayerContext/index.tsx
+++ b/frontend/src/pages/Player/ReplayerContext/index.tsx
@@ -111,8 +111,6 @@ export interface ReplayerContextInterface {
 	browserExtensionScriptURLs: string[]
 	isLoadingEvents: boolean
 	sessionMetadata: playerMetaData
-	currentEvent: string
-	setCurrentEvent: React.Dispatch<React.SetStateAction<string>>
 }
 
 export const [useReplayerContext, ReplayerContextProvider] =

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
@@ -91,13 +91,25 @@ export const ConsolePage = ({
 		return message.node
 	})
 
-	const lastActiveLogIndex = useMemo(() => {
-		return findLastActiveEventIndex(
-			time,
-			sessionMetadata.startTime,
-			messageNodes,
-		)
-	}, [time, sessionMetadata.startTime, messageNodes])
+	const [lastActiveLogIndex, setLastActiveLogIndex] = useState(-1)
+
+	useEffect(
+		() =>
+			_.throttle(
+				() => {
+					const activeIndex = findLastActiveEventIndex(
+						time,
+						sessionMetadata.startTime,
+						messageNodes,
+					)
+
+					setLastActiveLogIndex(activeIndex)
+				},
+				THROTTLED_UPDATE_MS,
+				{ leading: true, trailing: false },
+			),
+		[time, sessionMetadata.startTime, messageNodes],
+	)
 
 	useEffect(() => {
 		analytics.track('session_view-console-logs')

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ErrorsPage/ErrorsPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ErrorsPage/ErrorsPage.tsx
@@ -23,6 +23,7 @@ import React, {
 	useLayoutEffect,
 	useMemo,
 	useRef,
+	useState,
 } from 'react'
 import { useLocation } from 'react-router-dom'
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
@@ -58,16 +59,27 @@ const ErrorsPage = ({
 	/** Only errors recorded after this feature was released will have the timestamp. */
 
 	const hasTimestamp = !loading && errors?.every((error) => !!error.timestamp)
-	const lastActiveErrorIndex = useMemo(() => {
-		if (hasTimestamp) {
-			return findLastActiveEventIndex(
-				time,
-				sessionMetadata.startTime,
-				errors,
-			)
-		}
-		return -1
-	}, [errors, hasTimestamp, sessionMetadata.startTime, time])
+	const [lastActiveErrorIndex, setLastActiveErrorIndex] = useState(-1)
+
+	useEffect(
+		() =>
+			_.throttle(
+				() => {
+					if (hasTimestamp) {
+						const activeIndex = findLastActiveEventIndex(
+							time,
+							sessionMetadata.startTime,
+							errors,
+						)
+
+						setLastActiveErrorIndex(activeIndex)
+					}
+				},
+				THROTTLED_UPDATE_MS,
+				{ leading: true, trailing: false },
+			),
+		[errors, hasTimestamp, sessionMetadata.startTime, time],
+	)
 
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	const scrollFunction = useCallback(

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -27,7 +27,14 @@ import {
 import { formatTime, MillisToMinutesAndSeconds } from '@util/time'
 import _ from 'lodash'
 import moment from 'moment'
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
+import {
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react'
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
 
 import { ErrorObject } from '@/graph/generated/schemas'
@@ -168,13 +175,25 @@ export const NetworkPage = ({
 		return current
 	}, [parsedResources, filter, requestTypes, requestStatuses, startTime])
 
-	const currentResourceIdx = useMemo(() => {
-		return findLastActiveEventIndex(
-			Math.round(time),
-			startTime,
-			resourcesToRender,
-		)
-	}, [resourcesToRender, startTime, time])
+	const [currentResourceIdx, setCurrentResourceIdx] = useState(-1)
+
+	useEffect(
+		() =>
+			_.throttle(
+				() => {
+					const activeIndex = findLastActiveEventIndex(
+						Math.round(time),
+						startTime,
+						resourcesToRender,
+					)
+
+					setCurrentResourceIdx(activeIndex)
+				},
+				THROTTLED_UPDATE_MS,
+				{ leading: true, trailing: false },
+			),
+		[resourcesToRender, startTime, time],
+	)
 
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	const scrollFunction = useCallback(

--- a/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelinePopover/TimelinePopover.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelinePopover/TimelinePopover.tsx
@@ -48,13 +48,8 @@ const TimelinePopover = ({ bucket }: Props) => {
 	const location = useLocation()
 
 	const { setActiveEvent, setRightPanelView } = usePlayerUIContext()
-	const {
-		setCurrentEvent,
-		pause,
-		errors,
-		eventsForTimelineIndicator,
-		isPlayerReady,
-	} = useReplayerContext()
+	const { pause, errors, eventsForTimelineIndicator, isPlayerReady } =
+		useReplayerContext()
 	const {
 		setShowRightPanel,
 		setSelectedDevToolsTab,
@@ -136,7 +131,6 @@ const TimelinePopover = ({ bucket }: Props) => {
 			)
 			setShowRightPanel(true)
 			setSelectedRightPlayerPanelTab(RightPlayerPanelTabType.Events)
-			setCurrentEvent(identifier)
 			setActiveEvent(event)
 			setRightPanelView(RightPanelView.Event)
 		}

--- a/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
+++ b/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
@@ -135,7 +135,8 @@ const EventStreamV2 = function () {
 		if (!isInteractingWithStreamEvents) {
 			scrollFunction(lastEventIndex)
 		}
-	}, [isInteractingWithStreamEvents, scrollFunction, lastEventIndex])
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [lastEventIndex])
 
 	const isLoading =
 		!replayer || state === ReplayerState.Loading || events.length === 0

--- a/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
+++ b/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
@@ -17,11 +17,15 @@ import {
 	useReplayerContext,
 } from '@pages/Player/ReplayerContext'
 import { EmptyDevToolsCallout } from '@pages/Player/Toolbar/DevToolsWindowV2/EmptyDevToolsCallout/EmptyDevToolsCallout'
-import { Tab } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
+import {
+	findLastActiveEventIndex,
+	Tab,
+} from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
 import _ from 'lodash'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
 
+import { THROTTLED_UPDATE_MS } from '@/pages/Player/PlayerHook/PlayerState'
 import { styledVerticalScrollbar } from '@/style/common.css'
 
 import * as style from './EventStreamV2.css'
@@ -30,11 +34,10 @@ const EventStreamV2 = function () {
 	const {
 		session,
 		sessionMetadata,
+		time,
 		eventsForTimelineIndicator: replayerEvents,
 		state,
 		replayer,
-		currentEvent,
-		setCurrentEvent,
 	} = useReplayerContext()
 	const session_secure_id = session?.secure_id
 	const {
@@ -85,15 +88,33 @@ const EventStreamV2 = function () {
 		}
 	}, [data?.web_vitals, replayerEvents])
 
-	const usefulEvents = useMemo(() => events.filter(usefulEvent), [events])
-	const filteredEvents = useMemo(
+	const filteredEvents = useMemo(() => {
+		const usefulEvents = events.filter(usefulEvent)
+		return getFilteredEvents(
+			searchQuery!,
+			usefulEvents,
+			new Set(selectedTimelineAnnotationTypes),
+		)
+	}, [selectedTimelineAnnotationTypes, searchQuery, events])
+
+	const [lastEventIndex, setLastEventIndex] = useState(-1)
+
+	useEffect(
 		() =>
-			getFilteredEvents(
-				searchQuery!,
-				usefulEvents,
-				new Set(selectedTimelineAnnotationTypes),
+			_.throttle(
+				() => {
+					const activeIndex = findLastActiveEventIndex(
+						time,
+						sessionMetadata.startTime,
+						filteredEvents,
+					)
+
+					setLastEventIndex(activeIndex)
+				},
+				THROTTLED_UPDATE_MS,
+				{ leading: true, trailing: false },
 			),
-		[selectedTimelineAnnotationTypes, searchQuery, usefulEvents],
+		[time, sessionMetadata.startTime, filteredEvents],
 	)
 
 	// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -112,17 +133,9 @@ const EventStreamV2 = function () {
 
 	useEffect(() => {
 		if (!isInteractingWithStreamEvents) {
-			const currentEventIndex = usefulEvents.findIndex(
-				(event) => event.identifier === currentEvent,
-			)
-			scrollFunction(currentEventIndex)
+			scrollFunction(lastEventIndex)
 		}
-	}, [
-		currentEvent,
-		isInteractingWithStreamEvents,
-		scrollFunction,
-		usefulEvents,
-	])
+	}, [isInteractingWithStreamEvents, scrollFunction, lastEventIndex])
 
 	const isLoading =
 		!replayer || state === ReplayerState.Loading || events.length === 0
@@ -175,15 +188,12 @@ const EventStreamV2 = function () {
 							initialTopMostItemIndex={activeEventIndex}
 							itemContent={(index, event) => (
 								<StreamEventV2
-									e={event}
+									event={event}
 									key={index}
 									start={sessionMetadata.startTime}
 									isFirstCard={index === 0}
-									isCurrent={
-										event.identifier === currentEvent
-									}
-									onGoToHandler={(e) => {
-										setCurrentEvent(e)
+									isCurrent={index === lastEventIndex}
+									onGoToHandler={() => {
 										setActiveEvent(event)
 										setRightPanelView(RightPanelView.Event)
 										setActiveEventIndex(index)

--- a/frontend/src/pages/Player/components/EventStreamV2/StreamEventV2/StreamEventV2.tsx
+++ b/frontend/src/pages/Player/components/EventStreamV2/StreamEventV2/StreamEventV2.tsx
@@ -62,25 +62,25 @@ export const EVENT_TYPES_TO_COLORS: {
 }
 
 export const StreamEventV2 = function ({
-	e,
+	event,
 	start,
 	isCurrent,
 	onGoToHandler,
 }: {
-	e: HighlightEvent
+	event: HighlightEvent
 	start: number
 	isCurrent: boolean
-	onGoToHandler: (event: string) => void
+	onGoToHandler: () => void
 	isFirstCard: boolean
 }) {
 	const { pause } = useReplayerContext()
 	const { showPlayerAbsoluteTime } = usePlayerConfiguration()
-	const timeSinceStart = Math.max(e?.timestamp - start, 0)
-	const details = getEventRenderDetails(e)
+	const timeSinceStart = Math.max(event?.timestamp - start, 0)
+	const details = getEventRenderDetails(event)
 	const displayName = getTimelineEventDisplayName(details.title || '')
 	const shouldShowTimestamp =
-		e.type === EventType.Custom &&
-		!EVENT_TYPES_TO_NOT_RENDER_TIME.includes(e.data.tag)
+		event.type === EventType.Custom &&
+		!EVENT_TYPES_TO_NOT_RENDER_TIME.includes(event.data.tag)
 	return (
 		<Box px="8" cursor="pointer">
 			<Box
@@ -88,8 +88,7 @@ export const StreamEventV2 = function ({
 				onClick={(e) => {
 					// Stopping the event from propagating up to the parent button. This is to allow the element to stay opened when the user clicks on the GoToButton. Without this the element would close.
 					e.stopPropagation()
-					// Sets the current event as null. It will be reset as the player continues.
-					onGoToHandler('')
+					onGoToHandler()
 					pause(timeSinceStart)
 
 					toast.success(


### PR DESCRIPTION
## Summary
The events on a session are not scrolling correctly.

Update the algorithm to use a time based search, similar to logs, errors and network resources. Add a throttle for each of these resources to limit the browser computations.

https://www.loom.com/share/4b88dd5d7e2a44238a6ba27b9688561e?sid=86b4665b-84e7-4274-89a4-bb7333f82000

## How did you test this change?
1. View a session
2. View the events
- [ ] Events are being scrolled through accurately
- [ ] Logs are being scrolled through accurately
- [ ] No concerns when running dev tools performance anaylizer
 
## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
