### PR TITLE
Additional logging and tracing for batch kafka workers

### DIFF
--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -184,7 +184,7 @@ func (client *Client) BatchWriteTraceRows(ctx context.Context, traceRows []*Clic
 		return nil
 	}
 
-	span, _ := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName("worker.kafka.batched.flushTraces.prepareRows"))
+	span, _ := util.StartSpanFromContext(ctx, "worker.kafka.batched.flushTraces.prepareRows")
 	span.SetAttribute("BatchSize", len(traceRows))
 
 	batch, err := client.conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s", TracesTable))

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -184,7 +184,7 @@ func (client *Client) BatchWriteTraceRows(ctx context.Context, traceRows []*Clic
 		return nil
 	}
 
-	span, _ := util.StartSpanFromContext(ctx, "worker.kafka.batched.flushTraces.prepareRows")
+	span, _ := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName("worker.kafka.batched.flushTraces.prepareRows"))
 	span.SetAttribute("BatchSize", len(traceRows))
 
 	batch, err := client.conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s", TracesTable))

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -142,10 +142,7 @@ func (k *KafkaBatchWorker) log(ctx context.Context, fields log.Fields, msg ...in
 }
 
 func (k *KafkaBatchWorker) flush(ctx context.Context) error {
-	k.log(ctx, nil,
-		log.Fields{"message_length": len(k.messages)},
-		"KafkaBatchWorker flushing messages",
-	)
+	k.log(ctx, log.Fields{"message_length": len(k.messages)}, "KafkaBatchWorker flushing messages")
 
 	s, _ := util.StartSpanFromContext(ctx, fmt.Sprintf("worker.kafka.%s.flush", k.Name))
 	s.SetAttribute("BatchSize", len(k.messages))

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -127,12 +127,12 @@ type KafkaWorker struct {
 }
 
 func (k *KafkaBatchWorker) log(ctx context.Context, fields log.Fields, msg ...interface{}) {
-	if k.lastPartitionId != nil {
+	if k.lastPartitionId == nil {
 		return
 	}
 
 	partitionId := *k.lastPartitionId
-	if partitionId == 408 || partitionId == 58 || partitionId == 289 {
+	if partitionId%25 == 0 {
 		log.WithContext(ctx).
 			WithField("worker_name", k.Name).
 			WithField("partition", partitionId).


### PR DESCRIPTION
## Summary
Having some trouble figuring out where messages may or may not have been drop, so add logging to help ensure everything is moving smoothly. Also change the kafka batch working resource to be the span name to help with optimized search.

## How did you test this change?
1. Ensure logs and traces can be seen locally

![Screenshot 2024-06-24 at 11 39 04 AM](https://github.com/highlight/highlight/assets/17744174/7af5610b-319c-488b-be4d-7d07d13538ee)

## Are there any deployment considerations?
Come back and clean up logs after debugging if appropriate

## Does this work require review from our design team?
N/A
