### PR TITLE
support visualizing custom trace events

### DIFF
--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -85,6 +85,7 @@ var defaultTraceKeys = []*modelInputs.QueryKey{
 	{Name: string(modelInputs.ReservedTraceKeyParentSpanID), Type: modelInputs.KeyTypeString},
 	{Name: string(modelInputs.ReservedTraceKeySecureSessionID), Type: modelInputs.KeyTypeString},
 	{Name: string(modelInputs.ReservedTraceKeyMetricName), Type: modelInputs.KeyTypeString},
+	{Name: string(modelInputs.ReservedTraceKeyMetricValue), Type: modelInputs.KeyTypeNumeric},
 }
 
 var TracesTableNoDefaultConfig = model.TableConfig[modelInputs.ReservedTraceKey]{

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -3,27 +3,20 @@ package clickhouse
 import (
 	"context"
 	"fmt"
-	"github.com/samber/lo"
 	"strings"
 	"time"
 
-	"github.com/openlyinc/pointy"
-
-	"github.com/highlight-run/highlight/backend/parser/listener"
-
-	"github.com/highlight/highlight/sdk/highlight-go"
-
-	"golang.org/x/exp/slices"
-
-	"github.com/highlight-run/highlight/backend/model"
-
-	"github.com/huandu/go-sqlbuilder"
-	e "github.com/pkg/errors"
-
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-
+	"github.com/highlight-run/highlight/backend/model"
+	"github.com/highlight-run/highlight/backend/parser/listener"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/util"
+	"github.com/highlight/highlight/sdk/highlight-go"
+	"github.com/huandu/go-sqlbuilder"
+	"github.com/openlyinc/pointy"
+	e "github.com/pkg/errors"
+	"github.com/samber/lo"
+	"golang.org/x/exp/slices"
 )
 
 const TracesTable = "traces"

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -31,7 +31,6 @@ const TracesSamplingTable = "traces_sampling"
 const TraceKeysTable = "trace_keys"
 const TraceKeyValuesTable = "trace_key_values"
 const TracesByIdTable = "traces_by_id"
-const SelectTraceColumns = "Timestamp, UUID, TraceId, SpanId, ParentSpanId, ProjectId, SecureSessionId, TraceState, SpanName, SpanKind, Duration, ServiceName, ServiceVersion, Environment, HasErrors, TraceAttributes, StatusCode, StatusMessage, Events.Timestamp, Events.Name, Events.Attributes"
 
 var traceKeysToColumns = map[modelInputs.ReservedTraceKey]string{
 	modelInputs.ReservedTraceKeySecureSessionID: "SecureSessionId",
@@ -75,6 +74,8 @@ var traceColumns = []string{
 	"Events.Name",
 	"Events.Attributes",
 }
+
+var selectTraceColumns = strings.Join(traceColumns, ", ")
 
 // These keys show up as recommendations, but with no recommended values due to high cardinality
 var defaultTraceKeys = []*modelInputs.QueryKey{
@@ -405,7 +406,7 @@ func (client *Client) ReadTrace(ctx context.Context, projectID int, traceID stri
 	var args []interface{}
 
 	sb.From(TracesByIdTable).
-		Select(SelectTraceColumns).
+		Select(selectTraceColumns).
 		Where(sb.Equal("ProjectId", projectID)).
 		Where(sb.Equal("TraceId", traceID))
 
@@ -430,7 +431,7 @@ func (client *Client) ReadTrace(ctx context.Context, projectID int, traceID stri
 	span.SetAttribute("mode", "fallback")
 
 	sb.From(TracesTable).
-		Select(SelectTraceColumns).
+		Select(selectTraceColumns).
 		Where(sb.Equal("ProjectId", projectID)).
 		Where(sb.Equal("TraceId", traceID)).
 		Where(sb.GE("Timestamp", time.Now().Add(-5*time.Minute))).

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -3,6 +3,7 @@ package clickhouse
 import (
 	"context"
 	"fmt"
+	"github.com/samber/lo"
 	"strings"
 	"time"
 
@@ -30,6 +31,7 @@ const TracesSamplingTable = "traces_sampling"
 const TraceKeysTable = "trace_keys"
 const TraceKeyValuesTable = "trace_key_values"
 const TracesByIdTable = "traces_by_id"
+const SelectTraceColumns = "Timestamp, UUID, TraceId, SpanId, ParentSpanId, ProjectId, SecureSessionId, TraceState, SpanName, SpanKind, Duration, ServiceName, ServiceVersion, Environment, HasErrors, TraceAttributes, StatusCode, StatusMessage, Events.Timestamp, Events.Name, Events.Attributes"
 
 var traceKeysToColumns = map[modelInputs.ReservedTraceKey]string{
 	modelInputs.ReservedTraceKeySecureSessionID: "SecureSessionId",
@@ -69,6 +71,9 @@ var traceColumns = []string{
 	"StatusMessage",
 	"Environment",
 	"HasErrors",
+	"Events.Timestamp",
+	"Events.Name",
+	"Events.Attributes",
 }
 
 // These keys show up as recommendations, but with no recommended values due to high cardinality
@@ -79,6 +84,7 @@ var defaultTraceKeys = []*modelInputs.QueryKey{
 	{Name: string(modelInputs.ReservedTraceKeyDuration), Type: modelInputs.KeyTypeNumeric},
 	{Name: string(modelInputs.ReservedTraceKeyParentSpanID), Type: modelInputs.KeyTypeString},
 	{Name: string(modelInputs.ReservedTraceKeySecureSessionID), Type: modelInputs.KeyTypeString},
+	{Name: string(modelInputs.ReservedTraceKeyMetricName), Type: modelInputs.KeyTypeString},
 }
 
 var TracesTableNoDefaultConfig = model.TableConfig[modelInputs.ReservedTraceKey]{
@@ -266,6 +272,7 @@ func (client *Client) ReadTraces(ctx context.Context, projectID int, params mode
 				TraceAttributes: expandJSON(result.TraceAttributes),
 				StatusCode:      result.StatusCode,
 				StatusMessage:   result.StatusMessage,
+				Events:          extractEvents(result),
 			},
 		}, nil
 	}
@@ -359,6 +366,7 @@ func getTracesFromRows(rows driver.Rows) ([]*modelInputs.Trace, error) {
 			TraceAttributes: expandJSON(result.TraceAttributes),
 			StatusCode:      result.StatusCode,
 			StatusMessage:   result.StatusMessage,
+			Events:          extractEvents(result),
 		})
 	}
 
@@ -375,19 +383,32 @@ func getTracesFromRows(rows driver.Rows) ([]*modelInputs.Trace, error) {
 	return traces, nil
 }
 
+func extractEvents(result ClickhouseTraceRow) []*modelInputs.TraceEvent {
+	return lo.Map(result.EventsTimestamp, func(t time.Time, idx int) *modelInputs.TraceEvent {
+		return &modelInputs.TraceEvent{
+			Timestamp: t,
+			Name:      result.EventsName[idx],
+			Attributes: lo.MapEntries(result.EventsAttributes[idx], func(k string, v string) (string, interface{}) {
+				return k, v
+			}),
+		}
+	})
+}
+
 func (client *Client) ReadTrace(ctx context.Context, projectID int, traceID string) ([]*modelInputs.Trace, error) {
+	span, ctx := util.StartSpanFromContext(ctx, "clickhouse.ReadTrace", util.Tag("projectID", projectID), util.Tag("traceID", traceID))
+	defer span.Finish()
+
 	sb := sqlbuilder.NewSelectBuilder()
 	var err error
 	var args []interface{}
 
 	sb.From(TracesByIdTable).
-		Select("Timestamp, UUID, TraceId, SpanId, ParentSpanId, ProjectId, SecureSessionId, TraceState, SpanName, SpanKind, Duration, ServiceName, ServiceVersion, Environment, HasErrors, TraceAttributes, StatusCode, StatusMessage").
+		Select(SelectTraceColumns).
 		Where(sb.Equal("ProjectId", projectID)).
 		Where(sb.Equal("TraceId", traceID))
 
 	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
-
-	span, _ := util.StartSpanFromContext(ctx, "traces", util.ResourceName("ReadTrace"))
 
 	rows, err := client.conn.Query(ctx, sql, args...)
 	if err != nil {
@@ -401,16 +422,14 @@ func (client *Client) ReadTrace(ctx context.Context, projectID int, traceID stri
 		return nil, err
 	}
 
-	span.Finish()
-
 	if len(traces) > 0 {
 		return traces, nil
 	}
 
-	span, _ = util.StartSpanFromContext(ctx, "traces", util.ResourceName("ReadTraceFallback"))
+	span.SetAttribute("mode", "fallback")
 
 	sb.From(TracesTable).
-		Select("Timestamp, UUID, TraceId, SpanId, ParentSpanId, ProjectId, SecureSessionId, TraceState, SpanName, SpanKind, Duration, ServiceName, ServiceVersion, Environment, HasErrors, TraceAttributes, StatusCode, StatusMessage").
+		Select(SelectTraceColumns).
 		Where(sb.Equal("ProjectId", projectID)).
 		Where(sb.Equal("TraceId", traceID)).
 		Where(sb.GE("Timestamp", time.Now().Add(-5*time.Minute))).
@@ -430,7 +449,6 @@ func (client *Client) ReadTrace(ctx context.Context, projectID int, traceID stri
 		return nil, err
 	}
 
-	span.Finish()
 	return traces, nil
 }
 

--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -115,6 +115,14 @@ func extractFields(ctx context.Context, params extractFieldsParams) (*extractedF
 					"Attributes": link.Attributes().AsRaw(),
 				}
 			}
+		} else {
+			fields.events = []map[string]any{
+				{
+					"Timestamp":  params.event.Timestamp().AsTime(),
+					"Name":       params.event.Name(),
+					"Attributes": params.event.Attributes().AsRaw(),
+				},
+			}
 		}
 	}
 

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -289,9 +289,8 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 							projectTraceMetrics[fields.projectID] = make(map[string][]*model.MetricInput)
 						}
 						projectTraceMetrics[fields.projectID][fields.sessionID] = append(projectTraceMetrics[fields.projectID][fields.sessionID], metric)
-					} else {
-						lg(ctx, fields).Warnf("otel received unknown event %s", event.Name())
 					}
+					// process unknown events as trace events
 				}
 
 				// skip logrus spans

--- a/backend/parser/parser.go
+++ b/backend/parser/parser.go
@@ -5,7 +5,11 @@ import (
 	"github.com/highlight-run/highlight/backend/model"
 	parser "github.com/highlight-run/highlight/backend/parser/antlr"
 	"github.com/highlight-run/highlight/backend/parser/listener"
+	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
+	"github.com/highlight-run/highlight/backend/util"
 	"github.com/huandu/go-sqlbuilder"
+	"go.opentelemetry.io/otel/trace"
+	"strings"
 )
 
 func GetSearchListener[T ~string](sqlBuilder *sqlbuilder.SelectBuilder, query string, tableConfig model.TableConfig[T]) *listener.SearchListener[T] {
@@ -13,12 +17,19 @@ func GetSearchListener[T ~string](sqlBuilder *sqlbuilder.SelectBuilder, query st
 }
 
 func GetSearchFilters[T ~string](query string, tableConfig model.TableConfig[T], listener *listener.SearchListener[T]) listener.Filters {
-	is := antlr.NewInputStream(query + " " + tableConfig.DefaultFilter)
+	s := util.StartSpan("GetSearchFilters", util.WithSpanKind(trace.SpanKindServer), util.Tag("query", query))
+	defer s.Finish()
+
+	if !strings.Contains(query, string(modelInputs.ReservedTraceKeyMetricName)) {
+		query = query + " " + tableConfig.DefaultFilter
+	}
+	is := antlr.NewInputStream(query)
 	lexer := parser.NewSearchGrammarLexer(is)
 	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
 	p := parser.NewSearchGrammarParser(stream)
 
 	antlr.ParseTreeWalkerDefault.Walk(listener, p.Search_query())
+	s.SetAttribute("processed_query", query)
 	return listener.GetFilters()
 }
 

--- a/frontend/src/components/CustomColumnPopover/index.tsx
+++ b/frontend/src/components/CustomColumnPopover/index.tsx
@@ -37,6 +37,8 @@ type TraceColumnType =
 	| 'session'
 	| 'duration'
 	| 'boolean'
+	| 'metric_name'
+	| 'metric_value'
 export type TraceCustomColumn = CustomColumn<TraceColumnType>
 
 export type ValidCustomColumn = CustomColumn<any>

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -14379,6 +14379,11 @@ export const GetTraceDocument = gql`
 				startTime
 				statusCode
 				statusMessage
+				events {
+					timestamp
+					name
+					attributes
+				}
 			}
 			errors {
 				created_at
@@ -14481,6 +14486,11 @@ export const GetTracesDocument = gql`
 					traceAttributes
 					statusCode
 					statusMessage
+					events {
+						timestamp
+						name
+						attributes
+					}
 				}
 			}
 			pageInfo {

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4901,7 +4901,18 @@ export type GetTraceQuery = { __typename?: 'Query' } & {
 					| 'startTime'
 					| 'statusCode'
 					| 'statusMessage'
-				>
+				> & {
+						events?: Types.Maybe<
+							Array<
+								Types.Maybe<
+									{ __typename?: 'TraceEvent' } & Pick<
+										Types.TraceEvent,
+										'timestamp' | 'name' | 'attributes'
+									>
+								>
+							>
+						>
+					}
 			>
 			errors: Array<
 				{ __typename?: 'TraceError' } & Pick<
@@ -4954,7 +4965,18 @@ export type GetTracesQuery = { __typename?: 'Query' } & {
 						| 'traceAttributes'
 						| 'statusCode'
 						| 'statusMessage'
-					>
+					> & {
+							events?: Types.Maybe<
+								Array<
+									Types.Maybe<
+										{ __typename?: 'TraceEvent' } & Pick<
+											Types.TraceEvent,
+											'timestamp' | 'name' | 'attributes'
+										>
+									>
+								>
+							>
+						}
 				}
 		>
 		pageInfo: { __typename?: 'PageInfo' } & Pick<

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2329,6 +2329,11 @@ query GetTrace(
 			startTime
 			statusCode
 			statusMessage
+			events {
+				timestamp
+				name
+				attributes
+			}
 		}
 		errors {
 			created_at
@@ -2381,6 +2386,11 @@ query GetTraces(
 				traceAttributes
 				statusCode
 				statusMessage
+				events {
+					timestamp
+					name
+					attributes
+				}
 			}
 		}
 		pageInfo {

--- a/frontend/src/pages/Traces/CustomColumns/accessors.ts
+++ b/frontend/src/pages/Traces/CustomColumns/accessors.ts
@@ -1,0 +1,20 @@
+import { TraceEdge } from '@graph/schemas'
+
+const AccessKeyAccessor = function (accessKey: string) {
+	return `node.${accessKey}`
+}
+
+const MetricNameAccessor = () => {
+	return (row: TraceEdge) => row.node.events?.at(0)?.attributes['metric.name']
+}
+
+const MetricValueAccessor = () => {
+	return (row: TraceEdge) =>
+		row.node.events?.at(0)?.attributes['metric.value']
+}
+
+export const ColumnAccessors = {
+	accessKey: AccessKeyAccessor,
+	metric_name: MetricNameAccessor,
+	metric_value: MetricValueAccessor,
+} as const

--- a/frontend/src/pages/Traces/CustomColumns/columns.ts
+++ b/frontend/src/pages/Traces/CustomColumns/columns.ts
@@ -106,8 +106,8 @@ const METRIC_NAME_COLUMN: TraceCustomColumn = {
 
 const METRIC_VALUE_COLUMN: TraceCustomColumn = {
 	id: 'metric_value',
-	label: 'Metric',
-	type: 'number',
+	label: 'Metric Value',
+	type: 'string',
 	size: '1fr',
 	accessKey: 'metric_value',
 }

--- a/frontend/src/pages/Traces/CustomColumns/columns.ts
+++ b/frontend/src/pages/Traces/CustomColumns/columns.ts
@@ -99,7 +99,7 @@ const SPAN_KIND_COLUMN: TraceCustomColumn = {
 const METRIC_NAME_COLUMN: TraceCustomColumn = {
 	id: 'metric_name',
 	label: 'Metric',
-	type: 'string',
+	type: 'metric_name',
 	size: '1fr',
 	accessKey: 'metric_name',
 }
@@ -107,7 +107,7 @@ const METRIC_NAME_COLUMN: TraceCustomColumn = {
 const METRIC_VALUE_COLUMN: TraceCustomColumn = {
 	id: 'metric_value',
 	label: 'Metric Value',
-	type: 'string',
+	type: 'metric_value',
 	size: '1fr',
 	accessKey: 'metric_value',
 }

--- a/frontend/src/pages/Traces/CustomColumns/columns.ts
+++ b/frontend/src/pages/Traces/CustomColumns/columns.ts
@@ -96,6 +96,22 @@ const SPAN_KIND_COLUMN: TraceCustomColumn = {
 	accessKey: 'spanKind',
 }
 
+const METRIC_NAME_COLUMN: TraceCustomColumn = {
+	id: 'metric_name',
+	label: 'Metric',
+	type: 'string',
+	size: '1fr',
+	accessKey: 'metric_name',
+}
+
+const METRIC_VALUE_COLUMN: TraceCustomColumn = {
+	id: 'metric_value',
+	label: 'Metric',
+	type: 'number',
+	size: '1fr',
+	accessKey: 'metric_value',
+}
+
 export const DEFAULT_TRACE_COLUMNS = [
 	SPAN_NAME_COLUMN,
 	SERVICE_NAME_COLUMN,
@@ -118,4 +134,6 @@ export const HIGHLIGHT_STANDARD_COLUMNS: Record<string, TraceCustomColumn> = {
 	environment: ENVIRONMENT_COLUMN,
 	timestamp: TIMESTAMP_COLUMN,
 	span_kind: SPAN_KIND_COLUMN,
+	metric_name: METRIC_NAME_COLUMN,
+	metric_value: METRIC_VALUE_COLUMN,
 }

--- a/frontend/src/pages/Traces/CustomColumns/renderers.tsx
+++ b/frontend/src/pages/Traces/CustomColumns/renderers.tsx
@@ -231,4 +231,6 @@ export const ColumnRenderers = {
 	duration: DurationRenderer,
 	session: SessionColumnRenderer,
 	string: StringColumnRenderer,
+	metric_name: StringColumnRenderer,
+	metric_value: StringColumnRenderer,
 }

--- a/frontend/src/pages/Traces/TracesList.tsx
+++ b/frontend/src/pages/Traces/TracesList.tsx
@@ -1,4 +1,5 @@
 import { Box, Callout, Stack, Table, Text } from '@highlight-run/ui/components'
+import { ColumnAccessors } from '@pages/Traces/CustomColumns/accessors'
 import { ColumnRenderers } from '@pages/Traces/CustomColumns/renderers'
 import useLocalStorage from '@rehooks/local-storage'
 import {
@@ -173,14 +174,10 @@ export const TracesList: React.FC<Props> = ({
 				},
 			})
 
-			const accessorFn =
-				column.id === 'metric_name'
-					? (row: TraceEdge) =>
-							row.node.events?.at(0)?.attributes['metric.name']
-					: column.id === 'metric_value'
-					? (row: TraceEdge) =>
-							row.node.events?.at(0)?.attributes['metric.value']
-					: `node.${column.accessKey}`
+			const accessorFn = (
+				ColumnAccessors[column.type as keyof typeof ColumnAccessors] ||
+				ColumnAccessors.accessKey
+			)(column.accessKey)
 
 			// @ts-ignore
 			const accessor = columnHelper.accessor(accessorFn, {

--- a/frontend/src/pages/Traces/TracesList.tsx
+++ b/frontend/src/pages/Traces/TracesList.tsx
@@ -1,4 +1,5 @@
 import { Box, Callout, Stack, Table, Text } from '@highlight-run/ui/components'
+import { ColumnRenderers } from '@pages/Traces/CustomColumns/renderers'
 import useLocalStorage from '@rehooks/local-storage'
 import {
 	ColumnDef,
@@ -45,7 +46,6 @@ import {
 	DEFAULT_TRACE_COLUMNS,
 	HIGHLIGHT_STANDARD_COLUMNS,
 } from './CustomColumns/columns'
-import { ColumnRenderers } from './CustomColumns/renderers'
 
 type Props = {
 	loading: boolean
@@ -173,32 +173,34 @@ export const TracesList: React.FC<Props> = ({
 				},
 			})
 
-			columns.push(
-				columnHelper.accessor(
-					column.id === 'metric_name'
-						? (row) => row.node.events[0].attributes['metric.name']
-						: column.id === 'metric_value'
-						? (row) => row.node.events[0].attributes['metric.value']
-						: `node.${column.accessKey}`,
-					{
-						id: column.id,
-						cell: ({ row, getValue }) => {
-							const ColumnRenderer =
-								ColumnRenderers[column.type] ||
-								ColumnRenderers.string
+			const accessorFn =
+				column.id === 'metric_name'
+					? (row: TraceEdge) =>
+							row.node.events?.at(0)?.attributes['metric.name']
+					: column.id === 'metric_value'
+					? (row: TraceEdge) =>
+							row.node.events?.at(0)?.attributes['metric.value']
+					: `node.${column.accessKey}`
 
-							return (
-								<ColumnRenderer
-									key={column.id}
-									row={row}
-									getValue={getValue}
-									first={first}
-								/>
-							)
-						},
-					},
-				),
-			)
+			// @ts-ignore
+			const accessor = columnHelper.accessor(accessorFn, {
+				id: column.id,
+				cell: ({ row, getValue }) => {
+					const ColumnRenderer =
+						ColumnRenderers[column.type] || ColumnRenderers.string
+
+					return (
+						<ColumnRenderer
+							key={column.id}
+							row={row}
+							getValue={getValue}
+							first={first}
+						/>
+					)
+				},
+			})
+
+			columns.push(accessor)
 		})
 
 		// add custom column

--- a/frontend/src/pages/Traces/TracesList.tsx
+++ b/frontend/src/pages/Traces/TracesList.tsx
@@ -158,7 +158,7 @@ export const TracesList: React.FC<Props> = ({
 	const columnData = useMemo(() => {
 		const gridColumns: string[] = []
 		const columnHeaders: ColumnHeader[] = []
-		const columns: ColumnDef<TraceEdge, any>[] = []
+		const columns: ColumnDef<TraceEdge, string>[] = []
 
 		selectedColumns.forEach((column, index) => {
 			const first = index === 0
@@ -173,24 +173,32 @@ export const TracesList: React.FC<Props> = ({
 				},
 			})
 
-			// @ts-ignore
-			const accessor = columnHelper.accessor(`node.${column.accessKey}`, {
-				cell: ({ row, getValue }) => {
-					const ColumnRenderer =
-						ColumnRenderers[column.type] || ColumnRenderers.string
+			columns.push(
+				columnHelper.accessor(
+					column.id === 'metric_name'
+						? (row) => row.node.events[0].attributes['metric.name']
+						: column.id === 'metric_value'
+						? (row) => row.node.events[0].attributes['metric.value']
+						: `node.${column.accessKey}`,
+					{
+						id: column.id,
+						cell: ({ row, getValue }) => {
+							const ColumnRenderer =
+								ColumnRenderers[column.type] ||
+								ColumnRenderers.string
 
-					return (
-						<ColumnRenderer
-							key={column.id}
-							row={row}
-							getValue={getValue}
-							first={first}
-						/>
-					)
-				},
-			})
-
-			columns.push(accessor)
+							return (
+								<ColumnRenderer
+									key={column.id}
+									row={row}
+									getValue={getValue}
+									first={first}
+								/>
+							)
+						},
+					},
+				),
+			)
 		})
 
 		// add custom column

--- a/frontend/src/pages/Traces/utils.ts
+++ b/frontend/src/pages/Traces/utils.ts
@@ -236,7 +236,7 @@ export const formatTraceAttributes = (attributes: { [key: string]: any }) => {
 		span_id: attributes.spanID,
 		span_kind: attributes.spanKind,
 		status_code: attributes.statusCode,
-		events: attributes.events.map(({ __typename, ...other }: any) => ({
+		events: attributes.events?.map(({ __typename, ...other }: any) => ({
 			...other,
 		})),
 		host,

--- a/frontend/src/pages/Traces/utils.ts
+++ b/frontend/src/pages/Traces/utils.ts
@@ -236,6 +236,9 @@ export const formatTraceAttributes = (attributes: { [key: string]: any }) => {
 		span_id: attributes.spanID,
 		span_kind: attributes.spanKind,
 		status_code: attributes.statusCode,
+		events: attributes.events.map(({ __typename, ...other }: any) => ({
+			...other,
+		})),
 		host,
 		os,
 		process,


### PR DESCRIPTION
## Summary

Supports visualizing trace `metric.name` events as custom trace attributes
for visualizing metrics coming out of a session, such as web vitals of viewport size.

This allows searching for sessions where a given metric value is set.

Closes HIG-4575

## How did you test this change?

![Screenshot from 2024-06-24 14-19-40](https://github.com/highlight/highlight/assets/1351531/d5d09056-033d-4d9d-9853-60d2d08a0df1)

![Screenshot from 2024-06-24 14-21-17](https://github.com/highlight/highlight/assets/1351531/2e6d2917-872d-449d-9ed5-5557fe2db8f4)

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
