### PR TITLE
fixup! Additional logging and tracing for batch kafka workers (#8832)

### DIFF
--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -640,11 +640,13 @@ func (k *KafkaBatchWorker) ProcessMessages(ctx context.Context) {
 			defer receiveCancel()
 			task := k.KafkaQueue.Receive(receiveCtx)
 			s1.Finish()
-			if task != nil && task.GetType() != kafkaqueue.HealthCheck {
-				k.messages = append(k.messages, task)
+			
+			if task != nil {
+				k.lastPartitionId = &task.GetKafkaMessage().Partition
+				if task.GetType() != kafkaqueue.HealthCheck {
+					k.messages = append(k.messages, task)
+				}
 			}
-
-			k.lastPartitionId = &task.GetKafkaMessage().Partition
 
 			if time.Since(k.lastFlush) > k.BatchedFlushTimeout || len(k.messages) >= k.BatchFlushSize {
 				s.SetAttribute("FlushDelay", time.Since(k.lastFlush).Seconds())

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -640,7 +640,7 @@ func (k *KafkaBatchWorker) ProcessMessages(ctx context.Context) {
 			defer receiveCancel()
 			task := k.KafkaQueue.Receive(receiveCtx)
 			s1.Finish()
-			
+
 			if task != nil {
 				k.lastPartitionId = &task.GetKafkaMessage().Partition
 				if task.GetType() != kafkaqueue.HealthCheck {


### PR DESCRIPTION
## Summary

Fixes panic from main when no batched queue messages are to be flushed.

![Screenshot from 2024-06-25 16-12-48](https://github.com/highlight/highlight/assets/1351531/5a9b818a-9ce3-491e-8963-c781fae1c29f)


## How did you test this change?

Local deploy
![Screenshot from 2024-06-25 16-13-37](https://github.com/highlight/highlight/assets/1351531/99fdba25-f869-41ac-851e-7c1ec570f42f)


## Are there any deployment considerations?

no

## Does this work require review from our design team?

no