### PR TITLE
support collector OTLP header authentication

### DIFF
--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -3,6 +3,7 @@ package otel
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -70,6 +71,7 @@ func newExtractedFields() *extractedFields {
 }
 
 type extractFieldsParams struct {
+	headers   http.Header
 	resource  *pcommon.Resource
 	span      *ptrace.Span
 	event     *ptrace.SpanEvent
@@ -201,6 +203,10 @@ func extractFields(ctx context.Context, params extractFieldsParams) (*extractedF
 	if val, ok := fields.attrs[highlight.ProjectIDAttribute]; ok {
 		fields.projectID = val
 		delete(fields.attrs, highlight.ProjectIDAttribute)
+	}
+
+	if val := params.headers.Get(highlight.ProjectIDHeader); val != "" {
+		fields.projectID = val
 	}
 
 	if val, ok := fields.attrs[highlight.DeprecatedSessionIDAttribute]; ok {

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -190,6 +190,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 				}
 
 				fields, err := extractFields(r.Context(), extractFieldsParams{
+					headers:  r.Header,
 					resource: &resource,
 					span:     &span,
 					curTime:  curTime,
@@ -208,6 +209,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 					}
 					event := events.At(l)
 					fields, err := extractFields(r.Context(), extractFieldsParams{
+						headers:  r.Header,
 						resource: &resource,
 						span:     &span,
 						event:    &event,
@@ -435,6 +437,7 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 				logRecord := logRecords.At(k)
 
 				fields, err := extractFields(r.Context(), extractFieldsParams{
+					headers:                r.Header,
 					resource:               &resource,
 					logRecord:              &logRecord,
 					curTime:                curTime,

--- a/backend/otel/samples/log.json
+++ b/backend/otel/samples/log.json
@@ -1,0 +1,42 @@
+{
+	"resourceLogs": [
+		{
+			"resource": {
+				"attributes": [
+					{
+						"key": "service.name",
+						"value": {
+							"stringValue": "my-service"
+						}
+					}
+				]
+			},
+			"scopeLogs": [
+				{
+					"scope": {},
+					"logRecords": [
+						{
+							"timeUnixNano": "1719358500000000000",
+							"severityNumber": 9,
+							"severityText": "Info",
+							"name": "logA",
+							"body": {
+								"stringValue": "Hello, world! This is sent from a curl command."
+							},
+							"attributes": [
+								{
+									"key": "foo",
+									"value": {
+										"stringValue": "bar"
+									}
+								}
+							],
+							"traceId": "08040201000000000000000000000000",
+							"spanId": "0102040800000000"
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/deploy/otel-collector.yaml
+++ b/deploy/otel-collector.yaml
@@ -14,6 +14,7 @@ receivers:
         protocols:
             grpc:
                 endpoint: '0.0.0.0:4317'
+                include_metadata: true
             http:
                 endpoint: '0.0.0.0:4318'
                 max_request_body_size: 0
@@ -27,6 +28,8 @@ receivers:
 exporters:
     otlphttp:
         endpoint: 'http://pub.prod.vpc.highlight.io:8082/otel'
+        auth:
+            authenticator: headers_setter
         timeout: 30s
         read_buffer_size: 32768
         write_buffer_size: 32768
@@ -45,6 +48,9 @@ processors:
         spike_limit_mib: 1024
         check_interval: 0.1s
     batch:
+        metadata_keys:
+            - x-highlight-project
+        metadata_cardinality_limit: 1000
         timeout: 1s
         send_batch_size: 1000
         send_batch_max_size: 10000
@@ -55,7 +61,7 @@ service:
         metrics:
             address: '0.0.0.0:8888'
             level: detailed
-    extensions: [health_check]
+    extensions: [headers_setter, health_check]
     pipelines:
         traces:
             receivers: [otlp]
@@ -70,6 +76,11 @@ service:
             processors: [memory_limiter, batch]
             exporters: [otlphttp]
 extensions:
+    headers_setter:
+        headers:
+            - action: upsert
+              key: x-highlight-project
+              from_context: x-highlight-project
     health_check:
         endpoint: '0.0.0.0:4319'
         path: '/health/status'

--- a/docker/collector.yml
+++ b/docker/collector.yml
@@ -14,6 +14,7 @@ receivers:
         protocols:
             grpc:
                 endpoint: '0.0.0.0:4317'
+                include_metadata: true
             http:
                 endpoint: '0.0.0.0:4318'
                 max_request_body_size: 0
@@ -30,6 +31,8 @@ exporters:
         sampling_thereafter: 1000
     otlphttp:
         endpoint: 'https://host.docker.internal:8082/otel'
+        auth:
+            authenticator: headers_setter
         tls:
             insecure_skip_verify: true
         timeout: 30s
@@ -46,6 +49,9 @@ exporters:
             max_elapsed_time: 300s
 processors:
     batch:
+        metadata_keys:
+            - x-highlight-project
+        metadata_cardinality_limit: 1000
         timeout: 1s
         send_batch_size: 1000
         send_batch_max_size: 10000
@@ -56,7 +62,7 @@ service:
         metrics:
             address: '0.0.0.0:8888'
             level: detailed
-    extensions: [health_check]
+    extensions: [headers_setter, health_check]
     pipelines:
         traces:
             receivers: [otlp]
@@ -71,6 +77,11 @@ service:
             processors: [batch]
             exporters: [otlphttp, logging]
 extensions:
+    headers_setter:
+        headers:
+            - action: upsert
+              key: x-highlight-project
+              from_context: x-highlight-project
     health_check:
         endpoint: '0.0.0.0:4319'
         path: '/health/status'

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -27,6 +27,7 @@ const OTLPDefaultEndpoint = "https://otel.highlight.io:4318"
 
 const ErrorURLAttribute = "URL"
 
+const ProjectIDHeader = "x-highlight-project"
 const DeprecatedProjectIDAttribute = "highlight_project_id"
 const DeprecatedSessionIDAttribute = "highlight_session_id"
 const DeprecatedRequestIDAttribute = "highlight_trace_id"


### PR DESCRIPTION
## Summary

Adds support for OTLP HTTP header `x-highlight-project` for setting the highlight project
ID for data sent by a given opentelemetry collector.

Allows integration with Traceloop as documented in https://github.com/traceloop/docs/pull/33

## How did you test this change?

unit test
![Screenshot from 2024-06-25 16-23-16](https://github.com/highlight/highlight/assets/1351531/46f4785f-7b87-437c-8501-4132dd80d629)

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
