### PR TITLE
Enable caching for highlight.io#build

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -23,7 +23,8 @@
 		"highlight.io#build": {
 			"dependsOn": ["^build"],
 			"outputs": [".next/**"],
-			"env": ["GRAPHCMS_TOKEN"]
+			"env": ["GRAPHCMS_TOKEN"],
+			"cache": true
 		},
 		"highlight.io#lint": {
 			"dependsOn": ["^build"]


### PR DESCRIPTION
## Summary

When running the app via `yarn dev:frontend` we rebuild the `highlight.io` package every time because we have `cache: false` set for the `dev` task. However, the contents of this package don't change often and it's not even a critical part of the main app. This PR sets `cache: true` for the `highlight.io#build` step which allows the cache to be hit and save a lot of time starting up the app locally.

<img width="1413" alt="Screenshot 2024-06-27 at 10 10 34 AM" src="https://github.com/highlight/highlight/assets/308182/4a70615f-9bff-46be-bf29-23b0c86e8bc0">

## How did you test this change?

Ran a `dev:frontend` build with and without the setting. Confirmed that with caching enabled the cache was leveraged locally and the time to start up the app was much faster.

## Are there any deployment considerations?

No, I don't believe so. I think the cache is not leveraged in CI, so this only impacts local builds.

## Does this work require review from our design team?

N/A
