### PR TITLE
update billing page included counts

### DIFF
--- a/frontend/src/pages/Billing/BillingPageV2.tsx
+++ b/frontend/src/pages/Billing/BillingPageV2.tsx
@@ -626,7 +626,7 @@ const BillingPageV2 = ({}: BillingPageProps) => {
 				<Stack>
 					<Heading level="h4">Billing plans</Heading>
 					{isAWSMP ? null : (
-						<Box display="inline-flex" gap="6">
+						<Box display="inline-flex" gap="4" alignItems="center">
 							<Text size="small" color="weak">
 								Prices are flexible around your needs. Custom
 								quote?

--- a/frontend/src/pages/Billing/BillingPageV2.tsx
+++ b/frontend/src/pages/Billing/BillingPageV2.tsx
@@ -626,15 +626,17 @@ const BillingPageV2 = ({}: BillingPageProps) => {
 				<Stack>
 					<Heading level="h4">Billing plans</Heading>
 					{isAWSMP ? null : (
-						<Box display="inline-flex">
+						<Box display="inline-flex" gap="6">
 							<Text size="small" color="weak">
 								Prices are flexible around your needs. Custom
-								quote?{' '}
-								<CalendlyButton
-									text="Reach out to sales"
-									howCanWeHelp="Custom quote"
-								/>
+								quote?
 							</Text>
+							<CalendlyButton
+								text="Book a call."
+								size="xSmall"
+								emphasis="low"
+								howCanWeHelp="Custom quote"
+							/>
 						</Box>
 					)}
 					{billingIssue ? (

--- a/frontend/src/pages/Billing/BillingPageV2.tsx
+++ b/frontend/src/pages/Billing/BillingPageV2.tsx
@@ -94,6 +94,7 @@ const UsageCard = ({
 	billingLimitCents,
 	usageAmount,
 	usageLimitAmount,
+	planType,
 	includedQuantity,
 	isPaying,
 	enableBillingLimits,
@@ -213,7 +214,8 @@ const UsageCard = ({
 										{usageAmount.toLocaleString()}{' '}
 										{productType.toLocaleLowerCase()}
 									</b>{' '}
-									this month. 300000 are included in the free
+									this month. {includedQuantity} are included
+									on the {planType}
 									tier.
 								</Text>
 							</Box>

--- a/frontend/src/pages/Billing/BillingPageV2.tsx
+++ b/frontend/src/pages/Billing/BillingPageV2.tsx
@@ -1,3 +1,4 @@
+import { CalendlyButton } from '@components/CalendlyModal/CalendlyButton'
 import LoadingBox from '@components/LoadingBox'
 import { toast } from '@components/Toaster'
 import { USD } from '@dinero.js/currencies'
@@ -7,7 +8,6 @@ import {
 	Callout,
 	Heading,
 	IconProps,
-	IconSolidArrowSmRight,
 	IconSolidCheveronDown,
 	IconSolidCheveronRight,
 	IconSolidExclamation,
@@ -26,7 +26,6 @@ import {
 import { vars } from '@highlight-run/ui/vars'
 import { BarChart } from '@pages/Graphing/components/BarChart'
 import { TIMESTAMP_KEY } from '@pages/Graphing/components/Graph'
-import { getPlanChangeEmail } from '@util/billing/billing'
 import { dinero, toDecimal } from 'dinero.js'
 import moment from 'moment'
 import React, { useEffect } from 'react'
@@ -215,8 +214,7 @@ const UsageCard = ({
 										{productType.toLocaleLowerCase()}
 									</b>{' '}
 									this month. {includedQuantity} are included
-									on the {planType}
-									tier.
+									on the {planType} tier.
 								</Text>
 							</Box>
 						</Tooltip>
@@ -632,20 +630,10 @@ const BillingPageV2 = ({}: BillingPageProps) => {
 							<Text size="small" color="weak">
 								Prices are flexible around your needs. Custom
 								quote?{' '}
-								<a
-									href={getPlanChangeEmail({
-										workspaceID: workspace_id,
-										planType: PlanType.Enterprise,
-									})}
-								>
-									<Box
-										display="inline-flex"
-										alignItems="center"
-									>
-										Reach out to sales{' '}
-										<IconSolidArrowSmRight />
-									</Box>
-								</a>
+								<CalendlyButton
+									text="Reach out to sales"
+									howCanWeHelp="Custom quote"
+								/>
 							</Text>
 						</Box>
 					)}


### PR DESCRIPTION
## Summary

Billing page was incorrectly showing included number of resources.

## How did you test this change?

before
![Screenshot from 2024-06-28 14-28-53](https://github.com/highlight/highlight/assets/1351531/1e5d39e4-daae-4dfe-974a-e34693c5cae4)


after
![Screenshot from 2024-06-28 14-39-27](https://github.com/highlight/highlight/assets/1351531/35409621-ecaa-42d5-92be-03c7bc96dcf9)


## Are there any deployment considerations?

no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

no
<!--
 Request review from julian-highlight / our design team 
-->
