### PR TITLE
fix datasync queue

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -91,6 +91,8 @@ func GetTopic(options GetTopicOptions) string {
 
 type ConfigOverride struct {
 	Async            *bool
+	BatchSize        *int
+	BatchTimeout     *time.Duration
 	QueueCapacity    *int
 	MinBytes         *int
 	MaxWait          *time.Duration
@@ -200,6 +202,12 @@ func New(ctx context.Context, topic string, mode Mode, configOverride *ConfigOve
 			deref := *configOverride
 			if deref.Async != nil {
 				pool.kafkaP.Async = *deref.Async
+			}
+			if deref.BatchSize != nil {
+				pool.kafkaP.BatchSize = *deref.BatchSize
+			}
+			if deref.BatchTimeout != nil {
+				pool.kafkaP.BatchTimeout = *deref.BatchTimeout
 			}
 			if deref.MessageSizeBytes != nil {
 				pool.kafkaP.BatchBytes = *deref.MessageSizeBytes

--- a/backend/main.go
+++ b/backend/main.go
@@ -317,12 +317,17 @@ func main() {
 		}
 	}
 
+	// sync writes with batching per-partition
 	kafkaProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDefault}), kafkaqueue.Producer, nil)
-	kafkaDataSyncProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDataSync}), kafkaqueue.Producer, nil)
+	// sync writes without batching
+	kafkaDataSyncProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDataSync}), kafkaqueue.Producer, &kafkaqueue.ConfigOverride{BatchSize: ptr.Int(1)})
+
 	// async writes for workers (where order of write between workers does not matter)
 	kCfg := &kafkaqueue.ConfigOverride{Async: ptr.Bool(true)}
 	kafkaBatchedProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeBatched}), kafkaqueue.Producer, kCfg)
+	defer kafkaBatchedProducer.Stop(ctx)
 	kafkaTracesProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeTraces}), kafkaqueue.Producer, kCfg)
+	defer kafkaTracesProducer.Stop(ctx)
 
 	lambda, err := lambda.NewLambdaClient()
 	if err != nil {

--- a/backend/main.go
+++ b/backend/main.go
@@ -318,11 +318,11 @@ func main() {
 	}
 
 	kafkaProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDefault}), kafkaqueue.Producer, nil)
+	kafkaDataSyncProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDataSync}), kafkaqueue.Producer, nil)
 	// async writes for workers (where order of write between workers does not matter)
 	kCfg := &kafkaqueue.ConfigOverride{Async: ptr.Bool(true)}
 	kafkaBatchedProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeBatched}), kafkaqueue.Producer, kCfg)
 	kafkaTracesProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeTraces}), kafkaqueue.Producer, kCfg)
-	kafkaDataSyncProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDataSync}), kafkaqueue.Producer, kCfg)
 
 	lambda, err := lambda.NewLambdaClient()
 	if err != nil {

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -95,7 +95,7 @@ func TestMain(m *testing.M) {
 		Redis:            redisClient,
 		Clickhouse:       chClient,
 		StorageClient:    &storage.FilesystemClient{},
-		Store:            store.NewStore(db, redisClient, integrations.NewIntegrationsClient(db), &storage.FilesystemClient{}, &kafka_queue.MockMessageQueue{}, chClient),
+		Store:            store.NewStore(db, redisClient, integrations.NewIntegrationsClient(db), &storage.FilesystemClient{}, &kafka_queue.MockMessageQueue{}, nil),
 		EmbeddingsClient: &mockEmbeddingsClient{},
 		DataSyncQueue:    &kafka_queue.MockMessageQueue{},
 		TracesQueue:      &kafka_queue.MockMessageQueue{},
@@ -465,7 +465,7 @@ func TestUpdatingErrorState(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, errorGroup.State, privateModel.ErrorStateOpen)
 
-		_, err = resolver.Store.UpdateErrorGroupStateBySystem(ctx, store.UpdateErrorGroupParams{
+		err = resolver.Store.UpdateErrorGroupStateBySystem(ctx, store.UpdateErrorGroupParams{
 			ID:    errorGroup.ID,
 			State: privateModel.ErrorStateResolved,
 		})
@@ -481,7 +481,7 @@ func TestUpdatingErrorState(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, errorGroup.State, privateModel.ErrorStateOpen)
 
-		_, err = resolver.Store.UpdateErrorGroupStateBySystem(ctx, store.UpdateErrorGroupParams{
+		err = resolver.Store.UpdateErrorGroupStateBySystem(ctx, store.UpdateErrorGroupParams{
 			ID:    errorGroup.ID,
 			State: privateModel.ErrorStateIgnored,
 		})

--- a/backend/store/error_groups.go
+++ b/backend/store/error_groups.go
@@ -3,8 +3,10 @@ package store
 import (
 	"context"
 	"errors"
+	"strconv"
 	"time"
 
+	kafka_queue "github.com/highlight-run/highlight/backend/kafka-queue"
 	"github.com/highlight-run/highlight/backend/model"
 	privateModel "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"gorm.io/gorm/clause"
@@ -101,32 +103,48 @@ type UpdateErrorGroupParams struct {
 
 func (store *Store) UpdateErrorGroupStateByAdmin(ctx context.Context,
 	admin model.Admin, params UpdateErrorGroupParams) (*model.ErrorGroup, error) {
-	return store.updateErrorGroupState(ctx, &admin, params)
+	err := store.updateErrorGroupState(ctx, &admin, params)
+	if err != nil {
+		return nil, err
+	}
+
+	// For user-driven state updates, write the error group directly to Clickhouse.
+	// Write to the data sync queue as well to guarantee eventual consistency.
+	var errorGroup model.ErrorGroup
+	if err = store.DB.WithContext(ctx).Where(&model.ErrorGroup{Model: model.Model{ID: params.ID}}).First(&errorGroup).Error; err != nil {
+		return nil, err
+	}
+
+	err = store.ClickhouseClient.WriteErrorGroups(ctx, []*model.ErrorGroup{&errorGroup})
+	if err != nil {
+		return nil, err
+	}
+
+	return &errorGroup, nil
 }
 
 func (store *Store) UpdateErrorGroupStateBySystem(ctx context.Context,
-	params UpdateErrorGroupParams) (*model.ErrorGroup, error) {
+	params UpdateErrorGroupParams) error {
 	return store.updateErrorGroupState(ctx, nil, params)
 }
 
 func (store *Store) updateErrorGroupState(ctx context.Context,
-	admin *model.Admin, params UpdateErrorGroupParams) (*model.ErrorGroup, error) {
-	errorGroup := model.ErrorGroup{}
+	admin *model.Admin, params UpdateErrorGroupParams) error {
 
 	if err := AssertRecordFound(store.DB.WithContext(ctx).Where(&model.ErrorGroup{
 		Model: model.Model{
 			ID: params.ID,
 		},
-	}).Model(&errorGroup).Clauses(clause.Returning{}).Updates(map[string]interface{}{
+	}).Model(&model.ErrorGroup{}).Clauses(clause.Returning{}).Updates(map[string]interface{}{
 		"State":        params.State,
 		"SnoozedUntil": params.SnoozedUntil,
 	})); err != nil {
-		return nil, err
+		return err
 	}
 
 	eventType, err := getEventType(params.State)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	eventData := map[string]interface{}{}
@@ -141,16 +159,16 @@ func (store *Store) updateErrorGroupState(ctx context.Context,
 		ErrorGroupID: params.ID,
 		EventData:    eventData,
 	})
+
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	err = store.ClickhouseClient.WriteErrorGroups(ctx, []*model.ErrorGroup{&errorGroup})
-	if err != nil {
-		return nil, err
+	if err := store.DataSyncQueue.Submit(ctx, strconv.Itoa(params.ID), &kafka_queue.Message{Type: kafka_queue.ErrorGroupDataSync, ErrorGroupDataSync: &kafka_queue.ErrorGroupDataSyncArgs{ErrorGroupID: params.ID}}); err != nil {
+		return err
 	}
 
-	return &errorGroup, nil
+	return nil
 
 }
 

--- a/backend/store/error_groups_test.go
+++ b/backend/store/error_groups_test.go
@@ -161,16 +161,18 @@ func TestUpdateErrorGroupStateBySystem(t *testing.T) {
 		SnoozedUntil: &now,
 	}
 
-	unchangedErrorGroup, err := store.UpdateErrorGroupStateBySystem(context.TODO(), params)
+	err := store.UpdateErrorGroupStateBySystem(context.TODO(), params)
 	assert.EqualError(t, err, "record not found")
-	assert.Nil(t, unchangedErrorGroup)
 
 	store.DB.Create(&errorGroup)
 
 	params.ID = errorGroup.ID
 
-	updatedErrorGroup, err := store.UpdateErrorGroupStateBySystem(context.TODO(), params)
+	err = store.UpdateErrorGroupStateBySystem(context.TODO(), params)
 	assert.NoError(t, err)
+
+	var updatedErrorGroup *model.ErrorGroup
+	store.DB.Model(model.ErrorGroup{}).Where("id = ?", params.ID).First(&updatedErrorGroup)
 
 	assert.Equal(t, params.State, updatedErrorGroup.State)
 	assert.Equal(t, params.SnoozedUntil.Format(time.RFC3339), updatedErrorGroup.SnoozedUntil.Format(time.RFC3339))

--- a/backend/worker/autoresolver.go
+++ b/backend/worker/autoresolver.go
@@ -89,7 +89,7 @@ func (autoResolver *AutoResolver) resolveStaleErrorsForProject(ctx context.Conte
 
 		log.WithContext(ctx).WithFields(logFields).Info("Autoresolving error group")
 
-		_, err := autoResolver.store.UpdateErrorGroupStateBySystem(ctx, store.UpdateErrorGroupParams{
+		err := autoResolver.store.UpdateErrorGroupStateBySystem(ctx, store.UpdateErrorGroupParams{
 			ID:    errorGroup.ID,
 			State: privateModel.ErrorStateResolved,
 		})

--- a/backend/worker/autoresolver_test.go
+++ b/backend/worker/autoresolver_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/highlight-run/highlight/backend/clickhouse"
 	"github.com/highlight-run/highlight/backend/integrations"
 	kafka_queue "github.com/highlight-run/highlight/backend/kafka-queue"
 	"github.com/highlight-run/highlight/backend/redis"
@@ -31,12 +30,7 @@ func createAutoResolver() *AutoResolver {
 		testLogger.Error(e.Wrap(err, "error creating testdb"))
 	}
 
-	chClient, err = clickhouse.NewClient(clickhouse.TestDatabase)
-	if err != nil {
-		testLogger.Error(e.Wrap(err, "error creating clickhouse client"))
-	}
-
-	store := store.NewStore(db, redis.NewClient(), integrations.NewIntegrationsClient(db), &storage.FilesystemClient{}, &kafka_queue.MockMessageQueue{}, chClient)
+	store := store.NewStore(db, redis.NewClient(), integrations.NewIntegrationsClient(db), &storage.FilesystemClient{}, &kafka_queue.MockMessageQueue{}, nil)
 	return NewAutoResolver(store, db)
 }
 


### PR DESCRIPTION
## Summary

Testing a hypothesis that autoresolver error group updates may be
missing from clickhouse because we were writing to the datasync queue
async and not waiting for a batched write flush. This is particularly noticeable
with the autoresolver where the job would run one-off and not
wait for the datasync queue write to complete.

## How did you test this change?

deploying to prod

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
