### PR TITLE
Harold UI improvements

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6318,8 +6318,7 @@ body {
 }
 ._1k082jh0:after {
   content: "";
-  background: linear-gradient(45deg, rgba(162, 138, 220) 0%, rgba(216, 165, 216) 50%, rgba(233, 192, 186) 100%);
-  border: 2px solid transparent;
+  border: 2px solid var(--_1pyqka9l);
   border-radius: 5px;
   inset: 0;
   mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0);

--- a/frontend/src/components/Search/SearchForm/AiSearch/index.tsx
+++ b/frontend/src/components/Search/SearchForm/AiSearch/index.tsx
@@ -76,6 +76,7 @@ export const AiSearch: React.FC<any> = ({}) => {
 				dateSuggestion.selectedPreset,
 			)
 			setAiMode(false)
+			setAiQuery('')
 		}
 	}
 
@@ -85,7 +86,7 @@ export const AiSearch: React.FC<any> = ({}) => {
 		}
 
 		if (displayError) {
-			return 'Oops... Harold AI is having issues.'
+			return `Oops... there was an issue. ${aiSuggestionError}`
 		}
 
 		if (submitted) {
@@ -234,11 +235,15 @@ export const AiSearch: React.FC<any> = ({}) => {
 							e.preventDefault()
 							submitQuery(aiQuery)
 						}
+						if (e.key === 'Escape') {
+							setAiMode(false)
+						}
 					}}
 					style={{
 						paddingLeft: 40,
 						top: 6,
 					}}
+					autoFocus
 					data-hl-record
 				/>
 			</Box>

--- a/frontend/src/components/Search/SearchForm/AiSearch/style.css.ts
+++ b/frontend/src/components/Search/SearchForm/AiSearch/style.css.ts
@@ -11,9 +11,7 @@ export const container = style({
 
 	selectors: {
 		'&:after': {
-			background:
-				'linear-gradient(45deg, rgba(162, 138, 220) 0%, rgba(216, 165, 216) 50%, rgba(233, 192, 186) 100%)',
-			border: '2px solid transparent',
+			border: `2px solid ${vars.theme.interactive.fill.primary.enabled}`,
 			content: '',
 			borderRadius: 5,
 			inset: 0,


### PR DESCRIPTION
## Summary
Make the following UI updates to Harold:
- [x] Clicking 'escape' once i get into the query text UI should take me out of it (essentially click 'cancel' for me)
- [x] Write the error message to the user (so they know if there prompt is wrong or if its an error with highlight)
- [x] We shouldn't cache the query text if you accept or edit a query.
- [x] Clicking 'generate query…' should force my cursor into the input box
- [x] Make this outline a solid purple (same color as the icon)

## How did you test this change?
1) Navigate to the logs page
2) When typing in a generated query ensure each of the following check points above is satisfied

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
