### PR TITLE
update session attributes to work for values with _

### DIFF
--- a/backend/clickhouse/migrations/000106_update_session_attributtes.down.sql
+++ b/backend/clickhouse/migrations/000106_update_session_attributtes.down.sql
@@ -1,0 +1,17 @@
+DROP VIEW IF EXISTS sessions_joined_vw;
+CREATE VIEW IF NOT EXISTS sessions_joined_vw AS
+select ProjectID as ProjectId,
+       CreatedAt as Timestamp,
+       mapFromArrays(
+               arrayMap(x->splitByChar('_', x, 2) [2], FieldKeys),
+               arrayMap(
+                       (k, kv)->substring(kv, length(k) + 2),
+                       arrayZip(FieldKeys, FieldKeyValues)
+               )
+       ) as SessionAttributes,
+       arrayMap((kv) -> (
+                     arrayStringConcat(arraySlice(splitByChar('_', kv), 2, length(splitByChar('_', kv)) - 2), '_'),
+                     splitByChar('_', kv)[length(splitByChar('_', kv))]
+       ), FieldKeyValues) as SessionAttributePairs,
+       *
+from sessions FINAL SETTINGS splitby_max_substrings_includes_remaining_string = 1;

--- a/backend/clickhouse/migrations/000106_update_session_attributtes.up.sql
+++ b/backend/clickhouse/migrations/000106_update_session_attributtes.up.sql
@@ -9,9 +9,9 @@ select ProjectID as ProjectId,
                        arrayZip(FieldKeys, FieldKeyValues)
                )
        ) as SessionAttributes,
-       arrayMap((kv) -> (
-                     arrayStringConcat(arraySlice(splitByChar('_', kv), 2, -2), '_'),
-                     arrayStringConcat(arraySlice(splitByChar('_', kv), 3), '_')
-       ), FieldKeyValues) as SessionAttributePairs,
+       arrayMap((k, kv) -> (
+                   arrayStringConcat(arraySlice(splitByChar('_', k), 2), '_'),
+                   substring(kv, length(k) + 2)
+       ), arrayZip(FieldKeys, FieldKeyValues)) as SessionAttributePairs,
        *
 from sessions FINAL SETTINGS splitby_max_substrings_includes_remaining_string = 1;

--- a/backend/clickhouse/migrations/000106_update_session_attributtes.up.sql
+++ b/backend/clickhouse/migrations/000106_update_session_attributtes.up.sql
@@ -1,0 +1,17 @@
+DROP VIEW IF EXISTS sessions_joined_vw;
+CREATE VIEW IF NOT EXISTS sessions_joined_vw AS
+select ProjectID as ProjectId,
+       CreatedAt as Timestamp,
+       mapFromArrays(
+               arrayMap(x->splitByChar('_', x, 2) [2], FieldKeys),
+               arrayMap(
+                       (k, kv)->substring(kv, length(k) + 2),
+                       arrayZip(FieldKeys, FieldKeyValues)
+               )
+       ) as SessionAttributes,
+       arrayMap((kv) -> (
+                     arrayStringConcat(arraySlice(splitByChar('_', kv), 2, -2), '_'),
+                     arrayStringConcat(arraySlice(splitByChar('_', kv), 3), '_')
+       ), FieldKeyValues) as SessionAttributePairs,
+       *
+from sessions FINAL SETTINGS splitby_max_substrings_includes_remaining_string = 1;


### PR DESCRIPTION
## Summary

As reported by a customer, session attributes with a `_` in the value would
work because the `SessionAttributePairs` mv would incorrectly index them.

## How did you test this change?

Locally testing new SQL migration against prod.

`select
    arrayFilter((k, v) -> v like '%\_%', SessionAttributePairs)
from sessions_joined_vw;`
![Screenshot from 2024-07-01 09-08-36](https://github.com/highlight/highlight/assets/1351531/6f0a0dea-a622-4db8-a13d-68f02dd44bd1)

![Screenshot from 2024-07-01 09-11-05](https://github.com/highlight/highlight/assets/1351531/9c2de8be-29f8-4a6c-82e5-0e53fde97303)


## Are there any deployment considerations?

no

## Does this work require review from our design team?

no