### PR TITLE
Clean up feature flags

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -18,7 +18,6 @@ import {
 	IconSolidArrowSmRight,
 	IconSolidAtSymbol,
 	IconSolidChartBar,
-	IconSolidChartPie,
 	IconSolidChat,
 	IconSolidCheck,
 	IconSolidCog,
@@ -152,7 +151,6 @@ export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 	const { projectId } = useProjectId()
 	const { projectId: localStorageProjectId } = useLocalStorageProjectId()
 	const { isLoggedIn, signOut } = useAuthContext()
-	const showAnalytics = useFeatureFlag(Feature.Analytics)
 	const showMetrics = useFeatureFlag(Feature.Metrics)
 	const { allProjects, currentWorkspace } = useApplicationContext()
 	const workspaceId = currentWorkspace?.id
@@ -349,33 +347,6 @@ export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 											kind="secondary"
 										/>
 										<Menu.List>
-											{showAnalytics && (
-												<Link
-													to={`/${projectId}/dashboards`}
-													className={linkStyle}
-												>
-													<Menu.Item>
-														<Box
-															display="flex"
-															alignItems="center"
-															gap="4"
-														>
-															<IconSolidChartBar
-																size={14}
-																color={
-																	vars.theme
-																		.interactive
-																		.fill
-																		.secondary
-																		.content
-																		.text
-																}
-															/>
-															Dashboards
-														</Box>
-													</Menu.Item>
-												</Link>
-											)}
 											<Link
 												to={`/${projectId}/integrations`}
 												className={linkStyle}
@@ -401,33 +372,6 @@ export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 													</Box>
 												</Menu.Item>
 											</Link>
-											{showAnalytics && (
-												<Link
-													to={`/${projectId}/analytics`}
-													className={linkStyle}
-												>
-													<Menu.Item>
-														<Box
-															display="flex"
-															alignItems="center"
-															gap="4"
-														>
-															<IconSolidChartPie
-																size={14}
-																color={
-																	vars.theme
-																		.interactive
-																		.fill
-																		.secondary
-																		.content
-																		.text
-																}
-															/>
-															Analytics
-														</Box>
-													</Menu.Item>
-												</Link>
-											)}
 											<Link
 												to={`/${projectId}/setup`}
 												className={linkStyle}

--- a/frontend/src/hooks/useFeatureFlag/useFeatureFlag.ts
+++ b/frontend/src/hooks/useFeatureFlag/useFeatureFlag.ts
@@ -14,44 +14,25 @@ interface Config {
 }
 
 export enum Feature {
-	HistogramTimelineV2,
-	AiSessionInsights,
-	Analytics,
+	AiQueryBuilder,
+	MetricAlerts,
 	Metrics,
 }
 
 // configures the criteria and percentage of population for which the feature is active.
 // can configure to rollout by project, workspace, or admin
 export const FeatureConfig: { [key: number]: Config } = {
-	[Feature.HistogramTimelineV2]: {
-		workspace: true,
-		percent: 100,
-		projectOverride: new Set<string>([
-			// Portal
-			'79',
-			// Impira
-			'122',
-			'153',
-			'172',
-			// Sunsama
-			'657',
-			// Synder
-			'1031',
-		]),
-	},
-	[Feature.AiSessionInsights]: {
-		workspace: true,
-		percent: 100,
-	},
-	[Feature.Analytics]: {
+	[Feature.AiQueryBuilder]: {
 		workspace: true,
 		percent: 0,
 		workspaceOverride: new Set<string>([
-			// Numero
-			'701',
-			// MediaJel
-			'9634',
+			// Highlight
+			'1',
 		]),
+	},
+	[Feature.MetricAlerts]: {
+		workspace: true,
+		percent: 0,
 	},
 	[Feature.Metrics]: {
 		workspace: true,

--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -39,6 +39,7 @@ import {
 	useGetMetricsQuery,
 	useGetWorkspaceSettingsQuery,
 } from '@/graph/generated/hooks'
+import useFeatureFlag, { Feature } from '@/hooks/useFeatureFlag/useFeatureFlag'
 import { useNumericProjectId } from '@/hooks/useProjectId'
 import { useSearchTime } from '@/hooks/useSearchTime'
 import { TIMESTAMP_KEY } from '@/pages/Graphing/components/Graph'
@@ -83,6 +84,7 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 		project_id: string
 	}>()
 	const { currentWorkspace } = useApplicationContext()
+	const aiQueryBuilderFlag = useFeatureFlag(Feature.AiQueryBuilder)
 	const [aiMode, setAiMode] = useState(false)
 	const [query, setQuery] = useQueryParam('query', QueryParam)
 	const queryParts = useMemo(() => {
@@ -259,6 +261,10 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 		} as AiSuggestion
 	}, [aiData])
 
+	const enableAiQueryBuilder =
+		aiQueryBuilderFlag &&
+		workspaceSettings?.workspaceSettings?.ai_query_builder
+
 	return (
 		<SearchContext
 			initialQuery={query}
@@ -301,11 +307,7 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 						timeMode={timeMode}
 						savedSegmentType={SavedSegmentEntityType.Log}
 						textAreaRef={textAreaRef}
-						enableAIMode={
-							projectId === '1' &&
-							workspaceSettings?.workspaceSettings
-								?.ai_query_builder
-						}
+						enableAIMode={enableAiQueryBuilder}
 					/>
 					<LogsCount
 						startDate={searchTimeContext.startDate}

--- a/frontend/src/pages/Player/RightPlayerPanel/components/Tabs/index.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/Tabs/index.tsx
@@ -11,7 +11,6 @@ import {
 } from '@pages/Player/context/PlayerUIContext'
 
 import { useGetWorkspaceSettingsQuery } from '@/graph/generated/hooks'
-import useFeatureFlag, { Feature } from '@/hooks/useFeatureFlag/useFeatureFlag'
 import EventStreamV2 from '@/pages/Player/components/EventStreamV2/EventStreamV2'
 import MetadataPanel from '@/pages/Player/MetadataPanel/MetadataPanel'
 import SessionInsights from '@/pages/Player/RightPlayerPanel/components/SessionInsights/SessionInsights'
@@ -20,7 +19,6 @@ import { useApplicationContext } from '@/routers/AppRouter/context/ApplicationCo
 const RightPanelTabs = () => {
 	const { selectedRightPanelTab, setSelectedRightPanelTab } =
 		usePlayerUIContext()
-	const showSessionInsights = useFeatureFlag(Feature.AiSessionInsights)
 
 	const { currentWorkspace } = useApplicationContext()
 
@@ -29,8 +27,7 @@ const RightPanelTabs = () => {
 		skip: !currentWorkspace?.id,
 	})
 
-	const showAiInsights =
-		showSessionInsights && data?.workspaceSettings?.ai_application
+	const showAiInsights = data?.workspaceSettings?.ai_application
 
 	return (
 		<Tabs<RightPlayerTab>


### PR DESCRIPTION
## Summary
Clean up the feature flags that are no longer used:
- `Feature.HistogramTimelineV2`: not references
- `Feature.AiSessionInsights`: ramped up to 100% for over a year
- `Feature.Analytics`: pages no longer exist

Add the following feature toggles:
- `Feature.AiQueryBuilder`: turns on logs query builder (only Highlight enabled)
- `Feature.MetricAlerts`: turns on new alerts page (no workspaces)

## How did you test this change?
1. Builds successful
2. No links for Analytics and Dashboards for relevant projects
3. AiSessionInsights still works

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A