### PR TITLE
HIG-4768 add new session exclusion reasons to ui

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -11539,7 +11539,7 @@ type Session {
 	identifier: String!
 	identified: Boolean!
 	created_at: Timestamp!
-	payload_updated_at: Timestamp!
+	payload_updated_at: Timestamp
 	length: Int
 	active_length: Int
 	user_object: Any
@@ -68270,14 +68270,11 @@ func (ec *executionContext) _Session_payload_updated_at(ctx context.Context, fie
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(*time.Time)
 	fc.Result = res
-	return ec.marshalNTimestamp2ᚖtimeᚐTime(ctx, field.Selections, res)
+	return ec.marshalOTimestamp2ᚖtimeᚐTime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Session_payload_updated_at(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -95055,9 +95052,6 @@ func (ec *executionContext) _Session(ctx context.Context, sel ast.SelectionSet, 
 			}
 		case "payload_updated_at":
 			out.Values[i] = ec._Session_payload_updated_at(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "length":
 			out.Values[i] = ec._Session_length(ctx, field, obj)
 		case "active_length":

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -52,7 +52,7 @@ type Session {
 	identifier: String!
 	identified: Boolean!
 	created_at: Timestamp!
-	payload_updated_at: Timestamp!
+	payload_updated_at: Timestamp
 	length: Int
 	active_length: Int
 	user_object: Any

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -3342,7 +3342,7 @@ export type Session = {
 	os_name: Scalars['String']
 	os_version: Scalars['String']
 	payload_size?: Maybe<Scalars['Int64']>
-	payload_updated_at: Scalars['Timestamp']
+	payload_updated_at?: Maybe<Scalars['Timestamp']>
 	postal: Scalars['String']
 	privacy_setting?: Maybe<Scalars['String']>
 	processed?: Maybe<Scalars['Boolean']>

--- a/frontend/src/pages/Player/SessionView.tsx
+++ b/frontend/src/pages/Player/SessionView.tsx
@@ -3,7 +3,7 @@ import 'rc-slider/assets/index.css'
 import ElevatedCard from '@components/ElevatedCard/ElevatedCard'
 import LoadingBox from '@components/LoadingBox'
 import { useIsSessionPendingQuery } from '@graph/hooks'
-import { Session } from '@graph/schemas'
+import { Session, SessionExcludedReason } from '@graph/schemas'
 import { Box, Callout, Text } from '@highlight-run/ui/components'
 import { useWindowSize } from '@hooks/useWindowSize'
 import { CompleteSetup } from '@pages/Player/components/CompleteSetup/CompleteSetup'
@@ -287,7 +287,7 @@ export const SessionFiller: React.FC<{
 			} else {
 				let reasonText: React.ReactNode
 				switch (session?.excluded_reason) {
-					case 'BillingQuotaExceeded':
+					case SessionExcludedReason.BillingQuotaExceeded:
 						reasonText = (
 							<>
 								This session was recorded after your billing
@@ -302,7 +302,7 @@ export const SessionFiller: React.FC<{
 							</>
 						)
 						break
-					case 'RetentionPeriodExceeded':
+					case SessionExcludedReason.RetentionPeriodExceeded:
 						reasonText = (
 							<>
 								This session is older than your plan's retention
@@ -316,6 +316,37 @@ export const SessionFiller: React.FC<{
 								.
 							</>
 						)
+						break
+					case SessionExcludedReason.NoUserEvents:
+					case SessionExcludedReason.NoTimelineIndicatorEvents:
+					case SessionExcludedReason.NoUserInteractionEvents:
+					case SessionExcludedReason.NoActivity:
+						reasonText =
+							'This session was excluded because it has no user interactions.'
+						break
+					case SessionExcludedReason.NoError:
+						reasonText =
+							'This session was excluded because it has no errors, according to your project settings.'
+						break
+					case SessionExcludedReason.IgnoredUser:
+						reasonText =
+							'This session was excluded because the user is set as ignored in your project settings.'
+						break
+					case SessionExcludedReason.ExclusionFilter:
+						reasonText =
+							'This session was excluded because it matches one of the exclusion filters in your project settings.'
+						break
+					case SessionExcludedReason.Initializing:
+						reasonText =
+							'This session is still being processed and will be ready to view soon.'
+						break
+					case SessionExcludedReason.Sampled:
+						reasonText =
+							'This session was excluded by the sampling settings in your project.'
+						break
+					case SessionExcludedReason.RateLimitMinute:
+						reasonText =
+							'This session was excluded by the rate limit settings in your project.'
 						break
 					default:
 						reasonText =


### PR DESCRIPTION
## Summary
- some of the newer exclusion reasons would show the default "session does not exist or has not been made public" error, which is confusing when a user gets linked to an excluded session e.g. from an alert
- update the logic to have all exclusion types
- relax `payload_updated_at` not-null requirement as some of these sessions do not have this set (e.g. if no events)
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
