### PR TITLE
[SUP-63] fix logging from background tasks

### DIFF
--- a/e2e/python/highlight_fastapi/main_2.py
+++ b/e2e/python/highlight_fastapi/main_2.py
@@ -2,14 +2,16 @@ import asyncio
 import sys
 import highlight_io
 import uvicorn
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, BackgroundTasks
 from highlight_io.integrations.fastapi import FastAPIMiddleware
+import logging
+
 
 # `instrument_logging=True` sets up logging instrumentation.
 # if you do not want to send logs or are using `loguru`, pass `instrument_logging=False`
 H = highlight_io.H(
     11983,
-    instrument_logging=False,
+    instrument_logging=True,
     service_name="my-app",
     service_version="git-sha",
 )
@@ -24,6 +26,16 @@ async def read_root(request: Request):
     result = 1 / 0
     return {"Hello": "World"}
 
+def log_in_background():
+    logging.info("logging in background task")
+    return
+
+@app.get("/background")
+async def read_background(request: Request, background_tasks: BackgroundTasks):
+    logging.info("starting a background task")
+    background_tasks.add_task(log_in_background)
+    logging.info("started a background task")
+    return {"Hello": "World"}
 
 async def main():
     "Run scheduler and the API"

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -480,7 +480,7 @@ class H(object):
 
         def factory(*args, **kwargs) -> LogRecord:
             span = otel_trace.get_current_span()
-            if span != INVALID_SPAN:
+            if span != INVALID_SPAN and span.is_recording():
                 manager = contextlib.nullcontext(enter_result=span)
             else:
                 manager = self.trace("highlight.log")

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "highlight-io"
-version = "0.8.3"
+version = "0.8.4"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 license = "Apache-2.0"
 authors = [


### PR DESCRIPTION
## Summary
- we fail to send logs to Highlight in FastAPI background tasks with our `FastAPIMiddleware` because the current span has ended (the request returned before the background task started)
- one workaround implemented here is to create a new span in the `LogRecordFactory` if the current span has stopped recording
- it also works to remove the `is_recording` check in the log hook - unsure if this causes issues elsewhere

closes #8827
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- used e2e test to validate background task's logs were sent
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
