### PR TITLE
report client screen size

### DIFF
--- a/.changeset/witty-parents-relax.md
+++ b/.changeset/witty-parents-relax.md
@@ -1,5 +1,0 @@
----
-'highlight.run': patch
----
-
-add screen measurements to session viewport data

--- a/.changeset/witty-parents-relax.md
+++ b/.changeset/witty-parents-relax.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+add screen measurements to session viewport data

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -745,12 +745,6 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			})
 			// recordStop is not part of listeners because we do not actually want to stop rrweb
 			// rrweb has some bugs that make the stop -> restart workflow broken (eg iframe listeners)
-			const viewport = {
-				height: window.innerHeight,
-				width: window.innerWidth,
-			}
-			this.addCustomEvent('Viewport', viewport)
-			this.submitViewportMetrics(viewport)
 
 			if (!this._recordStop) {
 				if (this.options.recordCrossOriginIframe) {
@@ -1086,13 +1080,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 		}
 	}
 
-	submitViewportMetrics({
-		height,
-		width,
-	}: {
-		height: number
-		width: number
-	}) {
+	submitViewportMetrics({ height, width, availHeight, availWidth }: Screen) {
 		this.recordMetric([
 			{
 				name: MetricName.ViewportHeight,
@@ -1103,6 +1091,18 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			{
 				name: MetricName.ViewportWidth,
 				value: width,
+				category: MetricCategory.Device,
+				group: window.location.href,
+			},
+			{
+				name: MetricName.ScreenHeight,
+				value: availHeight,
+				category: MetricCategory.Device,
+				group: window.location.href,
+			},
+			{
+				name: MetricName.ScreenWidth,
+				value: availWidth,
 				category: MetricCategory.Device,
 				group: window.location.href,
 			},

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -36,7 +36,10 @@ import stringify from 'json-stringify-safe'
 import { print } from 'graphql'
 import { determineMaskInputOptions } from './utils/privacy'
 
-import { ViewportResizeListener } from './listeners/viewport-resize-listener'
+import {
+	ViewportResizeListener,
+	type ViewportResizeListenerArgs,
+} from './listeners/viewport-resize-listener'
 import { SegmentIntegrationListener } from './listeners/segment-integration-listener'
 import { ClickListener } from './listeners/click-listener/click-listener'
 import { FocusListener } from './listeners/focus-listener/focus-listener'
@@ -912,10 +915,12 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			)
 
 			this.listeners.push(
-				ViewportResizeListener((viewport) => {
-					this.addCustomEvent('Viewport', viewport)
-					this.submitViewportMetrics(viewport)
-				}),
+				ViewportResizeListener(
+					(viewport: ViewportResizeListenerArgs) => {
+						this.addCustomEvent('Viewport', viewport)
+						this.submitViewportMetrics(viewport)
+					},
+				),
 			)
 			this.listeners.push(
 				ClickListener((clickTarget, event) => {
@@ -1080,7 +1085,12 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 		}
 	}
 
-	submitViewportMetrics({ height, width, availHeight, availWidth }: Screen) {
+	submitViewportMetrics({
+		height,
+		width,
+		availHeight,
+		availWidth,
+	}: ViewportResizeListenerArgs) {
 		this.recordMetric([
 			{
 				name: MetricName.ViewportHeight,

--- a/sdk/client/src/listeners/viewport-resize-listener.tsx
+++ b/sdk/client/src/listeners/viewport-resize-listener.tsx
@@ -1,25 +1,20 @@
-interface ViewportResizeListenerCallback {
-	height: number
-	width: number
-}
-
-/**
- * Listens to when resize events on the viewport.
- * Takes the last value after DELAY ms passes. We're doing this to avoid taking the intermediate values while the user is resizing.
- */
-export const ViewportResizeListener = (
-	callback: (args: ViewportResizeListenerCallback) => void,
-) => {
+export const ViewportResizeListener = (callback: (args: Screen) => void) => {
 	let id: ReturnType<typeof setTimeout>
 	const DELAY = 500
 
 	const onResize = () => {
 		clearTimeout(id)
 		id = setTimeout(() => {
-			callback({ height: window.innerHeight, width: window.innerWidth })
+			callback({
+				...window.screen,
+				height: window.innerHeight,
+				width: window.innerWidth,
+			})
 		}, DELAY)
 	}
 	window.addEventListener('resize', onResize)
 
+	// call on initial listener creation
+	onResize()
 	return () => window.removeEventListener('resize', onResize)
 }

--- a/sdk/client/src/listeners/viewport-resize-listener.tsx
+++ b/sdk/client/src/listeners/viewport-resize-listener.tsx
@@ -1,4 +1,10 @@
-export const ViewportResizeListener = (callback: (args: Screen) => void) => {
+export type ViewportResizeListenerArgs = Omit<Screen, 'orientation'> & {
+	orientation: number
+}
+
+export const ViewportResizeListener = (
+	callback: (args: ViewportResizeListenerArgs) => void,
+) => {
 	let id: ReturnType<typeof setTimeout>
 	const DELAY = 500
 
@@ -6,9 +12,13 @@ export const ViewportResizeListener = (callback: (args: Screen) => void) => {
 		clearTimeout(id)
 		id = setTimeout(() => {
 			callback({
-				...window.screen,
 				height: window.innerHeight,
 				width: window.innerWidth,
+				availHeight: window.screen.availHeight,
+				availWidth: window.screen.availWidth,
+				colorDepth: window.screen.colorDepth,
+				pixelDepth: window.screen.pixelDepth,
+				orientation: window.screen.orientation.angle,
 			})
 		}, DELAY)
 	}

--- a/sdk/client/src/types/client.ts
+++ b/sdk/client/src/types/client.ts
@@ -167,6 +167,8 @@ export enum MetricName {
 	DeviceMemory = 'DeviceMemory',
 	ViewportHeight = 'ViewportHeight',
 	ViewportWidth = 'ViewportWidth',
+	ScreenHeight = 'ScreenHeight',
+	ScreenWidth = 'ScreenWidth',
 	ViewportArea = 'ViewportArea',
 }
 export enum MetricCategory {

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -1,5 +1,11 @@
 # highlight.run
 
+## 9.0.3
+
+### Patch Changes
+
+-   50c74161e: add screen measurements to session viewport data
+
 ## 9.0.2
 
 ### Patch Changes

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "9.0.2",
+	"version": "9.0.3",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "9.0.2"
+export default "9.0.3"

--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @highlight-run/next
 
+## 7.5.10
+
+### Patch Changes
+
+-   Updated dependencies [50c74161e]
+    -   highlight.run@9.0.3
+    -   @highlight-run/node@3.9.0
+
 ## 7.5.9
 
 ### Patch Changes

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "7.5.9",
+	"version": "7.5.10",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-remix/CHANGELOG.md
+++ b/sdk/highlight-remix/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @highlight-run/remix
 
+## 2.0.41
+
+### Patch Changes
+
+-   Updated dependencies [50c74161e]
+    -   highlight.run@9.0.3
+    -   @highlight-run/node@3.9.0
+
 ## 2.0.40
 
 ### Patch Changes

--- a/sdk/highlight-remix/package.json
+++ b/sdk/highlight-remix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/remix",
-	"version": "2.0.40",
+	"version": "2.0.41",
 	"description": "Client for interfacing with Highlight in Remix",
 	"packageManager": "yarn@4.0.2",
 	"author": "",


### PR DESCRIPTION
## Summary

Adds `window.screen` metrics to the reported session metadata to report
full monitor size in addition to the window size.

## How did you test this change?

local

![Screenshot from 2024-07-01 15-29-03](https://github.com/highlight/highlight/assets/1351531/16d1cb58-e8f9-43de-aa72-fa8b6999c08c)
![Screenshot from 2024-07-01 15-29-20](https://github.com/highlight/highlight/assets/1351531/eba2640d-4b60-495e-be29-8243827089f0)


## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
