### PR TITLE
fix stripe issue breaking workspace creation on local deploy

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -495,11 +495,11 @@ func (r *mutationResolver) CreateWorkspace(ctx context.Context, name string, pro
 		c, err = r.PricingClient.Customers.New(params)
 		if err != nil {
 			log.WithContext(ctx).Error(err, "error creating stripe customer")
+		} else {
+			if err := r.DB.WithContext(ctx).Model(&workspace).Updates(&model.Workspace{StripeCustomerID: &c.ID}).Error; err != nil {
+				return nil, e.Wrap(err, "error updating workspace StripeCustomerID")
+			}
 		}
-	}
-
-	if err := r.DB.WithContext(ctx).Model(&workspace).Updates(&model.Workspace{StripeCustomerID: &c.ID}).Error; err != nil {
-		return nil, e.Wrap(err, "error updating workspace StripeCustomerID")
 	}
 
 	return workspace, nil


### PR DESCRIPTION
## Summary

Recent changes in #7909 mock the stripe client to make it possible to not use it, but some
places in our code still depend on the return value not being nil.

## How did you test this change?

Local deploy (hobby mode) successfully creating a workspace

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no