### PR TITLE
avoid processing multiple ruby span events

### DIFF
--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -202,7 +202,6 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 				traceID := cast(fields.requestID, span.TraceID().String())
 				spanID := span.SpanID().String()
 
-				// TODO(vkorolik) deduplicate
 				spanHasErrors := false
 				for l := 0; l < events.Len(); l++ {
 					if skipped {


### PR DESCRIPTION
## Summary

Ruby SDK produces multiple span events resulting in duplicate exceptions being recorded.

## How did you test this change?

Prod deploy monitoring customer project.

## Are there any deployment considerations?

no, will debug why this is an issue only with ruby sdk

## Does this work require review from our design team?

no