### PR TITLE
Update deprecated types in Remix

### DIFF
--- a/.changeset/light-olives-design.md
+++ b/.changeset/light-olives-design.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/remix': patch
+---
+
+Update deprecated DataFunctionArgs type in Remix

--- a/docs-content/getting-started/fullstack-frameworks/remix.md
+++ b/docs-content/getting-started/fullstack-frameworks/remix.md
@@ -135,7 +135,7 @@ Alternatively, you can wrap Highlight's error handler and execute your own custo
 
 ```javascript
 // app/entry.server.tsx
-import type { DataFunctionArgs } from '@remix-run/node'
+import type { LoaderFunctionArgs, ActionFunctionArgs } from '@remix-run/node'
 
 import { H, HandleError } from '@highlight-run/remix/server'
 
@@ -143,7 +143,7 @@ const nodeOptions = { projectID: process.env.HIGHLIGHT_PROJECT_ID }
 
 export function handleError(
 	error: unknown,
-	dataFunctionArgs: DataFunctionArgs,
+	dataFunctionArgs: LoaderFunctionArgs | ActionFunctionArgs,
 ) {
 	const handleError = HandleError(nodeOptions)
 

--- a/e2e/remix/app/entry.server.tsx
+++ b/e2e/remix/app/entry.server.tsx
@@ -7,7 +7,8 @@
 import { H, HandleError } from '@highlight-run/remix/server'
 import type {
 	AppLoadContext,
-	DataFunctionArgs,
+	LoaderFunctionArgs,
+	ActionFunctionArgs,
 	EntryContext,
 } from '@remix-run/node'
 
@@ -29,7 +30,7 @@ const nodeOptions: NodeOptions = {
 
 export function handleError(
 	error: unknown,
-	dataFunctionArgs: DataFunctionArgs,
+	dataFunctionArgs: LoaderFunctionArgs | ActionFunctionArgs,
 ) {
 	const handleError = HandleError(nodeOptions)
 

--- a/sdk/highlight-remix/src/server.ts
+++ b/sdk/highlight-remix/src/server.ts
@@ -1,5 +1,5 @@
 import { H, NodeOptions } from '@highlight-run/node'
-import type { DataFunctionArgs } from '@remix-run/node'
+import type { LoaderFunctionArgs, ActionFunctionArgs } from '@remix-run/node'
 import { SESSION_SECURE_ID } from './constants'
 
 export { H } from '@highlight-run/node'
@@ -7,7 +7,10 @@ export { H } from '@highlight-run/node'
 export function HandleError(nodeOptions: NodeOptions) {
 	H.init(nodeOptions)
 
-	return function handleError(error: unknown, { request }: DataFunctionArgs) {
+	return function handleError(
+		error: unknown,
+		{ request }: LoaderFunctionArgs | ActionFunctionArgs,
+	) {
 		if (error instanceof Error) {
 			const cookies = parseCookies(request.headers.get('Cookie') ?? '')
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

`DataFunctionArgs` type has been deprecated in Remix v2.4.0 (see [changelog](https://github.com/remix-run/remix/blob/e8d1aea4fb023b0967da02914d630b1f1c4a35e4/CHANGELOG.md#minor-changes-6)). Therefore, I have updated this type to `LoaderFunctionArgs | ActionFunctionArgs` (Ref: [handleError documentation](https://remix.run/docs/en/main/file-conventions/entry.server#handleerror)).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
No

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
No

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
No