### PR TITLE
Update alert backend queries and mutations

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1921,10 +1921,11 @@ func (s *Session) GetUserProperties() (map[string]string, error) {
 type Alert struct {
 	Model
 	ProjectID         int
+	MetricId          string
 	Name              string
 	ProductType       modelInputs.ProductType
 	FunctionType      modelInputs.MetricAggregator
-	Metric            string
+	FunctionColumn    *string
 	Query             *string
 	GroupByKey        *string
 	Disabled          bool                `gorm:"default:false"`
@@ -1933,7 +1934,7 @@ type Alert struct {
 
 	// fields for threshold alert
 	BelowThreshold    *bool
-	ThresholdCount    *int
+	ThresholdValue    *float64
 	ThresholdWindow   *int
 	ThresholdCooldown *int
 }

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -6,10 +6,11 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
-	"github.com/highlight-run/highlight/backend/env"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/highlight-run/highlight/backend/env"
 
 	Email "github.com/highlight-run/highlight/backend/email"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
@@ -1923,6 +1924,7 @@ type Alert struct {
 	Name              string
 	ProductType       modelInputs.ProductType
 	FunctionType      modelInputs.MetricAggregator
+	Metric            string
 	Query             *string
 	GroupByKey        *string
 	Disabled          bool                `gorm:"default:false"`

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -836,7 +836,7 @@ type ComplexityRoot struct {
 		ChangeAdminRole                       func(childComplexity int, workspaceID int, adminID int, newRole string) int
 		ChangeProjectMembership               func(childComplexity int, workspaceID int, adminID int, projectIds []int) int
 		CreateAdmin                           func(childComplexity int) int
-		CreateAlert                           func(childComplexity int, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int) int
+		CreateAlert                           func(childComplexity int, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, belowThreshold *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int) int
 		CreateCloudflareProxy                 func(childComplexity int, workspaceID int, proxySubdomain string) int
 		CreateErrorAlert                      func(childComplexity int, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, query string, regexGroups []*string, frequency int, defaultArg *bool) int
 		CreateErrorComment                    func(childComplexity int, projectID int, errorGroupSecureID string, text string, textForEmail string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, errorURL string, authorName string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
@@ -898,7 +898,7 @@ type ComplexityRoot struct {
 		TestErrorEnhancement                  func(childComplexity int, errorObjectID int, githubRepoPath string, githubPrefix *string, buildPrefix *string, saveError *bool) int
 		UpdateAdminAboutYouDetails            func(childComplexity int, adminDetails model.AdminAboutYouDetails) int
 		UpdateAdminAndCreateWorkspace         func(childComplexity int, adminAndWorkspaceDetails model.AdminAndWorkspaceDetails) int
-		UpdateAlert                           func(childComplexity int, projectID int, alertID int, name *string, productType *model.ProductType, functionType *model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdValue *int, thresholdWindow *int, thresholdCooldown *int) int
+		UpdateAlert                           func(childComplexity int, projectID int, alertID int, name *string, productType *model.ProductType, functionType *model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, belowThreshold *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int) int
 		UpdateAlertDisabled                   func(childComplexity int, projectID int, alertID int, disabled bool) int
 		UpdateAllowMeterOverage               func(childComplexity int, workspaceID int, allowMeterOverage bool) int
 		UpdateAllowedEmailOrigins             func(childComplexity int, workspaceID int, allowedAutoJoinEmailOrigins string) int
@@ -1783,8 +1783,8 @@ type MutationResolver interface {
 	SyncSlackIntegration(ctx context.Context, projectID int) (*model.SlackSyncResponse, error)
 	CreateMetricMonitor(ctx context.Context, projectID int, name string, aggregator model.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
 	UpdateMetricMonitor(ctx context.Context, metricMonitorID int, projectID int, name *string, aggregator *model.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, disabled *bool, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
-	CreateAlert(ctx context.Context, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int) (*model1.Alert, error)
-	UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *model.ProductType, functionType *model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdValue *int, thresholdWindow *int, thresholdCooldown *int) (*model1.Alert, error)
+	CreateAlert(ctx context.Context, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, belowThreshold *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int) (*model1.Alert, error)
+	UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *model.ProductType, functionType *model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, belowThreshold *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int) (*model1.Alert, error)
 	UpdateAlertDisabled(ctx context.Context, projectID int, alertID int, disabled bool) (bool, error)
 	DeleteAlert(ctx context.Context, projectID int, alertID int) (bool, error)
 	CreateErrorAlert(ctx context.Context, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, query string, regexGroups []*string, frequency int, defaultArg *bool) (*model1.ErrorAlert, error)
@@ -5653,7 +5653,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.CreateAlert(childComplexity, args["project_id"].(int), args["name"].(string), args["product_type"].(model.ProductType), args["function_type"].(model.MetricAggregator), args["function_column"].(*string), args["query"].(*string), args["group_by_key"].(*string), args["disabled"].(*bool), args["below_threshold"].(*bool), args["threshold_value"].(*float64), args["threshold_window"].(*int), args["threshold_cooldown"].(*int)), true
+		return e.complexity.Mutation.CreateAlert(childComplexity, args["project_id"].(int), args["name"].(string), args["product_type"].(model.ProductType), args["function_type"].(model.MetricAggregator), args["function_column"].(*string), args["query"].(*string), args["group_by_key"].(*string), args["below_threshold"].(*bool), args["threshold_value"].(*float64), args["threshold_window"].(*int), args["threshold_cooldown"].(*int)), true
 
 	case "Mutation.createCloudflareProxy":
 		if e.complexity.Mutation.CreateCloudflareProxy == nil {
@@ -6397,7 +6397,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.UpdateAlert(childComplexity, args["project_id"].(int), args["alert_id"].(int), args["name"].(*string), args["product_type"].(*model.ProductType), args["function_type"].(*model.MetricAggregator), args["function_column"].(*string), args["query"].(*string), args["group_by_key"].(*string), args["disabled"].(*bool), args["below_threshold"].(*bool), args["threshold_value"].(*int), args["threshold_window"].(*int), args["threshold_cooldown"].(*int)), true
+		return e.complexity.Mutation.UpdateAlert(childComplexity, args["project_id"].(int), args["alert_id"].(int), args["name"].(*string), args["product_type"].(*model.ProductType), args["function_type"].(*model.MetricAggregator), args["function_column"].(*string), args["query"].(*string), args["group_by_key"].(*string), args["below_threshold"].(*bool), args["threshold_value"].(*float64), args["threshold_window"].(*int), args["threshold_cooldown"].(*int)), true
 
 	case "Mutation.updateAlertDisabled":
 		if e.complexity.Mutation.UpdateAlertDisabled == nil {
@@ -14274,7 +14274,6 @@ type Mutation {
 		function_column: String
 		query: String
 		group_by_key: String
-		disabled: Boolean
 		below_threshold: Boolean
 		threshold_value: Float
 		threshold_window: Int
@@ -14289,9 +14288,8 @@ type Mutation {
 		function_column: String
 		query: String
 		group_by_key: String
-		disabled: Boolean
 		below_threshold: Boolean
-		threshold_value: Int
+		threshold_value: Float
 		threshold_window: Int
 		threshold_cooldown: Int # TODO(spenny): add destinations
 	): Alert
@@ -14680,50 +14678,41 @@ func (ec *executionContext) field_Mutation_createAlert_args(ctx context.Context,
 	}
 	args["group_by_key"] = arg6
 	var arg7 *bool
-	if tmp, ok := rawArgs["disabled"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("disabled"))
+	if tmp, ok := rawArgs["below_threshold"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("below_threshold"))
 		arg7, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["disabled"] = arg7
-	var arg8 *bool
-	if tmp, ok := rawArgs["below_threshold"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("below_threshold"))
-		arg8, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["below_threshold"] = arg8
-	var arg9 *float64
+	args["below_threshold"] = arg7
+	var arg8 *float64
 	if tmp, ok := rawArgs["threshold_value"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_value"))
-		arg9, err = ec.unmarshalOFloat2ᚖfloat64(ctx, tmp)
+		arg8, err = ec.unmarshalOFloat2ᚖfloat64(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["threshold_value"] = arg9
-	var arg10 *int
+	args["threshold_value"] = arg8
+	var arg9 *int
 	if tmp, ok := rawArgs["threshold_window"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_window"))
+		arg9, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["threshold_window"] = arg9
+	var arg10 *int
+	if tmp, ok := rawArgs["threshold_cooldown"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_cooldown"))
 		arg10, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["threshold_window"] = arg10
-	var arg11 *int
-	if tmp, ok := rawArgs["threshold_cooldown"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_cooldown"))
-		arg11, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["threshold_cooldown"] = arg11
+	args["threshold_cooldown"] = arg10
 	return args, nil
 }
 
@@ -17614,50 +17603,41 @@ func (ec *executionContext) field_Mutation_updateAlert_args(ctx context.Context,
 	}
 	args["group_by_key"] = arg7
 	var arg8 *bool
-	if tmp, ok := rawArgs["disabled"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("disabled"))
+	if tmp, ok := rawArgs["below_threshold"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("below_threshold"))
 		arg8, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["disabled"] = arg8
-	var arg9 *bool
-	if tmp, ok := rawArgs["below_threshold"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("below_threshold"))
-		arg9, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+	args["below_threshold"] = arg8
+	var arg9 *float64
+	if tmp, ok := rawArgs["threshold_value"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_value"))
+		arg9, err = ec.unmarshalOFloat2ᚖfloat64(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["below_threshold"] = arg9
+	args["threshold_value"] = arg9
 	var arg10 *int
-	if tmp, ok := rawArgs["threshold_value"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_value"))
+	if tmp, ok := rawArgs["threshold_window"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_window"))
 		arg10, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["threshold_value"] = arg10
+	args["threshold_window"] = arg10
 	var arg11 *int
-	if tmp, ok := rawArgs["threshold_window"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_window"))
+	if tmp, ok := rawArgs["threshold_cooldown"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_cooldown"))
 		arg11, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["threshold_window"] = arg11
-	var arg12 *int
-	if tmp, ok := rawArgs["threshold_cooldown"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_cooldown"))
-		arg12, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["threshold_cooldown"] = arg12
+	args["threshold_cooldown"] = arg11
 	return args, nil
 }
 
@@ -48481,7 +48461,7 @@ func (ec *executionContext) _Mutation_createAlert(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["product_type"].(model.ProductType), fc.Args["function_type"].(model.MetricAggregator), fc.Args["function_column"].(*string), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["disabled"].(*bool), fc.Args["below_threshold"].(*bool), fc.Args["threshold_value"].(*float64), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int))
+		return ec.resolvers.Mutation().CreateAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["product_type"].(model.ProductType), fc.Args["function_type"].(model.MetricAggregator), fc.Args["function_column"].(*string), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["below_threshold"].(*bool), fc.Args["threshold_value"].(*float64), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -48567,7 +48547,7 @@ func (ec *executionContext) _Mutation_updateAlert(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().UpdateAlert(rctx, fc.Args["project_id"].(int), fc.Args["alert_id"].(int), fc.Args["name"].(*string), fc.Args["product_type"].(*model.ProductType), fc.Args["function_type"].(*model.MetricAggregator), fc.Args["function_column"].(*string), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["disabled"].(*bool), fc.Args["below_threshold"].(*bool), fc.Args["threshold_value"].(*int), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int))
+		return ec.resolvers.Mutation().UpdateAlert(rctx, fc.Args["project_id"].(int), fc.Args["alert_id"].(int), fc.Args["name"].(*string), fc.Args["product_type"].(*model.ProductType), fc.Args["function_type"].(*model.MetricAggregator), fc.Args["function_column"].(*string), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["below_threshold"].(*bool), fc.Args["threshold_value"].(*float64), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -137,16 +137,17 @@ type ComplexityRoot struct {
 		BelowThreshold    func(childComplexity int) int
 		Destinations      func(childComplexity int) int
 		Disabled          func(childComplexity int) int
+		FunctionColumn    func(childComplexity int) int
 		FunctionType      func(childComplexity int) int
 		GroupByKey        func(childComplexity int) int
 		ID                func(childComplexity int) int
 		LastAdminToEditID func(childComplexity int) int
-		Metric            func(childComplexity int) int
+		MetricId          func(childComplexity int) int
 		Name              func(childComplexity int) int
 		ProductType       func(childComplexity int) int
 		Query             func(childComplexity int) int
 		ThresholdCooldown func(childComplexity int) int
-		ThresholdCount    func(childComplexity int) int
+		ThresholdValue    func(childComplexity int) int
 		ThresholdWindow   func(childComplexity int) int
 		UpdatedAt         func(childComplexity int) int
 	}
@@ -835,7 +836,7 @@ type ComplexityRoot struct {
 		ChangeAdminRole                       func(childComplexity int, workspaceID int, adminID int, newRole string) int
 		ChangeProjectMembership               func(childComplexity int, workspaceID int, adminID int, projectIds []int) int
 		CreateAdmin                           func(childComplexity int) int
-		CreateAlert                           func(childComplexity int, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, metric string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) int
+		CreateAlert                           func(childComplexity int, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int) int
 		CreateCloudflareProxy                 func(childComplexity int, workspaceID int, proxySubdomain string) int
 		CreateErrorAlert                      func(childComplexity int, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, query string, regexGroups []*string, frequency int, defaultArg *bool) int
 		CreateErrorComment                    func(childComplexity int, projectID int, errorGroupSecureID string, text string, textForEmail string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, errorURL string, authorName string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
@@ -897,7 +898,7 @@ type ComplexityRoot struct {
 		TestErrorEnhancement                  func(childComplexity int, errorObjectID int, githubRepoPath string, githubPrefix *string, buildPrefix *string, saveError *bool) int
 		UpdateAdminAboutYouDetails            func(childComplexity int, adminDetails model.AdminAboutYouDetails) int
 		UpdateAdminAndCreateWorkspace         func(childComplexity int, adminAndWorkspaceDetails model.AdminAndWorkspaceDetails) int
-		UpdateAlert                           func(childComplexity int, projectID int, alertID int, name *string, productType *model.ProductType, functionType *model.MetricAggregator, metric *string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) int
+		UpdateAlert                           func(childComplexity int, projectID int, alertID int, name *string, productType *model.ProductType, functionType *model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdValue *int, thresholdWindow *int, thresholdCooldown *int) int
 		UpdateAlertDisabled                   func(childComplexity int, projectID int, alertID int, disabled bool) int
 		UpdateAllowMeterOverage               func(childComplexity int, workspaceID int, allowMeterOverage bool) int
 		UpdateAllowedEmailOrigins             func(childComplexity int, workspaceID int, allowedAutoJoinEmailOrigins string) int
@@ -1782,8 +1783,8 @@ type MutationResolver interface {
 	SyncSlackIntegration(ctx context.Context, projectID int) (*model.SlackSyncResponse, error)
 	CreateMetricMonitor(ctx context.Context, projectID int, name string, aggregator model.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
 	UpdateMetricMonitor(ctx context.Context, metricMonitorID int, projectID int, name *string, aggregator *model.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, disabled *bool, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
-	CreateAlert(ctx context.Context, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, metric string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) (*model1.Alert, error)
-	UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *model.ProductType, functionType *model.MetricAggregator, metric *string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) (*model1.Alert, error)
+	CreateAlert(ctx context.Context, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int) (*model1.Alert, error)
+	UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *model.ProductType, functionType *model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdValue *int, thresholdWindow *int, thresholdCooldown *int) (*model1.Alert, error)
 	UpdateAlertDisabled(ctx context.Context, projectID int, alertID int, disabled bool) (bool, error)
 	DeleteAlert(ctx context.Context, projectID int, alertID int) (bool, error)
 	CreateErrorAlert(ctx context.Context, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, query string, regexGroups []*string, frequency int, defaultArg *bool) (*model1.ErrorAlert, error)
@@ -2425,6 +2426,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Alert.Disabled(childComplexity), true
 
+	case "Alert.function_column":
+		if e.complexity.Alert.FunctionColumn == nil {
+			break
+		}
+
+		return e.complexity.Alert.FunctionColumn(childComplexity), true
+
 	case "Alert.function_type":
 		if e.complexity.Alert.FunctionType == nil {
 			break
@@ -2453,12 +2461,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Alert.LastAdminToEditID(childComplexity), true
 
-	case "Alert.metric":
-		if e.complexity.Alert.Metric == nil {
+	case "Alert.metric_id":
+		if e.complexity.Alert.MetricId == nil {
 			break
 		}
 
-		return e.complexity.Alert.Metric(childComplexity), true
+		return e.complexity.Alert.MetricId(childComplexity), true
 
 	case "Alert.name":
 		if e.complexity.Alert.Name == nil {
@@ -2488,12 +2496,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Alert.ThresholdCooldown(childComplexity), true
 
-	case "Alert.threshold_count":
-		if e.complexity.Alert.ThresholdCount == nil {
+	case "Alert.threshold_value":
+		if e.complexity.Alert.ThresholdValue == nil {
 			break
 		}
 
-		return e.complexity.Alert.ThresholdCount(childComplexity), true
+		return e.complexity.Alert.ThresholdValue(childComplexity), true
 
 	case "Alert.threshold_window":
 		if e.complexity.Alert.ThresholdWindow == nil {
@@ -5645,7 +5653,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.CreateAlert(childComplexity, args["project_id"].(int), args["name"].(string), args["product_type"].(model.ProductType), args["function_type"].(model.MetricAggregator), args["metric"].(string), args["query"].(*string), args["group_by_key"].(*string), args["disabled"].(*bool), args["below_threshold"].(*bool), args["threshold_count"].(*int), args["threshold_window"].(*int), args["threshold_cooldown"].(*int)), true
+		return e.complexity.Mutation.CreateAlert(childComplexity, args["project_id"].(int), args["name"].(string), args["product_type"].(model.ProductType), args["function_type"].(model.MetricAggregator), args["function_column"].(*string), args["query"].(*string), args["group_by_key"].(*string), args["disabled"].(*bool), args["below_threshold"].(*bool), args["threshold_value"].(*float64), args["threshold_window"].(*int), args["threshold_cooldown"].(*int)), true
 
 	case "Mutation.createCloudflareProxy":
 		if e.complexity.Mutation.CreateCloudflareProxy == nil {
@@ -6389,7 +6397,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.UpdateAlert(childComplexity, args["project_id"].(int), args["alert_id"].(int), args["name"].(*string), args["product_type"].(*model.ProductType), args["function_type"].(*model.MetricAggregator), args["metric"].(*string), args["query"].(*string), args["group_by_key"].(*string), args["disabled"].(*bool), args["below_threshold"].(*bool), args["threshold_count"].(*int), args["threshold_window"].(*int), args["threshold_cooldown"].(*int)), true
+		return e.complexity.Mutation.UpdateAlert(childComplexity, args["project_id"].(int), args["alert_id"].(int), args["name"].(*string), args["product_type"].(*model.ProductType), args["function_type"].(*model.MetricAggregator), args["function_column"].(*string), args["query"].(*string), args["group_by_key"].(*string), args["disabled"].(*bool), args["below_threshold"].(*bool), args["threshold_value"].(*int), args["threshold_window"].(*int), args["threshold_cooldown"].(*int)), true
 
 	case "Mutation.updateAlertDisabled":
 		if e.complexity.Mutation.UpdateAlertDisabled == nil {
@@ -13078,10 +13086,11 @@ type AlertDestination {
 type Alert {
 	id: ID!
 	updated_at: Timestamp!
+	metric_id: String!
 	name: String!
 	product_type: ProductType!
 	function_type: MetricAggregator!
-	metric: String!
+	function_column: String
 	query: String
 	group_by_key: String
 	disabled: Boolean!
@@ -13090,7 +13099,7 @@ type Alert {
 
 	# threshold alerts
 	below_threshold: Boolean
-	threshold_count: Int
+	threshold_value: Float
 	threshold_window: Int
 	threshold_cooldown: Int
 }
@@ -14262,12 +14271,12 @@ type Mutation {
 		name: String!
 		product_type: ProductType!
 		function_type: MetricAggregator!
-		metric: String!
+		function_column: String
 		query: String
 		group_by_key: String
 		disabled: Boolean
 		below_threshold: Boolean
-		threshold_count: Int
+		threshold_value: Float
 		threshold_window: Int
 		threshold_cooldown: Int # TODO(spenny): add destinations
 	): Alert
@@ -14277,12 +14286,12 @@ type Mutation {
 		name: String
 		product_type: ProductType
 		function_type: MetricAggregator
-		metric: String
+		function_column: String
 		query: String
 		group_by_key: String
 		disabled: Boolean
 		below_threshold: Boolean
-		threshold_count: Int
+		threshold_value: Int
 		threshold_window: Int
 		threshold_cooldown: Int # TODO(spenny): add destinations
 	): Alert
@@ -14643,15 +14652,15 @@ func (ec *executionContext) field_Mutation_createAlert_args(ctx context.Context,
 		}
 	}
 	args["function_type"] = arg3
-	var arg4 string
-	if tmp, ok := rawArgs["metric"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("metric"))
-		arg4, err = ec.unmarshalNString2string(ctx, tmp)
+	var arg4 *string
+	if tmp, ok := rawArgs["function_column"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("function_column"))
+		arg4, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["metric"] = arg4
+	args["function_column"] = arg4
 	var arg5 *string
 	if tmp, ok := rawArgs["query"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
@@ -14688,15 +14697,15 @@ func (ec *executionContext) field_Mutation_createAlert_args(ctx context.Context,
 		}
 	}
 	args["below_threshold"] = arg8
-	var arg9 *int
-	if tmp, ok := rawArgs["threshold_count"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_count"))
-		arg9, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+	var arg9 *float64
+	if tmp, ok := rawArgs["threshold_value"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_value"))
+		arg9, err = ec.unmarshalOFloat2ᚖfloat64(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["threshold_count"] = arg9
+	args["threshold_value"] = arg9
 	var arg10 *int
 	if tmp, ok := rawArgs["threshold_window"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_window"))
@@ -17578,14 +17587,14 @@ func (ec *executionContext) field_Mutation_updateAlert_args(ctx context.Context,
 	}
 	args["function_type"] = arg4
 	var arg5 *string
-	if tmp, ok := rawArgs["metric"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("metric"))
+	if tmp, ok := rawArgs["function_column"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("function_column"))
 		arg5, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["metric"] = arg5
+	args["function_column"] = arg5
 	var arg6 *string
 	if tmp, ok := rawArgs["query"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
@@ -17623,14 +17632,14 @@ func (ec *executionContext) field_Mutation_updateAlert_args(ctx context.Context,
 	}
 	args["below_threshold"] = arg9
 	var arg10 *int
-	if tmp, ok := rawArgs["threshold_count"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_count"))
+	if tmp, ok := rawArgs["threshold_value"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_value"))
 		arg10, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["threshold_count"] = arg10
+	args["threshold_value"] = arg10
 	var arg11 *int
 	if tmp, ok := rawArgs["threshold_window"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_window"))
@@ -24762,6 +24771,50 @@ func (ec *executionContext) fieldContext_Alert_updated_at(ctx context.Context, f
 	return fc, nil
 }
 
+func (ec *executionContext) _Alert_metric_id(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_metric_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MetricId, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Alert_metric_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Alert",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Alert_name(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Alert_name(ctx, field)
 	if err != nil {
@@ -24894,8 +24947,8 @@ func (ec *executionContext) fieldContext_Alert_function_type(ctx context.Context
 	return fc, nil
 }
 
-func (ec *executionContext) _Alert_metric(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Alert_metric(ctx, field)
+func (ec *executionContext) _Alert_function_column(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_function_column(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -24908,24 +24961,21 @@ func (ec *executionContext) _Alert_metric(ctx context.Context, field graphql.Col
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Metric, nil
+		return obj.FunctionColumn, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Alert_metric(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Alert_function_column(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Alert",
 		Field:      field,
@@ -25202,8 +25252,8 @@ func (ec *executionContext) fieldContext_Alert_below_threshold(ctx context.Conte
 	return fc, nil
 }
 
-func (ec *executionContext) _Alert_threshold_count(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Alert_threshold_count(ctx, field)
+func (ec *executionContext) _Alert_threshold_value(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_threshold_value(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -25216,7 +25266,7 @@ func (ec *executionContext) _Alert_threshold_count(ctx context.Context, field gr
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.ThresholdCount, nil
+		return obj.ThresholdValue, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -25225,19 +25275,19 @@ func (ec *executionContext) _Alert_threshold_count(ctx context.Context, field gr
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*int)
+	res := resTmp.(*float64)
 	fc.Result = res
-	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Alert_threshold_count(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Alert_threshold_value(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Alert",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
+			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -48431,7 +48481,7 @@ func (ec *executionContext) _Mutation_createAlert(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["product_type"].(model.ProductType), fc.Args["function_type"].(model.MetricAggregator), fc.Args["metric"].(string), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["disabled"].(*bool), fc.Args["below_threshold"].(*bool), fc.Args["threshold_count"].(*int), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int))
+		return ec.resolvers.Mutation().CreateAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["product_type"].(model.ProductType), fc.Args["function_type"].(model.MetricAggregator), fc.Args["function_column"].(*string), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["disabled"].(*bool), fc.Args["below_threshold"].(*bool), fc.Args["threshold_value"].(*float64), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -48457,14 +48507,16 @@ func (ec *executionContext) fieldContext_Mutation_createAlert(ctx context.Contex
 				return ec.fieldContext_Alert_id(ctx, field)
 			case "updated_at":
 				return ec.fieldContext_Alert_updated_at(ctx, field)
+			case "metric_id":
+				return ec.fieldContext_Alert_metric_id(ctx, field)
 			case "name":
 				return ec.fieldContext_Alert_name(ctx, field)
 			case "product_type":
 				return ec.fieldContext_Alert_product_type(ctx, field)
 			case "function_type":
 				return ec.fieldContext_Alert_function_type(ctx, field)
-			case "metric":
-				return ec.fieldContext_Alert_metric(ctx, field)
+			case "function_column":
+				return ec.fieldContext_Alert_function_column(ctx, field)
 			case "query":
 				return ec.fieldContext_Alert_query(ctx, field)
 			case "group_by_key":
@@ -48477,8 +48529,8 @@ func (ec *executionContext) fieldContext_Mutation_createAlert(ctx context.Contex
 				return ec.fieldContext_Alert_destinations(ctx, field)
 			case "below_threshold":
 				return ec.fieldContext_Alert_below_threshold(ctx, field)
-			case "threshold_count":
-				return ec.fieldContext_Alert_threshold_count(ctx, field)
+			case "threshold_value":
+				return ec.fieldContext_Alert_threshold_value(ctx, field)
 			case "threshold_window":
 				return ec.fieldContext_Alert_threshold_window(ctx, field)
 			case "threshold_cooldown":
@@ -48515,7 +48567,7 @@ func (ec *executionContext) _Mutation_updateAlert(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().UpdateAlert(rctx, fc.Args["project_id"].(int), fc.Args["alert_id"].(int), fc.Args["name"].(*string), fc.Args["product_type"].(*model.ProductType), fc.Args["function_type"].(*model.MetricAggregator), fc.Args["metric"].(*string), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["disabled"].(*bool), fc.Args["below_threshold"].(*bool), fc.Args["threshold_count"].(*int), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int))
+		return ec.resolvers.Mutation().UpdateAlert(rctx, fc.Args["project_id"].(int), fc.Args["alert_id"].(int), fc.Args["name"].(*string), fc.Args["product_type"].(*model.ProductType), fc.Args["function_type"].(*model.MetricAggregator), fc.Args["function_column"].(*string), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["disabled"].(*bool), fc.Args["below_threshold"].(*bool), fc.Args["threshold_value"].(*int), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -48541,14 +48593,16 @@ func (ec *executionContext) fieldContext_Mutation_updateAlert(ctx context.Contex
 				return ec.fieldContext_Alert_id(ctx, field)
 			case "updated_at":
 				return ec.fieldContext_Alert_updated_at(ctx, field)
+			case "metric_id":
+				return ec.fieldContext_Alert_metric_id(ctx, field)
 			case "name":
 				return ec.fieldContext_Alert_name(ctx, field)
 			case "product_type":
 				return ec.fieldContext_Alert_product_type(ctx, field)
 			case "function_type":
 				return ec.fieldContext_Alert_function_type(ctx, field)
-			case "metric":
-				return ec.fieldContext_Alert_metric(ctx, field)
+			case "function_column":
+				return ec.fieldContext_Alert_function_column(ctx, field)
 			case "query":
 				return ec.fieldContext_Alert_query(ctx, field)
 			case "group_by_key":
@@ -48561,8 +48615,8 @@ func (ec *executionContext) fieldContext_Mutation_updateAlert(ctx context.Contex
 				return ec.fieldContext_Alert_destinations(ctx, field)
 			case "below_threshold":
 				return ec.fieldContext_Alert_below_threshold(ctx, field)
-			case "threshold_count":
-				return ec.fieldContext_Alert_threshold_count(ctx, field)
+			case "threshold_value":
+				return ec.fieldContext_Alert_threshold_value(ctx, field)
 			case "threshold_window":
 				return ec.fieldContext_Alert_threshold_window(ctx, field)
 			case "threshold_cooldown":
@@ -57955,14 +58009,16 @@ func (ec *executionContext) fieldContext_Query_alerts(ctx context.Context, field
 				return ec.fieldContext_Alert_id(ctx, field)
 			case "updated_at":
 				return ec.fieldContext_Alert_updated_at(ctx, field)
+			case "metric_id":
+				return ec.fieldContext_Alert_metric_id(ctx, field)
 			case "name":
 				return ec.fieldContext_Alert_name(ctx, field)
 			case "product_type":
 				return ec.fieldContext_Alert_product_type(ctx, field)
 			case "function_type":
 				return ec.fieldContext_Alert_function_type(ctx, field)
-			case "metric":
-				return ec.fieldContext_Alert_metric(ctx, field)
+			case "function_column":
+				return ec.fieldContext_Alert_function_column(ctx, field)
 			case "query":
 				return ec.fieldContext_Alert_query(ctx, field)
 			case "group_by_key":
@@ -57975,8 +58031,8 @@ func (ec *executionContext) fieldContext_Query_alerts(ctx context.Context, field
 				return ec.fieldContext_Alert_destinations(ctx, field)
 			case "below_threshold":
 				return ec.fieldContext_Alert_below_threshold(ctx, field)
-			case "threshold_count":
-				return ec.fieldContext_Alert_threshold_count(ctx, field)
+			case "threshold_value":
+				return ec.fieldContext_Alert_threshold_value(ctx, field)
 			case "threshold_window":
 				return ec.fieldContext_Alert_threshold_window(ctx, field)
 			case "threshold_cooldown":
@@ -58042,14 +58098,16 @@ func (ec *executionContext) fieldContext_Query_alert(ctx context.Context, field 
 				return ec.fieldContext_Alert_id(ctx, field)
 			case "updated_at":
 				return ec.fieldContext_Alert_updated_at(ctx, field)
+			case "metric_id":
+				return ec.fieldContext_Alert_metric_id(ctx, field)
 			case "name":
 				return ec.fieldContext_Alert_name(ctx, field)
 			case "product_type":
 				return ec.fieldContext_Alert_product_type(ctx, field)
 			case "function_type":
 				return ec.fieldContext_Alert_function_type(ctx, field)
-			case "metric":
-				return ec.fieldContext_Alert_metric(ctx, field)
+			case "function_column":
+				return ec.fieldContext_Alert_function_column(ctx, field)
 			case "query":
 				return ec.fieldContext_Alert_query(ctx, field)
 			case "group_by_key":
@@ -58062,8 +58120,8 @@ func (ec *executionContext) fieldContext_Query_alert(ctx context.Context, field 
 				return ec.fieldContext_Alert_destinations(ctx, field)
 			case "below_threshold":
 				return ec.fieldContext_Alert_below_threshold(ctx, field)
-			case "threshold_count":
-				return ec.fieldContext_Alert_threshold_count(ctx, field)
+			case "threshold_value":
+				return ec.fieldContext_Alert_threshold_value(ctx, field)
 			case "threshold_window":
 				return ec.fieldContext_Alert_threshold_window(ctx, field)
 			case "threshold_cooldown":
@@ -84347,6 +84405,11 @@ func (ec *executionContext) _Alert(ctx context.Context, sel ast.SelectionSet, ob
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "metric_id":
+			out.Values[i] = ec._Alert_metric_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "name":
 			out.Values[i] = ec._Alert_name(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -84362,11 +84425,8 @@ func (ec *executionContext) _Alert(ctx context.Context, sel ast.SelectionSet, ob
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "metric":
-			out.Values[i] = ec._Alert_metric(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
+		case "function_column":
+			out.Values[i] = ec._Alert_function_column(ctx, field, obj)
 		case "query":
 			out.Values[i] = ec._Alert_query(ctx, field, obj)
 		case "group_by_key":
@@ -84385,8 +84445,8 @@ func (ec *executionContext) _Alert(ctx context.Context, sel ast.SelectionSet, ob
 			}
 		case "below_threshold":
 			out.Values[i] = ec._Alert_below_threshold(ctx, field, obj)
-		case "threshold_count":
-			out.Values[i] = ec._Alert_threshold_count(ctx, field, obj)
+		case "threshold_value":
+			out.Values[i] = ec._Alert_threshold_value(ctx, field, obj)
 		case "threshold_window":
 			out.Values[i] = ec._Alert_threshold_window(ctx, field, obj)
 		case "threshold_cooldown":

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -141,6 +141,7 @@ type ComplexityRoot struct {
 		GroupByKey        func(childComplexity int) int
 		ID                func(childComplexity int) int
 		LastAdminToEditID func(childComplexity int) int
+		Metric            func(childComplexity int) int
 		Name              func(childComplexity int) int
 		ProductType       func(childComplexity int) int
 		Query             func(childComplexity int) int
@@ -834,7 +835,7 @@ type ComplexityRoot struct {
 		ChangeAdminRole                       func(childComplexity int, workspaceID int, adminID int, newRole string) int
 		ChangeProjectMembership               func(childComplexity int, workspaceID int, adminID int, projectIds []int) int
 		CreateAdmin                           func(childComplexity int) int
-		CreateAlert                           func(childComplexity int, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) int
+		CreateAlert                           func(childComplexity int, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, metric string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) int
 		CreateCloudflareProxy                 func(childComplexity int, workspaceID int, proxySubdomain string) int
 		CreateErrorAlert                      func(childComplexity int, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, query string, regexGroups []*string, frequency int, defaultArg *bool) int
 		CreateErrorComment                    func(childComplexity int, projectID int, errorGroupSecureID string, text string, textForEmail string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, errorURL string, authorName string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
@@ -896,7 +897,7 @@ type ComplexityRoot struct {
 		TestErrorEnhancement                  func(childComplexity int, errorObjectID int, githubRepoPath string, githubPrefix *string, buildPrefix *string, saveError *bool) int
 		UpdateAdminAboutYouDetails            func(childComplexity int, adminDetails model.AdminAboutYouDetails) int
 		UpdateAdminAndCreateWorkspace         func(childComplexity int, adminAndWorkspaceDetails model.AdminAndWorkspaceDetails) int
-		UpdateAlert                           func(childComplexity int, projectID int, alertID int, name *string, productType *model.ProductType, functionType *model.MetricAggregator, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) int
+		UpdateAlert                           func(childComplexity int, projectID int, alertID int, name *string, productType *model.ProductType, functionType *model.MetricAggregator, metric *string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) int
 		UpdateAlertDisabled                   func(childComplexity int, projectID int, alertID int, disabled bool) int
 		UpdateAllowMeterOverage               func(childComplexity int, workspaceID int, allowMeterOverage bool) int
 		UpdateAllowedEmailOrigins             func(childComplexity int, workspaceID int, allowedAutoJoinEmailOrigins string) int
@@ -1781,8 +1782,8 @@ type MutationResolver interface {
 	SyncSlackIntegration(ctx context.Context, projectID int) (*model.SlackSyncResponse, error)
 	CreateMetricMonitor(ctx context.Context, projectID int, name string, aggregator model.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
 	UpdateMetricMonitor(ctx context.Context, metricMonitorID int, projectID int, name *string, aggregator *model.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, disabled *bool, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
-	CreateAlert(ctx context.Context, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) (*model1.Alert, error)
-	UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *model.ProductType, functionType *model.MetricAggregator, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) (*model1.Alert, error)
+	CreateAlert(ctx context.Context, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, metric string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) (*model1.Alert, error)
+	UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *model.ProductType, functionType *model.MetricAggregator, metric *string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) (*model1.Alert, error)
 	UpdateAlertDisabled(ctx context.Context, projectID int, alertID int, disabled bool) (bool, error)
 	DeleteAlert(ctx context.Context, projectID int, alertID int) (bool, error)
 	CreateErrorAlert(ctx context.Context, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, query string, regexGroups []*string, frequency int, defaultArg *bool) (*model1.ErrorAlert, error)
@@ -2451,6 +2452,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Alert.LastAdminToEditID(childComplexity), true
+
+	case "Alert.metric":
+		if e.complexity.Alert.Metric == nil {
+			break
+		}
+
+		return e.complexity.Alert.Metric(childComplexity), true
 
 	case "Alert.name":
 		if e.complexity.Alert.Name == nil {
@@ -5637,7 +5645,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.CreateAlert(childComplexity, args["project_id"].(int), args["name"].(string), args["product_type"].(model.ProductType), args["function_type"].(model.MetricAggregator), args["query"].(*string), args["group_by_key"].(*string), args["disabled"].(*bool), args["below_threshold"].(*bool), args["threshold_count"].(*int), args["threshold_window"].(*int), args["threshold_cooldown"].(*int)), true
+		return e.complexity.Mutation.CreateAlert(childComplexity, args["project_id"].(int), args["name"].(string), args["product_type"].(model.ProductType), args["function_type"].(model.MetricAggregator), args["metric"].(string), args["query"].(*string), args["group_by_key"].(*string), args["disabled"].(*bool), args["below_threshold"].(*bool), args["threshold_count"].(*int), args["threshold_window"].(*int), args["threshold_cooldown"].(*int)), true
 
 	case "Mutation.createCloudflareProxy":
 		if e.complexity.Mutation.CreateCloudflareProxy == nil {
@@ -6381,7 +6389,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.UpdateAlert(childComplexity, args["project_id"].(int), args["alert_id"].(int), args["name"].(*string), args["product_type"].(*model.ProductType), args["function_type"].(*model.MetricAggregator), args["query"].(*string), args["group_by_key"].(*string), args["disabled"].(*bool), args["below_threshold"].(*bool), args["threshold_count"].(*int), args["threshold_window"].(*int), args["threshold_cooldown"].(*int)), true
+		return e.complexity.Mutation.UpdateAlert(childComplexity, args["project_id"].(int), args["alert_id"].(int), args["name"].(*string), args["product_type"].(*model.ProductType), args["function_type"].(*model.MetricAggregator), args["metric"].(*string), args["query"].(*string), args["group_by_key"].(*string), args["disabled"].(*bool), args["below_threshold"].(*bool), args["threshold_count"].(*int), args["threshold_window"].(*int), args["threshold_cooldown"].(*int)), true
 
 	case "Mutation.updateAlertDisabled":
 		if e.complexity.Mutation.UpdateAlertDisabled == nil {
@@ -13073,6 +13081,7 @@ type Alert {
 	name: String!
 	product_type: ProductType!
 	function_type: MetricAggregator!
+	metric: String!
 	query: String
 	group_by_key: String
 	disabled: Boolean!
@@ -14253,6 +14262,7 @@ type Mutation {
 		name: String!
 		product_type: ProductType!
 		function_type: MetricAggregator!
+		metric: String!
 		query: String
 		group_by_key: String
 		disabled: Boolean
@@ -14267,6 +14277,7 @@ type Mutation {
 		name: String
 		product_type: ProductType
 		function_type: MetricAggregator
+		metric: String
 		query: String
 		group_by_key: String
 		disabled: Boolean
@@ -14632,69 +14643,78 @@ func (ec *executionContext) field_Mutation_createAlert_args(ctx context.Context,
 		}
 	}
 	args["function_type"] = arg3
-	var arg4 *string
-	if tmp, ok := rawArgs["query"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
-		arg4, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+	var arg4 string
+	if tmp, ok := rawArgs["metric"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("metric"))
+		arg4, err = ec.unmarshalNString2string(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["query"] = arg4
+	args["metric"] = arg4
 	var arg5 *string
-	if tmp, ok := rawArgs["group_by_key"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("group_by_key"))
+	if tmp, ok := rawArgs["query"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
 		arg5, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["group_by_key"] = arg5
-	var arg6 *bool
-	if tmp, ok := rawArgs["disabled"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("disabled"))
-		arg6, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+	args["query"] = arg5
+	var arg6 *string
+	if tmp, ok := rawArgs["group_by_key"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("group_by_key"))
+		arg6, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["disabled"] = arg6
+	args["group_by_key"] = arg6
 	var arg7 *bool
-	if tmp, ok := rawArgs["below_threshold"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("below_threshold"))
+	if tmp, ok := rawArgs["disabled"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("disabled"))
 		arg7, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["below_threshold"] = arg7
-	var arg8 *int
-	if tmp, ok := rawArgs["threshold_count"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_count"))
-		arg8, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+	args["disabled"] = arg7
+	var arg8 *bool
+	if tmp, ok := rawArgs["below_threshold"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("below_threshold"))
+		arg8, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["threshold_count"] = arg8
+	args["below_threshold"] = arg8
 	var arg9 *int
-	if tmp, ok := rawArgs["threshold_window"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_window"))
+	if tmp, ok := rawArgs["threshold_count"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_count"))
 		arg9, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["threshold_window"] = arg9
+	args["threshold_count"] = arg9
 	var arg10 *int
-	if tmp, ok := rawArgs["threshold_cooldown"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_cooldown"))
+	if tmp, ok := rawArgs["threshold_window"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_window"))
 		arg10, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["threshold_cooldown"] = arg10
+	args["threshold_window"] = arg10
+	var arg11 *int
+	if tmp, ok := rawArgs["threshold_cooldown"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_cooldown"))
+		arg11, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["threshold_cooldown"] = arg11
 	return args, nil
 }
 
@@ -17558,68 +17578,77 @@ func (ec *executionContext) field_Mutation_updateAlert_args(ctx context.Context,
 	}
 	args["function_type"] = arg4
 	var arg5 *string
-	if tmp, ok := rawArgs["query"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
+	if tmp, ok := rawArgs["metric"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("metric"))
 		arg5, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["query"] = arg5
+	args["metric"] = arg5
 	var arg6 *string
-	if tmp, ok := rawArgs["group_by_key"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("group_by_key"))
+	if tmp, ok := rawArgs["query"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
 		arg6, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["group_by_key"] = arg6
-	var arg7 *bool
-	if tmp, ok := rawArgs["disabled"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("disabled"))
-		arg7, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+	args["query"] = arg6
+	var arg7 *string
+	if tmp, ok := rawArgs["group_by_key"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("group_by_key"))
+		arg7, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["disabled"] = arg7
+	args["group_by_key"] = arg7
 	var arg8 *bool
-	if tmp, ok := rawArgs["below_threshold"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("below_threshold"))
+	if tmp, ok := rawArgs["disabled"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("disabled"))
 		arg8, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["below_threshold"] = arg8
-	var arg9 *int
-	if tmp, ok := rawArgs["threshold_count"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_count"))
-		arg9, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+	args["disabled"] = arg8
+	var arg9 *bool
+	if tmp, ok := rawArgs["below_threshold"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("below_threshold"))
+		arg9, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["threshold_count"] = arg9
+	args["below_threshold"] = arg9
 	var arg10 *int
-	if tmp, ok := rawArgs["threshold_window"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_window"))
+	if tmp, ok := rawArgs["threshold_count"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_count"))
 		arg10, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["threshold_window"] = arg10
+	args["threshold_count"] = arg10
 	var arg11 *int
-	if tmp, ok := rawArgs["threshold_cooldown"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_cooldown"))
+	if tmp, ok := rawArgs["threshold_window"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_window"))
 		arg11, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["threshold_cooldown"] = arg11
+	args["threshold_window"] = arg11
+	var arg12 *int
+	if tmp, ok := rawArgs["threshold_cooldown"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_cooldown"))
+		arg12, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["threshold_cooldown"] = arg12
 	return args, nil
 }
 
@@ -24860,6 +24889,50 @@ func (ec *executionContext) fieldContext_Alert_function_type(ctx context.Context
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type MetricAggregator does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Alert_metric(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_metric(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Metric, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Alert_metric(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Alert",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -48358,7 +48431,7 @@ func (ec *executionContext) _Mutation_createAlert(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["product_type"].(model.ProductType), fc.Args["function_type"].(model.MetricAggregator), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["disabled"].(*bool), fc.Args["below_threshold"].(*bool), fc.Args["threshold_count"].(*int), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int))
+		return ec.resolvers.Mutation().CreateAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["product_type"].(model.ProductType), fc.Args["function_type"].(model.MetricAggregator), fc.Args["metric"].(string), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["disabled"].(*bool), fc.Args["below_threshold"].(*bool), fc.Args["threshold_count"].(*int), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -48390,6 +48463,8 @@ func (ec *executionContext) fieldContext_Mutation_createAlert(ctx context.Contex
 				return ec.fieldContext_Alert_product_type(ctx, field)
 			case "function_type":
 				return ec.fieldContext_Alert_function_type(ctx, field)
+			case "metric":
+				return ec.fieldContext_Alert_metric(ctx, field)
 			case "query":
 				return ec.fieldContext_Alert_query(ctx, field)
 			case "group_by_key":
@@ -48440,7 +48515,7 @@ func (ec *executionContext) _Mutation_updateAlert(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().UpdateAlert(rctx, fc.Args["project_id"].(int), fc.Args["alert_id"].(int), fc.Args["name"].(*string), fc.Args["product_type"].(*model.ProductType), fc.Args["function_type"].(*model.MetricAggregator), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["disabled"].(*bool), fc.Args["below_threshold"].(*bool), fc.Args["threshold_count"].(*int), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int))
+		return ec.resolvers.Mutation().UpdateAlert(rctx, fc.Args["project_id"].(int), fc.Args["alert_id"].(int), fc.Args["name"].(*string), fc.Args["product_type"].(*model.ProductType), fc.Args["function_type"].(*model.MetricAggregator), fc.Args["metric"].(*string), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["disabled"].(*bool), fc.Args["below_threshold"].(*bool), fc.Args["threshold_count"].(*int), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -48472,6 +48547,8 @@ func (ec *executionContext) fieldContext_Mutation_updateAlert(ctx context.Contex
 				return ec.fieldContext_Alert_product_type(ctx, field)
 			case "function_type":
 				return ec.fieldContext_Alert_function_type(ctx, field)
+			case "metric":
+				return ec.fieldContext_Alert_metric(ctx, field)
 			case "query":
 				return ec.fieldContext_Alert_query(ctx, field)
 			case "group_by_key":
@@ -57884,6 +57961,8 @@ func (ec *executionContext) fieldContext_Query_alerts(ctx context.Context, field
 				return ec.fieldContext_Alert_product_type(ctx, field)
 			case "function_type":
 				return ec.fieldContext_Alert_function_type(ctx, field)
+			case "metric":
+				return ec.fieldContext_Alert_metric(ctx, field)
 			case "query":
 				return ec.fieldContext_Alert_query(ctx, field)
 			case "group_by_key":
@@ -57969,6 +58048,8 @@ func (ec *executionContext) fieldContext_Query_alert(ctx context.Context, field 
 				return ec.fieldContext_Alert_product_type(ctx, field)
 			case "function_type":
 				return ec.fieldContext_Alert_function_type(ctx, field)
+			case "metric":
+				return ec.fieldContext_Alert_metric(ctx, field)
 			case "query":
 				return ec.fieldContext_Alert_query(ctx, field)
 			case "group_by_key":
@@ -84278,6 +84359,11 @@ func (ec *executionContext) _Alert(ctx context.Context, sel ast.SelectionSet, ob
 			}
 		case "function_type":
 			out.Values[i] = ec._Alert_function_type(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "metric":
+			out.Values[i] = ec._Alert_metric(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1586,6 +1586,7 @@ type Alert {
 	name: String!
 	product_type: ProductType!
 	function_type: MetricAggregator!
+	metric: String!
 	query: String
 	group_by_key: String
 	disabled: Boolean!
@@ -2766,6 +2767,7 @@ type Mutation {
 		name: String!
 		product_type: ProductType!
 		function_type: MetricAggregator!
+		metric: String!
 		query: String
 		group_by_key: String
 		disabled: Boolean
@@ -2780,6 +2782,7 @@ type Mutation {
 		name: String
 		product_type: ProductType
 		function_type: MetricAggregator
+		metric: String
 		query: String
 		group_by_key: String
 		disabled: Boolean

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -2771,7 +2771,6 @@ type Mutation {
 		function_column: String
 		query: String
 		group_by_key: String
-		disabled: Boolean
 		below_threshold: Boolean
 		threshold_value: Float
 		threshold_window: Int
@@ -2786,9 +2785,8 @@ type Mutation {
 		function_column: String
 		query: String
 		group_by_key: String
-		disabled: Boolean
 		below_threshold: Boolean
-		threshold_value: Int
+		threshold_value: Float
 		threshold_window: Int
 		threshold_cooldown: Int # TODO(spenny): add destinations
 	): Alert

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1583,10 +1583,11 @@ type AlertDestination {
 type Alert {
 	id: ID!
 	updated_at: Timestamp!
+	metric_id: String!
 	name: String!
 	product_type: ProductType!
 	function_type: MetricAggregator!
-	metric: String!
+	function_column: String
 	query: String
 	group_by_key: String
 	disabled: Boolean!
@@ -1595,7 +1596,7 @@ type Alert {
 
 	# threshold alerts
 	below_threshold: Boolean
-	threshold_count: Int
+	threshold_value: Float
 	threshold_window: Int
 	threshold_cooldown: Int
 }
@@ -2767,12 +2768,12 @@ type Mutation {
 		name: String!
 		product_type: ProductType!
 		function_type: MetricAggregator!
-		metric: String!
+		function_column: String
 		query: String
 		group_by_key: String
 		disabled: Boolean
 		below_threshold: Boolean
-		threshold_count: Int
+		threshold_value: Float
 		threshold_window: Int
 		threshold_cooldown: Int # TODO(spenny): add destinations
 	): Alert
@@ -2782,12 +2783,12 @@ type Mutation {
 		name: String
 		product_type: ProductType
 		function_type: MetricAggregator
-		metric: String
+		function_column: String
 		query: String
 		group_by_key: String
 		disabled: Boolean
 		below_threshold: Boolean
-		threshold_count: Int
+		threshold_value: Int
 		threshold_window: Int
 		threshold_cooldown: Int # TODO(spenny): add destinations
 	): Alert

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/marketplacemetering"
 	"github.com/aws/smithy-go/ptr"
 	"github.com/clearbit/clearbit-go/clearbit"
+	"github.com/google/uuid"
 	"github.com/highlight-run/highlight/backend/alerts"
 	"github.com/highlight-run/highlight/backend/alerts/integrations/discord"
 	microsoft_teams "github.com/highlight-run/highlight/backend/alerts/integrations/microsoft-teams"
@@ -3308,27 +3309,22 @@ func (r *mutationResolver) UpdateMetricMonitor(ctx context.Context, metricMonito
 }
 
 // CreateAlert is the resolver for the createAlert field.
-func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name string, productType modelInputs.ProductType, functionType modelInputs.MetricAggregator, functionColumn *string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int) (*model.Alert, error) {
+func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name string, productType modelInputs.ProductType, functionType modelInputs.MetricAggregator, functionColumn *string, query *string, groupByKey *string, belowThreshold *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int) (*model.Alert, error) {
 	_, err := r.isUserInProject(ctx, projectID)
 	admin, _ := r.getCurrentAdmin(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	disabledVar := disabled
-	if disabledVar == nil {
-		disabledVar = pointy.Bool(false)
-	}
-
 	newAlert := &model.Alert{
 		ProjectID:         projectID,
+		MetricId:          uuid.New().String(),
 		Name:              name,
 		ProductType:       productType,
 		FunctionType:      functionType,
 		FunctionColumn:    functionColumn,
 		Query:             query,
 		GroupByKey:        groupByKey,
-		Disabled:          *disabledVar,
 		BelowThreshold:    belowThreshold,
 		ThresholdValue:    thresholdValue,
 		ThresholdWindow:   thresholdWindow,
@@ -3348,7 +3344,7 @@ func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name 
 }
 
 // UpdateAlert is the resolver for the updateAlert field.
-func (r *mutationResolver) UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *modelInputs.ProductType, functionType *modelInputs.MetricAggregator, functionColumn *string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdValue *int, thresholdWindow *int, thresholdCooldown *int) (*model.Alert, error) {
+func (r *mutationResolver) UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *modelInputs.ProductType, functionType *modelInputs.MetricAggregator, functionColumn *string, query *string, groupByKey *string, belowThreshold *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int) (*model.Alert, error) {
 	project, err := r.isUserInProject(ctx, projectID)
 	admin, _ := r.getCurrentAdmin(ctx)
 	if err != nil {
@@ -3356,41 +3352,18 @@ func (r *mutationResolver) UpdateAlert(ctx context.Context, projectID int, alert
 	}
 
 	alertUpdates := map[string]interface{}{
+		"MetricId":          uuid.New().String(),
 		"LastAdminToEditID": admin.ID,
-	}
-
-	if name != nil {
-		alertUpdates["Name"] = *name
-	}
-	if productType != nil {
-		alertUpdates["ProductType"] = *productType
-	}
-	if functionType != nil {
-		alertUpdates["FunctionType"] = *functionType
-	}
-	if functionColumn != nil {
-		alertUpdates["FunctionColumn"] = *functionColumn
-	}
-	if query != nil {
-		alertUpdates["Query"] = *query
-	}
-	if groupByKey != nil {
-		alertUpdates["GroupByKey"] = *groupByKey
-	}
-	if disabled != nil {
-		alertUpdates["Disabled"] = *disabled
-	}
-	if belowThreshold != nil {
-		alertUpdates["BelowThreshold"] = *belowThreshold
-	}
-	if thresholdValue != nil {
-		alertUpdates["ThresholdValue"] = *thresholdValue
-	}
-	if thresholdWindow != nil {
-		alertUpdates["ThresholdWindow"] = *thresholdWindow
-	}
-	if thresholdCooldown != nil {
-		alertUpdates["ThresholdCooldown"] = *thresholdCooldown
+		"Name":              name,
+		"ProductType":       productType,
+		"FunctionType":      functionType,
+		"FunctionColumn":    functionColumn,
+		"Query":             query,
+		"GroupByKey":        groupByKey,
+		"BelowThreshold":    belowThreshold,
+		"ThresholdValue":    thresholdValue,
+		"ThresholdWindow":   thresholdWindow,
+		"ThresholdCooldown": thresholdCooldown,
 	}
 
 	alert := &model.Alert{}

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3308,7 +3308,7 @@ func (r *mutationResolver) UpdateMetricMonitor(ctx context.Context, metricMonito
 }
 
 // CreateAlert is the resolver for the createAlert field.
-func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name string, productType modelInputs.ProductType, functionType modelInputs.MetricAggregator, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) (*model.Alert, error) {
+func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name string, productType modelInputs.ProductType, functionType modelInputs.MetricAggregator, metric string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) (*model.Alert, error) {
 	_, err := r.isUserInProject(ctx, projectID)
 	admin, _ := r.getCurrentAdmin(ctx)
 	if err != nil {
@@ -3325,6 +3325,7 @@ func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name 
 		Name:              name,
 		ProductType:       productType,
 		FunctionType:      functionType,
+		Metric:            metric,
 		Query:             query,
 		GroupByKey:        groupByKey,
 		Disabled:          *disabledVar,
@@ -3347,7 +3348,7 @@ func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name 
 }
 
 // UpdateAlert is the resolver for the updateAlert field.
-func (r *mutationResolver) UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *modelInputs.ProductType, functionType *modelInputs.MetricAggregator, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) (*model.Alert, error) {
+func (r *mutationResolver) UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *modelInputs.ProductType, functionType *modelInputs.MetricAggregator, metric *string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) (*model.Alert, error) {
 	project, err := r.isUserInProject(ctx, projectID)
 	admin, _ := r.getCurrentAdmin(ctx)
 	if err != nil {
@@ -3366,6 +3367,9 @@ func (r *mutationResolver) UpdateAlert(ctx context.Context, projectID int, alert
 	}
 	if functionType != nil {
 		alertUpdates["FunctionType"] = *functionType
+	}
+	if metric != nil {
+		alertUpdates["Metric"] = *metric
 	}
 	if query != nil {
 		alertUpdates["Query"] = *query
@@ -10101,76 +10105,3 @@ type sessionCommentResolver struct{ *Resolver }
 type subscriptionResolver struct{ *Resolver }
 type timelineIndicatorEventResolver struct{ *Resolver }
 type visualizationResolver struct{ *Resolver }
-
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//     it when you're done.
-//   - You have helper methods in this file. Move them out to keep these resolver files clean.
-func (r *errorAlertResolver) Name(ctx context.Context, obj *model.ErrorAlert) (*string, error) {
-	panic(fmt.Errorf("not implemented: Name - Name"))
-}
-func (r *errorAlertResolver) CountThreshold(ctx context.Context, obj *model.ErrorAlert) (int, error) {
-	panic(fmt.Errorf("not implemented: CountThreshold - CountThreshold"))
-}
-func (r *errorAlertResolver) ThresholdWindow(ctx context.Context, obj *model.ErrorAlert) (*int, error) {
-	panic(fmt.Errorf("not implemented: ThresholdWindow - ThresholdWindow"))
-}
-func (r *errorAlertResolver) LastAdminToEditID(ctx context.Context, obj *model.ErrorAlert) (*int, error) {
-	panic(fmt.Errorf("not implemented: LastAdminToEditID - LastAdminToEditID"))
-}
-func (r *errorAlertResolver) Type(ctx context.Context, obj *model.ErrorAlert) (string, error) {
-	panic(fmt.Errorf("not implemented: Type - Type"))
-}
-func (r *errorAlertResolver) Frequency(ctx context.Context, obj *model.ErrorAlert) (int, error) {
-	panic(fmt.Errorf("not implemented: Frequency - Frequency"))
-}
-func (r *errorAlertResolver) Disabled(ctx context.Context, obj *model.ErrorAlert) (bool, error) {
-	panic(fmt.Errorf("not implemented: Disabled - disabled"))
-}
-func (r *errorAlertResolver) Default(ctx context.Context, obj *model.ErrorAlert) (bool, error) {
-	panic(fmt.Errorf("not implemented: Default - default"))
-}
-func (r *logAlertResolver) Name(ctx context.Context, obj *model.LogAlert) (string, error) {
-	panic(fmt.Errorf("not implemented: Name - Name"))
-}
-func (r *logAlertResolver) CountThreshold(ctx context.Context, obj *model.LogAlert) (int, error) {
-	panic(fmt.Errorf("not implemented: CountThreshold - CountThreshold"))
-}
-func (r *logAlertResolver) ThresholdWindow(ctx context.Context, obj *model.LogAlert) (int, error) {
-	panic(fmt.Errorf("not implemented: ThresholdWindow - ThresholdWindow"))
-}
-func (r *logAlertResolver) LastAdminToEditID(ctx context.Context, obj *model.LogAlert) (*int, error) {
-	panic(fmt.Errorf("not implemented: LastAdminToEditID - LastAdminToEditID"))
-}
-func (r *logAlertResolver) Type(ctx context.Context, obj *model.LogAlert) (string, error) {
-	panic(fmt.Errorf("not implemented: Type - Type"))
-}
-func (r *logAlertResolver) Disabled(ctx context.Context, obj *model.LogAlert) (bool, error) {
-	panic(fmt.Errorf("not implemented: Disabled - disabled"))
-}
-func (r *logAlertResolver) Default(ctx context.Context, obj *model.LogAlert) (bool, error) {
-	panic(fmt.Errorf("not implemented: Default - default"))
-}
-func (r *sessionAlertResolver) Name(ctx context.Context, obj *model.SessionAlert) (*string, error) {
-	panic(fmt.Errorf("not implemented: Name - Name"))
-}
-func (r *sessionAlertResolver) CountThreshold(ctx context.Context, obj *model.SessionAlert) (int, error) {
-	panic(fmt.Errorf("not implemented: CountThreshold - CountThreshold"))
-}
-func (r *sessionAlertResolver) ThresholdWindow(ctx context.Context, obj *model.SessionAlert) (*int, error) {
-	panic(fmt.Errorf("not implemented: ThresholdWindow - ThresholdWindow"))
-}
-func (r *sessionAlertResolver) LastAdminToEditID(ctx context.Context, obj *model.SessionAlert) (*int, error) {
-	panic(fmt.Errorf("not implemented: LastAdminToEditID - LastAdminToEditID"))
-}
-func (r *sessionAlertResolver) Type(ctx context.Context, obj *model.SessionAlert) (string, error) {
-	panic(fmt.Errorf("not implemented: Type - Type"))
-}
-func (r *sessionAlertResolver) Disabled(ctx context.Context, obj *model.SessionAlert) (bool, error) {
-	panic(fmt.Errorf("not implemented: Disabled - disabled"))
-}
-func (r *sessionAlertResolver) Default(ctx context.Context, obj *model.SessionAlert) (bool, error) {
-	panic(fmt.Errorf("not implemented: Default - default"))
-}

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3308,7 +3308,7 @@ func (r *mutationResolver) UpdateMetricMonitor(ctx context.Context, metricMonito
 }
 
 // CreateAlert is the resolver for the createAlert field.
-func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name string, productType modelInputs.ProductType, functionType modelInputs.MetricAggregator, metric string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) (*model.Alert, error) {
+func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name string, productType modelInputs.ProductType, functionType modelInputs.MetricAggregator, functionColumn *string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int) (*model.Alert, error) {
 	_, err := r.isUserInProject(ctx, projectID)
 	admin, _ := r.getCurrentAdmin(ctx)
 	if err != nil {
@@ -3325,12 +3325,12 @@ func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name 
 		Name:              name,
 		ProductType:       productType,
 		FunctionType:      functionType,
-		Metric:            metric,
+		FunctionColumn:    functionColumn,
 		Query:             query,
 		GroupByKey:        groupByKey,
 		Disabled:          *disabledVar,
 		BelowThreshold:    belowThreshold,
-		ThresholdCount:    thresholdCount,
+		ThresholdValue:    thresholdValue,
 		ThresholdWindow:   thresholdWindow,
 		ThresholdCooldown: thresholdCooldown,
 		LastAdminToEditID: admin.ID,
@@ -3348,7 +3348,7 @@ func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name 
 }
 
 // UpdateAlert is the resolver for the updateAlert field.
-func (r *mutationResolver) UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *modelInputs.ProductType, functionType *modelInputs.MetricAggregator, metric *string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdCount *int, thresholdWindow *int, thresholdCooldown *int) (*model.Alert, error) {
+func (r *mutationResolver) UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *modelInputs.ProductType, functionType *modelInputs.MetricAggregator, functionColumn *string, query *string, groupByKey *string, disabled *bool, belowThreshold *bool, thresholdValue *int, thresholdWindow *int, thresholdCooldown *int) (*model.Alert, error) {
 	project, err := r.isUserInProject(ctx, projectID)
 	admin, _ := r.getCurrentAdmin(ctx)
 	if err != nil {
@@ -3368,8 +3368,8 @@ func (r *mutationResolver) UpdateAlert(ctx context.Context, projectID int, alert
 	if functionType != nil {
 		alertUpdates["FunctionType"] = *functionType
 	}
-	if metric != nil {
-		alertUpdates["Metric"] = *metric
+	if functionColumn != nil {
+		alertUpdates["FunctionColumn"] = *functionColumn
 	}
 	if query != nil {
 		alertUpdates["Query"] = *query
@@ -3383,8 +3383,8 @@ func (r *mutationResolver) UpdateAlert(ctx context.Context, projectID int, alert
 	if belowThreshold != nil {
 		alertUpdates["BelowThreshold"] = *belowThreshold
 	}
-	if thresholdCount != nil {
-		alertUpdates["ThresholdCount"] = *thresholdCount
+	if thresholdValue != nil {
+		alertUpdates["ThresholdValue"] = *thresholdValue
 	}
 	if thresholdWindow != nil {
 		alertUpdates["ThresholdWindow"] = *thresholdWindow

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -133,16 +133,17 @@ export type Alert = {
 	below_threshold?: Maybe<Scalars['Boolean']>
 	destinations: Array<Maybe<AlertDestination>>
 	disabled: Scalars['Boolean']
+	function_column?: Maybe<Scalars['String']>
 	function_type: MetricAggregator
 	group_by_key?: Maybe<Scalars['String']>
 	id: Scalars['ID']
 	last_admin_to_edit_id?: Maybe<Scalars['ID']>
-	metric: Scalars['String']
+	metric_id: Scalars['String']
 	name: Scalars['String']
 	product_type: ProductType
 	query?: Maybe<Scalars['String']>
 	threshold_cooldown?: Maybe<Scalars['Int']>
-	threshold_count?: Maybe<Scalars['Int']>
+	threshold_value?: Maybe<Scalars['Float']>
 	threshold_window?: Maybe<Scalars['Int']>
 	updated_at: Scalars['Timestamp']
 }
@@ -1295,15 +1296,15 @@ export type MutationChangeProjectMembershipArgs = {
 export type MutationCreateAlertArgs = {
 	below_threshold?: InputMaybe<Scalars['Boolean']>
 	disabled?: InputMaybe<Scalars['Boolean']>
+	function_column?: InputMaybe<Scalars['String']>
 	function_type: MetricAggregator
 	group_by_key?: InputMaybe<Scalars['String']>
-	metric: Scalars['String']
 	name: Scalars['String']
 	product_type: ProductType
 	project_id: Scalars['ID']
 	query?: InputMaybe<Scalars['String']>
 	threshold_cooldown?: InputMaybe<Scalars['Int']>
-	threshold_count?: InputMaybe<Scalars['Int']>
+	threshold_value?: InputMaybe<Scalars['Float']>
 	threshold_window?: InputMaybe<Scalars['Int']>
 }
 
@@ -1762,15 +1763,15 @@ export type MutationUpdateAlertArgs = {
 	alert_id: Scalars['ID']
 	below_threshold?: InputMaybe<Scalars['Boolean']>
 	disabled?: InputMaybe<Scalars['Boolean']>
+	function_column?: InputMaybe<Scalars['String']>
 	function_type?: InputMaybe<MetricAggregator>
 	group_by_key?: InputMaybe<Scalars['String']>
-	metric?: InputMaybe<Scalars['String']>
 	name?: InputMaybe<Scalars['String']>
 	product_type?: InputMaybe<ProductType>
 	project_id: Scalars['ID']
 	query?: InputMaybe<Scalars['String']>
 	threshold_cooldown?: InputMaybe<Scalars['Int']>
-	threshold_count?: InputMaybe<Scalars['Int']>
+	threshold_value?: InputMaybe<Scalars['Int']>
 	threshold_window?: InputMaybe<Scalars['Int']>
 }
 

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -137,6 +137,7 @@ export type Alert = {
 	group_by_key?: Maybe<Scalars['String']>
 	id: Scalars['ID']
 	last_admin_to_edit_id?: Maybe<Scalars['ID']>
+	metric: Scalars['String']
 	name: Scalars['String']
 	product_type: ProductType
 	query?: Maybe<Scalars['String']>
@@ -1296,6 +1297,7 @@ export type MutationCreateAlertArgs = {
 	disabled?: InputMaybe<Scalars['Boolean']>
 	function_type: MetricAggregator
 	group_by_key?: InputMaybe<Scalars['String']>
+	metric: Scalars['String']
 	name: Scalars['String']
 	product_type: ProductType
 	project_id: Scalars['ID']
@@ -1762,6 +1764,7 @@ export type MutationUpdateAlertArgs = {
 	disabled?: InputMaybe<Scalars['Boolean']>
 	function_type?: InputMaybe<MetricAggregator>
 	group_by_key?: InputMaybe<Scalars['String']>
+	metric?: InputMaybe<Scalars['String']>
 	name?: InputMaybe<Scalars['String']>
 	product_type?: InputMaybe<ProductType>
 	project_id: Scalars['ID']

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1295,7 +1295,6 @@ export type MutationChangeProjectMembershipArgs = {
 
 export type MutationCreateAlertArgs = {
 	below_threshold?: InputMaybe<Scalars['Boolean']>
-	disabled?: InputMaybe<Scalars['Boolean']>
 	function_column?: InputMaybe<Scalars['String']>
 	function_type: MetricAggregator
 	group_by_key?: InputMaybe<Scalars['String']>
@@ -1762,7 +1761,6 @@ export type MutationUpdateAdminAndCreateWorkspaceArgs = {
 export type MutationUpdateAlertArgs = {
 	alert_id: Scalars['ID']
 	below_threshold?: InputMaybe<Scalars['Boolean']>
-	disabled?: InputMaybe<Scalars['Boolean']>
 	function_column?: InputMaybe<Scalars['String']>
 	function_type?: InputMaybe<MetricAggregator>
 	group_by_key?: InputMaybe<Scalars['String']>
@@ -1771,7 +1769,7 @@ export type MutationUpdateAlertArgs = {
 	project_id: Scalars['ID']
 	query?: InputMaybe<Scalars['String']>
 	threshold_cooldown?: InputMaybe<Scalars['Int']>
-	threshold_value?: InputMaybe<Scalars['Int']>
+	threshold_value?: InputMaybe<Scalars['Float']>
 	threshold_window?: InputMaybe<Scalars['Int']>
 }
 


### PR DESCRIPTION
## Summary
Make the following updates to the backend mutations/queries
- add `MetricId` and `FunctionColumn` to alert table
- change int `ThresholdCount` to float `ThresholdValue`
- Remove `disabled` var from create/update mutations
- Update `MetricId` when ever alert is updated
- Allow all fields to overwrite to null value

## How did you test this change?
Test the create/update queries in postman

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
