### PR TITLE
[HIG-4777] cooldown logic for alerts

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -13047,6 +13047,7 @@ enum AlertState {
 	Normal
 	Pending
 	Alerting
+	AlertingSilently
 	NoData
 	Error
 }
@@ -13093,7 +13094,7 @@ type AlertStateChange {
 	State: AlertState!
 	PreviousState: AlertState!
 	Title: String!
-	GroupByKey: String
+	GroupByKey: String!
 }
 
 type SanitizedSlackChannel {
@@ -25757,11 +25758,14 @@ func (ec *executionContext) _AlertStateChange_GroupByKey(ctx context.Context, fi
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_AlertStateChange_GroupByKey(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -84430,6 +84434,9 @@ func (ec *executionContext) _AlertStateChange(ctx context.Context, sel ast.Selec
 			}
 		case "GroupByKey":
 			out.Values[i] = ec._AlertStateChange_GroupByKey(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -103,7 +103,7 @@ type AlertStateChange struct {
 	State         AlertState `json:"State"`
 	PreviousState AlertState `json:"PreviousState"`
 	Title         string     `json:"Title"`
-	GroupByKey    *string    `json:"GroupByKey,omitempty"`
+	GroupByKey    string     `json:"GroupByKey"`
 }
 
 type AllProjectSettings struct {
@@ -1097,24 +1097,26 @@ func (e AlertDestinationType) MarshalGQL(w io.Writer) {
 type AlertState string
 
 const (
-	AlertStateNormal   AlertState = "Normal"
-	AlertStatePending  AlertState = "Pending"
-	AlertStateAlerting AlertState = "Alerting"
-	AlertStateNoData   AlertState = "NoData"
-	AlertStateError    AlertState = "Error"
+	AlertStateNormal           AlertState = "Normal"
+	AlertStatePending          AlertState = "Pending"
+	AlertStateAlerting         AlertState = "Alerting"
+	AlertStateAlertingSilently AlertState = "AlertingSilently"
+	AlertStateNoData           AlertState = "NoData"
+	AlertStateError            AlertState = "Error"
 )
 
 var AllAlertState = []AlertState{
 	AlertStateNormal,
 	AlertStatePending,
 	AlertStateAlerting,
+	AlertStateAlertingSilently,
 	AlertStateNoData,
 	AlertStateError,
 }
 
 func (e AlertState) IsValid() bool {
 	switch e {
-	case AlertStateNormal, AlertStatePending, AlertStateAlerting, AlertStateNoData, AlertStateError:
+	case AlertStateNormal, AlertStatePending, AlertStateAlerting, AlertStateAlertingSilently, AlertStateNoData, AlertStateError:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1560,6 +1560,7 @@ enum AlertState {
 	Normal
 	Pending
 	Alerting
+	AlertingSilently
 	NoData
 	Error
 }
@@ -1606,7 +1607,7 @@ type AlertStateChange {
 	State: AlertState!
 	PreviousState: AlertState!
 	Title: String!
-	GroupByKey: String
+	GroupByKey: String!
 }
 
 type SanitizedSlackChannel {

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -165,6 +165,7 @@ export enum AlertDestinationType {
 
 export enum AlertState {
 	Alerting = 'Alerting',
+	AlertingSilently = 'AlertingSilently',
 	Error = 'Error',
 	NoData = 'NoData',
 	Normal = 'Normal',
@@ -174,7 +175,7 @@ export enum AlertState {
 export type AlertStateChange = {
 	__typename?: 'AlertStateChange'
 	AlertID: Scalars['ID']
-	GroupByKey?: Maybe<Scalars['String']>
+	GroupByKey: Scalars['String']
 	PreviousState: AlertState
 	State: AlertState
 	Title: Scalars['String']


### PR DESCRIPTION
## Summary
- for the given alert id, load the last timestamp where that alert had fired for each groupbykey
- when evaluating the alert, check that the current time is greater than the last alert's time + cooldown period
- adds a new alerting state `AlertingSilently` to signify that it's still in an alert state but had not notified
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally with a 120s cooldown period set:
![Screen Shot 2024-07-08 at 4 52 59 PM](https://github.com/highlight/highlight/assets/86132398/f0604977-99cc-47c7-bbb9-144bcb1a460f)

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
