### PR TITLE
[SUP-71] fallback to jpeg dataurl when webp not supported

### DIFF
--- a/.changeset/tiny-squids-raise.md
+++ b/.changeset/tiny-squids-raise.md
@@ -1,5 +1,0 @@
----
-'highlight.run': patch
----
-
-default to jpeg canvas recording when webp not supported

--- a/.changeset/tiny-squids-raise.md
+++ b/.changeset/tiny-squids-raise.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+default to jpeg canvas recording when webp not supported

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -88,6 +88,7 @@ import {
 	SNAPSHOT_SETTINGS,
 	VISIBILITY_DEBOUNCE_MS,
 } from './constants/sessions'
+import { getDefaultDataURLOptions } from './utils/utils'
 
 export const HighlightWarning = (context: string, msg: any) => {
 	console.warn(`Highlight Warning: (${context}): `, { output: msg })
@@ -341,6 +342,7 @@ export class Highlight {
 			canvasFactor: 0.5,
 			canvasMaxSnapshotDimension: 360,
 			canvasClearWebGLBuffer: true,
+			dataUrlOptions: getDefaultDataURLOptions(),
 			...(options.samplingStrategy ?? {
 				canvas: 2,
 			}),
@@ -721,10 +723,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 							this.samplingStrategy.canvasClearWebGLBuffer,
 						initialSnapshotDelay:
 							this.samplingStrategy.canvasInitialSnapshotDelay,
-						dataURLOptions: {
-							type: 'image/webp',
-							quality: 0.9,
-						},
+						dataURLOptions: this.samplingStrategy.dataUrlOptions,
 						maxSnapshotDimension:
 							this.samplingStrategy.canvasMaxSnapshotDimension,
 					},

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -61,8 +61,8 @@ export declare type SamplingStrategy = {
 	canvasInitialSnapshotDelay?: number
 	/**
 	 * Settings for canvas data serialization. Defaults to {"image/webp", 0.9} for browsers
-	 * that support WebP and {"image/jpeg", 0.6} for others. Can be overridden to any format
-	 * or compression ratio supported by [`toDataURL`](http://mdn.io/toDataURL).
+	 * that support WebP and {"image/jpeg", 0.6} for others. Can be overridden to any type
+	 * or quality value supported by [`toDataURL`](http://mdn.io/toDataURL).
 	 */
 	dataUrlOptions?: Partial<{
 		type: string

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -59,6 +59,15 @@ export declare type SamplingStrategy = {
 	 * Time (in milliseconds) to wait before the initial snapshot of canvas/video elements.
 	 */
 	canvasInitialSnapshotDelay?: number
+	/**
+	 * Settings for canvas data serialization. Defaults to {"image/webp", 0.9} for browsers
+	 * that support WebP and {"image/jpeg", 0.6} for others. Can be overridden to any format
+	 * or compression ratio supported by [`toDataURL`](http://mdn.io/toDataURL).
+	 */
+	dataUrlOptions?: Partial<{
+		type: string
+		quality: number
+	}>
 }
 
 export declare type HighlightOptions = {

--- a/sdk/client/src/utils/utils.ts
+++ b/sdk/client/src/utils/utils.ts
@@ -226,3 +226,27 @@ export function stringify(
 		return str
 	}
 }
+
+function supportsWebP(): boolean {
+	var elem = document.createElement('canvas')
+	if (!!(elem.getContext && elem.getContext('2d'))) {
+		return elem.toDataURL('image/webp').indexOf('data:image/webp') == 0
+	}
+	return false
+}
+
+export function getDefaultDataURLOptions(): {
+	type: string
+	quality: number
+} {
+	if (supportsWebP()) {
+		return {
+			type: 'image/webp',
+			quality: 0.9,
+		}
+	}
+	return {
+		type: 'image/jpeg',
+		quality: 0.6,
+	}
+}

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -1,5 +1,11 @@
 # highlight.run
 
+## 9.0.4
+
+### Patch Changes
+
+-   0a245b208: default to jpeg canvas recording when webp not supported
+
 ## 9.0.3
 
 ### Patch Changes

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "9.0.3",
+	"version": "9.0.4",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "9.0.3"
+export default "9.0.4"

--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @highlight-run/next
 
+## 7.5.11
+
+### Patch Changes
+
+-   Updated dependencies [0a245b208]
+    -   highlight.run@9.0.4
+    -   @highlight-run/node@3.9.0
+
 ## 7.5.10
 
 ### Patch Changes

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "7.5.10",
+	"version": "7.5.11",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-remix/CHANGELOG.md
+++ b/sdk/highlight-remix/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @highlight-run/remix
 
+## 2.0.42
+
+### Patch Changes
+
+-   Updated dependencies [0a245b208]
+    -   highlight.run@9.0.4
+    -   @highlight-run/node@3.9.0
+
 ## 2.0.41
 
 ### Patch Changes

--- a/sdk/highlight-remix/package.json
+++ b/sdk/highlight-remix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/remix",
-	"version": "2.0.41",
+	"version": "2.0.42",
 	"description": "Client for interfacing with Highlight in Remix",
 	"packageManager": "yarn@4.0.2",
 	"author": "",


### PR DESCRIPTION
## Summary
- safari does not support the `image/webp` format and silently falls back to png, which uses ~10x as much data since it's lossless
- this change detects if the browser supports webp, and if not, uses jpeg at .6 quality to approximate the same size payload
- also adds a `H.init` option to override the format and quality settings
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested in chrome / safari on `debug/canvas` page, monitored pushpayload size
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- publish via changesets
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
