### PR TITLE
Fix re-searching sessions

### DIFF
--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -257,6 +257,7 @@ export const PlayerPage = () => {
 		page,
 		disablePolling: !searchTimeContext.selectedPreset,
 		sortDesc: sessionFeedConfiguration.sortOrder === 'Descending',
+		presetSelected: !!searchTimeContext.selectedPreset,
 	})
 
 	const handleSubmit = useCallback(

--- a/frontend/src/pages/Sessions/useGetSessions.ts
+++ b/frontend/src/pages/Sessions/useGetSessions.ts
@@ -19,6 +19,7 @@ export const useGetSessions = ({
 	page = 1,
 	disablePolling,
 	sortDesc,
+	presetSelected,
 }: {
 	query: string
 	project_id: string | undefined
@@ -27,17 +28,17 @@ export const useGetSessions = ({
 	page?: number
 	disablePolling?: boolean
 	sortDesc: boolean
+	presetSelected: boolean
 }) => {
 	// Using these rounded dates to ensure the cache is hit on initial load. The
 	// query will still be sent and the data in the cache will be updated.
 	const roundedStartDate = moment(startDate)
 		.startOf('minute')
 		.subtract(moment(startDate).minute() % 10, 'minutes')
-	const endDateIsNearNow = moment().diff(moment(endDate), 'seconds') < 10
-	const momentEndDate = endDateIsNearNow
+	const momentEndDate = presetSelected
 		? moment(endDate).add(10, 'minutes')
 		: moment(endDate)
-	const roudnedEndDate = momentEndDate
+	const roundedEndDate = momentEndDate
 		.startOf('minute')
 		.subtract(moment(endDate).minute() % 10, 'minutes')
 
@@ -50,7 +51,7 @@ export const useGetSessions = ({
 				query,
 				date_range: {
 					start_date: roundedStartDate.format(TIME_FORMAT),
-					end_date: roudnedEndDate.format(TIME_FORMAT),
+					end_date: roundedEndDate.format(TIME_FORMAT),
 				},
 			},
 			sort_desc: sortDesc,


### PR DESCRIPTION
## Summary
Session search researches after 10 seconds when the endDate is no longer near now - use the selectedPreset to determine time to add to the endDate.

## How did you test this change?
1. View the sessions page
- [ ] No re-searching after ~10 seconds
- [ ] Caching improvements are still intact 

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
