### PR TITLE
[SUP-72] fix env replacements

### DIFF
--- a/docker/frontend-entrypoint.py
+++ b/docker/frontend-entrypoint.py
@@ -23,7 +23,7 @@ def main():
             data = re.sub('https://pri\.highlight\.io', private, data)
         if public:
             data = re.sub('http://localhost:8082/public', public, data)
-            data = re.sub('https://pub\.highlight\.run', private, data)
+            data = re.sub('https://pub\.highlight\.run', public, data)
         if frontend:
             data = re.sub('http://localhost:3000', frontend, data)
             data = re.sub('https://app\.highlight\.io', frontend, data)

--- a/docker/frontend-entrypoint.py
+++ b/docker/frontend-entrypoint.py
@@ -12,7 +12,7 @@ def main():
     frontend = os.environ.get('REACT_APP_FRONTEND_URI')
     auth = os.environ.get('REACT_APP_AUTH_MODE')
     use_ssl = os.environ.get('SSL') != 'false'
-    print("replacing", {"private": private, "public": public, "frontend": frontend})
+    print("replacing", {"private": private, "public": public, "frontend": frontend, "auth": auth})
 
     with open(CONSTANTS_FILE, 'r') as f:
         data = f.read()
@@ -20,10 +20,13 @@ def main():
             data = re.sub('firebase', auth, data)
         if private:
             data = re.sub('http://localhost:8082/private', private, data)
+            data = re.sub('https://pri.highlight.io', private, data)
         if public:
             data = re.sub('http://localhost:8082/public', public, data)
+            data = re.sub('https://pub.highlight.run', private, data)
         if frontend:
             data = re.sub('http://localhost:3000', frontend, data)
+            data = re.sub('https://app.highlight.io', frontend, data)
 
     try:
         with open(CONSTANTS_FILE, 'w') as f:

--- a/docker/frontend-entrypoint.py
+++ b/docker/frontend-entrypoint.py
@@ -20,13 +20,13 @@ def main():
             data = re.sub('firebase', auth, data)
         if private:
             data = re.sub('http://localhost:8082/private', private, data)
-            data = re.sub('https://pri.highlight.io', private, data)
+            data = re.sub('https://pri\.highlight\.io', private, data)
         if public:
             data = re.sub('http://localhost:8082/public', public, data)
-            data = re.sub('https://pub.highlight.run', private, data)
+            data = re.sub('https://pub\.highlight\.run', private, data)
         if frontend:
             data = re.sub('http://localhost:3000', frontend, data)
-            data = re.sub('https://app.highlight.io', frontend, data)
+            data = re.sub('https://app\.highlight\.io', frontend, data)
 
     try:
         with open(CONSTANTS_FILE, 'w') as f:

--- a/frontend/src/util/auth.tsx
+++ b/frontend/src/util/auth.tsx
@@ -7,6 +7,10 @@ import Firebase from 'firebase/compat/app'
 
 import { AUTH_MODE, PRIVATE_GRAPH_URI } from '@/constants'
 
+export function GetAuthMode(): string {
+	return AUTH_MODE
+}
+
 interface User {
 	email: string | null
 
@@ -255,37 +259,42 @@ class PasswordAuth {
 }
 
 export let auth: SimpleAuth
-if (AUTH_MODE === 'simple') {
-	auth = new SimpleAuth()
-} else if (AUTH_MODE === 'password') {
-	auth = new PasswordAuth()
-} else {
-	let firebaseConfig: any
-	let firebaseConfigString: string
+switch (AUTH_MODE) {
+	case 'simple':
+		auth = new SimpleAuth()
+		break
+	case 'password':
+		auth = new PasswordAuth()
+		break
+	default:
+		let firebaseConfig: any
+		let firebaseConfigString: string
 
-	if (import.meta.env.REACT_APP_FIREBASE_CONFIG_OBJECT) {
-		firebaseConfigString =
-			import.meta.env.REACT_APP_FIREBASE_CONFIG_OBJECT ?? ''
-	} else {
-		firebaseConfigString = window._highlightFirebaseConfigString
-	}
+		if (import.meta.env.REACT_APP_FIREBASE_CONFIG_OBJECT) {
+			firebaseConfigString =
+				import.meta.env.REACT_APP_FIREBASE_CONFIG_OBJECT ?? ''
+		} else {
+			firebaseConfigString = window._highlightFirebaseConfigString
+		}
 
-	// NOTE: we use eval() here (rather than JSON.parse) because its more in-tune
-	// with the string presented to a developer in the firebase console.
-	// This value is passed at build time, so security concerns are put aside.
-	try {
-		firebaseConfig = eval('(' + firebaseConfigString + ')')
-	} catch (_e) {
-		const e = _e as Error
-		throw new Error('Error parsing incoming firebase config' + e.toString())
-	}
+		// NOTE: we use eval() here (rather than JSON.parse) because its more in-tune
+		// with the string presented to a developer in the firebase console.
+		// This value is passed at build time, so security concerns are put aside.
+		try {
+			firebaseConfig = eval('(' + firebaseConfigString + ')')
+		} catch (_e) {
+			const e = _e as Error
+			throw new Error(
+				'Error parsing incoming firebase config' + e.toString(),
+			)
+		}
 
-	window._highlightFirebaseConfig = firebaseConfig
+		window._highlightFirebaseConfig = firebaseConfig
 
-	Firebase.initializeApp(firebaseConfig)
-	const googleProvider = new Firebase.auth.GoogleAuthProvider()
-	const githubProvider = new Firebase.auth.GithubAuthProvider()
-	auth = Firebase.auth()
-	auth.googleProvider = googleProvider
-	auth.githubProvider = githubProvider
+		Firebase.initializeApp(firebaseConfig)
+		const googleProvider = new Firebase.auth.GoogleAuthProvider()
+		const githubProvider = new Firebase.auth.GithubAuthProvider()
+		auth = Firebase.auth()
+		auth.googleProvider = googleProvider
+		auth.githubProvider = githubProvider
 }

--- a/frontend/src/util/auth.tsx
+++ b/frontend/src/util/auth.tsx
@@ -7,10 +7,6 @@ import Firebase from 'firebase/compat/app'
 
 import { AUTH_MODE, PRIVATE_GRAPH_URI } from '@/constants'
 
-export function GetAuthMode(): string {
-	return AUTH_MODE
-}
-
 interface User {
 	email: string | null
 


### PR DESCRIPTION
## Summary
- `frontend-entrypoint` should replace env variables that were set during the frontend build - this wasn't happening because the released docker builds have production values instead of dev ones
- the `AUTH_MODE` checks were being inlined by rollup? - fix that by using a switch statement because rollup doesn't seem to touch that
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran `doppler -c prod_aws run -- yarn build` and `python frontend-entrypoint.py` locally to validate that a `constants` file was created with all 4 variables and that all 4 were replaced
- will test this PR's docker image once it's built 
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will publish a new docker image after deploying
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
