### PR TITLE
[SUP-73] exclude archived slack channels

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -3478,7 +3478,8 @@ func (r *Resolver) GetSlackChannelsFromSlack(ctx context.Context, workspaceId in
 		existingChannels, _ := workspace.IntegratedSlackChannels()
 
 		getConversationsParam := slack.GetConversationsParameters{
-			Limit: 1000,
+			ExcludeArchived: true,
+			Limit:           1000,
 			// public_channel is for public channels in the Slack workspace
 			// private is for private channels in the Slack workspace that the Bot is included in
 			// mpim is for multi-person conversations in the Slack workspace that the Bot is included in


### PR DESCRIPTION
## Summary
- for certain customers, calling this api without archived channels caused too many api requests and we were hitting a rate limit
- doesn't make sense to have a lot of spam from archived channels anyway
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally, confirmed slack integration was working normally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will validate customer issue after deployment
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
