### PR TITLE
[HIG-4781] remove max size from bar charts

### DIFF
--- a/frontend/src/pages/Graphing/components/BarChart.tsx
+++ b/frontend/src/pages/Graphing/components/BarChart.tsx
@@ -216,7 +216,6 @@ export const BarChart = ({
 								key={key}
 								dataKey={key}
 								fill={getColor(idx, key, strokeColors)}
-								maxBarSize={30}
 								isAnimationActive={false}
 								stackId={
 									viewConfig.display === 'Stacked' ? 1 : idx


### PR DESCRIPTION
## Summary
- removes the `maxBarSize` property so bar charts with a small number of buckets / groups will use more space
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- @julian-highlight 
<!--
 Request review from julian-highlight / our design team 
-->
