### PR TITLE
Add destinations to alert form

### DIFF
--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -96,6 +96,12 @@ type AdminAndWorkspaceDetails struct {
 	PromoCode                   *string `json:"promo_code,omitempty"`
 }
 
+type AlertDestinationInput struct {
+	DestinationType AlertDestinationType `json:"destination_type"`
+	TypeID          string               `json:"type_id"`
+	TypeName        string               `json:"type_name"`
+}
+
 type AlertStateChange struct {
 	ID            int        `json:"id"`
 	Timestamp     time.Time  `json:"timestamp"`

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1581,6 +1581,12 @@ type AlertDestination {
 	type_name: String!
 }
 
+input AlertDestinationInput {
+	destination_type: AlertDestinationType!
+	type_id: String!
+	type_name: String!
+}
+
 type Alert {
 	id: ID!
 	updated_at: Timestamp!
@@ -2775,7 +2781,8 @@ type Mutation {
 		below_threshold: Boolean
 		threshold_value: Float
 		threshold_window: Int
-		threshold_cooldown: Int # TODO(spenny): add destinations
+		threshold_cooldown: Int
+		destinations: [AlertDestinationInput!]!
 	): Alert
 	updateAlert(
 		project_id: ID!
@@ -2789,7 +2796,8 @@ type Mutation {
 		below_threshold: Boolean
 		threshold_value: Float
 		threshold_window: Int
-		threshold_cooldown: Int # TODO(spenny): add destinations
+		threshold_cooldown: Int
+		destinations: [AlertDestinationInput!]
 	): Alert
 	updateAlertDisabled(
 		project_id: ID!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3309,7 +3309,7 @@ func (r *mutationResolver) UpdateMetricMonitor(ctx context.Context, metricMonito
 }
 
 // CreateAlert is the resolver for the createAlert field.
-func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name string, productType modelInputs.ProductType, functionType modelInputs.MetricAggregator, functionColumn *string, query *string, groupByKey *string, belowThreshold *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int) (*model.Alert, error) {
+func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name string, productType modelInputs.ProductType, functionType modelInputs.MetricAggregator, functionColumn *string, query *string, groupByKey *string, belowThreshold *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int, destinations []*modelInputs.AlertDestinationInput) (*model.Alert, error) {
 	_, err := r.isUserInProject(ctx, projectID)
 	admin, _ := r.getCurrentAdmin(ctx)
 	if err != nil {
@@ -3332,11 +3332,24 @@ func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name 
 		LastAdminToEditID: admin.ID,
 	}
 
-	if err := r.DB.WithContext(ctx).Create(newAlert).Error; err != nil {
+	createdAlert := &model.Alert{}
+	if err := r.DB.WithContext(ctx).Clauses(clause.Returning{}).Create(newAlert).Scan(&createdAlert).Error; err != nil {
 		return nil, err
 	}
 
-	// TODO(spenny): create destinations
+	alertDestinations := []*model.AlertDestination{}
+	for _, d := range destinations {
+		alertDestinations = append(alertDestinations, &model.AlertDestination{
+			AlertID:         createdAlert.ID,
+			DestinationType: d.DestinationType,
+			TypeID:          d.TypeID,
+			TypeName:        d.TypeName,
+		})
+	}
+
+	if err := r.DB.WithContext(ctx).Create(alertDestinations).Error; err != nil {
+		return nil, err
+	}
 
 	// TODO(spenny): send new message to destinations
 
@@ -3344,7 +3357,7 @@ func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name 
 }
 
 // UpdateAlert is the resolver for the updateAlert field.
-func (r *mutationResolver) UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *modelInputs.ProductType, functionType *modelInputs.MetricAggregator, functionColumn *string, query *string, groupByKey *string, belowThreshold *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int) (*model.Alert, error) {
+func (r *mutationResolver) UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *modelInputs.ProductType, functionType *modelInputs.MetricAggregator, functionColumn *string, query *string, groupByKey *string, belowThreshold *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int, destinations []*modelInputs.AlertDestinationInput) (*model.Alert, error) {
 	project, err := r.isUserInProject(ctx, projectID)
 	admin, _ := r.getCurrentAdmin(ctx)
 	if err != nil {

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6573,6 +6573,26 @@ body {
   display: flex;
   align-items: center;
 }
+._1c1rpkd0 {
+  color: var(--_1pyqka9b) !important;
+  width: 100%;
+}
+._1c1rpkd0:hover {
+  background: var(--_1pyqka91x);
+}
+._1c1rpkd0 .ant-select-selector {
+  padding: 0 6px !important;
+  border-radius: 6px !important;
+  border: var(--_1pyqka91o) solid 1px !important;
+  box-shadow: none !important;
+}
+._1c1rpkd0 .ant-select-selector:hover {
+  background: var(--_1pyqka91x) !important;
+}
+._1c1rpkd0 .ant-select-selection-item {
+  display: flex;
+  align-items: center;
+}
 ._7o1fd80 {
   width: 100%;
   height: 28px;

--- a/frontend/src/__generated/ve/pages/Alerts/DestinationInput/styles.css.js
+++ b/frontend/src/__generated/ve/pages/Alerts/DestinationInput/styles.css.js
@@ -1,0 +1,5 @@
+// src/pages/Alerts/DestinationInput/styles.css.ts
+var selectContainer = "_1c1rpkd0";
+export {
+  selectContainer
+};

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -3488,6 +3488,7 @@ export const UpdateAlertDocument = gql`
 		$threshold_value: Float
 		$threshold_window: Int
 		$threshold_cooldown: Int
+		$destinations: [AlertDestinationInput!]
 	) {
 		updateAlert(
 			project_id: $project_id
@@ -3502,6 +3503,7 @@ export const UpdateAlertDocument = gql`
 			threshold_value: $threshold_value
 			threshold_window: $threshold_window
 			threshold_cooldown: $threshold_cooldown
+			destinations: $destinations
 		) {
 			id
 			name
@@ -3539,6 +3541,7 @@ export type UpdateAlertMutationFn = Apollo.MutationFunction<
  *      threshold_value: // value for 'threshold_value'
  *      threshold_window: // value for 'threshold_window'
  *      threshold_cooldown: // value for 'threshold_cooldown'
+ *      destinations: // value for 'destinations'
  *   },
  * });
  */
@@ -12592,6 +12595,12 @@ export const GetAlertsPagePayloadDocument = gql`
 			name
 			product_type
 			disabled
+			destinations {
+				id
+				destination_type
+				type_id
+				type_name
+			}
 		}
 	}
 	${DiscordChannelFragmentFragmentDoc}
@@ -12664,6 +12673,12 @@ export const GetAlertDocument = gql`
 			threshold_value
 			threshold_window
 			threshold_cooldown
+			destinations {
+				id
+				destination_type
+				type_id
+				type_name
+			}
 		}
 	}
 `

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -3622,6 +3622,54 @@ export type UpdateAlertDisabledMutationOptions = Apollo.BaseMutationOptions<
 	Types.UpdateAlertDisabledMutation,
 	Types.UpdateAlertDisabledMutationVariables
 >
+export const DeleteAlertDocument = gql`
+	mutation DeleteAlert($project_id: ID!, $alert_id: ID!) {
+		deleteAlert(project_id: $project_id, alert_id: $alert_id)
+	}
+`
+export type DeleteAlertMutationFn = Apollo.MutationFunction<
+	Types.DeleteAlertMutation,
+	Types.DeleteAlertMutationVariables
+>
+
+/**
+ * __useDeleteAlertMutation__
+ *
+ * To run a mutation, you first call `useDeleteAlertMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteAlertMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deleteAlertMutation, { data, loading, error }] = useDeleteAlertMutation({
+ *   variables: {
+ *      project_id: // value for 'project_id'
+ *      alert_id: // value for 'alert_id'
+ *   },
+ * });
+ */
+export function useDeleteAlertMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.DeleteAlertMutation,
+		Types.DeleteAlertMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.DeleteAlertMutation,
+		Types.DeleteAlertMutationVariables
+	>(DeleteAlertDocument, baseOptions)
+}
+export type DeleteAlertMutationHookResult = ReturnType<
+	typeof useDeleteAlertMutation
+>
+export type DeleteAlertMutationResult =
+	Apollo.MutationResult<Types.DeleteAlertMutation>
+export type DeleteAlertMutationOptions = Apollo.BaseMutationOptions<
+	Types.DeleteAlertMutation,
+	Types.DeleteAlertMutationVariables
+>
 export const UpdateAdminAndCreateWorkspaceDocument = gql`
 	mutation UpdateAdminAndCreateWorkspace(
 		$admin_and_workspace_details: AdminAndWorkspaceDetails!

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -3399,6 +3399,7 @@ export const CreateAlertDocument = gql`
 		$threshold_value: Float
 		$threshold_window: Int
 		$threshold_cooldown: Int
+		$destinations: [AlertDestinationInput!]!
 	) {
 		createAlert(
 			project_id: $project_id
@@ -3412,6 +3413,7 @@ export const CreateAlertDocument = gql`
 			threshold_value: $threshold_value
 			threshold_window: $threshold_window
 			threshold_cooldown: $threshold_cooldown
+			destinations: $destinations
 		) {
 			id
 			name
@@ -3448,6 +3450,7 @@ export type CreateAlertMutationFn = Apollo.MutationFunction<
  *      threshold_value: // value for 'threshold_value'
  *      threshold_window: // value for 'threshold_window'
  *      threshold_cooldown: // value for 'threshold_cooldown'
+ *      destinations: // value for 'destinations'
  *   },
  * });
  */

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -1081,6 +1081,16 @@ export type UpdateAlertDisabledMutation = { __typename?: 'Mutation' } & Pick<
 	'updateAlertDisabled'
 >
 
+export type DeleteAlertMutationVariables = Types.Exact<{
+	project_id: Types.Scalars['ID']
+	alert_id: Types.Scalars['ID']
+}>
+
+export type DeleteAlertMutation = { __typename?: 'Mutation' } & Pick<
+	Types.Mutation,
+	'deleteAlert'
+>
+
 export type UpdateAdminAndCreateWorkspaceMutationVariables = Types.Exact<{
 	admin_and_workspace_details: Types.AdminAndWorkspaceDetails
 }>
@@ -5506,6 +5516,7 @@ export const namedOperations = {
 		CreateAlert: 'CreateAlert' as const,
 		UpdateAlert: 'UpdateAlert' as const,
 		UpdateAlertDisabled: 'UpdateAlertDisabled' as const,
+		DeleteAlert: 'DeleteAlert' as const,
 		UpdateAdminAndCreateWorkspace: 'UpdateAdminAndCreateWorkspace' as const,
 		UpdateAdminAboutYouDetails: 'UpdateAdminAboutYouDetails' as const,
 		UpdateErrorAlert: 'UpdateErrorAlert' as const,

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -1029,6 +1029,9 @@ export type CreateAlertMutationVariables = Types.Exact<{
 	threshold_value?: Types.Maybe<Types.Scalars['Float']>
 	threshold_window?: Types.Maybe<Types.Scalars['Int']>
 	threshold_cooldown?: Types.Maybe<Types.Scalars['Int']>
+	destinations:
+		| Array<Types.AlertDestinationInput>
+		| Types.AlertDestinationInput
 }>
 
 export type CreateAlertMutation = { __typename?: 'Mutation' } & {

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -1056,6 +1056,9 @@ export type UpdateAlertMutationVariables = Types.Exact<{
 	threshold_value?: Types.Maybe<Types.Scalars['Float']>
 	threshold_window?: Types.Maybe<Types.Scalars['Int']>
 	threshold_cooldown?: Types.Maybe<Types.Scalars['Int']>
+	destinations?: Types.Maybe<
+		Array<Types.AlertDestinationInput> | Types.AlertDestinationInput
+	>
 }>
 
 export type UpdateAlertMutation = { __typename?: 'Mutation' } & {
@@ -4359,7 +4362,19 @@ export type GetAlertsPagePayloadQuery = { __typename?: 'Query' } & {
 			{ __typename?: 'Alert' } & Pick<
 				Types.Alert,
 				'id' | 'updated_at' | 'name' | 'product_type' | 'disabled'
-			>
+			> & {
+					destinations: Array<
+						Types.Maybe<
+							{ __typename?: 'AlertDestination' } & Pick<
+								Types.AlertDestination,
+								| 'id'
+								| 'destination_type'
+								| 'type_id'
+								| 'type_name'
+							>
+						>
+					>
+				}
 		>
 	>
 }
@@ -4385,7 +4400,16 @@ export type GetAlertQuery = { __typename?: 'Query' } & {
 		| 'threshold_value'
 		| 'threshold_window'
 		| 'threshold_cooldown'
-	>
+	> & {
+			destinations: Array<
+				Types.Maybe<
+					{ __typename?: 'AlertDestination' } & Pick<
+						Types.AlertDestination,
+						'id' | 'destination_type' | 'type_id' | 'type_name'
+					>
+				>
+			>
+		}
 }
 
 export type GetMetricMonitorsQueryVariables = Types.Exact<{

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -157,6 +157,12 @@ export type AlertDestination = {
 	type_name: Scalars['String']
 }
 
+export type AlertDestinationInput = {
+	destination_type: AlertDestinationType
+	type_id: Scalars['String']
+	type_name: Scalars['String']
+}
+
 export enum AlertDestinationType {
 	Discord = 'Discord',
 	Email = 'Email',
@@ -1296,6 +1302,7 @@ export type MutationChangeProjectMembershipArgs = {
 
 export type MutationCreateAlertArgs = {
 	below_threshold?: InputMaybe<Scalars['Boolean']>
+	destinations: Array<AlertDestinationInput>
 	function_column?: InputMaybe<Scalars['String']>
 	function_type: MetricAggregator
 	group_by_key?: InputMaybe<Scalars['String']>
@@ -1762,6 +1769,7 @@ export type MutationUpdateAdminAndCreateWorkspaceArgs = {
 export type MutationUpdateAlertArgs = {
 	alert_id: Scalars['ID']
 	below_threshold?: InputMaybe<Scalars['Boolean']>
+	destinations?: InputMaybe<Array<AlertDestinationInput>>
 	function_column?: InputMaybe<Scalars['String']>
 	function_type?: InputMaybe<MetricAggregator>
 	group_by_key?: InputMaybe<Scalars['String']>

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -977,6 +977,7 @@ mutation CreateAlert(
 	$threshold_value: Float
 	$threshold_window: Int
 	$threshold_cooldown: Int
+	$destinations: [AlertDestinationInput!]!
 ) {
 	createAlert(
 		project_id: $project_id
@@ -990,6 +991,7 @@ mutation CreateAlert(
 		threshold_value: $threshold_value
 		threshold_window: $threshold_window
 		threshold_cooldown: $threshold_cooldown
+		destinations: $destinations
 	) {
 		id
 		name

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -1047,6 +1047,10 @@ mutation UpdateAlertDisabled(
 	)
 }
 
+mutation DeleteAlert($project_id: ID!, $alert_id: ID!) {
+	deleteAlert(project_id: $project_id, alert_id: $alert_id)
+}
+
 mutation UpdateAdminAndCreateWorkspace(
 	$admin_and_workspace_details: AdminAndWorkspaceDetails!
 ) {

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -1012,6 +1012,7 @@ mutation UpdateAlert(
 	$threshold_value: Float
 	$threshold_window: Int
 	$threshold_cooldown: Int
+	$destinations: [AlertDestinationInput!]
 ) {
 	updateAlert(
 		project_id: $project_id
@@ -1026,6 +1027,7 @@ mutation UpdateAlert(
 		threshold_value: $threshold_value
 		threshold_window: $threshold_window
 		threshold_cooldown: $threshold_cooldown
+		destinations: $destinations
 	) {
 		id
 		name

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1870,6 +1870,12 @@ query GetAlertsPagePayload($project_id: ID!) {
 		name
 		product_type
 		disabled
+		destinations {
+			id
+			destination_type
+			type_id
+			type_name
+		}
 	}
 }
 
@@ -1889,6 +1895,12 @@ query GetAlert($id: ID!) {
 		threshold_value
 		threshold_window
 		threshold_cooldown
+		destinations {
+			id
+			destination_type
+			type_id
+			type_name
+		}
 	}
 }
 

--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -228,6 +228,7 @@ export const AlertForm: React.FC = () => {
 			setThresholdCooldown(
 				data.alert.threshold_cooldown ?? DEFAULT_COOLDOWN,
 			)
+			setDestinations(data.alert.destinations as AlertDestinationInput[])
 		},
 	})
 

--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/graph/generated/hooks'
 import { namedOperations } from '@/graph/generated/operations'
 import { MetricAggregator, ProductType } from '@/graph/generated/schemas'
+import { AlertDestinationInput } from '@/graph/generated/schemas'
 import { useProjectId } from '@/hooks/useProjectId'
 import { useSearchTime } from '@/hooks/useSearchTime'
 import { FREQUENCIES } from '@/pages/Alerts/AlertConfigurationCard/AlertConfigurationConstants'
@@ -144,6 +145,10 @@ export const AlertForm: React.FC = () => {
 	const [thresholdCooldown, setThresholdCooldown] =
 		useState<number>(DEFAULT_COOLDOWN)
 
+	const [destinations, setDestinations] = useState<AlertDestinationInput[]>(
+		[],
+	)
+
 	const viewConfig = getViewConfig(
 		'Line chart',
 		LINE_DISPLAY[0],
@@ -166,6 +171,7 @@ export const AlertForm: React.FC = () => {
 			threshold_value: thresholdValue,
 			threshold_window: thresholdWindow,
 			threshold_cooldown: thresholdCooldown,
+			destinations,
 		}
 
 		if (isEdit) {
@@ -571,7 +577,10 @@ export const AlertForm: React.FC = () => {
 								</SidebarSection>
 								<Divider className="m-0" />
 								<SidebarSection>
-									<DestinationInput />
+									<DestinationInput
+										destinations={destinations}
+										setDestinations={setDestinations}
+									/>
 								</SidebarSection>
 							</Form>
 						</Box>

--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -34,6 +34,7 @@ import {
 	ALERT_CONDITION_OPTIONS,
 	AlertCondition,
 } from '@/pages/Alerts/constants'
+import { DestinationInput } from '@/pages/Alerts/DestinationInput'
 import { Combobox } from '@/pages/Graphing/Combobox'
 import Graph, { getViewConfig } from '@/pages/Graphing/components/Graph'
 import {
@@ -567,6 +568,10 @@ export const AlertForm: React.FC = () => {
 											searchConfig={searchOptionsConfig}
 										/>
 									</LabeledRow>
+								</SidebarSection>
+								<Divider className="m-0" />
+								<SidebarSection>
+									<DestinationInput />
 								</SidebarSection>
 							</Form>
 						</Box>

--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -145,6 +145,9 @@ export const AlertForm: React.FC = () => {
 	const [thresholdCooldown, setThresholdCooldown] =
 		useState<number>(DEFAULT_COOLDOWN)
 
+	const [initialDestinations, setInitialDestinations] = useState<
+		AlertDestinationInput[]
+	>([])
 	const [destinations, setDestinations] = useState<AlertDestinationInput[]>(
 		[],
 	)
@@ -227,6 +230,9 @@ export const AlertForm: React.FC = () => {
 			setThresholdWindow(data.alert.threshold_window ?? DEFAULT_WINDOW)
 			setThresholdCooldown(
 				data.alert.threshold_cooldown ?? DEFAULT_COOLDOWN,
+			)
+			setInitialDestinations(
+				data.alert.destinations as AlertDestinationInput[],
 			)
 			setDestinations(data.alert.destinations as AlertDestinationInput[])
 		},
@@ -579,7 +585,9 @@ export const AlertForm: React.FC = () => {
 								<Divider className="m-0" />
 								<SidebarSection>
 									<DestinationInput
-										destinations={destinations}
+										initialDestinations={
+											initialDestinations
+										}
 										setDestinations={setDestinations}
 									/>
 								</SidebarSection>

--- a/frontend/src/pages/Alerts/Alerts.tsx
+++ b/frontend/src/pages/Alerts/Alerts.tsx
@@ -42,6 +42,8 @@ import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/Button'
 import { Link } from '@/components/Link'
 import {
+	AlertDestination,
+	AlertDestinationType,
 	DiscordChannel,
 	MicrosoftTeamsChannel,
 	ProductType,
@@ -196,21 +198,57 @@ export default function AlertsPage() {
 }
 
 function formatAlertDataForTable(alert: any, config: AlertConfiguration) {
+	const slackChannels =
+		alert?.ChannelsToNotify || alert?.channels_to_notify || []
+	const discordChannels =
+		alert?.DiscordChannelsToNotify ||
+		alert?.discord_channels_to_notify ||
+		[]
+	const microsoftTeamsChannels =
+		alert?.MicrosoftTeamsChennelsToNotify ||
+		alert?.microsoft_teams_channels_to_notify ||
+		[]
+	const emails = alert?.EmailsToNotify || alert?.emails_to_notify || []
+	const webhookDestinations =
+		alert?.WebhookDestinations || alert?.webhook_destinations || []
+
+	const destinations = alert.destinations || []
+	destinations.forEach((destination: AlertDestination) => {
+		switch (destination.destination_type) {
+			case AlertDestinationType.Slack:
+				slackChannels.push({
+					webhook_channel: destination.type_name,
+					webhook_channel_id: destination.type_id,
+				})
+				break
+			case AlertDestinationType.Discord:
+				discordChannels.push({
+					id: destination.type_id,
+					name: destination.type_name,
+				})
+				break
+			case AlertDestinationType.MicrosoftTeams:
+				microsoftTeamsChannels.push({
+					id: destination.type_id,
+					name: destination.type_name,
+				})
+				break
+			case AlertDestinationType.Email:
+				emails.push(destination.type_name)
+				break
+			case AlertDestinationType.Webhook:
+				webhookDestinations.push(destination.type_name)
+				break
+		}
+	})
+
 	return {
 		...alert,
-		ChannelsToNotify:
-			alert?.ChannelsToNotify || alert?.channels_to_notify || [],
-		DiscordChannelsToNotify:
-			alert?.DiscordChannelsToNotify ||
-			alert?.discord_channels_to_notify ||
-			[],
-		MicrosoftTeamsChennelsToNotify:
-			alert?.MicrosoftTeamsChennelsToNotify ||
-			alert?.microsoft_teams_channels_to_notify ||
-			[],
-		EmailsToNotify: alert?.EmailsToNotify || alert?.emails_to_notify || [],
-		WebhookDestinations:
-			alert?.WebhookDestinations || alert?.webhook_destinations || [],
+		ChannelsToNotify: slackChannels,
+		DiscordChannelsToNotify: discordChannels,
+		MicrosoftTeamsChennelsToNotify: microsoftTeamsChannels,
+		EmailsToNotify: emails,
+		WebhookDestinations: webhookDestinations,
 		configuration: config,
 		type: alert?.product_type || config.name,
 		name: alert?.name || alert?.Name || config.name,

--- a/frontend/src/pages/Alerts/DestinationInput/index.tsx
+++ b/frontend/src/pages/Alerts/DestinationInput/index.tsx
@@ -31,6 +31,11 @@ type Channel = {
 	enabled?: boolean
 }
 
+type ChannelOption = {
+	label: string
+	value: string
+}
+
 const DESTINATION_CHANNELS: Channel[] = [
 	{
 		id: AlertDestinationType.Slack,
@@ -64,18 +69,88 @@ type Props = {
 	setDestinations: (destinations: AlertDestinationInput[]) => void
 }
 
-export const DestinationInput: React.FC<Props> = ({ setDestinations }) => {
+export const DestinationInput: React.FC<Props> = ({
+	destinations,
+	setDestinations,
+}) => {
 	const { alertsPayload, slackUrl } = useAlertsContext()
 	const { slackLoading, syncSlack } = useSlackSync()
 
 	const [selectedChannelIds, setSelectedChannelIds] = useState<string[]>([])
 	const [slackSearchQuery, setSlackSearchQuery] = useState('')
 
-	const [selectedSlackChannels, setSelectedSlackChannels] = useState([])
-	const [selectedDiscordChannels, setSelectedDiscordChannels] = useState([])
-	const [selectedTeamsChannels, setSelectedTeamsChannels] = useState([])
-	const [selectedEmails, setSelectedEmails] = useState([])
-	const [selectedWebhooks, setSelectedWebhooks] = useState([])
+	const [selectedSlackChannels, setSelectedSlackChannels] = useState<
+		ChannelOption[]
+	>([])
+	const [selectedDiscordChannels, setSelectedDiscordChannels] = useState<
+		ChannelOption[]
+	>([])
+	const [selectedTeamsChannels, setSelectedTeamsChannels] = useState<
+		ChannelOption[]
+	>([])
+	const [selectedEmails, setSelectedEmails] = useState<ChannelOption[]>([])
+	const [selectedWebhooks, setSelectedWebhooks] = useState<ChannelOption[]>(
+		[],
+	)
+
+	// load in initial channels
+	useEffect(() => {
+		const selectedChannels: { [key: string]: boolean } = {}
+		const slackChannels: ChannelOption[] = []
+		const discordChannels: ChannelOption[] = []
+		const teamsChannels: ChannelOption[] = []
+		const emails: ChannelOption[] = []
+		const webhooks: ChannelOption[] = []
+
+		destinations.forEach((destination) => {
+			switch (destination.destination_type) {
+				case AlertDestinationType.Slack:
+					selectedChannels[AlertDestinationType.Slack] = true
+					slackChannels.push({
+						label: destination.type_name,
+						value: destination.type_id,
+					})
+					break
+				case AlertDestinationType.Discord:
+					selectedChannels[AlertDestinationType.Discord] = true
+					discordChannels.push({
+						label: destination.type_name,
+						value: destination.type_id,
+					})
+					break
+				case AlertDestinationType.MicrosoftTeams:
+					selectedChannels[AlertDestinationType.MicrosoftTeams] = true
+					teamsChannels.push({
+						label: destination.type_name,
+						value: destination.type_id,
+					})
+					break
+				case AlertDestinationType.Email:
+					selectedChannels[AlertDestinationType.Email] = true
+					emails.push({
+						label: destination.type_name,
+						value: destination.type_id,
+					})
+					break
+				case AlertDestinationType.Webhook:
+					selectedChannels[AlertDestinationType.Webhook] = true
+					webhooks.push({
+						label: destination.type_name,
+						value: destination.type_id,
+					})
+					break
+			}
+		})
+
+		setSelectedChannelIds(Object.keys(selectedChannels))
+		setSelectedSlackChannels(slackChannels)
+		setSelectedDiscordChannels(discordChannels)
+		setSelectedTeamsChannels(teamsChannels)
+		setSelectedEmails(emails)
+		setSelectedWebhooks(webhooks)
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [])
 
 	// keep destinations in sync with local state
 	useEffect(() => {
@@ -323,10 +398,10 @@ export const DestinationInput: React.FC<Props> = ({ setDestinations }) => {
 }
 
 const convertOptionsToDestinations = (
-	options: any,
+	options: ChannelOption[],
 	destinationType: AlertDestinationType,
 ) => {
-	return options.map((v: any) => ({
+	return options.map((v: ChannelOption) => ({
 		destination_type: destinationType,
 		type_name: v.label ?? v.value,
 		type_id: v.value,

--- a/frontend/src/pages/Alerts/DestinationInput/index.tsx
+++ b/frontend/src/pages/Alerts/DestinationInput/index.tsx
@@ -1,0 +1,302 @@
+import Select from '@components/Select/Select'
+import {
+	Box,
+	IconSolidDiscord,
+	IconSolidGlobeAlt,
+	IconSolidMail,
+	IconSolidMicrosoftTeams,
+	IconSolidPlus,
+	IconSolidSlack,
+	Menu,
+} from '@highlight-run/ui/components'
+import * as React from 'react'
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+import { AlertDestinationType } from '@/graph/generated/schemas'
+import { useSlackSync } from '@/hooks/useSlackSync'
+import SlackLoadOrConnect from '@/pages/Alerts/AlertConfigurationCard/SlackLoadOrConnect'
+import { useAlertsContext } from '@/pages/Alerts/AlertsContext/AlertsContext'
+import { LabeledRow } from '@/pages/Graphing/LabeledRow'
+
+import * as styles from './styles.css'
+
+type Channel = {
+	id: AlertDestinationType
+	label: string
+	icon: JSX.Element
+	enabled?: boolean
+}
+
+const DESTINATION_CHANNELS: Channel[] = [
+	{
+		id: AlertDestinationType.Slack,
+		label: 'Slack channels',
+		icon: <IconSolidSlack />,
+	},
+	{
+		id: AlertDestinationType.Discord,
+		label: 'Discord channels',
+		icon: <IconSolidDiscord />,
+	},
+	{
+		id: AlertDestinationType.MicrosoftTeams,
+		label: 'Microsoft Teams channels',
+		icon: <IconSolidMicrosoftTeams />,
+	},
+	{
+		id: AlertDestinationType.Email,
+		label: 'Emails',
+		icon: <IconSolidMail />,
+	},
+	{
+		id: AlertDestinationType.Webhook,
+		label: 'Webhooks',
+		icon: <IconSolidGlobeAlt />,
+	},
+]
+
+export const DestinationInput: React.FC = ({}) => {
+	const { alertsPayload, slackUrl } = useAlertsContext()
+	const { slackLoading, syncSlack } = useSlackSync()
+
+	const [selectedChannelIds, setSelectedChannelIds] = useState<string[]>([])
+	const [slackSearchQuery, setSlackSearchQuery] = useState('')
+
+	const [selectedSlackChannels, setSelectedSlackChannels] = useState()
+	const [selectedDiscordChannels, setSelectedDiscordChannels] = useState()
+	const [selectedTeamsChannels, setSelectedTeamsChannels] = useState()
+	const [selectedEmails, setSelectedEmails] = useState()
+	const [selectedWebhooks, setSelectedWebhooks] = useState()
+
+	const possibleChannels = useMemo(
+		() =>
+			DESTINATION_CHANNELS.filter(
+				(channel) => !selectedChannelIds.includes(channel.id),
+			),
+
+		[selectedChannelIds],
+	)
+
+	const handleChannelClick = (channelId: string) => {
+		setSelectedChannelIds((prev) => [...prev, channelId])
+	}
+
+	const slackChannels = useMemo(
+		() =>
+			(alertsPayload?.slack_channel_suggestion ?? []).map(
+				({ webhook_channel, webhook_channel_id }) => ({
+					displayValue: webhook_channel!,
+					value: webhook_channel_id!,
+					id: webhook_channel_id!,
+				}),
+			),
+		[alertsPayload?.slack_channel_suggestion],
+	)
+
+	const discordChannels = useMemo(
+		() =>
+			(alertsPayload?.discord_channel_suggestions ?? []).map(
+				({ name, id }) => ({
+					displayValue: name,
+					value: id,
+					id: id,
+				}),
+			),
+		[alertsPayload?.discord_channel_suggestions],
+	)
+
+	const microsoftTeamsChannels = useMemo(
+		() =>
+			(alertsPayload?.microsoft_teams_channel_suggestions ?? []).map(
+				({ name, id }) => ({
+					displayValue: name,
+					value: id,
+					id: id,
+				}),
+			),
+		[alertsPayload?.microsoft_teams_channel_suggestions],
+	)
+
+	const emails = useMemo(
+		() =>
+			(alertsPayload?.admins ?? []).map((wa) => ({
+				displayValue: wa.admin!.email,
+				value: wa.admin!.email,
+				id: wa.admin!.email,
+			})),
+		[alertsPayload?.admins],
+	)
+
+	return (
+		<>
+			{selectedChannelIds.includes(AlertDestinationType.Slack) && (
+				<LabeledRow
+					label="Slack channels to notifiy"
+					name={AlertDestinationType.Slack}
+				>
+					<Select
+						aria-label="Slack channels to notify"
+						placeholder="Select Slack channels"
+						options={slackChannels}
+						optionFilterProp="label"
+						onFocus={syncSlack}
+						onSearch={(value) => {
+							setSlackSearchQuery(value)
+						}}
+						onChange={(values) => {
+							setSelectedSlackChannels(
+								values.map((v: any) => ({
+									webhook_channel_name: v.label,
+									webhook_channel_id: v.value,
+									...v,
+								})),
+							)
+						}}
+						notFoundContent={
+							<SlackLoadOrConnect
+								isLoading={slackLoading}
+								searchQuery={slackSearchQuery}
+								slackUrl={slackUrl}
+								isSlackIntegrated={
+									alertsPayload?.is_integrated_with_slack ??
+									false
+								}
+							/>
+						}
+						className={styles.selectContainer}
+						mode="multiple"
+						labelInValue
+						value={selectedSlackChannels}
+					/>
+				</LabeledRow>
+			)}
+			{selectedChannelIds.includes(AlertDestinationType.Discord) && (
+				<LabeledRow
+					label="Discord channels to notifiy"
+					name={AlertDestinationType.Slack}
+				>
+					<Select
+						aria-label="Discord channels to notify"
+						placeholder="Select Discord channels"
+						options={discordChannels}
+						optionFilterProp="label"
+						onChange={(values) => {
+							setSelectedDiscordChannels(
+								values.map((v: any) => ({
+									name: v.label,
+									id: v.value,
+									...v,
+								})),
+							)
+						}}
+						notFoundContent={
+							discordChannels.length === 0 ? (
+								<Link to="/integrations">
+									Connect Highlight with Discord
+								</Link>
+							) : (
+								'Discord channel not found'
+							)
+						}
+						className={styles.selectContainer}
+						mode="multiple"
+						labelInValue
+						value={selectedDiscordChannels}
+					/>
+				</LabeledRow>
+			)}
+			{selectedChannelIds.includes(
+				AlertDestinationType.MicrosoftTeams,
+			) && (
+				<LabeledRow
+					label="Microsoft Teams channels to notifiy"
+					name={AlertDestinationType.Slack}
+				>
+					<Select
+						aria-label="Microsoft Teams channels to notify"
+						placeholder="Select Microsoft Teams channels"
+						options={microsoftTeamsChannels}
+						optionFilterProp="label"
+						onChange={(values) => {
+							setSelectedTeamsChannels(
+								values.map((v: any) => ({
+									name: v.label,
+									id: v.value,
+									...v,
+								})),
+							)
+						}}
+						notFoundContent={
+							microsoftTeamsChannels.length === 0 ? (
+								<Link to="/integrations">
+									Connect Highlight with Microsoft Teams
+								</Link>
+							) : (
+								'Microsoft Teams channel not found'
+							)
+						}
+						className={styles.selectContainer}
+						mode="multiple"
+						labelInValue
+						value={selectedTeamsChannels}
+					/>
+				</LabeledRow>
+			)}
+			{selectedChannelIds.includes(AlertDestinationType.Email) && (
+				<LabeledRow
+					label="Emails to notifiy"
+					name={AlertDestinationType.Slack}
+				>
+					<Select
+						aria-label="Emails to notify"
+						placeholder="Select emails"
+						options={emails}
+						onChange={setSelectedEmails}
+						notFoundContent={<p>No email suggestions</p>}
+						className={styles.selectContainer}
+						mode="multiple"
+						value={selectedEmails}
+					/>
+				</LabeledRow>
+			)}
+			{selectedChannelIds.includes(AlertDestinationType.Webhook) && (
+				<LabeledRow
+					label="Webhooks to notifiy"
+					name={AlertDestinationType.Slack}
+				>
+					<Select
+						aria-label="Webhooks to notify"
+						placeholder="Enter webhook addresses"
+						onChange={setSelectedWebhooks}
+						notFoundContent={null}
+						className={styles.selectContainer}
+						mode="tags"
+						value={selectedWebhooks}
+					/>
+				</LabeledRow>
+			)}
+
+			{possibleChannels.length > 0 && (
+				<Menu>
+					<Menu.Button iconLeft={<IconSolidPlus />} kind="secondary">
+						Add channel/email
+					</Menu.Button>
+					<Menu.List>
+						{possibleChannels.map((channel) => (
+							<Menu.Item
+								key={channel.id}
+								onClick={() => handleChannelClick(channel.id)}
+							>
+								<Box display="flex" alignItems="center" gap="4">
+									{channel.icon}
+									Add {channel.label}
+								</Box>
+							</Menu.Item>
+						))}
+					</Menu.List>
+				</Menu>
+			)}
+		</>
+	)
+}

--- a/frontend/src/pages/Alerts/DestinationInput/index.tsx
+++ b/frontend/src/pages/Alerts/DestinationInput/index.tsx
@@ -65,12 +65,12 @@ const DESTINATION_CHANNELS: Channel[] = [
 ]
 
 type Props = {
-	destinations: AlertDestinationInput[]
+	initialDestinations: AlertDestinationInput[]
 	setDestinations: (destinations: AlertDestinationInput[]) => void
 }
 
 export const DestinationInput: React.FC<Props> = ({
-	destinations,
+	initialDestinations,
 	setDestinations,
 }) => {
 	const { alertsPayload, slackUrl } = useAlertsContext()
@@ -93,7 +93,7 @@ export const DestinationInput: React.FC<Props> = ({
 		[],
 	)
 
-	// load in initial channels
+	// load in initial destinations
 	useEffect(() => {
 		const selectedChannels: { [key: string]: boolean } = {}
 		const slackChannels: ChannelOption[] = []
@@ -102,7 +102,7 @@ export const DestinationInput: React.FC<Props> = ({
 		const emails: ChannelOption[] = []
 		const webhooks: ChannelOption[] = []
 
-		destinations.forEach((destination) => {
+		initialDestinations.forEach((destination) => {
 			switch (destination.destination_type) {
 				case AlertDestinationType.Slack:
 					selectedChannels[AlertDestinationType.Slack] = true
@@ -148,9 +148,7 @@ export const DestinationInput: React.FC<Props> = ({
 		setSelectedTeamsChannels(teamsChannels)
 		setSelectedEmails(emails)
 		setSelectedWebhooks(webhooks)
-
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [])
+	}, [initialDestinations])
 
 	// keep destinations in sync with local state
 	useEffect(() => {

--- a/frontend/src/pages/Alerts/DestinationInput/styles.css.ts
+++ b/frontend/src/pages/Alerts/DestinationInput/styles.css.ts
@@ -1,0 +1,28 @@
+import { vars } from '@highlight-run/ui/vars'
+import { globalStyle, style } from '@vanilla-extract/css'
+
+export const selectContainer = style({
+	color: `${vars.theme.static.content.default} !important`,
+	width: '100%',
+	selectors: {
+		'&:hover': {
+			background: vars.theme.interactive.overlay.secondary.hover,
+		},
+	},
+})
+
+globalStyle(`${selectContainer} .ant-select-selector`, {
+	padding: `0 6px !important`,
+	borderRadius: `6px !important`,
+	border: `${vars.border.secondary} !important`,
+	boxShadow: 'none !important',
+})
+
+globalStyle(`${selectContainer} .ant-select-selector:hover`, {
+	background: `${vars.theme.interactive.overlay.secondary.hover} !important`,
+})
+
+globalStyle(`${selectContainer} .ant-select-selection-item`, {
+	display: 'flex',
+	alignItems: 'center',
+})


### PR DESCRIPTION
## Summary
Allow the alert form to add different destinations for the alert to be sent.

https://www.loom.com/share/b2c86216ea904ee6b8190af7f58bd797?sid=ad135e28-18ae-4166-93ab-a1c47e00749b

## How did you test this change?
1) Create an alert
2) Add a destination before saving
- [ ] AlertDestination created in postgres
3) Update the alert
4) Update the destination
- [ ] All previous AlertDestinations deleted
- [ ] All new AlertDestinations created
5) Delete alert
- [ ] No alert exists
- [ ] No AlertDestinations exist

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
