### PR TITLE
fix cross-origin iframe parent recording start

### DIFF
--- a/.changeset/small-peas-knock.md
+++ b/.changeset/small-peas-knock.md
@@ -1,5 +1,0 @@
----
-'highlight.run': patch
----
-
-fix cross-origin iframe recording

--- a/.changeset/small-peas-knock.md
+++ b/.changeset/small-peas-knock.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+fix cross-origin iframe recording

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -698,6 +698,8 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			}
 			emit.bind(this)
 
+			const alreadyRecording = !!this._recordStop
+
 			// if we were already recording, stop recording to reset rrweb state (eg. reset _sid)
 			if (this._recordStop) {
 				this._recordStop()
@@ -707,6 +709,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			const [maskAllInputs, maskInputOptions] = determineMaskInputOptions(
 				this.privacySetting,
 			)
+
 			this._recordStop = record({
 				ignoreClass: 'highlight-ignore',
 				blockClass: 'highlight-block',
@@ -747,10 +750,10 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 						  }
 						: undefined,
 			})
+
 			// recordStop is not part of listeners because we do not actually want to stop rrweb
 			// rrweb has some bugs that make the stop -> restart workflow broken (eg iframe listeners)
-
-			if (!this._recordStop) {
+			if (!alreadyRecording) {
 				if (this.options.recordCrossOriginIframe) {
 					this._setupCrossOriginIframeParent()
 				}

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -699,7 +699,6 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			emit.bind(this)
 
 			const alreadyRecording = !!this._recordStop
-
 			// if we were already recording, stop recording to reset rrweb state (eg. reset _sid)
 			if (this._recordStop) {
 				this._recordStop()

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -1,5 +1,11 @@
 # highlight.run
 
+## 9.0.5
+
+### Patch Changes
+
+-   e239b1a02: fix cross-origin iframe recording
+
 ## 9.0.4
 
 ### Patch Changes

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "9.0.4",
+	"version": "9.0.5",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "9.0.4"
+export default "9.0.5"

--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @highlight-run/next
 
+## 7.5.12
+
+### Patch Changes
+
+-   Updated dependencies [e239b1a02]
+    -   highlight.run@9.0.5
+    -   @highlight-run/node@3.9.0
+
 ## 7.5.11
 
 ### Patch Changes

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "7.5.11",
+	"version": "7.5.12",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-remix/CHANGELOG.md
+++ b/sdk/highlight-remix/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @highlight-run/remix
 
+## 2.0.43
+
+### Patch Changes
+
+-   Updated dependencies [e239b1a02]
+    -   highlight.run@9.0.5
+    -   @highlight-run/node@3.9.0
+
 ## 2.0.42
 
 ### Patch Changes

--- a/sdk/highlight-remix/package.json
+++ b/sdk/highlight-remix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/remix",
-	"version": "2.0.42",
+	"version": "2.0.43",
 	"description": "Client for interfacing with Highlight in Remix",
 	"packageManager": "yarn@4.0.2",
 	"author": "",


### PR DESCRIPTION
## Summary
- looks like some earlier refactoring broke iframe recording - the child iframe would wait indefinitely for a message from the parent as `this._recordStop` was always true
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- set up cross-origin iframe recording locally, validated issue before / fixed after
https://www.loom.com/share/142e5b5fd764453fb6691b86315b4895
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will release new client version w/ changeset
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
