### PR TITLE
correct active interval calculation logic

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -751,7 +751,7 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 			StartTime:       startInterval.StartTime,
 			EndTime:         allIntervals[len(allIntervals)-1].EndTime,
 			Duration:        int(allIntervals[len(allIntervals)-1].EndTime.Sub(startInterval.StartTime).Milliseconds()),
-			Active:          allIntervals[len(allIntervals)-1].Active,
+			Active:          activeInterval,
 		})
 	}
 

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -769,8 +769,9 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 	}
 	log.WithContext(ctx).
 		WithFields(log.Fields{
+			"project_id":          s.ProjectID,
 			"session_id":          s.ID,
-			"secure_session_id":   s.SecureID,
+			"session_secure_id":   s.SecureID,
 			"old_active_duration": oldActiveDuration,
 			"new_active_duration": accumulator.ActiveDuration,
 			"num_intervals":       len(finalIntervals),

--- a/e2e/tests/src/test_cypress.py
+++ b/e2e/tests/src/test_cypress.py
@@ -34,7 +34,7 @@ def validate_session(data: dict[str, any]):
             < value
             < datetime.now().astimezone() + timedelta(days=1)
         )
-    assert session["length"] > session["active_length"]
+    assert session["length"] >= session["active_length"]
 
     user = json.loads(session["user_properties"])
     assert user["identified_email"] in {"false", "true"}


### PR DESCRIPTION
## Summary

* Ensure that sessions with the last interval as inactive record that correctly
* Calculate active time based on user activity rather than relying on rrweb event intervals

## How did you test this change?

local deploy

more accurate active duration reported on a session that was closed and reloaded
<img width="742" alt="image" src="https://github.com/user-attachments/assets/2ffe0413-cc53-47a0-abe7-f7995b051e6f" />

<img width="818" alt="Screenshot 2025-01-17 at 14 11 00" src="https://github.com/user-attachments/assets/a77adb7e-fb85-4806-9107-b4a5cf20bca4" />

## Are there any deployment considerations?

monitoring new active time, customer outreach

## Does this work require review from our design team?

no
