### PR TITLE
Fix option dropdown scroll

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6810,6 +6810,10 @@ body {
 ._4e4xu50 > div {
   width: 100%;
 }
+._4e4xu52 {
+  max-height: 300px;
+  overflow-y: auto;
+}
 ._1b4bur70 {
   height: 40px;
 }

--- a/frontend/src/__generated/ve/pages/Graphing/OptionDropdown/styles.css.js
+++ b/frontend/src/__generated/ve/pages/Graphing/OptionDropdown/styles.css.js
@@ -1,7 +1,9 @@
 // src/pages/Graphing/OptionDropdown/styles.css.ts
 var menuButton = "_4e4xu50";
 var menuButtonInner = "_4e4xu51";
+var menuList = "_4e4xu52";
 export {
   menuButton,
-  menuButtonInner
+  menuButtonInner,
+  menuList
 };

--- a/frontend/src/pages/Graphing/OptionDropdown/index.tsx
+++ b/frontend/src/pages/Graphing/OptionDropdown/index.tsx
@@ -53,7 +53,7 @@ export const OptionDropdown = <T extends string>({
 					<IconSolidCheveronDown />
 				</Box>
 			</Menu.Button>
-			<Menu.List>
+			<Menu.List cssClass={style.menuList}>
 				{options.map((p, idx) => {
 					let innerContent: React.ReactNode = (
 						<Stack

--- a/frontend/src/pages/Graphing/OptionDropdown/styles.css.ts
+++ b/frontend/src/pages/Graphing/OptionDropdown/styles.css.ts
@@ -14,3 +14,8 @@ export const menuButtonInner = style({
 globalStyle(`${menuButton} > div`, {
 	width: '100%',
 })
+
+export const menuList = style({
+	maxHeight: '300px',
+	overflowY: 'auto',
+})


### PR DESCRIPTION
## Summary
If their are too many options for the option dropdown, it is impossible to reach some of them. Make it scrollable.

https://www.loom.com/share/9fb0d4b33fe84a4690fa82b9c2dfcfff?sid=4939ed20-3e76-4890-bc68-34d67a3a7bb8

## How did you test this change?
1. View the new alert form (`/alerts/new`)
2. Click of alert frequency
- [ ] Dropdown is scrollable

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
