### PR TITLE
Report resource timings in nanoseconds

### DIFF
--- a/sdk/client/src/otel/index.ts
+++ b/sdk/client/src/otel/index.ts
@@ -283,7 +283,8 @@ const getSpanName = (
 	body: Request['body'] | BrowserXHR['_body'],
 ) => {
 	let parsedBody
-	const pathname = new URL(url).pathname
+	const urlObject = new URL(url)
+	const pathname = urlObject.pathname
 	let spanName = `${method} - ${pathname}`
 
 	try {
@@ -297,7 +298,9 @@ const getSpanName = (
 					: undefined
 
 			if (queryName) {
-				spanName = `${queryName} (GraphQL: ${pathname})`
+				spanName = `${queryName} (GraphQL: ${
+					urlObject.host + urlObject.pathname
+				})`
 			}
 		}
 	} catch {

--- a/sdk/client/src/otel/index.ts
+++ b/sdk/client/src/otel/index.ts
@@ -448,10 +448,11 @@ const assignResourceFetchDurations = (
 	resource: PerformanceResourceTiming,
 ) => {
 	const durations = {
-		domain_lookup: resource.domainLookupEnd - resource.domainLookupStart,
-		connect: resource.connectEnd - resource.connectStart,
-		request: resource.responseEnd - resource.requestStart,
-		response: resource.responseEnd - resource.responseStart,
+		domain_lookup:
+			(resource.domainLookupEnd - resource.domainLookupStart) * 1e6,
+		connect: (resource.connectEnd - resource.connectStart) * 1e6,
+		request: (resource.responseEnd - resource.requestStart) * 1e6,
+		response: (resource.responseEnd - resource.responseStart) * 1e6,
 	}
 
 	Object.entries(durations).forEach(([key, value]) => {

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -1,5 +1,11 @@
 # highlight.run
 
+## 9.1.1
+
+### Patch Changes
+
+-   05fbf19aa: report performance resource timings in nanoseconds
+
 ## 9.1.0
 
 ### Minor Changes

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Patch Changes
 
 -   05fbf19aa: report performance resource timings in nanoseconds
+-   24c5b00b6: fix span renaming of GraphQL requests
 
 ## 9.1.0
 

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "9.1.0",
+	"version": "9.1.1",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "9.1.0"
+export default "9.1.1"


### PR DESCRIPTION
## Summary

The `PerformanceResourceTiming` events we get from `DocumentLoadInstrumentation` are reported in milliseconds while the other performance events are in nanoseconds. This PR converts ms => ns.

Also updates the span name for GraphQL requests from `${operation} (GraphQL ${pathname})` to `${operation} (GraphQL ${host + pathname})` which fixes the display of our span from `GetLogsIntegration (GraphQL: /)` to `GetLogsIntegration (GraphQL: pri.highlight.io/)`.

## How did you test this change?

Rebuilt the SDK and click tested locally to ensure the changes look good.

## Are there any deployment considerations?

N/A -> should only fix a minor issue with data reported from our SDKs.

## Does this work require review from our design team?

N/A