### PR TITLE
use timeout for geolocation call

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/highlight-run/highlight/backend/env"
 	"hash/fnv"
 	"io"
 	"net/http"
@@ -18,6 +17,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/highlight-run/highlight/backend/env"
 
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
@@ -939,7 +940,9 @@ func GetLocationFromIP(ctx context.Context, ip string) (location *Location, err 
 	url := fmt.Sprintf("http://geolocation-db.com/json/%s", ip)
 	method := "GET"
 
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: 3 * time.Second,
+	}
 	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- seems that the http://geolocation-db.com website is down, use a shorter timeout to avoid initialize session taking so long
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- testing initialize session locally to make sure sessions are still created
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will monitor backlog in prod after deployment
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
