### PR TITLE
make session-delete-job worker handler for enterprise deployment

### DIFF
--- a/backend/util/runtime.go
+++ b/backend/util/runtime.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"flag"
+
 	"github.com/highlight-run/highlight/backend/env"
 	log "github.com/sirupsen/logrus"
 )
@@ -51,6 +52,7 @@ const (
 	PublicWorkerDataSync     Handler = "public-worker-datasync"
 	PublicWorkerTraces       Handler = "public-worker-traces"
 	AutoResolveStaleErrors   Handler = "auto-resolve-stale-errors"
+	StartSessionDeleteJob    Handler = "start-session-delete-job"
 )
 
 func (lt Handler) IsValid() bool {

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -1116,32 +1116,13 @@ func (w *Worker) StartMetricAlertWatcher(ctx context.Context) {
 }
 
 func (w *Worker) StartSessionDeleteJob(ctx context.Context) {
-	retentionEnv := env.Config.SessionRetentionDays
-	if retentionEnv == "" {
-		log.WithContext(ctx).Info("SESSION_RETENTION_DAYS not set, skipping SessionDeleteJob")
-		return
-	}
-	sessionRetentionDays, err := strconv.Atoi(env.Config.SessionRetentionDays)
-	if err != nil {
-		log.WithContext(ctx).Error("Error parsing SESSION_RETENTION_DAYS, skipping SessionDeleteJob")
-		return
-	}
-	if sessionRetentionDays <= 0 {
-		log.WithContext(ctx).Error("sessionRetentionDays <= 0, skipping SessionDeleteJob")
-		return
-	}
-
-	w.doSessionDeleteLoop(ctx, sessionRetentionDays)
-}
-
-func (w *Worker) doSessionDeleteLoop(ctx context.Context, sessionRetentionDays int) {
 	log.WithContext(ctx).Info("Starting SessionDeleteJob")
 
 	deleteHandlers := delete_handlers.InitHandlers(w.Resolver.DB, w.Resolver.ClickhouseClient, nil, w.Resolver.StorageClient)
 
-	deleteHandlers.ProcessRetentionDeletions(ctx, sessionRetentionDays)
+	deleteHandlers.ProcessRetentionDeletions(ctx)
 	for range time.Tick(time.Hour * 24) {
-		deleteHandlers.ProcessRetentionDeletions(ctx, sessionRetentionDays)
+		deleteHandlers.ProcessRetentionDeletions(ctx)
 	}
 }
 
@@ -1359,6 +1340,8 @@ func (w *Worker) GetHandler(ctx context.Context, handlerFlag util.Handler) func(
 		return w.GetPublicWorker(kafkaqueue.TopicTypeTraces)
 	case util.AutoResolveStaleErrors:
 		return w.AutoResolveStaleErrors
+	case util.StartSessionDeleteJob:
+		return w.StartSessionDeleteJob
 	case "":
 		// no handler provided defaults to the session worker
 		return w.Start

--- a/docker/compose.enterprise.yml
+++ b/docker/compose.enterprise.yml
@@ -71,6 +71,14 @@ services:
             - -runtime=worker
             - -worker-handler=public-worker-traces
 
+    backend-session-cleanup-worker:
+        extends: backend-session-worker
+        container_name: backend-session-cleanup-worker
+        command:
+            - /build/backend
+            - -runtime=worker
+            - -worker-handler=start-session-delete-job
+
     frontend:
         container_name: frontend
         image: ${FRONTEND_IMAGE_NAME-ghcr.io/highlight/highlight-frontend:latest}

--- a/docker/configure-collector.sh
+++ b/docker/configure-collector.sh
@@ -2,11 +2,17 @@
 
 COLLECTOR_CONFIG="./collector.yml"
 if [[ "$IN_DOCKER_GO" == "true" ]]; then
-  if grep -q 'https://host.docker.internal' "$COLLECTOR_CONFIG"; then
-    sed -i'' -e 's/https:\/\/host\.docker\.internal:8082/http:\/\/backend:8082/g' $COLLECTOR_CONFIG
-  fi
-  if grep -q 'insecure_skip_verify' "$COLLECTOR_CONFIG"; then
-    sed -i'' -e '36d;37d' $COLLECTOR_CONFIG
+  if [[ "$SSL" != "true" ]]; then
+    if grep -q 'https://host.docker.internal' "$COLLECTOR_CONFIG"; then
+      sed -i'' -e 's/https:\/\/host\.docker\.internal:8082/http:\/\/backend:8082/g' $COLLECTOR_CONFIG
+    fi
+    if grep -q 'insecure_skip_verify' "$COLLECTOR_CONFIG"; then
+      sed -i'' -e '36d;37d' $COLLECTOR_CONFIG
+    fi
+  else
+    if grep -q 'https://host.docker.internal' "$COLLECTOR_CONFIG"; then
+      sed -i'' -e 's/https:\/\/host\.docker\.internal:8082/https:\/\/backend:8082/g' $COLLECTOR_CONFIG
+    fi
   fi
 elif [[ "$SSL" != "true" ]]; then
   if grep -q 'https://host.docker.internal' "$COLLECTOR_CONFIG"; then


### PR DESCRIPTION
## Summary
- otel endpoint was configured to use http despite SSL = true
- `StartSessionDeleteJob` was running in the `all` runtime, but an enterprise deployment uses separate containers with separate runtimes (frontend, backend, worker)
- create a new worker handler and add it to `compose.enterprise.yml`
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- testing this docker image in an enterprise deployment
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will release new docker version after merging
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
