### PR TITLE
Start sending new alerts to microsoft teams

### DIFF
--- a/backend/alerts/v2/alerts.go
+++ b/backend/alerts/v2/alerts.go
@@ -43,11 +43,20 @@ func SendAlerts(ctx context.Context, db *gorm.DB, mailClient *sendgrid.Client, l
 		destinationsByType[destination.DestinationType] = append(destinationsByType[destination.DestinationType], destination)
 	}
 
+	var project model.Project
+	if err := db.WithContext(ctx).Model(&model.Project{}).Preload("Workspace").Where(&model.Project{Model: model.Model{ID: alert.ProjectID}}).Take(&project).Error; err != nil {
+		log.WithContext(ctx).Error(e.Wrap(err, "error querying project"))
+		return
+	}
+
+	frontendURL := env.Config.FrontendUri
 	alertInput := destinationsV2.AlertInput{
-		Alert:      alert,
-		AlertValue: value,
-		Group:      alertGroup,
-		GroupValue: alertGroupValue,
+		Alert:       alert,
+		AlertLink:   fmt.Sprintf("%s/alerts/%d/%d", frontendURL, alert.ProjectID, alert.ID),
+		AlertValue:  value,
+		Group:       alertGroup,
+		GroupValue:  alertGroupValue,
+		ProjectName: *project.Name,
 	}
 
 	switch alert.ProductType {
@@ -82,30 +91,15 @@ func SendAlerts(ctx context.Context, db *gorm.DB, mailClient *sendgrid.Client, l
 	for _, destinations := range destinationsByType {
 		switch destinations[0].DestinationType {
 		case modelInputs.AlertDestinationTypeSlack:
-			project := model.Project{}
-			if err := db.WithContext(ctx).Model(&model.Project{}).Preload("Workspace").Where(&model.Project{Model: model.Model{ID: alert.ProjectID}}).Take(&project).Error; err != nil {
-				log.WithContext(ctx).Error(e.Wrap(err, "error querying slack access token"))
-				continue
-			}
 			slackV2.SendAlerts(ctx, project.Workspace.SlackAccessToken, &alertInput, destinations)
 		case modelInputs.AlertDestinationTypeDiscord:
-			project := model.Project{}
-			if err := db.WithContext(ctx).Model(&model.Project{}).Preload("Workspace").Where(&model.Project{Model: model.Model{ID: alert.ProjectID}}).Take(&project).Error; err != nil {
-				log.WithContext(ctx).Error(e.Wrap(err, "error querying discord access token"))
-				continue
-			}
 			discordV2.SendAlerts(ctx, project.Workspace.DiscordGuildId, &alertInput, destinations)
 		case modelInputs.AlertDestinationTypeMicrosoftTeams:
-			project := model.Project{}
-			if err := db.WithContext(ctx).Model(&model.Project{}).Preload("Workspace").Where(&model.Project{Model: model.Model{ID: alert.ProjectID}}).Take(&project).Error; err != nil {
-				log.WithContext(ctx).Error(e.Wrap(err, "error querying microsoft teams access token"))
-				continue
-			}
 			microsoftteamsV2.SendAlerts(ctx, project.Workspace.MicrosoftTeamsTenantId, &alertInput, destinations)
 		case modelInputs.AlertDestinationTypeEmail:
-			emailV2.SendAlerts(ctx, lambdaClient, &alertInput, destinations)
+			emailV2.SendAlerts(ctx, mailClient, lambdaClient, &alertInput, destinations)
 		case modelInputs.AlertDestinationTypeWebhook:
-			webhookV2.SendAlerts(ctx, lambdaClient, &alertInput, destinations)
+			webhookV2.SendAlerts(ctx, &alertInput, destinations)
 		default:
 			log.WithContext(ctx).WithFields(
 				log.Fields{
@@ -227,7 +221,9 @@ func buildLogAlertInput(ctx context.Context, db *gorm.DB, alertInput *destinatio
 		alertInput.Alert.ProjectID, queryStr, startDateStr, endDateStr)
 
 	return &destinationsV2.LogInput{
-		LogsLink: logsURL,
+		LogsLink:  logsURL,
+		StartDate: start,
+		EndDate:   end,
 	}
 }
 
@@ -245,6 +241,8 @@ func buildTraceAlertInput(ctx context.Context, db *gorm.DB, alertInput *destinat
 
 	return &destinationsV2.TraceInput{
 		TracesLink: tracesURL,
+		StartDate:  start,
+		EndDate:    end,
 	}
 }
 

--- a/backend/alerts/v2/destinations/destinations.go
+++ b/backend/alerts/v2/destinations/destinations.go
@@ -1,15 +1,19 @@
 package destinationsV2
 
 import (
+	"time"
+
 	"github.com/highlight-run/highlight/backend/model"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 )
 
 type AlertInput struct {
 	Alert        *model.Alert
+	AlertLink    string
 	AlertValue   float64
 	Group        string
 	GroupValue   string
+	ProjectName  string
 	SessionInput *SessionInput
 	ErrorInput   *ErrorInput
 	LogInput     *LogInput
@@ -39,11 +43,15 @@ type ErrorInput struct {
 }
 
 type LogInput struct {
-	LogsLink string
+	LogsLink  string
+	StartDate time.Time
+	EndDate   time.Time
 }
 
 type TraceInput struct {
 	TracesLink string
+	StartDate  time.Time
+	EndDate    time.Time
 }
 
 type MetricInput struct {

--- a/backend/alerts/v2/destinations/discord/messages.go
+++ b/backend/alerts/v2/destinations/discord/messages.go
@@ -412,7 +412,6 @@ func deliverAlerts(ctx context.Context, discordGuildId string, messageSend *disc
 			_, err := bot.Session.ChannelMessageSendComplex(channelId, messageSend)
 			if err != nil {
 				log.WithContext(ctx).Error(errors.Wrap(err, "couldn't send discord alert"))
-				return
 			}
 		}(destination.TypeID)
 	}

--- a/backend/alerts/v2/destinations/email/messages.go
+++ b/backend/alerts/v2/destinations/email/messages.go
@@ -2,26 +2,37 @@ package emailV2
 
 import (
 	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/sendgrid/sendgrid-go"
+	log "github.com/sirupsen/logrus"
 
 	destinationsV2 "github.com/highlight-run/highlight/backend/alerts/v2/destinations"
+	Email "github.com/highlight-run/highlight/backend/email"
 	"github.com/highlight-run/highlight/backend/lambda"
 	"github.com/highlight-run/highlight/backend/model"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
-	log "github.com/sirupsen/logrus"
 )
 
-func SendAlerts(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+type EmailData struct {
+	SubjectLine  string
+	Template     lambda.ReactEmailTemplate
+	TemplateData map[string]interface{}
+}
+
+func SendAlerts(ctx context.Context, mailClient *sendgrid.Client, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
 	switch alertInput.Alert.ProductType {
 	case modelInputs.ProductTypeSessions:
-		sendSessionAlert(ctx, lambdaClient, alertInput, destinations)
+		sendSessionAlert(ctx, mailClient, lambdaClient, alertInput, destinations)
 	case modelInputs.ProductTypeErrors:
-		sendErrorAlert(ctx, lambdaClient, alertInput, destinations)
+		sendErrorAlert(ctx, mailClient, lambdaClient, alertInput, destinations)
 	case modelInputs.ProductTypeLogs:
-		sendLogAlert(ctx, lambdaClient, alertInput, destinations)
+		sendLogAlert(ctx, mailClient, lambdaClient, alertInput, destinations)
 	case modelInputs.ProductTypeTraces:
-		sendTraceAlert(ctx, lambdaClient, alertInput, destinations)
+		sendTraceAlert(ctx, mailClient, lambdaClient, alertInput, destinations)
 	case modelInputs.ProductTypeMetrics:
-		sendMetricAlert(ctx, lambdaClient, alertInput, destinations)
+		sendMetricAlert(ctx, mailClient, lambdaClient, alertInput, destinations)
 	default:
 		log.WithContext(ctx).WithFields(
 			log.Fields{
@@ -31,52 +42,183 @@ func SendAlerts(ctx context.Context, lambdaClient *lambda.Client, alertInput *de
 	}
 }
 
-func sendSessionAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 email notification")
+func sendSessionAlert(ctx context.Context, mailClient *sendgrid.Client, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	query := "[empty query]"
+	if alertInput.Alert.Query != nil {
+		query = *alertInput.Alert.Query
+	}
+
+	emailData := &EmailData{
+		SubjectLine: fmt.Sprintf("%s fired!", alertInput.Alert.Name),
+		Template:    lambda.ReactEmailTemplateSessionsAlert,
+		TemplateData: map[string]interface{}{
+			"alertName":   alertInput.Alert.Name,
+			"alertLink":   alertInput.AlertLink,
+			"projectName": alertInput.ProjectName,
+			"query":       query,
+			"secureID":    alertInput.SessionInput.SecureID,
+			"sessionLink": alertInput.SessionInput.SessionLink,
+			"identifier":  alertInput.SessionInput.Identifier,
+		},
+	}
+
+	deliverAlerts(ctx, mailClient, lambdaClient, emailData, destinations)
 }
 
-func sendErrorAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 email notification")
+func sendErrorAlert(ctx context.Context, mailClient *sendgrid.Client, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	emailData := &EmailData{
+		SubjectLine: "Error subject line",
+		Template:    lambda.ReactEmailTemplateErrorsAlert,
+		TemplateData: map[string]interface{}{
+			"alertLink":       alertInput.AlertLink,
+			"errorCount":      int(alertInput.AlertValue),
+			"errorEvent":      alertInput.ErrorInput.Event,
+			"errorLink":       alertInput.ErrorInput.ErrorLink,
+			"projectName":     alertInput.ProjectName,
+			"serviceName":     alertInput.ErrorInput.ServiceName,
+			"sessionExcluded": alertInput.ErrorInput.SessionExcluded,
+			"sessionLink":     alertInput.ErrorInput.SessionLink,
+		},
+	}
+
+	deliverAlerts(ctx, mailClient, lambdaClient, emailData, destinations)
 }
 
-func sendLogAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 email notification")
+func sendLogAlert(ctx context.Context, mailClient *sendgrid.Client, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	query := "[empty query]"
+	if alertInput.Alert.Query != nil {
+		query = *alertInput.Alert.Query
+	}
+
+	var functionName string
+	var functionValue interface{}
+	var thresholdValue interface{}
+	if alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCount || alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCountDistinct || alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCountDistinctKey {
+		functionName = "Count"
+		functionValue = int(alertInput.AlertValue)
+		thresholdValue = int(*alertInput.Alert.ThresholdValue)
+	} else {
+		functionName = alertInput.Alert.FunctionType.String()
+		functionValue = alertInput.AlertValue
+		thresholdValue = *alertInput.Alert.ThresholdValue
+	}
+
+	emailData := &EmailData{
+		SubjectLine: fmt.Sprintf("%s fired!", alertInput.Alert.Name),
+		Template:    lambda.ReactEmailTemplateLogsAlert,
+		TemplateData: map[string]interface{}{
+			"alertLink":      alertInput.AlertLink,
+			"alertName":      alertInput.Alert.Name,
+			"belowThreshold": alertInput.Alert.BelowThreshold,
+			"functionValue":  functionValue,
+			"functionName":   functionName,
+			"logsLink":       alertInput.LogInput.LogsLink,
+			"projectName":    alertInput.ProjectName,
+			"query":          query,
+			"thresholdValue": thresholdValue,
+		},
+	}
+
+	deliverAlerts(ctx, mailClient, lambdaClient, emailData, destinations)
 }
 
-func sendTraceAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 email notification")
+func sendTraceAlert(ctx context.Context, mailClient *sendgrid.Client, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	query := "[empty query]"
+	if alertInput.Alert.Query != nil {
+		query = *alertInput.Alert.Query
+	}
+
+	var functionName string
+	var functionValue interface{}
+	var thresholdValue interface{}
+	if alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCount || alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCountDistinct || alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCountDistinctKey {
+		functionName = "Count"
+		functionValue = int(alertInput.AlertValue)
+		thresholdValue = int(*alertInput.Alert.ThresholdValue)
+	} else {
+		functionName = alertInput.Alert.FunctionType.String()
+		functionValue = alertInput.AlertValue
+		thresholdValue = *alertInput.Alert.ThresholdValue
+	}
+
+	emailData := &EmailData{
+		SubjectLine: fmt.Sprintf("%s fired!", alertInput.Alert.Name),
+		Template:    lambda.ReactEmailTemplateLogsAlert,
+		TemplateData: map[string]interface{}{
+			"alertLink":      alertInput.AlertLink,
+			"alertName":      alertInput.Alert.Name,
+			"belowThreshold": alertInput.Alert.BelowThreshold,
+			"functionValue":  functionValue,
+			"functionName":   functionName,
+			"tracesLink":     alertInput.TraceInput.TracesLink,
+			"projectName":    alertInput.ProjectName,
+			"query":          query,
+			"thresholdValue": thresholdValue,
+		},
+	}
+
+	deliverAlerts(ctx, mailClient, lambdaClient, emailData, destinations)
 }
 
-func sendMetricAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 email notification")
+func sendMetricAlert(ctx context.Context, mailClient *sendgrid.Client, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	query := "[empty query]"
+	if alertInput.Alert.Query != nil {
+		query = *alertInput.Alert.Query
+	}
+
+	var functionName string
+	var functionValue interface{}
+	var thresholdValue interface{}
+	if alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCount || alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCountDistinct || alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCountDistinctKey {
+		functionName = "Count"
+		functionValue = int(alertInput.AlertValue)
+		thresholdValue = int(*alertInput.Alert.ThresholdValue)
+	} else {
+		functionName = alertInput.Alert.FunctionType.String()
+		functionValue = alertInput.AlertValue
+		thresholdValue = *alertInput.Alert.ThresholdValue
+	}
+
+	emailData := &EmailData{
+		SubjectLine: fmt.Sprintf("%s fired!", alertInput.Alert.Name),
+		Template:    lambda.ReactEmailTemplateLogsAlert,
+		TemplateData: map[string]interface{}{
+			"alertLink":      alertInput.AlertLink,
+			"alertName":      alertInput.Alert.Name,
+			"belowThreshold": alertInput.Alert.BelowThreshold,
+			"functionValue":  functionValue,
+			"functionName":   functionName, "dashboardsLink": alertInput.MetricInput.DashboardLink,
+			"projectName":    alertInput.ProjectName,
+			"query":          query,
+			"thresholdValue": thresholdValue,
+		},
+	}
+
+	deliverAlerts(ctx, mailClient, lambdaClient, emailData, destinations)
+}
+
+func deliverAlerts(ctx context.Context, mailClient *sendgrid.Client, lambdaClient *lambda.Client, emailTemplate *EmailData, destinations []model.AlertDestination) {
+	if mailClient == nil {
+		log.WithContext(ctx).Error("mail client is nil")
+		return
+	}
+
+	if lambdaClient == nil {
+		log.WithContext(ctx).Error("lambda client is nil")
+		return
+	}
+
+	emailHtml, err := lambdaClient.FetchReactEmailHTML(ctx, emailTemplate.Template, emailTemplate.TemplateData)
+	if err != nil {
+		log.WithContext(ctx).Error(errors.Wrap(err, "error fetching email html"))
+		return
+	}
+
+	for _, destination := range destinations {
+		go func(email string) {
+			if err := Email.SendReactEmailAlert(ctx, mailClient, email, emailHtml, emailTemplate.SubjectLine); err != nil {
+				log.WithContext(ctx).Error(err)
+			}
+		}(destination.TypeID)
+	}
 }

--- a/backend/alerts/v2/destinations/microsoft-teams/messages.go
+++ b/backend/alerts/v2/destinations/microsoft-teams/messages.go
@@ -1,28 +1,37 @@
-package microsoftteamsv2
+package microsoftteamsV2
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	microsoft_teams "github.com/highlight-run/highlight/backend/alerts/integrations/microsoft-teams"
 	destinationsV2 "github.com/highlight-run/highlight/backend/alerts/v2/destinations"
-	"github.com/highlight-run/highlight/backend/lambda"
+	microsoftteamsV2_templates "github.com/highlight-run/highlight/backend/alerts/v2/destinations/microsoft-teams/templates"
 	"github.com/highlight-run/highlight/backend/model"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
-	log "github.com/sirupsen/logrus"
+	"github.com/highlight-run/highlight/backend/routing"
 )
 
-func SendAlerts(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+func SendAlerts(ctx context.Context, microsoftTeamsTenantId *string, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	if microsoftTeamsTenantId == nil {
+		log.WithContext(ctx).Error("microsoft teams access token is nil")
+		return
+	}
 
 	switch alertInput.Alert.ProductType {
 	case modelInputs.ProductTypeSessions:
-		sendSessionAlert(ctx, lambdaClient, alertInput, destinations)
+		sendSessionAlert(ctx, *microsoftTeamsTenantId, alertInput, destinations)
 	case modelInputs.ProductTypeErrors:
-		sendErrorAlert(ctx, lambdaClient, alertInput, destinations)
+		sendErrorAlert(ctx, *microsoftTeamsTenantId, alertInput, destinations)
 	case modelInputs.ProductTypeLogs:
-		sendLogAlert(ctx, lambdaClient, alertInput, destinations)
+		sendLogAlert(ctx, *microsoftTeamsTenantId, alertInput, destinations)
 	case modelInputs.ProductTypeTraces:
-		sendTraceAlert(ctx, lambdaClient, alertInput, destinations)
+		sendTraceAlert(ctx, *microsoftTeamsTenantId, alertInput, destinations)
 	case modelInputs.ProductTypeMetrics:
-		sendMetricAlert(ctx, lambdaClient, alertInput, destinations)
+		sendMetricAlert(ctx, *microsoftTeamsTenantId, alertInput, destinations)
 	default:
 		log.WithContext(ctx).WithFields(
 			log.Fields{
@@ -32,52 +41,242 @@ func SendAlerts(ctx context.Context, lambdaClient *lambda.Client, alertInput *de
 	}
 }
 
-func sendSessionAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 microsoft teams notification")
+func sendSessionAlert(ctx context.Context, microsoftTeamsTenantId string, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	sessionUserIdentifier := alertInput.SessionInput.Identifier
+	if sessionUserIdentifier == "" {
+		sessionUserIdentifier = "*unidentified* user"
+	}
+
+	query := "[empty query]"
+	if alertInput.Alert.Query != nil {
+		query = *alertInput.Alert.Query
+	}
+
+	messagePayload := microsoftteamsV2_templates.SessionAlertPayload{
+		AlertName:        alertInput.Alert.Name,
+		Query:            query,
+		SecureID:         alertInput.SessionInput.SecureID,
+		Identifier:       sessionUserIdentifier,
+		SessionURL:       alertInput.SessionInput.SessionLink,
+		MoreSessionsLink: alertInput.SessionInput.MoreSessionsLink,
+	}
+
+	deliverMessage(ctx, microsoftTeamsTenantId, microsoftteamsV2_templates.SessionAlertMessageTemplate, messagePayload, destinations)
 }
 
-func sendErrorAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 microsoft teams notification")
+func sendErrorAlert(ctx context.Context, microsoftTeamsTenantId string, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	locationName := alertInput.ErrorInput.ProjectName
+	if alertInput.ErrorInput.ServiceName != "" {
+		locationName = alertInput.ErrorInput.ServiceName + " - " + locationName
+	}
+
+	errorEvent := alertInput.ErrorInput.Event
+	if len(errorEvent) > 250 {
+		errorEvent = errorEvent[:250] + "..."
+	}
+
+	var sessionLinkText string
+	if alertInput.ErrorInput.SessionExcluded {
+		if alertInput.ErrorInput.SessionIdentifier == "" {
+			sessionLinkText = "No recorded session"
+		} else {
+			sessionLinkText = fmt.Sprintf("No recorded session (%s)", alertInput.ErrorInput.SessionIdentifier)
+		}
+	} else {
+		sessionUserIdentifier := alertInput.ErrorInput.SessionIdentifier
+		if sessionUserIdentifier == "" {
+			sessionUserIdentifier = "_unidentified_ user"
+		}
+
+		sessionLinkText = fmt.Sprintf(
+			"[#%s (%s)](%s)",
+			alertInput.ErrorInput.SessionSecureID,
+			sessionUserIdentifier,
+			alertInput.ErrorInput.SessionLink,
+		)
+	}
+
+	messagePayload := microsoftteamsV2_templates.ErrorAlertPayload{
+		ErrorCount:      int(alertInput.AlertValue),
+		Location:        locationName,
+		ErrorLink:       alertInput.ErrorInput.ErrorLink,
+		Event:           errorEvent,
+		SessionLinkText: sessionLinkText,
+		ResolveLink:     routing.AttachQueryParam(ctx, alertInput.ErrorInput.ErrorLink, "action", "resolved"),
+		IgnoreLink:      routing.AttachQueryParam(ctx, alertInput.ErrorInput.ErrorLink, "action", "ignored"),
+		SnoozeLink:      routing.AttachQueryParam(ctx, alertInput.ErrorInput.ErrorLink, "action", "snooze"),
+	}
+
+	deliverMessage(ctx, microsoftTeamsTenantId, microsoftteamsV2_templates.ErrorAlertMessageTemplate, messagePayload, destinations)
 }
 
-func sendLogAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 microsoft teams notification")
+func sendLogAlert(ctx context.Context, microsoftTeamsTenantId string, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	var alertText string
+	var countText string
+
+	threholdRelation := "above"
+	if *alertInput.Alert.BelowThreshold {
+		threholdRelation = "below"
+	}
+
+	query := "[empty query]"
+	if alertInput.Alert.Query != nil {
+		query = *alertInput.Alert.Query
+	}
+
+	if alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCount || alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCountDistinct || alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCountDistinctKey {
+		alertText = fmt.Sprintf(
+			"Log count for query **%s** was %s the threshold.",
+			query,
+			threholdRelation,
+		)
+		countText = fmt.Sprintf(
+			"*Count*: %d | *Threshold*: %d",
+			int(alertInput.AlertValue),
+			int(*alertInput.Alert.ThresholdValue),
+		)
+	} else {
+		alertText = fmt.Sprintf(
+			"Log %s for query **%s** was %s the threshold.",
+			alertInput.Alert.FunctionType,
+			query,
+			threholdRelation,
+		)
+		countText = fmt.Sprintf(
+			"*%s*: %f | *Threshold*: %f",
+			alertInput.Alert.FunctionType,
+			alertInput.AlertValue,
+			*alertInput.Alert.ThresholdValue,
+		)
+	}
+
+	messagePayload := microsoftteamsV2_templates.LogAlertPayload{
+		AlertName: alertInput.Alert.Name,
+		AlertText: alertText,
+		CountText: countText,
+		LogsLink:  alertInput.LogInput.LogsLink,
+	}
+
+	deliverMessage(ctx, microsoftTeamsTenantId, microsoftteamsV2_templates.LogAlertMessageTemplate, messagePayload, destinations)
 }
 
-func sendTraceAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 microsoft teams notification")
+func sendTraceAlert(ctx context.Context, microsoftTeamsTenantId string, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	var alertText string
+	var countText string
+
+	threholdRelation := "above"
+	if *alertInput.Alert.BelowThreshold {
+		threholdRelation = "below"
+	}
+
+	query := "[empty query]"
+	if alertInput.Alert.Query != nil {
+		query = *alertInput.Alert.Query
+	}
+
+	if alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCount || alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCountDistinct || alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCountDistinctKey {
+		alertText = fmt.Sprintf(
+			"Trace count for query **%s** was %s the threshold.",
+			query,
+			threholdRelation,
+		)
+		countText = fmt.Sprintf(
+			"*Count*: %d | *Threshold*: %d",
+			int(alertInput.AlertValue),
+			int(*alertInput.Alert.ThresholdValue),
+		)
+	} else {
+		alertText = fmt.Sprintf(
+			"Trace %s for query **%s** was %s the threshold.",
+			alertInput.Alert.FunctionType,
+			query,
+			threholdRelation,
+		)
+		countText = fmt.Sprintf(
+			"*%s*: %f | *Threshold*: %f",
+			alertInput.Alert.FunctionType,
+			alertInput.AlertValue,
+			*alertInput.Alert.ThresholdValue,
+		)
+	}
+
+	messagePayload := microsoftteamsV2_templates.TraceAlertPayload{
+		AlertName:  alertInput.Alert.Name,
+		AlertText:  alertText,
+		CountText:  countText,
+		TracesLink: alertInput.TraceInput.TracesLink,
+	}
+
+	deliverMessage(ctx, microsoftTeamsTenantId, microsoftteamsV2_templates.TraceAlertMessageTemplate, messagePayload, destinations)
 }
 
-func sendMetricAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 microsoft teams notification")
+func sendMetricAlert(ctx context.Context, microsoftTeamsTenantId string, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	var alertText string
+	var countText string
+
+	threholdRelation := "above"
+	if *alertInput.Alert.BelowThreshold {
+		threholdRelation = "below"
+	}
+
+	query := "[empty query]"
+	if alertInput.Alert.Query != nil {
+		query = *alertInput.Alert.Query
+	}
+
+	if alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCount || alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCountDistinct || alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCountDistinctKey {
+		alertText = fmt.Sprintf(
+			"Metric count for query **%s** was %s the threshold.",
+			query,
+			threholdRelation,
+		)
+		countText = fmt.Sprintf(
+			"*Count*: %d | *Threshold*: %d",
+			int(alertInput.AlertValue),
+			int(*alertInput.Alert.ThresholdValue),
+		)
+	} else {
+		alertText = fmt.Sprintf(
+			"Metric %s for query **%s** was %s the threshold.",
+			alertInput.Alert.FunctionType,
+			query,
+			threholdRelation,
+		)
+		countText = fmt.Sprintf(
+			"*%s*: %f | *Threshold*: %f",
+			alertInput.Alert.FunctionType,
+			alertInput.AlertValue,
+			*alertInput.Alert.ThresholdValue,
+		)
+	}
+
+	messagePayload := microsoftteamsV2_templates.MetricAlertPayload{
+		AlertName:   alertInput.Alert.Name,
+		AlertText:   alertText,
+		CountText:   countText,
+		MetricsLink: alertInput.MetricInput.DashboardLink,
+	}
+
+	deliverMessage(ctx, microsoftTeamsTenantId, microsoftteamsV2_templates.MetricAlertMessageTemplate, messagePayload, destinations)
+}
+
+func deliverMessage(ctx context.Context, microsoftTeamsTenantId string, messageTemplate []byte, messagePayload interface{}, destinations []model.AlertDestination) {
+	bot, err := microsoft_teams.NewMicrosoftTeamsBot(microsoftTeamsTenantId)
+	if err != nil {
+		log.WithContext(ctx).Error(errors.Wrap(err, "couldn't create new microsoft teams bot"))
+		return
+	}
+
+	for _, destination := range destinations {
+		channelId := destination.TypeID
+
+		go func() {
+			err := bot.SendMessageWithAdaptiveCard(channelId, messageTemplate, messagePayload)
+			if err != nil {
+				log.WithContext(ctx).Error(errors.Wrap(err, "couldn't send microsoft teams alert"))
+				return
+			}
+		}()
+
+	}
 }

--- a/backend/alerts/v2/destinations/microsoft-teams/messages.go
+++ b/backend/alerts/v2/destinations/microsoft-teams/messages.go
@@ -272,7 +272,6 @@ func deliverAlerts(ctx context.Context, microsoftTeamsTenantId string, messageTe
 			err := bot.SendMessageWithAdaptiveCard(channelId, messageTemplate, messagePayload)
 			if err != nil {
 				log.WithContext(ctx).Error(errors.Wrap(err, "couldn't send microsoft teams alert"))
-				return
 			}
 		}(destination.TypeID)
 

--- a/backend/alerts/v2/destinations/microsoft-teams/templates/error-alert.go
+++ b/backend/alerts/v2/destinations/microsoft-teams/templates/error-alert.go
@@ -1,0 +1,57 @@
+package microsoftteamsV2_templates
+
+type ErrorAlertPayload struct {
+	ErrorCount      int
+	Location        string
+	ErrorLink       string
+	Event           string
+	SessionLinkText string
+	ResolveLink     string
+	IgnoreLink      string
+	SnoozeLink      string
+}
+
+var ErrorAlertMessageTemplate = []byte(`{
+	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+	"type": "AdaptiveCard",
+	"version": "1.6",
+	"body": [
+		{
+		"type": "TextBlock",
+		"size": "Large",
+		"weight": "Bolder",
+		"text": "Error Alert: {{.ErrorCount}} Recent Occurances"
+		},
+		{
+		"type": "TextBlock",
+		"text": "[Error event in {{.Location}}]({{.ErrorLink}})"
+		},
+		{
+		"type": "TextBlock",
+		"fontType": "Monospace",
+		"text": "{{.Event}}",
+		"wrap": true
+		},
+		{
+		"type": "TextBlock",
+		"text": "**Session** {{.SessionLinkText}}"
+		}
+	],
+	"actions": [
+		{
+			"type":  "Action.OpenUrl",
+			"title": "Resolve",
+			"url":   "{{.ResolveLink}}"
+		},
+		{
+			"type":  "Action.OpenUrl",
+			"title": "Ignore",
+			"url":   "{{.IgnoreLink}}"
+		},
+		{
+			"type":  "Action.OpenUrl",
+			"title": "Snooze",
+			"url":   "{{.SnoozeLink}}"
+		}
+	]
+  }`)

--- a/backend/alerts/v2/destinations/microsoft-teams/templates/log-alert.go
+++ b/backend/alerts/v2/destinations/microsoft-teams/templates/log-alert.go
@@ -1,0 +1,37 @@
+package microsoftteamsV2_templates
+
+type LogAlertPayload struct {
+	AlertName string
+	AlertText string
+	CountText string
+	LogsLink  string
+}
+
+var LogAlertMessageTemplate = []byte(`{
+	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+	"type": "AdaptiveCard",
+	"version": "1.6",
+	"body": [
+		{
+			"type":   "TextBlock",
+			"size":   "Large",
+			"weight": "Bolder",
+			"text":   "{{.AlertName}} fired!"
+		},
+		{
+			"type":   "TextBlock",
+			"text":   "{{.AlertText}}"
+		},
+		{
+			"type":   "TextBlock",
+			"text":   "{{.CountText}}"
+		}
+	],
+	"actions": [
+		{
+			"type":  "Action.OpenUrl",
+			"title": "View Logs",
+			"url":   "{{.LogsLink}}"
+		}
+	]
+  }`)

--- a/backend/alerts/v2/destinations/microsoft-teams/templates/metric-alert.go
+++ b/backend/alerts/v2/destinations/microsoft-teams/templates/metric-alert.go
@@ -1,0 +1,37 @@
+package microsoftteamsV2_templates
+
+type MetricAlertPayload struct {
+	AlertName   string
+	AlertText   string
+	CountText   string
+	MetricsLink string
+}
+
+var MetricAlertMessageTemplate = []byte(`{
+	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+	"type": "AdaptiveCard",
+	"version": "1.6",
+	"body": [
+		{
+			"type":   "TextBlock",
+			"size":   "Large",
+			"weight": "Bolder",
+			"text":   "{{.AlertName}} fired!"
+		},
+		{
+			"type":   "TextBlock",
+			"text":   "{{.AlertText}}"
+		},
+		{
+			"type":   "TextBlock",
+			"text":   "{{.CountText}}"
+		}
+	],
+	"actions": [
+		{
+			"type":  "Action.OpenUrl",
+			"title": "View Metrics",
+			"url":   "{{.MetricsLink}}"
+		}
+	]
+  }`)

--- a/backend/alerts/v2/destinations/microsoft-teams/templates/session-alert.go
+++ b/backend/alerts/v2/destinations/microsoft-teams/templates/session-alert.go
@@ -1,0 +1,48 @@
+package microsoftteamsV2_templates
+
+type SessionAlertPayload struct {
+	AlertName        string
+	Query            string
+	SecureID         string
+	Identifier       string
+	SessionURL       string
+	MoreSessionsLink string
+}
+
+var SessionAlertMessageTemplate = []byte(`{
+	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+	"type": "AdaptiveCard",
+	"version": "1.6",
+	"body": [
+		{
+			"type":   "TextBlock",
+			"size":   "Large",
+			"weight": "Bolder",
+			"text":   "{{.AlertName}} fired!"
+		},
+		{
+			"type":   "TextBlock",
+			"text":   "Session found that matches query: **{{.Query}}**"
+		},
+		{
+			"type":   "TextBlock",
+			"text":   "**Session**: [#{{.SecureID}}]({{.SessionURL}})"
+		},
+		{
+			"type":   "TextBlock",
+			"text":   "**User Identifier**: {{.Identifier}}"
+		}
+	],
+	"actions": [
+		{
+			"type":  "Action.OpenUrl",
+			"title": "View Session",
+			"url":   "{{.SessionURL}}"
+		},
+		{
+			"type":  "Action.OpenUrl",
+			"title": "View More Sessions",
+			"url":   "{{.MoreSessionsLink}}"
+		}
+	]
+  }`)

--- a/backend/alerts/v2/destinations/microsoft-teams/templates/trace-alert.go
+++ b/backend/alerts/v2/destinations/microsoft-teams/templates/trace-alert.go
@@ -1,0 +1,37 @@
+package microsoftteamsV2_templates
+
+type TraceAlertPayload struct {
+	AlertName  string
+	AlertText  string
+	CountText  string
+	TracesLink string
+}
+
+var TraceAlertMessageTemplate = []byte(`{
+	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+	"type": "AdaptiveCard",
+	"version": "1.6",
+	"body": [
+		{
+			"type":   "TextBlock",
+			"size":   "Large",
+			"weight": "Bolder",
+			"text":   "{{.AlertName}} fired!"
+		},
+		{
+			"type":   "TextBlock",
+			"text":   "{{.AlertText}}"
+		},
+		{
+			"type":   "TextBlock",
+			"text":   "{{.CountText}}"
+		}
+	],
+	"actions": [
+		{
+			"type":  "Action.OpenUrl",
+			"title": "View Traces",
+			"url":   "{{.TracesLink}}"
+		}
+	]
+  }`)

--- a/backend/alerts/v2/destinations/slack/messages.go
+++ b/backend/alerts/v2/destinations/slack/messages.go
@@ -515,7 +515,6 @@ func deliverAlerts(ctx context.Context, slackAccessToken string, destinations []
 			)
 			if err != nil {
 				log.WithContext(ctx).Error(errors.Wrap(err, "couldn't send slack alert"))
-				return
 			}
 		}(destination.TypeID, destination.TypeName)
 	}

--- a/backend/alerts/v2/destinations/webhook/messages.go
+++ b/backend/alerts/v2/destinations/webhook/messages.go
@@ -2,26 +2,32 @@ package webhookV2
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
 	destinationsV2 "github.com/highlight-run/highlight/backend/alerts/v2/destinations"
-	"github.com/highlight-run/highlight/backend/lambda"
 	"github.com/highlight-run/highlight/backend/model"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
+	"github.com/highlight-run/highlight/backend/routing"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-func SendAlerts(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+func SendAlerts(ctx context.Context, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
 	switch alertInput.Alert.ProductType {
 	case modelInputs.ProductTypeSessions:
-		sendSessionAlert(ctx, lambdaClient, alertInput, destinations)
+		sendSessionAlert(ctx, alertInput, destinations)
 	case modelInputs.ProductTypeErrors:
-		sendErrorAlert(ctx, lambdaClient, alertInput, destinations)
+		sendErrorAlert(ctx, alertInput, destinations)
 	case modelInputs.ProductTypeLogs:
-		sendLogAlert(ctx, lambdaClient, alertInput, destinations)
+		sendLogAlert(ctx, alertInput, destinations)
 	case modelInputs.ProductTypeTraces:
-		sendTraceAlert(ctx, lambdaClient, alertInput, destinations)
+		sendTraceAlert(ctx, alertInput, destinations)
 	case modelInputs.ProductTypeMetrics:
-		sendMetricAlert(ctx, lambdaClient, alertInput, destinations)
+		sendMetricAlert(ctx, alertInput, destinations)
 	default:
 		log.WithContext(ctx).WithFields(
 			log.Fields{
@@ -31,52 +37,222 @@ func SendAlerts(ctx context.Context, lambdaClient *lambda.Client, alertInput *de
 	}
 }
 
-func sendSessionAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 webhook notification")
+type SessionAlertPayload struct {
+	Event      string
+	AlertName  string
+	Query      string
+	SecureID   string
+	Identifier string
+	SessionURL string
 }
 
-func sendErrorAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 webhook notification")
+func sendSessionAlert(ctx context.Context, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	query := ""
+	if alertInput.Alert.Query != nil {
+		query = *alertInput.Alert.Query
+	}
+
+	messagePayload := SessionAlertPayload{
+		Event:      model.AlertType.SESSIONS,
+		AlertName:  alertInput.Alert.Name,
+		Query:      query,
+		SecureID:   alertInput.SessionInput.SecureID,
+		Identifier: alertInput.SessionInput.Identifier,
+		SessionURL: alertInput.SessionInput.SessionLink,
+	}
+
+	sendAlerts(ctx, messagePayload, destinations)
 }
 
-func sendLogAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 webhook notification")
+type ErrorAlertPayload struct {
+	Event           string
+	AlertName       string
+	Query           string
+	ErrorCount      int64
+	ErrorTitle      string
+	SessionSecureID string
+	SessionURL      string
+	SessionExcluded bool
+	UserIdentifier  string
+	ErrorURL        string
+	ErrorResolveURL string
+	ErrorIgnoreURL  string
+	ErrorSnoozeURL  string
 }
 
-func sendTraceAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 webhook notification")
+func sendErrorAlert(ctx context.Context, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	query := ""
+	if alertInput.Alert.Query != nil {
+		query = *alertInput.Alert.Query
+	}
+
+	messagePayload := ErrorAlertPayload{
+		Event:           model.AlertType.ERRORS,
+		AlertName:       alertInput.Alert.Name,
+		Query:           query,
+		ErrorCount:      int64(alertInput.AlertValue),
+		ErrorTitle:      alertInput.ErrorInput.Event,
+		SessionSecureID: alertInput.ErrorInput.SessionSecureID,
+		SessionURL:      alertInput.ErrorInput.SessionLink,
+		SessionExcluded: alertInput.ErrorInput.SessionExcluded,
+		UserIdentifier:  alertInput.ErrorInput.SessionIdentifier,
+		ErrorURL:        alertInput.ErrorInput.ErrorLink,
+		ErrorResolveURL: routing.AttachQueryParam(ctx, alertInput.ErrorInput.ErrorLink, "action", "resolved"),
+		ErrorIgnoreURL:  routing.AttachQueryParam(ctx, alertInput.ErrorInput.ErrorLink, "action", "ignored"),
+		ErrorSnoozeURL:  routing.AttachQueryParam(ctx, alertInput.ErrorInput.ErrorLink, "action", "snooze"),
+	}
+
+	sendAlerts(ctx, messagePayload, destinations)
 }
 
-func sendMetricAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 webhook notification")
+type LogAlertPayload struct {
+	Event          string
+	AlertName      string
+	Query          string
+	Count          float64
+	StartDate      time.Time
+	EndDate        time.Time
+	Function       modelInputs.MetricAggregator
+	FunctionColumn string
+	Threshold      float64
+	BelowThreshold bool
+	LogsURL        string
+}
+
+func sendLogAlert(ctx context.Context, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	query := ""
+	if alertInput.Alert.Query != nil {
+		query = *alertInput.Alert.Query
+	}
+
+	functionColumn := ""
+	if alertInput.Alert.FunctionColumn != nil {
+		functionColumn = *alertInput.Alert.FunctionColumn
+	}
+
+	messagePayload := LogAlertPayload{
+		Event:          model.AlertType.LOGS,
+		AlertName:      alertInput.Alert.Name,
+		Query:          query,
+		Count:          alertInput.AlertValue,
+		StartDate:      alertInput.LogInput.StartDate,
+		EndDate:        alertInput.LogInput.EndDate,
+		Function:       alertInput.Alert.FunctionType,
+		FunctionColumn: functionColumn,
+		Threshold:      *alertInput.Alert.ThresholdValue,
+		BelowThreshold: *alertInput.Alert.BelowThreshold,
+		LogsURL:        alertInput.LogInput.LogsLink,
+	}
+
+	sendAlerts(ctx, messagePayload, destinations)
+}
+
+type TraceAlertPayload struct {
+	Event          string
+	AlertName      string
+	Query          string
+	Count          float64
+	StartDate      time.Time
+	EndDate        time.Time
+	Function       modelInputs.MetricAggregator
+	FunctionColumn string
+	Threshold      float64
+	BelowThreshold bool
+	TracesURL      string
+}
+
+func sendTraceAlert(ctx context.Context, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	query := ""
+	if alertInput.Alert.Query != nil {
+		query = *alertInput.Alert.Query
+	}
+
+	functionColumn := ""
+	if alertInput.Alert.FunctionColumn != nil {
+		functionColumn = *alertInput.Alert.FunctionColumn
+	}
+
+	messagePayload := TraceAlertPayload{
+		Event:          model.AlertType.TRACES,
+		AlertName:      alertInput.Alert.Name,
+		Query:          query,
+		Count:          alertInput.AlertValue,
+		StartDate:      alertInput.LogInput.StartDate,
+		EndDate:        alertInput.LogInput.EndDate,
+		Function:       alertInput.Alert.FunctionType,
+		FunctionColumn: functionColumn,
+		Threshold:      *alertInput.Alert.ThresholdValue,
+		BelowThreshold: *alertInput.Alert.BelowThreshold,
+		TracesURL:      alertInput.TraceInput.TracesLink,
+	}
+
+	sendAlerts(ctx, messagePayload, destinations)
+}
+
+type MetricAlertPayload struct {
+	Event          string
+	AlertName      string
+	Query          string
+	Count          float64
+	Function       modelInputs.MetricAggregator
+	FunctionColumn string
+	Threshold      float64
+	BelowThreshold bool
+	DashboardURL   string
+}
+
+func sendMetricAlert(ctx context.Context, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	query := ""
+	if alertInput.Alert.Query != nil {
+		query = *alertInput.Alert.Query
+	}
+
+	functionColumn := ""
+	if alertInput.Alert.FunctionColumn != nil {
+		functionColumn = *alertInput.Alert.FunctionColumn
+	}
+
+	messagePayload := MetricAlertPayload{
+		Event:          model.AlertType.TRACES,
+		AlertName:      alertInput.Alert.Name,
+		Query:          query,
+		Count:          alertInput.AlertValue,
+		Function:       alertInput.Alert.FunctionType,
+		FunctionColumn: functionColumn,
+		Threshold:      *alertInput.Alert.ThresholdValue,
+		BelowThreshold: *alertInput.Alert.BelowThreshold,
+		DashboardURL:   alertInput.MetricInput.DashboardLink,
+	}
+
+	sendAlerts(ctx, messagePayload, destinations)
+}
+
+func sendAlerts(ctx context.Context, messagePayload interface{}, destinations []model.AlertDestination) {
+	payloadJson, err := json.Marshal(messagePayload)
+	if err != nil {
+		log.WithContext(ctx).Error(errors.Wrap(err, "couldn't marshal message payload"))
+		return
+	}
+
+	for _, destination := range destinations {
+		go func(webhookUrl string) {
+			resp, err := retryablehttp.Post(webhookUrl, "application/json", payloadJson)
+			if err != nil {
+				log.WithContext(ctx).Error(errors.Wrap(err, "couldn't send to webhook"))
+				return
+			}
+
+			if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+				logFields := log.Fields{}
+				if err := json.Unmarshal(payloadJson, &logFields); err == nil {
+					ctx := context.TODO()
+					logFields["Destination"] = webhookUrl
+					logFields["StatusCode"] = resp.StatusCode
+					log.WithContext(ctx).WithFields(logFields).Info("webhook sent successfully")
+				}
+			} else {
+				log.WithContext(ctx).Error(errors.New(fmt.Sprintf("webhook %s received unexpected response code %d", webhookUrl, resp.StatusCode)))
+			}
+		}(destination.TypeID)
+	}
 }

--- a/backend/lambda/lambda.go
+++ b/backend/lambda/lambda.go
@@ -5,11 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/highlight-run/highlight/backend/env"
 	"io"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/highlight-run/highlight/backend/env"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
@@ -168,14 +169,22 @@ func (s *Client) GetSessionInsightRequest(ctx context.Context, url string, proje
 type ReactEmailTemplate string
 
 const (
+	// deprecated emails
 	ReactEmailTemplateErrorAlert      ReactEmailTemplate = "error-alert"
 	ReactEmailTemplateLogAlert        ReactEmailTemplate = "log-alert"
 	ReactEmailTemplateNewSessionAlert ReactEmailTemplate = "new-session-alert"
 	ReactEmailTemplateNewUserAlert    ReactEmailTemplate = "new-user-alert"
 	ReactEmailTemplateRageClickAlert  ReactEmailTemplate = "rage-click-alert"
-	ReactEmailTemplateSessionInsights ReactEmailTemplate = "session-insights"
 	ReactEmailTemplateTrackEventAlert ReactEmailTemplate = "track-event-properties-alert"
 	ReactEmailTemplateTrackUserAlert  ReactEmailTemplate = "track-user-properties-alert"
+	// new alert emails
+	ReactEmailTemplateSessionsAlert ReactEmailTemplate = "sessions-alert"
+	ReactEmailTemplateErrorsAlert   ReactEmailTemplate = "errors-alert"
+	ReactEmailTemplateLogsAlert     ReactEmailTemplate = "logs-alert"
+	ReactEmailTemplateTracesAlert   ReactEmailTemplate = "traces-alert"
+	ReactEmailTemplateMetricsAlert  ReactEmailTemplate = "metrics-alert"
+	// session insights
+	ReactEmailTemplateSessionInsights ReactEmailTemplate = "session-insights"
 )
 
 func (s *Client) GetSessionInsightEmailHtml(ctx context.Context, toEmail string, unsubscribeUrl string, data utils.SessionInsightsData) (string, error) {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -51,6 +51,7 @@ const (
 
 // TODO(et) - replace this with generated SessionAlertType
 var AlertType = struct {
+	// deprecated alerts
 	ERROR            string
 	NEW_USER         string
 	TRACK_PROPERTIES string
@@ -59,7 +60,14 @@ var AlertType = struct {
 	RAGE_CLICK       string
 	NEW_SESSION      string
 	LOG              string
+	// new alerts
+	SESSIONS string
+	ERRORS   string
+	LOGS     string
+	TRACES   string
+	METRICS  string
 }{
+	// deprecated alerts
 	ERROR:            "ERROR_ALERT",
 	NEW_USER:         "NEW_USER_ALERT",
 	TRACK_PROPERTIES: "TRACK_PROPERTIES_ALERT",
@@ -68,6 +76,12 @@ var AlertType = struct {
 	RAGE_CLICK:       "RAGE_CLICK_ALERT",
 	NEW_SESSION:      "NEW_SESSION_ALERT",
 	LOG:              "LOG",
+	// new alerts
+	SESSIONS: "SESSIONS_ALERT",
+	ERRORS:   "ERRORS_ALERT",
+	LOGS:     "LOGS_ALERT",
+	TRACES:   "TRACES_ALERT",
+	METRICS:  "METRICS_ALERT",
 }
 
 var AdminRole = struct {

--- a/frontend/src/pages/Alerts/Alerts.tsx
+++ b/frontend/src/pages/Alerts/Alerts.tsx
@@ -246,7 +246,7 @@ function formatAlertDataForTable(alert: any, config: AlertConfiguration) {
 		...alert,
 		ChannelsToNotify: slackChannels,
 		DiscordChannelsToNotify: discordChannels,
-		MicrosoftTeamsChennelsToNotify: microsoftTeamsChannels,
+		MicrosoftTeamsChannelsToNotify: microsoftTeamsChannels,
 		EmailsToNotify: emails,
 		WebhookDestinations: webhookDestinations,
 		configuration: config,

--- a/packages/react-email-templates/emails/errors-alert-v2.tsx
+++ b/packages/react-email-templates/emails/errors-alert-v2.tsx
@@ -1,0 +1,145 @@
+import { Button, Column, Link, Text, Row } from '@react-email/components'
+import * as React from 'react'
+
+import { EmailHtml, HighlightLogo } from '../components/common'
+import {
+	AlertContainer,
+	Break,
+	CtaLink,
+	Footer,
+	highlightedTextStyle,
+	Subtitle,
+	textStyle,
+	Title,
+} from '../components/alerts'
+
+export interface ErrorsAlertV2EmailProps {
+	alertLink?: string
+	errorCount?: number
+	errorEvent?: string
+	errorLink?: string
+	projectName?: string
+	serviceName?: string
+	sessionExcluded?: boolean
+	sessionLink?: string
+}
+
+export const ErrorsAlertV2Email = ({
+	alertLink = 'https://localhost:3000/1/alerts/1',
+	errorCount = 20,
+	errorEvent = 'Uncaught ServerError: Response not successful: Received status code 500',
+	errorLink = 'https://localhost:3000/1/errors/rBV1x0XMOx7CMiKmOGBml9S7PEJY',
+	projectName = 'Highlight Production (app.highlight.io)',
+	serviceName = 'private-graph',
+	sessionExcluded = false,
+	sessionLink = 'https://localhost:3000/1/sessions/6r5FU4u4SYs4AG4kZjnLHyU5K2N7',
+}: ErrorsAlertV2EmailProps) => {
+	const location = serviceName || projectName
+
+	return (
+		<EmailHtml previewText={`Error in ${location}`}>
+			<HighlightLogo />
+			<Title>
+				<span style={highlightedTextStyle}>Error</span> in{' '}
+				<span style={highlightedTextStyle}>{location}</span>
+			</Title>
+			<Subtitle>{projectName}</Subtitle>
+
+			<AlertContainer>
+				<Text style={textStyle}>{errorEvent}</Text>
+
+				<Break />
+
+				<Row style={statContainer}>
+					<Column>
+						<Text style={leftStat}>
+							<span style={statHeader}>Occurences</span>
+							{errorCount}
+						</Text>
+					</Column>
+					<Column>
+						<Text style={rightStat}>
+							<span style={statHeader}>Session</span>
+							{sessionExcluded ? (
+								'No recorded session'
+							) : (
+								<Link href={sessionLink}>View session</Link>
+							)}
+						</Text>
+					</Column>
+				</Row>
+				<CtaLink href={errorLink} label="Open" />
+			</AlertContainer>
+
+			<Row style={actionContainer}>
+				<Column style={buttonColumn}>
+					<Button
+						href={`${errorLink}?action=resolved`}
+						style={actionButton}
+					>
+						Resolve
+					</Button>
+				</Column>
+				<Column style={buttonColumn}>
+					<Button
+						href={`${errorLink}?action=ignored`}
+						style={actionButton}
+					>
+						Ignore
+					</Button>
+				</Column>
+				<Column style={buttonColumn}>
+					<Button
+						href={`${errorLink}?action=snooze`}
+						style={actionButton}
+					>
+						Snooze
+					</Button>
+				</Column>
+			</Row>
+
+			<Break />
+
+			<Footer alertLink={alertLink} />
+		</EmailHtml>
+	)
+}
+
+const statContainer = {
+	marginBottom: '12px',
+}
+
+const leftStat = {
+	...textStyle,
+	textAlign: 'left' as const,
+}
+
+const rightStat = {
+	...textStyle,
+	textAlign: 'right' as const,
+}
+
+const statHeader = {
+	...textStyle,
+	color: '#9d97aa',
+	marginRight: '8px',
+}
+
+const actionContainer = {
+	marginBottom: '36px',
+}
+
+const buttonColumn = {
+	width: '33%',
+}
+
+const actionButton = {
+	backgroundColor: '#72E4FC',
+	borderRadius: '6px',
+	color: '#0D0225',
+	paddingTop: '5px',
+	paddingBottom: '5px',
+	width: '90%',
+}
+
+export default ErrorsAlertV2Email

--- a/packages/react-email-templates/emails/index.tsx
+++ b/packages/react-email-templates/emails/index.tsx
@@ -6,6 +6,11 @@ import { RageClickAlertEmail } from './rage-click-alert'
 import { SessionInsightsEmail } from './session-insights'
 import { TrackEventPropertiesAlertEmail } from './track-event-properties-alert'
 import { TrackUserPropertiesAlertEmail } from './track-user-properties-alert'
+import { LogsAlertV2Email } from './logs-alert-v2'
+import { SessionsAlertV2Email } from './sessions-alert-v2'
+import { TracesAlertV2Email } from './traces-alert-v2'
+import { ErrorsAlertV2Email } from './errors-alert-v2'
+import { MetricsAlertV2Email } from './metrics-alert-v2'
 
 export {
 	ErrorAlertEmail,
@@ -16,4 +21,9 @@ export {
 	SessionInsightsEmail,
 	TrackEventPropertiesAlertEmail,
 	TrackUserPropertiesAlertEmail,
+	SessionsAlertV2Email,
+	ErrorsAlertV2Email,
+	LogsAlertV2Email,
+	TracesAlertV2Email,
+	MetricsAlertV2Email,
 }

--- a/packages/react-email-templates/emails/logs-alert-v2.tsx
+++ b/packages/react-email-templates/emails/logs-alert-v2.tsx
@@ -1,0 +1,98 @@
+import { Column, Text, Row } from '@react-email/components'
+import * as React from 'react'
+
+import { EmailHtml, HighlightLogo } from '../components/common'
+import {
+	AlertContainer,
+	Break,
+	CtaLink,
+	Footer,
+	highlightedTextStyle,
+	Subtitle,
+	textStyle,
+	Title,
+} from '../components/alerts'
+
+export interface LogsAlertV2EmailProps {
+	alertLink?: string
+	alertName?: string
+	belowThreshold?: boolean
+	functionName?: string
+	functionValue?: number
+	logsLink?: string
+	projectName?: string
+	query?: string
+	thresholdValue?: number
+}
+
+export const LogsAlertV2Email = ({
+	alertLink = 'https://localhost:3000/1/alerts/1',
+	alertName = 'Log Alert',
+	belowThreshold = false,
+	functionName = 'Count',
+	functionValue = 24,
+	logsLink = 'https://localhost:3000/1/logs',
+	projectName = 'Highlight Production (app.highlight.io)',
+	query = 'level:info',
+	thresholdValue = 20,
+}: LogsAlertV2EmailProps) => (
+	<EmailHtml previewText={`${alertName} alert fired`}>
+		<HighlightLogo />
+		<Title>
+			<span style={highlightedTextStyle}>{alertName}</span> alert fired
+		</Title>
+		<Subtitle>{projectName}</Subtitle>
+
+		<AlertContainer>
+			<Text style={textStyle}>
+				Log {functionName} for query{' '}
+				<span style={highlightedTextStyle}>{query}</span> is currently{' '}
+				{belowThreshold ? 'below' : 'above'} the threshold.
+			</Text>
+
+			<Break />
+
+			<Row style={statContainer}>
+				<Column>
+					<Text style={leftStat}>
+						<span style={statHeader}>{functionName}</span>
+						{functionValue}
+					</Text>
+				</Column>
+				<Column>
+					<Text style={rightStat}>
+						<span style={statHeader}>Threshold</span>
+						{thresholdValue}
+					</Text>
+				</Column>
+			</Row>
+			<CtaLink href={logsLink} label="View logs" />
+		</AlertContainer>
+
+		<Break />
+
+		<Footer alertLink={alertLink} />
+	</EmailHtml>
+)
+
+const statContainer = {
+	marginBottom: '12px',
+}
+
+const leftStat = {
+	...textStyle,
+	textAlign: 'left' as const,
+}
+
+const rightStat = {
+	...textStyle,
+	textAlign: 'right' as const,
+}
+
+const statHeader = {
+	...textStyle,
+	color: '#9d97aa',
+	marginRight: '8px',
+}
+
+export default LogsAlertV2Email

--- a/packages/react-email-templates/emails/metrics-alert-v2.tsx
+++ b/packages/react-email-templates/emails/metrics-alert-v2.tsx
@@ -1,0 +1,99 @@
+import { Column, Text, Row } from '@react-email/components'
+import * as React from 'react'
+
+import { EmailHtml, HighlightLogo } from '../components/common'
+import {
+	AlertContainer,
+	Break,
+	CtaLink,
+	Footer,
+	highlightedTextStyle,
+	Subtitle,
+	textStyle,
+	Title,
+} from '../components/alerts'
+
+export interface MetricsAlertV2EmailProps {
+	alertLink?: string
+	alertName?: string
+	belowThreshold?: boolean
+	count?: number
+	dashboardsLink?: string
+	functionName?: string
+	functionValue?: number
+	projectName?: string
+	query?: string
+	thresholdValue?: number
+}
+
+export const MetricsAlertV2Email = ({
+	alertLink = 'https://localhost:3000/1/alerts/1',
+	alertName = 'Metric Alert',
+	belowThreshold = false,
+	functionName = 'Count',
+	functionValue = 24,
+	dashboardsLink = 'https://localhost:3000/1/dashboards',
+	projectName = 'Highlight Production (app.highlight.io)',
+	query = 'level:info',
+	thresholdValue = 20,
+}: MetricsAlertV2EmailProps) => (
+	<EmailHtml previewText={`${alertName} alert fired`}>
+		<HighlightLogo />
+		<Title>
+			<span style={highlightedTextStyle}>{alertName}</span> alert fired
+		</Title>
+		<Subtitle>{projectName}</Subtitle>
+
+		<AlertContainer>
+			<Text style={textStyle}>
+				Metrics {functionName} for query{' '}
+				<span style={highlightedTextStyle}>{query}</span> is currently{' '}
+				{belowThreshold ? 'below' : 'above'} the threshold.
+			</Text>
+
+			<Break />
+
+			<Row style={statContainer}>
+				<Column>
+					<Text style={leftStat}>
+						<span style={statHeader}>{functionName}</span>
+						{functionValue}
+					</Text>
+				</Column>
+				<Column>
+					<Text style={rightStat}>
+						<span style={statHeader}>Threshold</span>
+						{thresholdValue}
+					</Text>
+				</Column>
+			</Row>
+			<CtaLink href={dashboardsLink} label="View metrics" />
+		</AlertContainer>
+
+		<Break />
+
+		<Footer alertLink={alertLink} />
+	</EmailHtml>
+)
+
+const statContainer = {
+	marginBottom: '12px',
+}
+
+const leftStat = {
+	...textStyle,
+	textAlign: 'left' as const,
+}
+
+const rightStat = {
+	...textStyle,
+	textAlign: 'right' as const,
+}
+
+const statHeader = {
+	...textStyle,
+	color: '#9d97aa',
+	marginRight: '8px',
+}
+
+export default MetricsAlertV2Email

--- a/packages/react-email-templates/emails/sessions-alert-v2.tsx
+++ b/packages/react-email-templates/emails/sessions-alert-v2.tsx
@@ -1,0 +1,62 @@
+import { Text } from '@react-email/components'
+import * as React from 'react'
+
+import { EmailHtml, HighlightLogo } from '../components/common'
+import {
+	AlertContainer,
+	Break,
+	CtaLink,
+	Footer,
+	highlightedTextStyle,
+	Subtitle,
+	Title,
+	textStyle,
+} from '../components/alerts'
+
+export interface SessionsAlertV2EmailProps {
+	alertName?: string
+	alertLink?: string
+	projectName?: string
+	query?: string
+	secureId?: string
+	sessionLink?: string
+	userIdentifier?: string
+}
+
+export const SessionsAlertV2Email = ({
+	alertName = 'New Session Alert',
+	alertLink = 'https://localhost:3000/1/alerts/sessions/1',
+	projectName = 'Highlight Production (app.highlight.io)',
+	query = 'first_time=true',
+	secureId = '6r5FU4u4SYs4AG4kZjnLHyU5K2N7',
+	sessionLink = 'https://localhost:3000/1/sessions/6r5FU4u4SYs4AG4kZjnLHyU5K2N7',
+	userIdentifier = '1',
+}: SessionsAlertV2EmailProps) => (
+	<EmailHtml previewText={`${alertName} alert fired`}>
+		<HighlightLogo />
+		<Title>
+			<span style={highlightedTextStyle}>{alertName}</span> alert fired
+		</Title>
+		<Subtitle>{projectName}</Subtitle>
+
+		<AlertContainer hideBorder>
+			<Text style={textStyle}>
+				Session found that matches query:{' '}
+				<span style={highlightedTextStyle}>{query}</span>.
+			</Text>
+			<Text style={textStyle}>
+				#{secureId} ({userIdentifier})
+			</Text>
+
+			<Break />
+
+			<CtaLink href={sessionLink} label="View session" />
+		</AlertContainer>
+
+		<Break />
+
+		<Footer alertLink={alertLink} />
+	</EmailHtml>
+)
+
+export default SessionsAlertV2Email

--- a/packages/react-email-templates/emails/traces-alert-v2.tsx
+++ b/packages/react-email-templates/emails/traces-alert-v2.tsx
@@ -1,0 +1,98 @@
+import { Column, Text, Row } from '@react-email/components'
+import * as React from 'react'
+
+import { EmailHtml, HighlightLogo } from '../components/common'
+import {
+	AlertContainer,
+	Break,
+	CtaLink,
+	Footer,
+	highlightedTextStyle,
+	Subtitle,
+	textStyle,
+	Title,
+} from '../components/alerts'
+
+export interface TracesAlertV2EmailProps {
+	alertLink?: string
+	alertName?: string
+	belowThreshold?: boolean
+	functionName?: string
+	functionValue?: number
+	projectName?: string
+	query?: string
+	thresholdValue?: number
+	tracesLink?: string
+}
+
+export const TracesAlertV2Email = ({
+	alertLink = 'https://localhost:3000/1/alerts/1',
+	alertName = 'Trace Alert',
+	belowThreshold = false,
+	functionName = 'Count',
+	functionValue = 24,
+	projectName = 'Highlight Production (app.highlight.io)',
+	query = 'level:info',
+	thresholdValue = 20,
+	tracesLink = 'https://localhost:3000/1/traces',
+}: TracesAlertV2EmailProps) => (
+	<EmailHtml previewText={`${alertName} alert fired`}>
+		<HighlightLogo />
+		<Title>
+			<span style={highlightedTextStyle}>{alertName}</span> alert fired
+		</Title>
+		<Subtitle>{projectName}</Subtitle>
+
+		<AlertContainer>
+			<Text style={textStyle}>
+				Traces {functionName} for query{' '}
+				<span style={highlightedTextStyle}>{query}</span> is currently{' '}
+				{belowThreshold ? 'below' : 'above'} the threshold.
+			</Text>
+
+			<Break />
+
+			<Row style={statContainer}>
+				<Column>
+					<Text style={leftStat}>
+						<span style={statHeader}>{functionName}</span>
+						{functionValue}
+					</Text>
+				</Column>
+				<Column>
+					<Text style={rightStat}>
+						<span style={statHeader}>Threshold</span>
+						{thresholdValue}
+					</Text>
+				</Column>
+			</Row>
+			<CtaLink href={tracesLink} label="View traces" />
+		</AlertContainer>
+
+		<Break />
+
+		<Footer alertLink={alertLink} />
+	</EmailHtml>
+)
+
+const statContainer = {
+	marginBottom: '12px',
+}
+
+const leftStat = {
+	...textStyle,
+	textAlign: 'left' as const,
+}
+
+const rightStat = {
+	...textStyle,
+	textAlign: 'right' as const,
+}
+
+const statHeader = {
+	...textStyle,
+	color: '#9d97aa',
+	marginRight: '8px',
+}
+
+export default TracesAlertV2Email

--- a/packages/react-email-templates/src/index.ts
+++ b/packages/react-email-templates/src/index.ts
@@ -9,6 +9,11 @@ import {
 	SessionInsightsEmail,
 	TrackEventPropertiesAlertEmail,
 	TrackUserPropertiesAlertEmail,
+	SessionsAlertV2Email,
+	ErrorsAlertV2Email,
+	LogsAlertV2Email,
+	TracesAlertV2Email,
+	MetricsAlertV2Email,
 } from '../emails'
 
 export const handler = async (event?: APIGatewayEvent) => {
@@ -50,6 +55,16 @@ const getEmailTemplate = (template: string) => {
 			return TrackEventPropertiesAlertEmail
 		case 'track-user-properties-alert':
 			return TrackUserPropertiesAlertEmail
+		case 'sessions-alert':
+			return SessionsAlertV2Email
+		case 'errors-alert':
+			return ErrorsAlertV2Email
+		case 'logs-alert':
+			return LogsAlertV2Email
+		case 'traces-alert':
+			return TracesAlertV2Email
+		case 'metrics-alert':
+			return MetricsAlertV2Email
 		default:
 			console.error('No email template found for ', template)
 	}


### PR DESCRIPTION
## Summary
Start sending new alerts to microsoft teams

![Screenshot 2024-07-26 at 3 54 09 PM](https://github.com/user-attachments/assets/98603d7b-1a3e-4a53-8686-67f97ba50c4f)

![Screenshot 2024-07-26 at 3 53 47 PM](https://github.com/user-attachments/assets/3f47cf61-0b40-4a9f-934a-0eef71a382b7)

![Screenshot 2024-07-26 at 3 53 53 PM](https://github.com/user-attachments/assets/cc295438-8ca3-40a3-8dd3-41b8fb90478f)

![Screenshot 2024-07-26 at 3 53 31 PM](https://github.com/user-attachments/assets/601eb694-8639-46ab-b857-be615801b1b8)

![Screenshot 2024-07-26 at 3 53 20 PM](https://github.com/user-attachments/assets/c9c54911-c80d-4214-9fe4-765a2120646b)

## How did you test this change?
1) Create a new alert for each product type
2) Add a microsoft team channel for each alert
- [ ] Session alerts send
- [ ] Error alerts send
- [ ] Log alerts send
- [ ] Traces alerts send
- [ ] Metrics alerts send

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
