### PR TITLE
Start sending email alerts

### DIFF
--- a/backend/alerts/v2/alerts.go
+++ b/backend/alerts/v2/alerts.go
@@ -43,11 +43,20 @@ func SendAlerts(ctx context.Context, db *gorm.DB, mailClient *sendgrid.Client, l
 		destinationsByType[destination.DestinationType] = append(destinationsByType[destination.DestinationType], destination)
 	}
 
+	var project model.Project
+	if err := db.WithContext(ctx).Model(&model.Project{}).Preload("Workspace").Where(&model.Project{Model: model.Model{ID: alert.ProjectID}}).Take(&project).Error; err != nil {
+		log.WithContext(ctx).Error(e.Wrap(err, "error querying project"))
+		return
+	}
+
+	frontendURL := env.Config.FrontendUri
 	alertInput := destinationsV2.AlertInput{
-		Alert:      alert,
-		AlertValue: value,
-		Group:      alertGroup,
-		GroupValue: alertGroupValue,
+		Alert:       alert,
+		AlertLink:   fmt.Sprintf("%s/alerts/%d/%d", frontendURL, alert.ProjectID, alert.ID),
+		AlertValue:  value,
+		Group:       alertGroup,
+		GroupValue:  alertGroupValue,
+		ProjectName: *project.Name,
 	}
 
 	switch alert.ProductType {
@@ -82,28 +91,13 @@ func SendAlerts(ctx context.Context, db *gorm.DB, mailClient *sendgrid.Client, l
 	for _, destinations := range destinationsByType {
 		switch destinations[0].DestinationType {
 		case modelInputs.AlertDestinationTypeSlack:
-			project := model.Project{}
-			if err := db.WithContext(ctx).Model(&model.Project{}).Preload("Workspace").Where(&model.Project{Model: model.Model{ID: alert.ProjectID}}).Take(&project).Error; err != nil {
-				log.WithContext(ctx).Error(e.Wrap(err, "error querying slack access token"))
-				continue
-			}
 			slackV2.SendAlerts(ctx, project.Workspace.SlackAccessToken, &alertInput, destinations)
 		case modelInputs.AlertDestinationTypeDiscord:
-			project := model.Project{}
-			if err := db.WithContext(ctx).Model(&model.Project{}).Preload("Workspace").Where(&model.Project{Model: model.Model{ID: alert.ProjectID}}).Take(&project).Error; err != nil {
-				log.WithContext(ctx).Error(e.Wrap(err, "error querying discord access token"))
-				continue
-			}
 			discordV2.SendAlerts(ctx, project.Workspace.DiscordGuildId, &alertInput, destinations)
 		case modelInputs.AlertDestinationTypeMicrosoftTeams:
-			project := model.Project{}
-			if err := db.WithContext(ctx).Model(&model.Project{}).Preload("Workspace").Where(&model.Project{Model: model.Model{ID: alert.ProjectID}}).Take(&project).Error; err != nil {
-				log.WithContext(ctx).Error(e.Wrap(err, "error querying microsoft teams access token"))
-				continue
-			}
 			microsoftteamsV2.SendAlerts(ctx, project.Workspace.MicrosoftTeamsTenantId, &alertInput, destinations)
 		case modelInputs.AlertDestinationTypeEmail:
-			emailV2.SendAlerts(ctx, lambdaClient, &alertInput, destinations)
+			emailV2.SendAlerts(ctx, mailClient, lambdaClient, &alertInput, destinations)
 		case modelInputs.AlertDestinationTypeWebhook:
 			webhookV2.SendAlerts(ctx, &alertInput, destinations)
 		default:

--- a/backend/alerts/v2/destinations/destinations.go
+++ b/backend/alerts/v2/destinations/destinations.go
@@ -9,9 +9,11 @@ import (
 
 type AlertInput struct {
 	Alert        *model.Alert
+	AlertLink    string
 	AlertValue   float64
 	Group        string
 	GroupValue   string
+	ProjectName  string
 	SessionInput *SessionInput
 	ErrorInput   *ErrorInput
 	LogInput     *LogInput

--- a/backend/alerts/v2/destinations/discord/messages.go
+++ b/backend/alerts/v2/destinations/discord/messages.go
@@ -412,7 +412,6 @@ func deliverAlerts(ctx context.Context, discordGuildId string, messageSend *disc
 			_, err := bot.Session.ChannelMessageSendComplex(channelId, messageSend)
 			if err != nil {
 				log.WithContext(ctx).Error(errors.Wrap(err, "couldn't send discord alert"))
-				return
 			}
 		}(destination.TypeID)
 	}

--- a/backend/alerts/v2/destinations/email/messages.go
+++ b/backend/alerts/v2/destinations/email/messages.go
@@ -2,26 +2,37 @@ package emailV2
 
 import (
 	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/sendgrid/sendgrid-go"
+	log "github.com/sirupsen/logrus"
 
 	destinationsV2 "github.com/highlight-run/highlight/backend/alerts/v2/destinations"
+	Email "github.com/highlight-run/highlight/backend/email"
 	"github.com/highlight-run/highlight/backend/lambda"
 	"github.com/highlight-run/highlight/backend/model"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
-	log "github.com/sirupsen/logrus"
 )
 
-func SendAlerts(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+type EmailData struct {
+	SubjectLine  string
+	Template     lambda.ReactEmailTemplate
+	TemplateData map[string]interface{}
+}
+
+func SendAlerts(ctx context.Context, mailClient *sendgrid.Client, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
 	switch alertInput.Alert.ProductType {
 	case modelInputs.ProductTypeSessions:
-		sendSessionAlert(ctx, lambdaClient, alertInput, destinations)
+		sendSessionAlert(ctx, mailClient, lambdaClient, alertInput, destinations)
 	case modelInputs.ProductTypeErrors:
-		sendErrorAlert(ctx, lambdaClient, alertInput, destinations)
+		sendErrorAlert(ctx, mailClient, lambdaClient, alertInput, destinations)
 	case modelInputs.ProductTypeLogs:
-		sendLogAlert(ctx, lambdaClient, alertInput, destinations)
+		sendLogAlert(ctx, mailClient, lambdaClient, alertInput, destinations)
 	case modelInputs.ProductTypeTraces:
-		sendTraceAlert(ctx, lambdaClient, alertInput, destinations)
+		sendTraceAlert(ctx, mailClient, lambdaClient, alertInput, destinations)
 	case modelInputs.ProductTypeMetrics:
-		sendMetricAlert(ctx, lambdaClient, alertInput, destinations)
+		sendMetricAlert(ctx, mailClient, lambdaClient, alertInput, destinations)
 	default:
 		log.WithContext(ctx).WithFields(
 			log.Fields{
@@ -31,52 +42,183 @@ func SendAlerts(ctx context.Context, lambdaClient *lambda.Client, alertInput *de
 	}
 }
 
-func sendSessionAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 email notification")
+func sendSessionAlert(ctx context.Context, mailClient *sendgrid.Client, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	query := "[empty query]"
+	if alertInput.Alert.Query != nil {
+		query = *alertInput.Alert.Query
+	}
+
+	emailData := &EmailData{
+		SubjectLine: fmt.Sprintf("%s fired!", alertInput.Alert.Name),
+		Template:    lambda.ReactEmailTemplateSessionsAlert,
+		TemplateData: map[string]interface{}{
+			"alertName":   alertInput.Alert.Name,
+			"alertLink":   alertInput.AlertLink,
+			"projectName": alertInput.ProjectName,
+			"query":       query,
+			"secureID":    alertInput.SessionInput.SecureID,
+			"sessionLink": alertInput.SessionInput.SessionLink,
+			"identifier":  alertInput.SessionInput.Identifier,
+		},
+	}
+
+	deliverAlerts(ctx, mailClient, lambdaClient, emailData, destinations)
 }
 
-func sendErrorAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 email notification")
+func sendErrorAlert(ctx context.Context, mailClient *sendgrid.Client, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	emailData := &EmailData{
+		SubjectLine: "Error subject line",
+		Template:    lambda.ReactEmailTemplateErrorsAlert,
+		TemplateData: map[string]interface{}{
+			"alertLink":       alertInput.AlertLink,
+			"errorCount":      int(alertInput.AlertValue),
+			"errorEvent":      alertInput.ErrorInput.Event,
+			"errorLink":       alertInput.ErrorInput.ErrorLink,
+			"projectName":     alertInput.ProjectName,
+			"serviceName":     alertInput.ErrorInput.ServiceName,
+			"sessionExcluded": alertInput.ErrorInput.SessionExcluded,
+			"sessionLink":     alertInput.ErrorInput.SessionLink,
+		},
+	}
+
+	deliverAlerts(ctx, mailClient, lambdaClient, emailData, destinations)
 }
 
-func sendLogAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 email notification")
+func sendLogAlert(ctx context.Context, mailClient *sendgrid.Client, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	query := "[empty query]"
+	if alertInput.Alert.Query != nil {
+		query = *alertInput.Alert.Query
+	}
+
+	var functionName string
+	var functionValue interface{}
+	var thresholdValue interface{}
+	if alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCount || alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCountDistinct || alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCountDistinctKey {
+		functionName = "Count"
+		functionValue = int(alertInput.AlertValue)
+		thresholdValue = int(*alertInput.Alert.ThresholdValue)
+	} else {
+		functionName = alertInput.Alert.FunctionType.String()
+		functionValue = alertInput.AlertValue
+		thresholdValue = *alertInput.Alert.ThresholdValue
+	}
+
+	emailData := &EmailData{
+		SubjectLine: fmt.Sprintf("%s fired!", alertInput.Alert.Name),
+		Template:    lambda.ReactEmailTemplateLogsAlert,
+		TemplateData: map[string]interface{}{
+			"alertLink":      alertInput.AlertLink,
+			"alertName":      alertInput.Alert.Name,
+			"belowThreshold": alertInput.Alert.BelowThreshold,
+			"functionValue":  functionValue,
+			"functionName":   functionName,
+			"logsLink":       alertInput.LogInput.LogsLink,
+			"projectName":    alertInput.ProjectName,
+			"query":          query,
+			"thresholdValue": thresholdValue,
+		},
+	}
+
+	deliverAlerts(ctx, mailClient, lambdaClient, emailData, destinations)
 }
 
-func sendTraceAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 email notification")
+func sendTraceAlert(ctx context.Context, mailClient *sendgrid.Client, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	query := "[empty query]"
+	if alertInput.Alert.Query != nil {
+		query = *alertInput.Alert.Query
+	}
+
+	var functionName string
+	var functionValue interface{}
+	var thresholdValue interface{}
+	if alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCount || alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCountDistinct || alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCountDistinctKey {
+		functionName = "Count"
+		functionValue = int(alertInput.AlertValue)
+		thresholdValue = int(*alertInput.Alert.ThresholdValue)
+	} else {
+		functionName = alertInput.Alert.FunctionType.String()
+		functionValue = alertInput.AlertValue
+		thresholdValue = *alertInput.Alert.ThresholdValue
+	}
+
+	emailData := &EmailData{
+		SubjectLine: fmt.Sprintf("%s fired!", alertInput.Alert.Name),
+		Template:    lambda.ReactEmailTemplateLogsAlert,
+		TemplateData: map[string]interface{}{
+			"alertLink":      alertInput.AlertLink,
+			"alertName":      alertInput.Alert.Name,
+			"belowThreshold": alertInput.Alert.BelowThreshold,
+			"functionValue":  functionValue,
+			"functionName":   functionName,
+			"tracesLink":     alertInput.TraceInput.TracesLink,
+			"projectName":    alertInput.ProjectName,
+			"query":          query,
+			"thresholdValue": thresholdValue,
+		},
+	}
+
+	deliverAlerts(ctx, mailClient, lambdaClient, emailData, destinations)
 }
 
-func sendMetricAlert(ctx context.Context, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
-	log.WithContext(ctx).WithFields(
-		log.Fields{
-			"alertID":          alertInput.Alert.ID,
-			"alertProductType": alertInput.Alert.ProductType,
-			"group":            alertInput.Group,
-			"values":           alertInput.GroupValue,
-		}).Info("sending v2 email notification")
+func sendMetricAlert(ctx context.Context, mailClient *sendgrid.Client, lambdaClient *lambda.Client, alertInput *destinationsV2.AlertInput, destinations []model.AlertDestination) {
+	query := "[empty query]"
+	if alertInput.Alert.Query != nil {
+		query = *alertInput.Alert.Query
+	}
+
+	var functionName string
+	var functionValue interface{}
+	var thresholdValue interface{}
+	if alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCount || alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCountDistinct || alertInput.Alert.FunctionType == modelInputs.MetricAggregatorCountDistinctKey {
+		functionName = "Count"
+		functionValue = int(alertInput.AlertValue)
+		thresholdValue = int(*alertInput.Alert.ThresholdValue)
+	} else {
+		functionName = alertInput.Alert.FunctionType.String()
+		functionValue = alertInput.AlertValue
+		thresholdValue = *alertInput.Alert.ThresholdValue
+	}
+
+	emailData := &EmailData{
+		SubjectLine: fmt.Sprintf("%s fired!", alertInput.Alert.Name),
+		Template:    lambda.ReactEmailTemplateLogsAlert,
+		TemplateData: map[string]interface{}{
+			"alertLink":      alertInput.AlertLink,
+			"alertName":      alertInput.Alert.Name,
+			"belowThreshold": alertInput.Alert.BelowThreshold,
+			"functionValue":  functionValue,
+			"functionName":   functionName, "dashboardsLink": alertInput.MetricInput.DashboardLink,
+			"projectName":    alertInput.ProjectName,
+			"query":          query,
+			"thresholdValue": thresholdValue,
+		},
+	}
+
+	deliverAlerts(ctx, mailClient, lambdaClient, emailData, destinations)
+}
+
+func deliverAlerts(ctx context.Context, mailClient *sendgrid.Client, lambdaClient *lambda.Client, emailTemplate *EmailData, destinations []model.AlertDestination) {
+	if mailClient == nil {
+		log.WithContext(ctx).Error("mail client is nil")
+		return
+	}
+
+	if lambdaClient == nil {
+		log.WithContext(ctx).Error("lambda client is nil")
+		return
+	}
+
+	emailHtml, err := lambdaClient.FetchReactEmailHTML(ctx, emailTemplate.Template, emailTemplate.TemplateData)
+	if err != nil {
+		log.WithContext(ctx).Error(errors.Wrap(err, "error fetching email html"))
+		return
+	}
+
+	for _, destination := range destinations {
+		go func(email string) {
+			if err := Email.SendReactEmailAlert(ctx, mailClient, email, emailHtml, emailTemplate.SubjectLine); err != nil {
+				log.WithContext(ctx).Error(err)
+			}
+		}(destination.TypeID)
+	}
 }

--- a/backend/alerts/v2/destinations/microsoft-teams/messages.go
+++ b/backend/alerts/v2/destinations/microsoft-teams/messages.go
@@ -272,7 +272,6 @@ func deliverAlerts(ctx context.Context, microsoftTeamsTenantId string, messageTe
 			err := bot.SendMessageWithAdaptiveCard(channelId, messageTemplate, messagePayload)
 			if err != nil {
 				log.WithContext(ctx).Error(errors.Wrap(err, "couldn't send microsoft teams alert"))
-				return
 			}
 		}(destination.TypeID)
 

--- a/backend/alerts/v2/destinations/slack/messages.go
+++ b/backend/alerts/v2/destinations/slack/messages.go
@@ -515,7 +515,6 @@ func deliverAlerts(ctx context.Context, slackAccessToken string, destinations []
 			)
 			if err != nil {
 				log.WithContext(ctx).Error(errors.Wrap(err, "couldn't send slack alert"))
-				return
 			}
 		}(destination.TypeID, destination.TypeName)
 	}

--- a/backend/lambda/lambda.go
+++ b/backend/lambda/lambda.go
@@ -5,11 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/highlight-run/highlight/backend/env"
 	"io"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/highlight-run/highlight/backend/env"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
@@ -168,14 +169,22 @@ func (s *Client) GetSessionInsightRequest(ctx context.Context, url string, proje
 type ReactEmailTemplate string
 
 const (
+	// deprecated emails
 	ReactEmailTemplateErrorAlert      ReactEmailTemplate = "error-alert"
 	ReactEmailTemplateLogAlert        ReactEmailTemplate = "log-alert"
 	ReactEmailTemplateNewSessionAlert ReactEmailTemplate = "new-session-alert"
 	ReactEmailTemplateNewUserAlert    ReactEmailTemplate = "new-user-alert"
 	ReactEmailTemplateRageClickAlert  ReactEmailTemplate = "rage-click-alert"
-	ReactEmailTemplateSessionInsights ReactEmailTemplate = "session-insights"
 	ReactEmailTemplateTrackEventAlert ReactEmailTemplate = "track-event-properties-alert"
 	ReactEmailTemplateTrackUserAlert  ReactEmailTemplate = "track-user-properties-alert"
+	// new alert emails
+	ReactEmailTemplateSessionsAlert ReactEmailTemplate = "sessions-alert"
+	ReactEmailTemplateErrorsAlert   ReactEmailTemplate = "errors-alert"
+	ReactEmailTemplateLogsAlert     ReactEmailTemplate = "logs-alert"
+	ReactEmailTemplateTracesAlert   ReactEmailTemplate = "traces-alert"
+	ReactEmailTemplateMetricsAlert  ReactEmailTemplate = "metrics-alert"
+	// session insights
+	ReactEmailTemplateSessionInsights ReactEmailTemplate = "session-insights"
 )
 
 func (s *Client) GetSessionInsightEmailHtml(ctx context.Context, toEmail string, unsubscribeUrl string, data utils.SessionInsightsData) (string, error) {

--- a/packages/react-email-templates/emails/errors-alert-v2.tsx
+++ b/packages/react-email-templates/emails/errors-alert-v2.tsx
@@ -1,0 +1,145 @@
+import { Button, Column, Link, Text, Row } from '@react-email/components'
+import * as React from 'react'
+
+import { EmailHtml, HighlightLogo } from '../components/common'
+import {
+	AlertContainer,
+	Break,
+	CtaLink,
+	Footer,
+	highlightedTextStyle,
+	Subtitle,
+	textStyle,
+	Title,
+} from '../components/alerts'
+
+export interface ErrorsAlertV2EmailProps {
+	alertLink?: string
+	errorCount?: number
+	errorEvent?: string
+	errorLink?: string
+	projectName?: string
+	serviceName?: string
+	sessionExcluded?: boolean
+	sessionLink?: string
+}
+
+export const ErrorsAlertV2Email = ({
+	alertLink = 'https://localhost:3000/1/alerts/1',
+	errorCount = 20,
+	errorEvent = 'Uncaught ServerError: Response not successful: Received status code 500',
+	errorLink = 'https://localhost:3000/1/errors/rBV1x0XMOx7CMiKmOGBml9S7PEJY',
+	projectName = 'Highlight Production (app.highlight.io)',
+	serviceName = 'private-graph',
+	sessionExcluded = false,
+	sessionLink = 'https://localhost:3000/1/sessions/6r5FU4u4SYs4AG4kZjnLHyU5K2N7',
+}: ErrorsAlertV2EmailProps) => {
+	const location = serviceName || projectName
+
+	return (
+		<EmailHtml previewText={`Error in ${location}`}>
+			<HighlightLogo />
+			<Title>
+				<span style={highlightedTextStyle}>Error</span> in{' '}
+				<span style={highlightedTextStyle}>{location}</span>
+			</Title>
+			<Subtitle>{projectName}</Subtitle>
+
+			<AlertContainer>
+				<Text style={textStyle}>{errorEvent}</Text>
+
+				<Break />
+
+				<Row style={statContainer}>
+					<Column>
+						<Text style={leftStat}>
+							<span style={statHeader}>Occurences</span>
+							{errorCount}
+						</Text>
+					</Column>
+					<Column>
+						<Text style={rightStat}>
+							<span style={statHeader}>Session</span>
+							{sessionExcluded ? (
+								'No recorded session'
+							) : (
+								<Link href={sessionLink}>View session</Link>
+							)}
+						</Text>
+					</Column>
+				</Row>
+				<CtaLink href={errorLink} label="Open" />
+			</AlertContainer>
+
+			<Row style={actionContainer}>
+				<Column style={buttonColumn}>
+					<Button
+						href={`${errorLink}?action=resolved`}
+						style={actionButton}
+					>
+						Resolve
+					</Button>
+				</Column>
+				<Column style={buttonColumn}>
+					<Button
+						href={`${errorLink}?action=ignored`}
+						style={actionButton}
+					>
+						Ignore
+					</Button>
+				</Column>
+				<Column style={buttonColumn}>
+					<Button
+						href={`${errorLink}?action=snooze`}
+						style={actionButton}
+					>
+						Snooze
+					</Button>
+				</Column>
+			</Row>
+
+			<Break />
+
+			<Footer alertLink={alertLink} />
+		</EmailHtml>
+	)
+}
+
+const statContainer = {
+	marginBottom: '12px',
+}
+
+const leftStat = {
+	...textStyle,
+	textAlign: 'left' as const,
+}
+
+const rightStat = {
+	...textStyle,
+	textAlign: 'right' as const,
+}
+
+const statHeader = {
+	...textStyle,
+	color: '#9d97aa',
+	marginRight: '8px',
+}
+
+const actionContainer = {
+	marginBottom: '36px',
+}
+
+const buttonColumn = {
+	width: '33%',
+}
+
+const actionButton = {
+	backgroundColor: '#72E4FC',
+	borderRadius: '6px',
+	color: '#0D0225',
+	paddingTop: '5px',
+	paddingBottom: '5px',
+	width: '90%',
+}
+
+export default ErrorsAlertV2Email

--- a/packages/react-email-templates/emails/index.tsx
+++ b/packages/react-email-templates/emails/index.tsx
@@ -6,6 +6,11 @@ import { RageClickAlertEmail } from './rage-click-alert'
 import { SessionInsightsEmail } from './session-insights'
 import { TrackEventPropertiesAlertEmail } from './track-event-properties-alert'
 import { TrackUserPropertiesAlertEmail } from './track-user-properties-alert'
+import { LogsAlertV2Email } from './logs-alert-v2'
+import { SessionsAlertV2Email } from './sessions-alert-v2'
+import { TracesAlertV2Email } from './traces-alert-v2'
+import { ErrorsAlertV2Email } from './errors-alert-v2'
+import { MetricsAlertV2Email } from './metrics-alert-v2'
 
 export {
 	ErrorAlertEmail,
@@ -16,4 +21,9 @@ export {
 	SessionInsightsEmail,
 	TrackEventPropertiesAlertEmail,
 	TrackUserPropertiesAlertEmail,
+	SessionsAlertV2Email,
+	ErrorsAlertV2Email,
+	LogsAlertV2Email,
+	TracesAlertV2Email,
+	MetricsAlertV2Email,
 }

--- a/packages/react-email-templates/emails/logs-alert-v2.tsx
+++ b/packages/react-email-templates/emails/logs-alert-v2.tsx
@@ -1,0 +1,98 @@
+import { Column, Text, Row } from '@react-email/components'
+import * as React from 'react'
+
+import { EmailHtml, HighlightLogo } from '../components/common'
+import {
+	AlertContainer,
+	Break,
+	CtaLink,
+	Footer,
+	highlightedTextStyle,
+	Subtitle,
+	textStyle,
+	Title,
+} from '../components/alerts'
+
+export interface LogsAlertV2EmailProps {
+	alertLink?: string
+	alertName?: string
+	belowThreshold?: boolean
+	functionName?: string
+	functionValue?: number
+	logsLink?: string
+	projectName?: string
+	query?: string
+	thresholdValue?: number
+}
+
+export const LogsAlertV2Email = ({
+	alertLink = 'https://localhost:3000/1/alerts/1',
+	alertName = 'Log Alert',
+	belowThreshold = false,
+	functionName = 'Count',
+	functionValue = 24,
+	logsLink = 'https://localhost:3000/1/logs',
+	projectName = 'Highlight Production (app.highlight.io)',
+	query = 'level:info',
+	thresholdValue = 20,
+}: LogsAlertV2EmailProps) => (
+	<EmailHtml previewText={`${alertName} alert fired`}>
+		<HighlightLogo />
+		<Title>
+			<span style={highlightedTextStyle}>{alertName}</span> alert fired
+		</Title>
+		<Subtitle>{projectName}</Subtitle>
+
+		<AlertContainer>
+			<Text style={textStyle}>
+				Log {functionName} for query{' '}
+				<span style={highlightedTextStyle}>{query}</span> is currently{' '}
+				{belowThreshold ? 'below' : 'above'} the threshold.
+			</Text>
+
+			<Break />
+
+			<Row style={statContainer}>
+				<Column>
+					<Text style={leftStat}>
+						<span style={statHeader}>{functionName}</span>
+						{functionValue}
+					</Text>
+				</Column>
+				<Column>
+					<Text style={rightStat}>
+						<span style={statHeader}>Threshold</span>
+						{thresholdValue}
+					</Text>
+				</Column>
+			</Row>
+			<CtaLink href={logsLink} label="View logs" />
+		</AlertContainer>
+
+		<Break />
+
+		<Footer alertLink={alertLink} />
+	</EmailHtml>
+)
+
+const statContainer = {
+	marginBottom: '12px',
+}
+
+const leftStat = {
+	...textStyle,
+	textAlign: 'left' as const,
+}
+
+const rightStat = {
+	...textStyle,
+	textAlign: 'right' as const,
+}
+
+const statHeader = {
+	...textStyle,
+	color: '#9d97aa',
+	marginRight: '8px',
+}
+
+export default LogsAlertV2Email

--- a/packages/react-email-templates/emails/metrics-alert-v2.tsx
+++ b/packages/react-email-templates/emails/metrics-alert-v2.tsx
@@ -1,0 +1,99 @@
+import { Column, Text, Row } from '@react-email/components'
+import * as React from 'react'
+
+import { EmailHtml, HighlightLogo } from '../components/common'
+import {
+	AlertContainer,
+	Break,
+	CtaLink,
+	Footer,
+	highlightedTextStyle,
+	Subtitle,
+	textStyle,
+	Title,
+} from '../components/alerts'
+
+export interface MetricsAlertV2EmailProps {
+	alertLink?: string
+	alertName?: string
+	belowThreshold?: boolean
+	count?: number
+	dashboardsLink?: string
+	functionName?: string
+	functionValue?: number
+	projectName?: string
+	query?: string
+	thresholdValue?: number
+}
+
+export const MetricsAlertV2Email = ({
+	alertLink = 'https://localhost:3000/1/alerts/1',
+	alertName = 'Metric Alert',
+	belowThreshold = false,
+	functionName = 'Count',
+	functionValue = 24,
+	dashboardsLink = 'https://localhost:3000/1/dashboards',
+	projectName = 'Highlight Production (app.highlight.io)',
+	query = 'level:info',
+	thresholdValue = 20,
+}: MetricsAlertV2EmailProps) => (
+	<EmailHtml previewText={`${alertName} alert fired`}>
+		<HighlightLogo />
+		<Title>
+			<span style={highlightedTextStyle}>{alertName}</span> alert fired
+		</Title>
+		<Subtitle>{projectName}</Subtitle>
+
+		<AlertContainer>
+			<Text style={textStyle}>
+				Metrics {functionName} for query{' '}
+				<span style={highlightedTextStyle}>{query}</span> is currently{' '}
+				{belowThreshold ? 'below' : 'above'} the threshold.
+			</Text>
+
+			<Break />
+
+			<Row style={statContainer}>
+				<Column>
+					<Text style={leftStat}>
+						<span style={statHeader}>{functionName}</span>
+						{functionValue}
+					</Text>
+				</Column>
+				<Column>
+					<Text style={rightStat}>
+						<span style={statHeader}>Threshold</span>
+						{thresholdValue}
+					</Text>
+				</Column>
+			</Row>
+			<CtaLink href={dashboardsLink} label="View metrics" />
+		</AlertContainer>
+
+		<Break />
+
+		<Footer alertLink={alertLink} />
+	</EmailHtml>
+)
+
+const statContainer = {
+	marginBottom: '12px',
+}
+
+const leftStat = {
+	...textStyle,
+	textAlign: 'left' as const,
+}
+
+const rightStat = {
+	...textStyle,
+	textAlign: 'right' as const,
+}
+
+const statHeader = {
+	...textStyle,
+	color: '#9d97aa',
+	marginRight: '8px',
+}
+
+export default MetricsAlertV2Email

--- a/packages/react-email-templates/emails/sessions-alert-v2.tsx
+++ b/packages/react-email-templates/emails/sessions-alert-v2.tsx
@@ -1,0 +1,62 @@
+import { Text } from '@react-email/components'
+import * as React from 'react'
+
+import { EmailHtml, HighlightLogo } from '../components/common'
+import {
+	AlertContainer,
+	Break,
+	CtaLink,
+	Footer,
+	highlightedTextStyle,
+	Subtitle,
+	Title,
+	textStyle,
+} from '../components/alerts'
+
+export interface SessionsAlertV2EmailProps {
+	alertName?: string
+	alertLink?: string
+	projectName?: string
+	query?: string
+	secureId?: string
+	sessionLink?: string
+	userIdentifier?: string
+}
+
+export const SessionsAlertV2Email = ({
+	alertName = 'New Session Alert',
+	alertLink = 'https://localhost:3000/1/alerts/sessions/1',
+	projectName = 'Highlight Production (app.highlight.io)',
+	query = 'first_time=true',
+	secureId = '6r5FU4u4SYs4AG4kZjnLHyU5K2N7',
+	sessionLink = 'https://localhost:3000/1/sessions/6r5FU4u4SYs4AG4kZjnLHyU5K2N7',
+	userIdentifier = '1',
+}: SessionsAlertV2EmailProps) => (
+	<EmailHtml previewText={`${alertName} alert fired`}>
+		<HighlightLogo />
+		<Title>
+			<span style={highlightedTextStyle}>{alertName}</span> alert fired
+		</Title>
+		<Subtitle>{projectName}</Subtitle>
+
+		<AlertContainer hideBorder>
+			<Text style={textStyle}>
+				Session found that matches query:{' '}
+				<span style={highlightedTextStyle}>{query}</span>.
+			</Text>
+			<Text style={textStyle}>
+				#{secureId} ({userIdentifier})
+			</Text>
+
+			<Break />
+
+			<CtaLink href={sessionLink} label="View session" />
+		</AlertContainer>
+
+		<Break />
+
+		<Footer alertLink={alertLink} />
+	</EmailHtml>
+)
+
+export default SessionsAlertV2Email

--- a/packages/react-email-templates/emails/traces-alert-v2.tsx
+++ b/packages/react-email-templates/emails/traces-alert-v2.tsx
@@ -1,0 +1,98 @@
+import { Column, Text, Row } from '@react-email/components'
+import * as React from 'react'
+
+import { EmailHtml, HighlightLogo } from '../components/common'
+import {
+	AlertContainer,
+	Break,
+	CtaLink,
+	Footer,
+	highlightedTextStyle,
+	Subtitle,
+	textStyle,
+	Title,
+} from '../components/alerts'
+
+export interface TracesAlertV2EmailProps {
+	alertLink?: string
+	alertName?: string
+	belowThreshold?: boolean
+	functionName?: string
+	functionValue?: number
+	projectName?: string
+	query?: string
+	thresholdValue?: number
+	tracesLink?: string
+}
+
+export const TracesAlertV2Email = ({
+	alertLink = 'https://localhost:3000/1/alerts/1',
+	alertName = 'Trace Alert',
+	belowThreshold = false,
+	functionName = 'Count',
+	functionValue = 24,
+	projectName = 'Highlight Production (app.highlight.io)',
+	query = 'level:info',
+	thresholdValue = 20,
+	tracesLink = 'https://localhost:3000/1/traces',
+}: TracesAlertV2EmailProps) => (
+	<EmailHtml previewText={`${alertName} alert fired`}>
+		<HighlightLogo />
+		<Title>
+			<span style={highlightedTextStyle}>{alertName}</span> alert fired
+		</Title>
+		<Subtitle>{projectName}</Subtitle>
+
+		<AlertContainer>
+			<Text style={textStyle}>
+				Traces {functionName} for query{' '}
+				<span style={highlightedTextStyle}>{query}</span> is currently{' '}
+				{belowThreshold ? 'below' : 'above'} the threshold.
+			</Text>
+
+			<Break />
+
+			<Row style={statContainer}>
+				<Column>
+					<Text style={leftStat}>
+						<span style={statHeader}>{functionName}</span>
+						{functionValue}
+					</Text>
+				</Column>
+				<Column>
+					<Text style={rightStat}>
+						<span style={statHeader}>Threshold</span>
+						{thresholdValue}
+					</Text>
+				</Column>
+			</Row>
+			<CtaLink href={tracesLink} label="View traces" />
+		</AlertContainer>
+
+		<Break />
+
+		<Footer alertLink={alertLink} />
+	</EmailHtml>
+)
+
+const statContainer = {
+	marginBottom: '12px',
+}
+
+const leftStat = {
+	...textStyle,
+	textAlign: 'left' as const,
+}
+
+const rightStat = {
+	...textStyle,
+	textAlign: 'right' as const,
+}
+
+const statHeader = {
+	...textStyle,
+	color: '#9d97aa',
+	marginRight: '8px',
+}
+
+export default TracesAlertV2Email

--- a/packages/react-email-templates/src/index.ts
+++ b/packages/react-email-templates/src/index.ts
@@ -9,6 +9,11 @@ import {
 	SessionInsightsEmail,
 	TrackEventPropertiesAlertEmail,
 	TrackUserPropertiesAlertEmail,
+	SessionsAlertV2Email,
+	ErrorsAlertV2Email,
+	LogsAlertV2Email,
+	TracesAlertV2Email,
+	MetricsAlertV2Email,
 } from '../emails'
 
 export const handler = async (event?: APIGatewayEvent) => {
@@ -50,6 +55,16 @@ const getEmailTemplate = (template: string) => {
 			return TrackEventPropertiesAlertEmail
 		case 'track-user-properties-alert':
 			return TrackUserPropertiesAlertEmail
+		case 'sessions-alert':
+			return SessionsAlertV2Email
+		case 'errors-alert':
+			return ErrorsAlertV2Email
+		case 'logs-alert':
+			return LogsAlertV2Email
+		case 'traces-alert':
+			return TracesAlertV2Email
+		case 'metrics-alert':
+			return MetricsAlertV2Email
 		default:
 			console.error('No email template found for ', template)
 	}


### PR DESCRIPTION
## Summary
Start sending new alerts to emails

<img width="500" alt="Screenshot 2024-07-28 at 5 11 58 PM" src="https://github.com/user-attachments/assets/0fd07722-3e1f-4715-92b9-429b74816e01">
<img width="455" alt="Screenshot 2024-07-28 at 5 12 07 PM" src="https://github.com/user-attachments/assets/73bf67b1-0da1-479c-b7aa-5a7143c623e9">
<img width="490" alt="Screenshot 2024-07-28 at 5 12 16 PM" src="https://github.com/user-attachments/assets/8ef19252-449a-4763-8b0a-7842f1072299">
<img width="485" alt="Screenshot 2024-07-28 at 5 12 22 PM" src="https://github.com/user-attachments/assets/ce122024-cfe6-4bd6-a05e-67451e4a9716">
<img width="466" alt="Screenshot 2024-07-28 at 5 12 30 PM" src="https://github.com/user-attachments/assets/04b5acee-7ac2-410c-b8e6-c1ae7a0ad6fb">


## How did you test this change?
1) Create a new alert for each product type
2) Add an email channel for each alert
- [ ] Session alerts send
- [ ] Error alerts send
- [ ] Log alerts send
- [ ] Traces alerts send
- [ ] Metrics alerts send

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
