### PR TITLE
enable launch week 6 banners

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -980,8 +980,8 @@ const BillingBanner: React.FC = () => {
 
 	if (!bannerMessage && !hasTrial) {
 		const isLaunchWeek = moment().isBetween(
-			'2024-04-29T16:00:00Z', // 9AM PST
-			'2024-05-04T16:00:00Z',
+			'2024-07-29T16:00:00Z', // 9AM PST
+			'2024-08-03T16:00:00Z',
 		)
 		if (isLaunchWeek) {
 			return <LaunchWeekBanner />
@@ -1089,10 +1089,10 @@ const LaunchWeekBanner = () => {
 
 	const bannerMessage = (
 		<span>
-			Launch Week 5 is here.{' '}
+			Launch Week 6 is here.{' '}
 			<a
 				target="_blank"
-				href="https://www.highlight.io/blog/tag/launch-week-5"
+				href="https://www.youtube.com/playlist?list=PLtIz-bpzHkhhXNuWXTohSbozKz3t-WjOR"
 				className={styles.trialLink}
 				rel="noreferrer"
 			>

--- a/highlight.io/components/common/Navbar/Navbar.tsx
+++ b/highlight.io/components/common/Navbar/Navbar.tsx
@@ -23,10 +23,10 @@ import FeatureDropdown from './FeatureDropdown'
 const LaunchWeekBanner = () => {
 	const bannerMessage = (
 		<div className={styles.launchWeekText}>
-			Launch Week 5 is here.{' '}
+			Launch Week 6 is here.{' '}
 			<a
 				target="_blank"
-				href="https://www.highlight.io/blog/tag/launch-week-5"
+				href="https://www.youtube.com/playlist?list=PLtIz-bpzHkhhXNuWXTohSbozKz3t-WjOR"
 				rel="noreferrer"
 			>
 				Follow along
@@ -110,8 +110,8 @@ const Navbar = ({
 	}
 
 	const isLaunchWeek = moment().isBetween(
-		'2024-04-29T16:00:00Z',
-		'2024-05-04T16:00:00Z',
+		'2024-07-29T16:00:00Z',
+		'2024-08-03T16:00:00Z',
 	)
 
 	useEffect(() => {


### PR DESCRIPTION
## Summary
- turns on launch week 6 banners in app and landing page
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- testing in preview
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
