### PR TITLE
[SUP-81] call out tracingOrigins for cross-origin backends in docs

### DIFF
--- a/docs-content/getting-started/2_frontend-backend-mapping.md
+++ b/docs-content/getting-started/2_frontend-backend-mapping.md
@@ -26,7 +26,7 @@ If you haven't already, you need to install our client javascript bundle in the 
 
 ### Turn on `tracingOrigins`
 
-Set the `tracingOrigins` option to an array of patterns matching the location of your backend. You may also simply specify `true`, which will default `tracingOrigins` to all subdomains/domains of the url for your frontend app.
+Set the `tracingOrigins` option to an array of patterns matching the location of your backend. You may also simply specify `true`, which will default `tracingOrigins` to all subdomains/domains of the url for your frontend app. If your application makes cross-origin requests that you would like to trace, you will have to explicitly include those.
 
 ```javascript
 H.init("<YOUR_PROJECT_ID>", {


### PR DESCRIPTION
## Summary
- make it more clear that `tracingOrigins: true` is not enough for cross-origin requests
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- preview
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
