### PR TITLE
try github hosted runner

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -10,7 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
     yarn-monorepo:
         name: Build Yarn Turborepo
-        timeout-minutes: 30
+        timeout-minutes: 60
         runs-on: buildjet-4vcpu-ubuntu-2204
         # configures turborepo Remote Caching
         env:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -61,19 +61,6 @@ jobs:
             - name: Install Playwright Browsers
               run: npx playwright install --with-deps
 
-            - name: install chrome
-              run: |
-                  wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-                  apt-get update -y
-                  apt-get install -y ./google-chrome*.deb
-
-            - name: Test session screenshot lambda
-              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'
-              # uses PSQL_HOST from prod via doppler. has access since this runs on the code runner in prod VPC
-              run: doppler run -- yarn test:render
-              env:
-                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_RENDER_SECRET }}
-
             - name: Build & test (in a fork without doppler)
               run: yarn test:all
               env:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -68,11 +68,6 @@ jobs:
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
                   REACT_APP_COMMIT_SHA: ${{ github.sha }}
 
-            - name: Validate session screenshot lambda size
-              # this can only run after `yarn test:render` runs
-              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'
-              run: yarn workspace render zip && yarn workspace render check
-
             - name: Validate repo state
               run: |
                   git status --porcelain

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -11,7 +11,7 @@ jobs:
     yarn-monorepo:
         name: Build Yarn Turborepo
         timeout-minutes: 30
-        runs-on: codebuild-highlight-github-actions-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        runs-on: buildjet-4vcpu-ubuntu-2204
         # configures turborepo Remote Caching
         env:
             TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
## Summary
- use buildjet runner since running `yarn install` is hanging in codebuild for an unknown reason 
- remove session screenshot lambda tests as they require DB access - should replace this later
- increase timeout to 60 mins
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- github actions
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will make monorepo check required after deploying this
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
