### PR TITLE
fix highlight.run getSessionUrl only returning session ID 

### DIFF
--- a/.changeset/thin-geese-hang.md
+++ b/.changeset/thin-geese-hang.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+fix highlight.run getSessionUrl only returning session ID

--- a/.changeset/thin-geese-hang.md
+++ b/.changeset/thin-geese-hang.md
@@ -1,5 +1,0 @@
----
-'highlight.run': patch
----
-
-fix highlight.run getSessionUrl only returning session ID

--- a/cypress/e2e/client.cy.js
+++ b/cypress/e2e/client.cy.js
@@ -57,6 +57,22 @@ describe('client recording spec', () => {
 					win.eval(`fetch('${baseUrl}/index.html')`)
 					win.eval(`fetch('${baseUrl}/index.html', {method: 'POST'})`)
 					win.eval(`H.track('MyTrackEvent', {'foo': 'bar'})`)
+
+					const result = win.eval(`H.getSessionURL()`)
+					const session = result.substring(
+						0,
+						result.lastIndexOf('/') + 1,
+					)
+					const prefix = result.substring(
+						result.lastIndexOf('/') + 1,
+						result.length,
+					)
+
+					expect(prefix).to.eq('https://app.highlight.io/1/sessions')
+					expect(session).to.neq(
+						'https://app.highlight.io/1/sessions',
+					)
+					expect(session.length).to.eq(28)
 				})
 
 			cy.wait('@PushPayloadCompressed')

--- a/cypress/e2e/client.cy.js
+++ b/cypress/e2e/client.cy.js
@@ -20,7 +20,7 @@ describe('client recording spec', () => {
 			cy.wait('@PushPayloadCompressed')
 				.its('request.body.variables')
 				.should('have.property', 'data')
-				.then((data) => {
+				.then(async (data) => {
 					const { resources } = decompressPushPayload(data)
 					const parsedResources = JSON.parse(resources).resources
 					const firstResourceKeys = Object.keys(
@@ -58,21 +58,32 @@ describe('client recording spec', () => {
 					win.eval(`fetch('${baseUrl}/index.html', {method: 'POST'})`)
 					win.eval(`H.track('MyTrackEvent', {'foo': 'bar'})`)
 
-					const result = win.eval(`H.getSessionURL()`)
-					const session = result.substring(
+					const result = await win.eval(`H.getSessionURL()`)
+					console.log('getSessionURL', result)
+
+					const prefix = result.substring(
 						0,
 						result.lastIndexOf('/') + 1,
 					)
-					const prefix = result.substring(
+					const session = result.substring(
 						result.lastIndexOf('/') + 1,
 						result.length,
 					)
 
-					expect(prefix).to.eq('https://app.highlight.io/1/sessions')
-					expect(session).to.neq(
-						'https://app.highlight.io/1/sessions',
+					expect(prefix).to.eq('https://app.highlight.io/1/sessions/')
+					expect(session).to.not.eq(
+						'https://app.highlight.io/1/sessions/',
 					)
 					expect(session.length).to.eq(28)
+
+					const { url, urlWithTimestamp } = await win.eval(
+						`H.getSessionDetails()`,
+					)
+					const ts = Number(urlWithTimestamp.split('ts=').pop())
+					console.log('getSessionDetails ts', ts)
+					expect(url).to.eq(result)
+					expect(ts).to.greaterThan(0)
+					expect(ts).to.lessThan(5)
 				})
 
 			cy.wait('@PushPayloadCompressed')

--- a/sdk/client/src/constants/sessions.ts
+++ b/sdk/client/src/constants/sessions.ts
@@ -38,4 +38,4 @@ export const SNAPSHOT_SETTINGS = {
 // Debounce duplicate visibility events
 export const VISIBILITY_DEBOUNCE_MS = 100
 
-export const HIGHLIGHT_URL = 'app.highlight.run'
+export const HIGHLIGHT_URL = 'app.highlight.io'

--- a/sdk/client/src/constants/sessions.ts
+++ b/sdk/client/src/constants/sessions.ts
@@ -37,3 +37,5 @@ export const SNAPSHOT_SETTINGS = {
 
 // Debounce duplicate visibility events
 export const VISIBILITY_DEBOUNCE_MS = 100
+
+export const HIGHLIGHT_URL = 'app.highlight.run'

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -83,6 +83,7 @@ import {
 import { getItem, removeItem, setItem, setStorageMode } from './utils/storage'
 import {
 	FIRST_SEND_FREQUENCY,
+	HIGHLIGHT_URL,
 	MAX_SESSION_LENGTH,
 	SEND_FREQUENCY,
 	SNAPSHOT_SETTINGS,
@@ -138,8 +139,6 @@ type HighlightClassOptionsInternal = Omit<
 	HighlightClassOptions,
 	'firstloadVersion'
 >
-
-const HIGHLIGHT_URL = 'app.highlight.run'
 
 export class Highlight {
 	options!: HighlightClassOptions

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -1258,6 +1258,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			await this._sendPayload({ sendFn })
 			this.hasPushedData = true
 			this.sessionData.lastPushTime = Date.now()
+			setSessionData(this.sessionData)
 		} catch (e) {
 			if (this._isOnLocalHost) {
 				console.error(e)

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -526,17 +526,13 @@ export class Highlight {
 				return
 			}
 
-			const recordingStartTime = getItem(
-				SESSION_STORAGE_KEYS.RECORDING_START_TIME,
-			)
-			if (!recordingStartTime) {
+			const sessionData = getPreviousSessionData() ?? ({} as SessionData)
+			if (!sessionData?.sessionStartTime) {
 				this._recordingStartTime = new Date().getTime()
-				setItem(
-					SESSION_STORAGE_KEYS.RECORDING_START_TIME,
-					this._recordingStartTime.toString(),
-				)
+				sessionData.sessionStartTime = this._recordingStartTime
+				setSessionData(sessionData)
 			} else {
-				this._recordingStartTime = parseInt(recordingStartTime, 10)
+				this._recordingStartTime = sessionData?.sessionStartTime
 			}
 
 			let clientID = getItem(LOCAL_STORAGE_KEYS['CLIENT_ID'])

--- a/sdk/client/src/utils/sessionStorage/highlightSession.ts
+++ b/sdk/client/src/utils/sessionStorage/highlightSession.ts
@@ -11,10 +11,15 @@ export type SessionData = {
 	userObject?: Object
 }
 
-export const getPreviousSessionData = (): SessionData | undefined => {
+const getSessionData = (): SessionData | undefined => {
 	let storedSessionData = JSON.parse(
 		getItem(SESSION_STORAGE_KEYS.SESSION_DATA) || '{}',
 	)
+	return storedSessionData as SessionData
+}
+
+export const getPreviousSessionData = (): SessionData | undefined => {
+	let storedSessionData = getSessionData()
 	if (
 		storedSessionData &&
 		storedSessionData.lastPushTime &&
@@ -26,21 +31,25 @@ export const getPreviousSessionData = (): SessionData | undefined => {
 
 export const setSessionData = function (sessionData: SessionData | null) {
 	if (sessionData === null) {
-		removeItem(SESSION_STORAGE_KEYS.SESSION_DATA)
-		// preserve SESSION_STORAGE_KEYS.SESSION_SECURE_ID as that is used by network listeners
+		// preserve sessionSecureID as that is used by network listeners
+		setItem(
+			SESSION_STORAGE_KEYS.SESSION_DATA,
+			JSON.stringify({
+				sessionSecureID: getSessionData()?.sessionSecureID,
+			}),
+		)
 		return
 	}
 	setItem(SESSION_STORAGE_KEYS.SESSION_DATA, JSON.stringify(sessionData))
 }
 
 export const getSessionSecureID = function () {
-	const data = getPreviousSessionData()
+	const data = getSessionData()
 	return data?.sessionSecureID ?? ''
 }
 
 export const setSessionSecureID = function (sessionSecureID: string) {
-	const data =
-		getPreviousSessionData() ?? ({ sessionSecureID } as SessionData)
+	const data = getSessionData() ?? ({ sessionSecureID } as SessionData)
 	data.sessionSecureID = sessionSecureID
 	return setSessionData(data)
 }

--- a/sdk/client/src/utils/sessionStorage/highlightSession.ts
+++ b/sdk/client/src/utils/sessionStorage/highlightSession.ts
@@ -31,13 +31,16 @@ export const setSessionData = function (sessionData: SessionData | null) {
 		return
 	}
 	setItem(SESSION_STORAGE_KEYS.SESSION_DATA, JSON.stringify(sessionData))
-	setSessionSecureID(sessionData.sessionSecureID)
 }
 
 export const getSessionSecureID = function () {
-	return getItem(SESSION_STORAGE_KEYS.SESSION_SECURE_ID) ?? ''
+	const data = getPreviousSessionData()
+	return data?.sessionSecureID ?? ''
 }
 
 export const setSessionSecureID = function (sessionSecureID: string) {
-	return setItem(SESSION_STORAGE_KEYS.SESSION_SECURE_ID, sessionSecureID)
+	const data =
+		getPreviousSessionData() ?? ({ sessionSecureID } as SessionData)
+	data.sessionSecureID = sessionSecureID
+	return setSessionData(data)
 }

--- a/sdk/client/src/utils/sessionStorage/sessionStorageKeys.ts
+++ b/sdk/client/src/utils/sessionStorage/sessionStorageKeys.ts
@@ -1,8 +1,6 @@
 export enum SESSION_STORAGE_KEYS {
-	RECORDING_START_TIME = 'highlightRecordingStartTime',
 	SEGMENT_LAST_SENT_HASH_KEY = 'HIGHLIGHT_SEGMENT_LAST_SENT_HASH_KEY',
 	SESSION_DATA = 'sessionData',
-	SESSION_SECURE_ID = 'sessionSecureID',
 	USER_IDENTIFIER = 'highlightIdentifier',
 	USER_OBJECT = 'highlightUserObject',
 	PAYLOAD_ID = 'payloadId',

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -1,5 +1,11 @@
 # highlight.run
 
+## 9.1.3
+
+### Patch Changes
+
+-   efdf6b66a: fix highlight.run getSessionUrl only returning session ID
+
 ## 9.1.2
 
 ### Patch Changes

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "9.1.2",
+	"version": "9.1.3",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "9.1.2"
+export default "9.1.3"

--- a/sdk/firstload/src/index.test.tsx
+++ b/sdk/firstload/src/index.test.tsx
@@ -1,6 +1,9 @@
 import { H } from '.'
 import { HighlightPublicInterface } from '../../client/src/types/types'
-import { setSessionSecureID } from '@highlight-run/client/src/utils/sessionStorage/highlightSession'
+import {
+	setSessionData,
+	setSessionSecureID,
+} from '@highlight-run/client/src/utils/sessionStorage/highlightSession'
 
 describe('should work outside of the browser in unit test', () => {
 	let highlight: HighlightPublicInterface
@@ -48,7 +51,11 @@ describe('should work outside of the browser in unit test', () => {
 	})
 
 	it('should handle getSessionURL', async () => {
-		setSessionSecureID('https://app.highlight.io/1/sessions/foo')
+		setSessionData({
+			sessionSecureID: 'foo',
+			projectID: 1,
+		})
+		setSessionSecureID('foo')
 		expect(await highlight.getSessionURL()).toBe(
 			'https://app.highlight.io/1/sessions/foo',
 		)

--- a/sdk/firstload/src/index.test.tsx
+++ b/sdk/firstload/src/index.test.tsx
@@ -54,6 +54,7 @@ describe('should work outside of the browser in unit test', () => {
 		setSessionData({
 			sessionSecureID: 'foo',
 			projectID: 1,
+			lastPushTime: new Date().getTime(),
 		})
 		setSessionSecureID('foo')
 		expect(await highlight.getSessionURL()).toBe(

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -19,6 +19,7 @@ import {
 
 import { FirstLoadListeners } from '@highlight-run/client/src/listeners/first-load-listeners.js'
 import { GenerateSecureID } from '@highlight-run/client/src/utils/secure-id.js'
+import { HIGHLIGHT_URL } from '@highlight-run/client/src/constants/sessions.js'
 import { HighlightSegmentMiddleware } from './integrations/segment.js'
 import configureElectronHighlight from './environments/electron.js'
 import firstloadVersion from './__generated/version.js'
@@ -470,9 +471,12 @@ const H: HighlightPublicInterface = {
 	},
 	getSessionURL: () => {
 		return new Promise<string>((resolve, reject) => {
-			const res = getSessionSecureID()
-			if (res) {
-				resolve(res)
+			const data = getPreviousSessionData()
+			const sessionSecureID = getSessionSecureID()
+			if (data && sessionSecureID) {
+				resolve(
+					`https://${HIGHLIGHT_URL}/${data.projectID}/sessions/${sessionSecureID}`,
+				)
 			} else {
 				reject(new Error('Unable to get session URL'))
 			}

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -475,7 +475,9 @@ const H: HighlightPublicInterface = {
 		if (data && sessionSecureID) {
 			return `https://${HIGHLIGHT_URL}/${data.projectID}/sessions/${sessionSecureID}`
 		} else {
-			throw new Error('Unable to get session URL')
+			throw new Error(
+				`Unable to get session URL: ${data?.projectID}, ${sessionSecureID}}`,
+			)
 		}
 	},
 	getSessionDetails: async () => {

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -469,44 +469,38 @@ const H: HighlightPublicInterface = {
 			)
 		}
 	},
-	getSessionURL: () => {
-		return new Promise<string>((resolve, reject) => {
-			const data = getPreviousSessionData()
-			const sessionSecureID = getSessionSecureID()
-			if (data && sessionSecureID) {
-				resolve(
-					`https://${HIGHLIGHT_URL}/${data.projectID}/sessions/${sessionSecureID}`,
-				)
-			} else {
-				reject(new Error('Unable to get session URL'))
-			}
-		})
+	getSessionURL: async () => {
+		const data = getPreviousSessionData()
+		const sessionSecureID = getSessionSecureID()
+		if (data && sessionSecureID) {
+			return `https://${HIGHLIGHT_URL}/${data.projectID}/sessions/${sessionSecureID}`
+		} else {
+			throw new Error('Unable to get session URL')
+		}
 	},
-	getSessionDetails: () => {
-		return new Promise<SessionDetails>((resolve, reject) => {
-			H.onHighlightReady(() => {
-				const baseUrl = highlight_obj.getCurrentSessionURL()
-				if (baseUrl) {
-					const currentSessionTimestamp =
-						highlight_obj.getCurrentSessionTimestamp()
-					const now = new Date().getTime()
-					const url = new URL(baseUrl)
-					const urlWithTimestamp = new URL(baseUrl)
-					urlWithTimestamp.searchParams.set(
-						'ts',
-						// The delta between when the session recording started and now.
-						((now - currentSessionTimestamp) / 1000).toString(),
-					)
+	getSessionDetails: async () => {
+		const baseUrl = await H.getSessionURL()
+		const sessionData = getPreviousSessionData()
+		if (!baseUrl) {
+			throw new Error('Could not get session URL')
+		}
+		const currentSessionTimestamp = sessionData?.sessionStartTime
+		if (!currentSessionTimestamp) {
+			throw new Error('Could not get session start timestamp')
+		}
+		const now = new Date().getTime()
+		const url = new URL(baseUrl)
+		const urlWithTimestamp = new URL(baseUrl)
+		urlWithTimestamp.searchParams.set(
+			'ts',
+			// The delta between when the session recording started and now.
+			((now - currentSessionTimestamp) / 1000).toString(),
+		)
 
-					resolve({
-						url: url.toString(),
-						urlWithTimestamp: urlWithTimestamp.toString(),
-					})
-				} else {
-					reject(new Error('Could not get session URL'))
-				}
-			})
-		})
+		return {
+			url: url.toString(),
+			urlWithTimestamp: urlWithTimestamp.toString(),
+		} as SessionDetails
 	},
 	getRecordingState: () => {
 		return highlight_obj?.state ?? 'NotRecording'

--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @highlight-run/next
 
+## 7.5.14
+
+### Patch Changes
+
+-   Updated dependencies [efdf6b66a]
+    -   highlight.run@9.1.3
+    -   @highlight-run/node@3.9.0
+
 ## 7.5.13
 
 ### Patch Changes

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "7.5.13",
+	"version": "7.5.14",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-remix/CHANGELOG.md
+++ b/sdk/highlight-remix/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @highlight-run/remix
 
+## 2.0.45
+
+### Patch Changes
+
+-   Updated dependencies [efdf6b66a]
+    -   highlight.run@9.1.3
+    -   @highlight-run/node@3.9.0
+
 ## 2.0.44
 
 ### Patch Changes

--- a/sdk/highlight-remix/package.json
+++ b/sdk/highlight-remix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/remix",
-	"version": "2.0.44",
+	"version": "2.0.45",
 	"description": "Client for interfacing with Highlight in Remix",
 	"packageManager": "yarn@4.0.2",
 	"author": "",

--- a/sdk/highlight-remix/src/client.tsx
+++ b/sdk/highlight-remix/src/client.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect } from 'react'
+import { useEffect } from 'react'
 
 import Cookies from 'js-cookie'
-import { H } from 'highlight.run'
 import type { HighlightOptions } from 'highlight.run'
-import { SESSION_STORAGE_KEYS } from '@highlight-run/client/src/utils/sessionStorage/sessionStorageKeys'
+import { H } from 'highlight.run'
+import { SESSION_SECURE_ID } from './constants'
 
 export { H } from 'highlight.run'
 
@@ -30,10 +30,7 @@ export function HighlightInit({
 			}
 
 			if (sessionSecureID) {
-				Cookies.set(
-					SESSION_STORAGE_KEYS.SESSION_SECURE_ID,
-					sessionSecureID,
-				)
+				Cookies.set(SESSION_SECURE_ID, sessionSecureID)
 			}
 		}
 	}, [projectId, highlightOptions])

--- a/sdk/highlight-remix/src/constants.ts
+++ b/sdk/highlight-remix/src/constants.ts
@@ -1,0 +1,1 @@
+export const SESSION_SECURE_ID = 'sessionSecureID'

--- a/sdk/highlight-remix/src/server.ts
+++ b/sdk/highlight-remix/src/server.ts
@@ -1,6 +1,6 @@
 import { H, NodeOptions } from '@highlight-run/node'
 import type { DataFunctionArgs } from '@remix-run/node'
-import { SESSION_STORAGE_KEYS } from '@highlight-run/client/src/utils/sessionStorage/sessionStorageKeys'
+import { SESSION_SECURE_ID } from './constants'
 
 export { H } from '@highlight-run/node'
 
@@ -11,10 +11,7 @@ export function HandleError(nodeOptions: NodeOptions) {
 		if (error instanceof Error) {
 			const cookies = parseCookies(request.headers.get('Cookie') ?? '')
 
-			H.consumeError(
-				error,
-				cookies[SESSION_STORAGE_KEYS.SESSION_SECURE_ID],
-			)
+			H.consumeError(error, cookies[SESSION_SECURE_ID])
 		}
 	}
 }

--- a/sdk/highlight-remix/tsconfig.json
+++ b/sdk/highlight-remix/tsconfig.json
@@ -6,7 +6,6 @@
 			"dom.iterable",
 			"esnext"
 		],
-		"composite": true,
 		"skipLibCheck": true,
 		"esModuleInterop": true,
 		"allowSyntheticDefaultImports": true,


### PR DESCRIPTION
## Summary

* Fixes `getSessionURL` to return the full session url
* Updates `getSessionDetails` to return the URL with timestamp without blocking for the client.

## How did you test this change?

new cypress test additions

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
