### PR TITLE
Send confirmation alerts

### DIFF
--- a/backend/alerts/v2/destinations/destinations.go
+++ b/backend/alerts/v2/destinations/destinations.go
@@ -7,6 +7,25 @@ import (
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 )
 
+type NotificationType string
+
+const (
+	NotificationTypeAlertCreated NotificationType = "alert_created"
+	NotificationTypeAlertUpdated NotificationType = "alert_updated"
+)
+
+type NotificationInput struct {
+	NotificationType NotificationType
+	WorkspaceID      int
+	AlertUpsertInput *AlertUpsertInput
+}
+
+type AlertUpsertInput struct {
+	Alert *model.Alert
+	Admin *model.Admin
+}
+
+// specific to alert notifications
 type AlertInput struct {
 	Alert        *model.Alert
 	AlertLink    string

--- a/backend/alerts/v2/destinations/microsoft-teams/templates/alert-upsert.go
+++ b/backend/alerts/v2/destinations/microsoft-teams/templates/alert-upsert.go
@@ -1,0 +1,26 @@
+package microsoftteamsV2_templates
+
+type AlertUpsertPayload struct {
+	AdminName   string
+	AlertAction string
+	AlertName   string
+	AlertUrl    string
+}
+
+var AlertUpsertMessageTemplate = []byte(`{
+	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+	"type": "AdaptiveCard",
+	"version": "1.6",
+	"body": [
+		{
+			"type":   "TextBlock",
+			"size":   "Large",
+			"weight": "Bolder",
+			"text":   "Alert {{.AlertAction}}!"
+		},
+		{
+			"type":   "TextBlock",
+			"text":   "{{.AdminName}} has {{.AlertAction}} the alert '[{{.AlertName}}]({{.AlertUrl}})'."
+		}
+	]
+  }`)

--- a/backend/lambda/lambda.go
+++ b/backend/lambda/lambda.go
@@ -185,6 +185,8 @@ const (
 	ReactEmailTemplateMetricsAlert  ReactEmailTemplate = "metrics-alert"
 	// session insights
 	ReactEmailTemplateSessionInsights ReactEmailTemplate = "session-insights"
+	// notifications
+	ReactEmailTemplateAlertUpsert ReactEmailTemplate = "alert-upsert"
 )
 
 func (s *Client) GetSessionInsightEmailHtml(ctx context.Context, toEmail string, unsubscribeUrl string, data utils.SessionInsightsData) (string, error) {

--- a/packages/react-email-templates/emails/alert-upsert.tsx
+++ b/packages/react-email-templates/emails/alert-upsert.tsx
@@ -1,0 +1,35 @@
+import { Text, Link } from '@react-email/components'
+import * as React from 'react'
+
+import { EmailHtml, HighlightLogo } from '../components/common'
+import { Break, Footer, textStyle, Title } from '../components/alerts'
+
+export interface AlertUpsertEmailProps {
+	adminName?: string
+	alertAction?: string
+	alertLink?: string
+	alertName?: string
+}
+
+export const AlertUpsertEmail = ({
+	adminName = 'Spencer',
+	alertAction = 'created',
+	alertLink = 'https://localhost:3000/1/alerts/1',
+	alertName = 'Log Alert',
+}: AlertUpsertEmailProps) => (
+	<EmailHtml previewText={`${alertName} alert ${alertAction}`}>
+		<HighlightLogo />
+		<Title>Alert {alertAction}</Title>
+
+		<Text style={textStyle}>
+			{adminName} has {alertAction} the alert "
+			<Link href={alertLink}>{alertName}</Link>"
+		</Text>
+
+		<Break />
+
+		<Footer alertLink={alertLink} />
+	</EmailHtml>
+)
+
+export default AlertUpsertEmail

--- a/packages/react-email-templates/emails/index.tsx
+++ b/packages/react-email-templates/emails/index.tsx
@@ -11,6 +11,7 @@ import { SessionsAlertV2Email } from './sessions-alert-v2'
 import { TracesAlertV2Email } from './traces-alert-v2'
 import { ErrorsAlertV2Email } from './errors-alert-v2'
 import { MetricsAlertV2Email } from './metrics-alert-v2'
+import { AlertUpsertEmail } from './alert-upsert'
 
 export {
 	ErrorAlertEmail,
@@ -26,4 +27,5 @@ export {
 	LogsAlertV2Email,
 	TracesAlertV2Email,
 	MetricsAlertV2Email,
+	AlertUpsertEmail,
 }

--- a/packages/react-email-templates/src/index.ts
+++ b/packages/react-email-templates/src/index.ts
@@ -14,6 +14,7 @@ import {
 	LogsAlertV2Email,
 	TracesAlertV2Email,
 	MetricsAlertV2Email,
+	AlertUpsertEmail,
 } from '../emails'
 
 export const handler = async (event?: APIGatewayEvent) => {
@@ -65,6 +66,8 @@ const getEmailTemplate = (template: string) => {
 			return TracesAlertV2Email
 		case 'metrics-alert':
 			return MetricsAlertV2Email
+		case 'alert-upsert':
+			return AlertUpsertEmail
 		default:
 			console.error('No email template found for ', template)
 	}


### PR DESCRIPTION
## Summary
Send a confirmation notification to the destinations when an alert is created/updated

<img width="508" alt="Screenshot 2024-07-30 at 5 12 15 PM" src="https://github.com/user-attachments/assets/ce2d37a0-c600-4129-8a32-9556469a7b17">
<img width="527" alt="Screenshot 2024-07-30 at 5 12 27 PM" src="https://github.com/user-attachments/assets/11b3b336-b299-4b59-a776-dea41f7b9ffa">
<img width="930" alt="Screenshot 2024-07-30 at 5 12 38 PM" src="https://github.com/user-attachments/assets/83a9230f-ba96-45b5-9010-28f065bf41a2">

![Screenshot 2024-07-30 at 4 55 28 PM](https://github.com/user-attachments/assets/e3ab7dda-b868-4fa0-8681-f87c4f13ade7)

## How did you test this change?
When creating an alert, add each type of destination to the alert. Confirm the confirmations for:
- [ ] Slack
- [ ] Discord
- [ ] Microsoft teams
- [ ] Email
- [ ] Webhook

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A