### PR TITLE
Switch turbo lambda order

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -104,13 +104,13 @@ jobs:
               if: github.ref == 'refs/heads/main'
               run: yarn publish:ai
 
-            - name: Publish render lambda
-              if: github.ref == 'refs/heads/main'
-              run: yarn publish:render
-
             - name: Publish session-insights-email lambda
               if: github.ref == 'refs/heads/main'
               run: yarn publish:react-email-templates
+
+            - name: Publish render lambda
+              if: github.ref == 'refs/heads/main'
+              run: yarn publish:render
 
             - name: Publish changesets
               if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary
Publishing to `session-insights-email` lambda is blocked by a failing publish to render lambda. Switch the order to unblock while debugging

## How did you test this change?
N/A

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
