### PR TITLE
fix public session unsharing

### DIFF
--- a/backend/private-graph/graph/resolver_test.go
+++ b/backend/private-graph/graph/resolver_test.go
@@ -1084,10 +1084,15 @@ func TestUpdateSessionIsPublic(t *testing.T) {
 		}
 
 		workspace := model.Workspace{
-			Name:   ptr.String("test1"),
-			Admins: []model.Admin{admin},
+			Name: ptr.String("test1"),
 		}
 		if err := DB.Create(&workspace).Error; err != nil {
+			t.Fatal(e.Wrap(err, "error inserting workspace"))
+		}
+
+		if err := DB.Create(&model.WorkspaceAdmin{
+			WorkspaceID: workspace.ID, AdminID: admin.ID,
+		}).Error; err != nil {
 			t.Fatal(e.Wrap(err, "error inserting workspace"))
 		}
 

--- a/backend/private-graph/graph/resolver_test.go
+++ b/backend/private-graph/graph/resolver_test.go
@@ -1078,10 +1078,7 @@ func TestAdminEmailAddresses(t *testing.T) {
 
 func TestUpdateSessionIsPublic(t *testing.T) {
 	util.RunTestWithDBWipe(t, DB, func(t *testing.T) {
-		admin := model.Admin{
-			Model: model.Model{ID: 1},
-			UID:   ptr.String("a1b2c3"),
-		}
+		admin := model.Admin{UID: ptr.String("TestUpdateSessionIsPublic")}
 		if err := DB.Create(&admin).Error; err != nil {
 			t.Fatal(e.Wrap(err, "error inserting admin"))
 		}

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -4107,9 +4107,10 @@ func (r *mutationResolver) UpdateSessionIsPublic(ctx context.Context, sessionSec
 	if !settings.EnableUnlistedSharing {
 		return nil, AuthorizationError
 	}
-	if err := r.DB.WithContext(ctx).Model(session).Updates(&model.Session{
-		IsPublic: isPublic,
-	}).Error; err != nil {
+	if err := r.DB.WithContext(ctx).
+		Model(session).
+		Select("IsPublic").
+		Updates(&model.Session{IsPublic: isPublic}).Error; err != nil {
 		return nil, e.Wrap(err, "error updating session is_public")
 	}
 


### PR DESCRIPTION
## Summary

Unsharing a session would not persist the update because gorm does not update a `false` value
without an explicit `Select()` statement listing the column, since `false` is the default value.

## How did you test this change?

locally unsharing a session saving the update
new unit test

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no