### PR TITLE
avoid resending product overage emails

### DIFF
--- a/backend/email/email.go
+++ b/backend/email/email.go
@@ -52,6 +52,13 @@ const (
 	BillingInvalidPayment         EmailType = "BillingInvalidPayment"
 )
 
+var OneTimeBillingNotifications = []EmailType{
+	BillingSessionOverage,
+	BillingErrorsOverage,
+	BillingLogsOverage,
+	BillingTracesOverage,
+}
+
 func SendReactEmailAlert(ctx context.Context, MailClient *sendgrid.Client, email string, html string, subjectLine string) error {
 	to := &mail.Email{Address: email}
 	from := mail.NewEmail("Highlight", SendGridOutboundEmail)

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -1372,7 +1372,7 @@ func (r *Resolver) updateAWSMPBillingDetails(ctx context.Context, workspaceID in
 	log.WithContext(ctx).WithField("workspace_id", workspace.ID).WithField("customer", *customer).Info("billing update for aws mp")
 	now := time.Now()
 	end := time.Now().AddDate(0, 1, 0)
-	if err := r.updateBillingDetails(ctx, workspace, &planDetails{
+	if err := r.updateBillingDetails(ctx, workspace.ID, &planDetails{
 		tier:               pricing.AWSMPProducts[*customer.ProductCode],
 		unlimitedMembers:   true,
 		billingPeriodStart: &now,
@@ -1437,7 +1437,7 @@ func (r *Resolver) updateStripeBillingDetails(ctx context.Context, stripeCustome
 		return e.Wrapf(err, "BILLING_ERROR error retrieving workspace for customer %s", stripeCustomerID)
 	}
 
-	if err := r.updateBillingDetails(ctx, &workspace, &details); err != nil {
+	if err := r.updateBillingDetails(ctx, workspace.ID, &details); err != nil {
 		return e.Wrap(err, "BILLING_ERROR error updating billing details for stripe usage")
 	}
 
@@ -1456,7 +1456,34 @@ type planDetails struct {
 	nextInvoiceDate    *time.Time
 }
 
-func (r *Resolver) updateBillingDetails(ctx context.Context, workspace *model.Workspace, details *planDetails) error {
+func (r *Resolver) updateBillingDetails(ctx context.Context, workspaceID int, details *planDetails) error {
+	var workspace model.Workspace
+	if err := r.DB.WithContext(ctx).
+		Model(&model.Workspace{}).
+		Where(model.Workspace{Model: model.Model{ID: workspaceID}}).
+		Take(&workspace).Error; err != nil {
+		return e.Wrapf(err, "BILLING_ERROR error querying workspace %d", workspaceID)
+	}
+
+	// Make previous billing history email records inactive (so new active records can be added) once we start a new billing period
+	bpStart := time.Now().Truncate(time.Hour * 24 * 30)
+	if workspace.NextInvoiceDate != nil {
+		bpStart = (*workspace.NextInvoiceDate).AddDate(0, -1, 0)
+	} else if workspace.BillingPeriodStart != nil {
+		bpStart = *workspace.BillingPeriodStart
+	}
+	if err := r.DB.WithContext(ctx).Model(&model.BillingEmailHistory{}).
+		Where(model.BillingEmailHistory{Active: true, WorkspaceID: workspace.ID}).
+		Where("type not in ?", Email.OneTimeBillingNotifications).
+		Where("created_at < ?", bpStart).
+		Updates(map[string]interface{}{
+			"Active":      false,
+			"WorkspaceID": workspace.ID,
+			"DeletedAt":   time.Now(),
+		}).Error; err != nil {
+		return e.Wrapf(err, "BILLING_ERROR error updating BillingEmailHistory objects for workspace %d", workspace.ID)
+	}
+
 	updates := map[string]interface{}{
 		"PlanTier":           string(details.tier),
 		"UnlimitedMembers":   details.unlimitedMembers,
@@ -1466,22 +1493,11 @@ func (r *Resolver) updateBillingDetails(ctx context.Context, workspace *model.Wo
 		"TrialEndDate":       nil,
 	}
 
-	if err := r.DB.WithContext(ctx).Model(&model.Workspace{}).
-		Where(model.Workspace{Model: model.Model{ID: workspace.ID}}).
+	if err := r.DB.WithContext(ctx).
+		Model(&model.Workspace{}).
+		Where(model.Workspace{Model: model.Model{ID: workspaceID}}).
 		Updates(updates).Error; err != nil {
-		return e.Wrapf(err, "BILLING_ERROR error updating workspace fields for workspace %d", workspace.ID)
-	}
-
-	// Make previous billing history email records inactive (so new active records can be added)
-	if err := r.DB.WithContext(ctx).Model(&model.BillingEmailHistory{}).
-		Where(model.BillingEmailHistory{Active: true, WorkspaceID: workspace.ID}).
-		Where("type not in ?", Email.OneTimeBillingNotifications).
-		Updates(map[string]interface{}{
-			"Active":      false,
-			"WorkspaceID": workspace.ID,
-			"DeletedAt":   time.Now(),
-		}).Error; err != nil {
-		return e.Wrapf(err, "BILLING_ERROR error updating BillingEmailHistory objects for workspace %d", workspace.ID)
+		return e.Wrapf(err, "BILLING_ERROR error updating workspace fields for workspace %d", workspaceID)
 	}
 
 	// clear redis cache for stripe customer data

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -1475,6 +1475,7 @@ func (r *Resolver) updateBillingDetails(ctx context.Context, workspace *model.Wo
 	// Make previous billing history email records inactive (so new active records can be added)
 	if err := r.DB.WithContext(ctx).Model(&model.BillingEmailHistory{}).
 		Where(model.BillingEmailHistory{Active: true, WorkspaceID: workspace.ID}).
+		Where("type not in ?", Email.OneTimeBillingNotifications).
 		Updates(map[string]interface{}{
 			"Active":      false,
 			"WorkspaceID": workspace.ID,

--- a/backend/private-graph/graph/resolver_test.go
+++ b/backend/private-graph/graph/resolver_test.go
@@ -1157,9 +1157,9 @@ func TestQueryResolver_updateBillingDetails(t *testing.T) {
 		end := start.AddDate(0, 1, 0)
 		workspace := model.Workspace{
 			Name:               ptr.String("test1"),
-			NextInvoiceDate:    &end,
 			BillingPeriodStart: &start,
 			BillingPeriodEnd:   &end,
+			NextInvoiceDate:    &end,
 		}
 		if err := DB.Create(&workspace).Error; err != nil {
 			t.Fatal(e.Wrap(err, "error inserting workspace"))
@@ -1185,7 +1185,9 @@ func TestQueryResolver_updateBillingDetails(t *testing.T) {
 		ctx := context.Background()
 		r := &queryResolver{Resolver: &Resolver{DB: DB, Redis: redis.NewClient()}}
 
-		err := r.updateBillingDetails(ctx, workspace.ID, &planDetails{})
+		err := r.updateBillingDetails(ctx, workspace.ID, &planDetails{
+			modelInputs.PlanTypeEnterprise, true, &start, &end, &end,
+		})
 		assert.NoError(t, err)
 
 		hs = model.BillingEmailHistory{}

--- a/backend/private-graph/graph/resolver_test.go
+++ b/backend/private-graph/graph/resolver_test.go
@@ -1189,7 +1189,7 @@ func TestQueryResolver_updateBillingDetails(t *testing.T) {
 		assert.False(t, hs.Active)
 
 		hs = model.BillingEmailHistory{}
-		if err := DB.Debug().Model(&model.BillingEmailHistory{}).Where(&model.BillingEmailHistory{Type: email.BillingSessionOverage}).Take(&hs).Error; err != nil {
+		if err := DB.Model(&model.BillingEmailHistory{}).Where(&model.BillingEmailHistory{Type: email.BillingSessionOverage}).Take(&hs).Error; err != nil {
 			t.Fatal(e.Wrap(err, "error querying BillingEmailHistory"))
 		}
 		assert.True(t, hs.Active)


### PR DESCRIPTION
## Summary

Product overage charges would be resent every time a billing update occurred because
the email history for those email types would be cleared.

Avoid clearing the overage email types and only clear other types after a billing period is over.

## How did you test this change?

new unit test

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
