### PR TITLE
update support button to reference email link

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -57,7 +57,6 @@ import analytics from '@util/analytics'
 import { auth } from '@util/auth'
 import { isProjectWithinTrial } from '@util/billing/billing'
 import { titleCaseString } from '@util/string'
-import { showSupportMessage } from '@util/window'
 import { Divider } from 'antd'
 import clsx from 'clsx'
 import moment from 'moment'
@@ -775,7 +774,11 @@ export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 											</Menu.Item>
 											<Menu.Item
 												onClick={() => {
-													showSupportMessage()
+													window.open(
+														`mailto:sales@highlight.run?subject=Highlight Support` +
+															`&body=I need some help with my project ID ${projectId}.`,
+														'_blank',
+													)
 												}}
 											>
 												<Box


### PR DESCRIPTION
## Summary

* Updates the `Chat / Support` button to our sales email.

## How did you test this change?

[reflame](https://app.highlight.io/1/sessions?%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201J47FXHHJ6A9J99YECS7KEFDV%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22vadim%2Fsupport-button%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D)

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
