### PR TITLE
fix otel webjs tracer creation when otel code has not loaded

### DIFF
--- a/.changeset/calm-years-repeat.md
+++ b/.changeset/calm-years-repeat.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+fix otel webjs startSpan crashing when otel code has not loaded

--- a/.changeset/calm-years-repeat.md
+++ b/.changeset/calm-years-repeat.md
@@ -1,5 +1,0 @@
----
-'highlight.run': patch
----
-
-fix otel webjs startSpan crashing when otel code has not loaded

--- a/backend/assets/assets_test.go
+++ b/backend/assets/assets_test.go
@@ -12,7 +12,7 @@ func TestCreateLogDrain(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(HandleAsset))
 	defer server.Close()
 
-	resp, err := http.Get(fmt.Sprintf("%s?src=test&url=https://app.highlight.io/~r_app.webmanifest?~r_rid=knQ44NI79K8s_IOq_MbHMZ0JjqY", server.URL))
+	resp, err := http.Get(fmt.Sprintf("%s?src=test&url=https://preview.highlight.io/~r_app.webmanifest?~r_rid=knQ44NI79K8s_IOq_MbHMZ0JjqY", server.URL))
 	assert.NoError(t, err)
 	assert.Equal(t, resp.StatusCode, 200)
 	assert.Greater(t, resp.ContentLength, int64(256))

--- a/backend/private-graph/graph/resolver_test.go
+++ b/backend/private-graph/graph/resolver_test.go
@@ -1078,7 +1078,7 @@ func TestAdminEmailAddresses(t *testing.T) {
 
 func TestUpdateSessionIsPublic(t *testing.T) {
 	util.RunTestWithDBWipe(t, DB, func(t *testing.T) {
-		admin := model.Admin{UID: ptr.String("TestUpdateSessionIsPublic")}
+		admin := model.Admin{UID: ptr.String("a1b2c3")}
 		if err := DB.Create(&admin).Error; err != nil {
 			t.Fatal(e.Wrap(err, "error inserting admin"))
 		}

--- a/backend/stacktraces/enhancer_test.go
+++ b/backend/stacktraces/enhancer_test.go
@@ -277,7 +277,7 @@ func TestEnhanceStackTrace(t *testing.T) {
 		"test reflame": {
 			stackFrameInput: []*publicModelInput.StackFrameInput{
 				{
-					FileName:     ptr.String("https://app.highlight.io/~r/chunks/X3XZGGFJ.js?~r_rid=G5Qjykm00SuMZ-DTpV_ckUGZvRg"),
+					FileName:     ptr.String("https://preview.highlight.io/~r/chunks/X3XZGGFJ.js?~r_rid=G5Qjykm00SuMZ-DTpV_ckUGZvRg"),
 					LineNumber:   ptr.Int(1),
 					ColumnNumber: ptr.Int(1656),
 				},

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -1,5 +1,11 @@
 # highlight.run
 
+## 9.1.2
+
+### Patch Changes
+
+-   50dba067f: fix otel webjs startSpan crashing when otel code has not loaded
+
 ## 9.1.1
 
 ### Patch Changes

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "9.1.1",
+	"version": "9.1.2",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "9.1.1"
+export default "9.1.2"

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -403,7 +403,7 @@ const H: HighlightPublicInterface = {
 		const tracer = typeof getTracer === 'function' ? getTracer() : undefined
 		if (!tracer) {
 			if (typeof fn === 'function') {
-				return await fn()
+				return fn()
 			}
 			return
 		}

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -398,11 +398,13 @@ const H: HighlightPublicInterface = {
 		name: string,
 		options: SpanOptions | ((span: Span) => any),
 		context?: Context | ((span: Span) => any),
-		fn?: (span: Span) => any,
+		fn?: (span?: Span) => any,
 	): any => {
-		const tracer = getTracer()
-
+		const tracer = typeof getTracer === 'function' ? getTracer() : undefined
 		if (!tracer) {
+			if (typeof fn === 'function') {
+				return await fn()
+			}
 			return
 		}
 

--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @highlight-run/next
 
+## 7.5.13
+
+### Patch Changes
+
+-   Updated dependencies [50dba067f]
+    -   highlight.run@9.1.2
+    -   @highlight-run/node@3.9.0
+
 ## 7.5.12
 
 ### Patch Changes

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "7.5.12",
+	"version": "7.5.13",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-remix/CHANGELOG.md
+++ b/sdk/highlight-remix/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @highlight-run/remix
 
+## 2.0.44
+
+### Patch Changes
+
+-   Updated dependencies [50dba067f]
+    -   highlight.run@9.1.2
+    -   @highlight-run/node@3.9.0
+
 ## 2.0.43
 
 ### Patch Changes

--- a/sdk/highlight-remix/package.json
+++ b/sdk/highlight-remix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/remix",
-	"version": "2.0.43",
+	"version": "2.0.44",
 	"description": "Client for interfacing with Highlight in Remix",
 	"packageManager": "yarn@4.0.2",
 	"author": "",


### PR DESCRIPTION
## Summary

Ensures that calling `H.startSpan()` before the otel library has loaded resolves 
and calls the `fn` but without a span, preventing a delay and crash of the library.

## How did you test this change?

render preview of our frontend

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
