### PR TITLE
Flip view type and source form inputs

### DIFF
--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -511,21 +511,6 @@ export const GraphingEditor: React.FC = () => {
 								<Divider className="m-0" />
 								<SidebarSection>
 									<LabeledRow
-										label="Source"
-										name="source"
-										tooltip="The resource being queried, one of the four highlight.io resources."
-									>
-										<OptionDropdown<ProductType>
-											options={PRODUCTS}
-											selection={productType}
-											setSelection={setProductType}
-											icons={PRODUCT_ICONS}
-										/>
-									</LabeledRow>
-								</SidebarSection>
-								<Divider className="m-0" />
-								<SidebarSection>
-									<LabeledRow
 										label="View type"
 										name="viewType"
 									>
@@ -561,6 +546,21 @@ export const GraphingEditor: React.FC = () => {
 											}
 										/>
 									)}
+								</SidebarSection>
+								<Divider className="m-0" />
+								<SidebarSection>
+									<LabeledRow
+										label="Source"
+										name="source"
+										tooltip="The resource being queried, one of the four highlight.io resources."
+									>
+										<OptionDropdown<ProductType>
+											options={PRODUCTS}
+											selection={productType}
+											setSelection={setProductType}
+											icons={PRODUCT_ICONS}
+										/>
+									</LabeledRow>
 								</SidebarSection>
 								<Divider className="m-0" />
 								<SidebarSection>


### PR DESCRIPTION
## Summary
When working with funnels and retention charts, the source may be dependent on the type of chart. Change the order to have the type of chart above the source

## How did you test this change?
1. View metrics
- [ ] View type appears above source

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
