### PR TITLE
fix otel webjs event monkeypatch breaking mouse event listeners

### DIFF
--- a/.changeset/hungry-ravens-invite.md
+++ b/.changeset/hungry-ravens-invite.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+fix otel webjs event monkeypatch breaking mouse event listeners

--- a/.changeset/hungry-ravens-invite.md
+++ b/.changeset/hungry-ravens-invite.md
@@ -1,5 +1,0 @@
----
-'highlight.run': patch
----
-
-fix otel webjs event monkeypatch breaking mouse event listeners

--- a/sdk/client/src/otel/user-interaction.ts
+++ b/sdk/client/src/otel/user-interaction.ts
@@ -247,9 +247,9 @@ export class UserInteractionInstrumentation extends InstrumentationBase {
 					// Don't capture mousemove events too frequently
 					if (
 						event?.type === 'mousemove' &&
-						Date.now() - lastEventTimestamp < 100
+						Date.now() - lastEventTimestamp < 1000 / 60
 					) {
-						return
+						return original.call(this, type, listener, useCapture)
 					}
 
 					lastEventTimestamp = Date.now()

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -297,16 +297,16 @@ export declare interface HighlightPublicInterface {
 	 * @param callbackFn The function to run in the span.
 	 */
 	startSpan: {
-		<F extends (span: Span) => ReturnType<F>>(
+		<F extends (span?: Span) => ReturnType<F>>(
 			name: string,
 			fn: F,
 		): ReturnType<F>
-		<F extends (span: Span) => ReturnType<F>>(
+		<F extends (span?: Span) => ReturnType<F>>(
 			name: string,
 			options: SpanOptions,
 			fn: F,
 		): ReturnType<F>
-		<F extends (span: Span) => ReturnType<F>>(
+		<F extends (span?: Span) => ReturnType<F>>(
 			name: string,
 			options: SpanOptions,
 			context: Context,

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -1,5 +1,11 @@
 # highlight.run
 
+## 9.1.4
+
+### Patch Changes
+
+-   3e99f48ca: fix otel webjs event monkeypatch breaking mouse event listeners
+
 ## 9.1.3
 
 ### Patch Changes

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "9.1.3",
+	"version": "9.1.4",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "9.1.3"
+export default "9.1.4"

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -70,7 +70,7 @@ let onHighlightReadyTimeout: number | undefined = undefined
 let highlight_obj: Highlight
 let first_load_listeners: FirstLoadListeners
 let init_called = false
-type Callback = (span: Span) => any
+type Callback = (span?: Span) => any
 let getTracer: () => Tracer
 const H: HighlightPublicInterface = {
 	options: undefined,
@@ -397,14 +397,18 @@ const H: HighlightPublicInterface = {
 	},
 	startSpan: (
 		name: string,
-		options: SpanOptions | ((span: Span) => any),
-		context?: Context | ((span: Span) => any),
+		options: SpanOptions | ((span?: Span) => any),
+		context?: Context | ((span?: Span) => any),
 		fn?: (span?: Span) => any,
 	): any => {
 		const tracer = typeof getTracer === 'function' ? getTracer() : undefined
 		if (!tracer) {
-			if (typeof fn === 'function') {
-				return fn()
+			if (fn === undefined && context === undefined) {
+				;(options as Callback)()
+			} else if (fn === undefined) {
+				;(context as Callback)()
+			} else {
+				fn()
 			}
 			return
 		}

--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @highlight-run/next
 
+## 7.5.15
+
+### Patch Changes
+
+-   Updated dependencies [3e99f48ca]
+    -   highlight.run@9.1.4
+    -   @highlight-run/node@3.9.0
+
 ## 7.5.14
 
 ### Patch Changes

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "7.5.14",
+	"version": "7.5.15",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-remix/CHANGELOG.md
+++ b/sdk/highlight-remix/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @highlight-run/remix
 
+## 2.0.46
+
+### Patch Changes
+
+-   Updated dependencies [3e99f48ca]
+    -   highlight.run@9.1.4
+    -   @highlight-run/node@3.9.0
+
 ## 2.0.45
 
 ### Patch Changes

--- a/sdk/highlight-remix/package.json
+++ b/sdk/highlight-remix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/remix",
-	"version": "2.0.45",
+	"version": "2.0.46",
 	"description": "Client for interfacing with Highlight in Remix",
 	"packageManager": "yarn@4.0.2",
 	"author": "",


### PR DESCRIPTION
## Summary

* Fix opentelemetry webjs SDK plugin breaking mouse event listeners due to debouncing logic.

## How did you test this change?

https://www.loom.com/share/675d34193d3e4c98b72518f23863e5f9

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
