### PR TITLE
Fix logs's create alert link

### DIFF
--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -201,8 +201,8 @@ const SearchForm: React.FC<SearchFormProps> = ({
 			trackingId="logs_create-alert_click"
 			onClick={() => {
 				navigate({
-					pathname: `/${projectId}/alerts/logs/new`,
-					search: location.search,
+					pathname: `/${projectId}/alerts/new`,
+					search: `${location.search}&source=${productType}`,
 				})
 			}}
 			emphasis="medium"

--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -14,7 +14,7 @@ import { useParams } from '@util/react-router/useParams'
 import { Divider } from 'antd'
 import React, { PropsWithChildren, useEffect, useMemo, useState } from 'react'
 import { Helmet } from 'react-helmet'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useDebounce } from 'react-use'
 import { ReferenceArea, ReferenceLine } from 'recharts'
 
@@ -103,6 +103,7 @@ export const AlertForm: React.FC = () => {
 	const { alert_id } = useParams<{
 		alert_id: string
 	}>()
+	const [searchParams] = useSearchParams()
 
 	const isEdit = alert_id !== undefined
 
@@ -131,14 +132,16 @@ export const AlertForm: React.FC = () => {
 	const navigate = useNavigate()
 
 	const [alertName, setAlertName] = useState('')
-	const [productType, setProductType] = useState(PRODUCTS[0])
+	const [productType, setProductType] = useState(
+		(searchParams.get('source') as ProductType) || PRODUCTS[0],
+	)
 	const [functionType, setFunctionType] = useState(FUNCTION_TYPES[0])
 	const [functionColumn, setFunctionColumn] = useState('')
 
 	const isErrorAlert = productType === ProductType.Errors
 	const isSessionAlert = productType === ProductType.Sessions
 
-	const [query, setQuery] = useState('')
+	const [query, setQuery] = useState(searchParams.get('query') ?? '')
 	const [debouncedQuery, setDebouncedQuery] = useState('')
 	useDebounce(
 		() => {


### PR DESCRIPTION
## Summary
Update the log's "Create Alert" button to link to the new alert form with the correct prefilled inputs.

https://www.loom.com/share/b2dd6fbb4be049b08fa199d05b65ef43?sid=2aabd1b7-a65e-4876-a555-2367c38daab3

## How did you test this change?
1. Create an alert from the logs page
- [ ] Linked to correct alert form
- [ ] Source is Logs
- [ ] Query is prefilled (if appropriate)

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
