### PR TITLE
Fix dev-tools overflow

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6055,7 +6055,6 @@ body {
   flex-grow: 1;
   position: relative;
   min-width: 428px;
-  z-index: 0;
 }
 ._1gpgayi7 {
   align-items: center;

--- a/frontend/src/pages/Player/styles.css.ts
+++ b/frontend/src/pages/Player/styles.css.ts
@@ -67,7 +67,6 @@ export const playerCenterColumn = style({
 	flexGrow: 1,
 	position: 'relative',
 	minWidth: MIN_CENTER_COLUMN_WIDTH,
-	zIndex: 0,
 })
 
 export const draggable = style({


### PR DESCRIPTION
## Summary
Fix the overflow of the dev tool tips menus, and make sure the resource panel is not affected

![Screenshot 2024-08-07 at 4 01 51 PM](https://github.com/user-attachments/assets/7761c0fa-8518-4797-b825-f9dae711bf27)

![Screenshot 2024-08-07 at 4 06 55 PM](https://github.com/user-attachments/assets/b448129a-58d0-4aaf-acec-6fc6ed53c448)

## How did you test this change?
1. View a session
2. Open the Network tab in Highlight dev tools
- [ ] No weird z-index issues
3. Click on a network resource
- [ ] No wierd z-index issues

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A