### PR TITLE
fix member invite modal

### DIFF
--- a/frontend/src/components/Billing/EnterpriseFeatureButton.tsx
+++ b/frontend/src/components/Billing/EnterpriseFeatureButton.tsx
@@ -30,7 +30,7 @@ type Feature = keyof typeof FEATURE_DESCRIPTIONS
 interface Props {
 	setting: keyof AllWorkspaceSettings
 	name: Feature
-	fn: () => Promise<any>
+	fn: () => any
 	onShowModal?: () => void
 	onClose?: () => void
 	className?: string

--- a/frontend/src/pages/WorkspaceTeam/WorkspaceTeam.tsx
+++ b/frontend/src/pages/WorkspaceTeam/WorkspaceTeam.tsx
@@ -61,13 +61,14 @@ const WorkspaceTeam = () => {
 					<Authorization allowedRoles={[AdminRole.Admin]}>
 						<AutoJoinForm />
 					</Authorization>
-					<InviteMemberModal
-						workspaceId={workspace_id}
-						workspaceName={data?.workspace?.name}
-						workspaceInviteLinks={data?.workspace_invite_links}
-						showModal={showModal}
-						toggleShowModal={toggleShowModal}
-					/>
+					{showModal ? (
+						<InviteMemberModal
+							workspaceId={workspace_id}
+							workspaceName={data?.workspace?.name}
+							workspaceInviteLinks={data?.workspace_invite_links}
+							toggleShowModal={toggleShowModal}
+						/>
+					) : null}
 				</div>
 
 				<Tabs<MemberKeyType>
@@ -122,33 +123,34 @@ const TabContentContainer = ({
 }: {
 	children: any
 	title: string
-	toggleInviteModal: any
+	toggleInviteModal: React.Dispatch<React.SetStateAction<boolean>>
 }) => {
 	return (
-		<EnterpriseFeatureButton
-			setting="enable_business_seats"
-			name="More than 15 team members"
-			fn={toggleInviteModal}
-			variant="basic"
-		>
-			<Box mt="8">
-				<Stack
-					mb="8"
-					align="center"
-					justify="space-between"
-					direction="row"
+		<Box mt="8">
+			<Stack
+				mb="8"
+				align="center"
+				justify="space-between"
+				direction="row"
+			>
+				<h4 className={styles.tabTitle}>{title}</h4>
+				<EnterpriseFeatureButton
+					setting="enable_business_seats"
+					name="More than 15 team members"
+					fn={() => toggleInviteModal((shown) => !shown)}
+					variant="basic"
 				>
-					<h4 className={styles.tabTitle}>{title}</h4>
 					<Button
 						trackingId="WorkspaceTeamInviteMember"
 						iconLeft={<IconSolidUserAdd />}
+						onClick={() => console.log('invite users button')}
 					>
 						Invite users
 					</Button>
-				</Stack>
-				{children}
-			</Box>
-		</EnterpriseFeatureButton>
+				</EnterpriseFeatureButton>
+			</Stack>
+			{children}
+		</Box>
 	)
 }
 

--- a/frontend/src/pages/WorkspaceTeam/components/InviteMemberModal.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/InviteMemberModal.tsx
@@ -27,13 +27,11 @@ import Button from '../../../components/Button/Button/Button'
 import styles from './InviteMemberModal.module.css'
 
 function InviteMemberModal({
-	showModal,
 	toggleShowModal,
 	workspaceId,
 	workspaceName,
 	workspaceInviteLinks,
 }: {
-	showModal: boolean
 	toggleShowModal: (value: boolean) => void
 	workspaceId?: string
 	workspaceName?: string
@@ -101,10 +99,9 @@ function InviteMemberModal({
 
 	return (
 		<Modal
-			destroyOnClose
 			centered
 			title="Invite Member"
-			visible={showModal}
+			visible
 			width={600}
 			onCancel={() => {
 				toggleShowModal(false)


### PR DESCRIPTION
## Summary

* fixes an issue with the `Invite Members` modal breaking interactivity with the page after modal is closed
* fixes pending invite deletion confirmation modal triggering invite members modal

## How did you test this change?

https://www.loom.com/share/b7b0d543c7c64353b8d01154af1eab19

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no