### PR TITLE
stop recording data when the highlightrun sdk uploads cannot keep up

### DIFF
--- a/.changeset/sixty-pans-tan.md
+++ b/.changeset/sixty-pans-tan.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': minor
+---
+
+stop recording if pushpayload cannot keep up with uploading data

--- a/.changeset/sixty-pans-tan.md
+++ b/.changeset/sixty-pans-tan.md
@@ -1,5 +1,0 @@
----
-'highlight.run': minor
----
-
-stop recording if pushpayload cannot keep up with uploading data

--- a/sdk/client/src/constants/sessions.ts
+++ b/sdk/client/src/constants/sessions.ts
@@ -38,4 +38,7 @@ export const SNAPSHOT_SETTINGS = {
 // Debounce duplicate visibility events
 export const VISIBILITY_DEBOUNCE_MS = 100
 
+// Max allowed time to upload to public graph before triggering recording kill switch
+export const UPLOAD_TIMEOUT = 1000 * 15
+
 export const HIGHLIGHT_URL = 'app.highlight.io'

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -235,6 +235,12 @@ export class Highlight {
 					e.data.response.tag,
 					e.data.response.payload,
 				)
+			} else if (e.data.response?.type === MessageType.Stop) {
+				HighlightWarning(
+					'Stopping recording due to worker failure',
+					e.data.response,
+				)
+				this.stopRecording(false)
 			}
 		}
 

--- a/sdk/client/src/workers/types.ts
+++ b/sdk/client/src/workers/types.ts
@@ -17,6 +17,7 @@ export enum MessageType {
 	Metrics,
 	Feedback,
 	CustomEvent,
+	Stop,
 }
 
 export type InitializeMessage = {
@@ -85,6 +86,12 @@ export type CustomEventResponse = {
 	payload: any
 }
 
+export type StopEventResponse = {
+	type: MessageType.Stop
+	requestStart: number
+	asyncEventsResponse: AsyncEventsResponse
+}
+
 export type HighlightClientWorkerParams = {
 	message:
 		| InitializeMessage
@@ -96,5 +103,5 @@ export type HighlightClientWorkerParams = {
 }
 
 export type HighlightClientWorkerResponse = {
-	response?: AsyncEventsResponse | CustomEventResponse
+	response?: AsyncEventsResponse | CustomEventResponse | StopEventResponse
 }

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -1,5 +1,11 @@
 # highlight.run
 
+## 9.2.0
+
+### Minor Changes
+
+-   d67bd4425: stop recording if pushpayload cannot keep up with uploading data
+
 ## 9.1.5
 
 ### Patch Changes

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "9.1.5",
+	"version": "9.2.0",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "9.1.5"
+export default "9.2.0"

--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @highlight-run/next
 
+## 7.5.18
+
+### Patch Changes
+
+-   Updated dependencies [d67bd4425]
+    -   highlight.run@9.2.0
+    -   @highlight-run/node@3.9.0
+    -   @highlight-run/react@4.0.0
+
 ## 7.5.17
 
 ### Patch Changes

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "7.5.17",
+	"version": "7.5.18",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-react/CHANGELOG.md
+++ b/sdk/highlight-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @highlight-run/react
 
+## 4.0.0
+
+### Patch Changes
+
+-   Updated dependencies [d67bd4425]
+    -   highlight.run@9.2.0
+
 ## 3.2.5
 
 ### Patch Changes

--- a/sdk/highlight-react/package.json
+++ b/sdk/highlight-react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/react",
-	"version": "3.2.5",
+	"version": "4.0.0",
 	"description": "The official Highlight SDK for React",
 	"license": "Apache-2.0",
 	"peerDependencies": {

--- a/sdk/highlight-remix/CHANGELOG.md
+++ b/sdk/highlight-remix/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @highlight-run/remix
 
+## 2.0.49
+
+### Patch Changes
+
+-   Updated dependencies [d67bd4425]
+    -   highlight.run@9.2.0
+    -   @highlight-run/node@3.9.0
+    -   @highlight-run/react@4.0.0
+
 ## 2.0.48
 
 ### Patch Changes

--- a/sdk/highlight-remix/package.json
+++ b/sdk/highlight-remix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/remix",
-	"version": "2.0.48",
+	"version": "2.0.49",
 	"description": "Client for interfacing with Highlight in Remix",
 	"packageManager": "yarn@4.0.2",
 	"author": "",


### PR DESCRIPTION
## Summary

stop recording data when the highlight.run sdk uploads cannot keep up with `PushPayload`
this typically happens due to canvas / video element recording not being able to
upload quickly enough given upload BW restrictions. stopping recording will
prevent an OOM that would otherwise happen due to garbage collection not being
able to release the canvas / video element bitmaps.

requested by a customer that is using the video element serialization feature

## How did you test this change?

https://www.loom.com/share/1b49bc8236d34c58b2ba00390237b74d

## Are there any deployment considerations?

minor version

## Does this work require review from our design team?

no
