### PR TITLE
use session attributes to filter sessions on device id

### DIFF
--- a/backend/clickhouse/migrations/000109_remove_session_fingerprint.down.sql
+++ b/backend/clickhouse/migrations/000109_remove_session_fingerprint.down.sql
@@ -1,0 +1,2 @@
+alter table sessions
+    add column Fingerprint Int32;

--- a/backend/clickhouse/migrations/000109_remove_session_fingerprint.up.sql
+++ b/backend/clickhouse/migrations/000109_remove_session_fingerprint.up.sql
@@ -1,0 +1,2 @@
+alter table sessions
+    drop column Fingerprint;

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -25,7 +25,6 @@ import (
 const timeFormat = "2006-01-02T15:04:05.000Z"
 
 var fieldMap = map[string]string{
-	"fingerprint":       "Fingerprint",
 	"pages_visited":     "PagesVisited",
 	"viewed_by_me":      "ViewedByAdmins",
 	"created_at":        "CreatedAt",
@@ -68,7 +67,6 @@ var fieldMap = map[string]string{
 
 type ClickhouseSession struct {
 	ID                 int64
-	Fingerprint        int32
 	ProjectID          int32
 	PagesVisited       int32
 	ViewedByAdmins     clickhouse.ArraySet
@@ -190,7 +188,6 @@ func (client *Client) WriteSessions(ctx context.Context, sessions []*model.Sessi
 
 		chs := ClickhouseSession{
 			ID:                 int64(session.ID),
-			Fingerprint:        int32(session.Fingerprint),
 			ProjectID:          int32(session.ProjectID),
 			PagesVisited:       int32(session.PagesVisited),
 			ViewedByAdmins:     viewedByAdmins,
@@ -499,7 +496,7 @@ var SessionsJoinedTableConfig = model.TableConfig{
 	TableName:        SessionsJoinedTable,
 	AttributesColumn: "SessionAttributePairs",
 	AttributesList:   true,
-	BodyColumn:       `concat(coalesce(nullif(arrayFilter((k, v) -> k = 'email', SessionAttributePairs) [1].2,''), nullif(Identifier, ''), nullif(toString(Fingerprint), ''), 'unidentified'), ': ', City, if(City != '', ', ', ''), Country)`,
+	BodyColumn:       `concat(coalesce(nullif(arrayFilter((k, v) -> k = 'email', SessionAttributePairs) [1].2,''), nullif(Identifier, ''), nullif(arrayFilter((k, v) -> k = 'device_id', SessionAttributePairs) [1].2, ''), 'unidentified'), ': ', City, if(City != '', ', ', ''), Country)`,
 	KeysToColumns: map[string]string{
 		string(modelInputs.ReservedSessionKeyActiveLength):       "ActiveLength",
 		string(modelInputs.ReservedSessionKeyServiceVersion):     "AppVersion",
@@ -510,7 +507,6 @@ var SessionsJoinedTableConfig = model.TableConfig{
 		string(modelInputs.ReservedSessionKeyCountry):            "Country",
 		string(modelInputs.ReservedSessionKeyEnvironment):        "Environment",
 		string(modelInputs.ReservedSessionKeyExcluded):           "Excluded",
-		string(modelInputs.ReservedSessionKeyDeviceID):           "Fingerprint",
 		string(modelInputs.ReservedSessionKeyFirstTime):          "FirstTime",
 		string(modelInputs.ReservedSessionKeyHasComments):        "HasComments",
 		string(modelInputs.ReservedSessionKeyHasErrors):          "HasErrors",

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -238,7 +238,7 @@ func (client *Client) WriteSessions(ctx context.Context, sessions []*model.Sessi
 				NewStruct(new(ClickhouseSession)).
 				InsertInto(SessionsTable, chSessions...).
 				BuildWithFlavor(sqlbuilder.ClickHouse)
-			sessionsSql, sessionsArgs = replaceTimestampInserts(sessionsSql, sessionsArgs, map[int]bool{7: true, 8: true}, MicroSeconds)
+			sessionsSql, sessionsArgs = replaceTimestampInserts(sessionsSql, sessionsArgs, map[int]bool{6: true, 7: true}, MicroSeconds)
 			return client.conn.Exec(chCtx, sessionsSql, sessionsArgs...)
 		})
 	}

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -12615,7 +12615,6 @@ enum ReservedSessionKey {
 	city
 	completed
 	country
-	device_id
 	environment
 	excluded
 	first_time

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -2259,7 +2259,6 @@ const (
 	ReservedSessionKeyCity               ReservedSessionKey = "city"
 	ReservedSessionKeyCompleted          ReservedSessionKey = "completed"
 	ReservedSessionKeyCountry            ReservedSessionKey = "country"
-	ReservedSessionKeyDeviceID           ReservedSessionKey = "device_id"
 	ReservedSessionKeyEnvironment        ReservedSessionKey = "environment"
 	ReservedSessionKeyExcluded           ReservedSessionKey = "excluded"
 	ReservedSessionKeyFirstTime          ReservedSessionKey = "first_time"
@@ -2293,7 +2292,6 @@ var AllReservedSessionKey = []ReservedSessionKey{
 	ReservedSessionKeyCity,
 	ReservedSessionKeyCompleted,
 	ReservedSessionKeyCountry,
-	ReservedSessionKeyDeviceID,
 	ReservedSessionKeyEnvironment,
 	ReservedSessionKeyExcluded,
 	ReservedSessionKeyFirstTime,
@@ -2322,7 +2320,7 @@ var AllReservedSessionKey = []ReservedSessionKey{
 
 func (e ReservedSessionKey) IsValid() bool {
 	switch e {
-	case ReservedSessionKeyActiveLength, ReservedSessionKeyBrowserName, ReservedSessionKeyBrowserVersion, ReservedSessionKeyCity, ReservedSessionKeyCompleted, ReservedSessionKeyCountry, ReservedSessionKeyDeviceID, ReservedSessionKeyEnvironment, ReservedSessionKeyExcluded, ReservedSessionKeyFirstTime, ReservedSessionKeyHasComments, ReservedSessionKeyHasErrors, ReservedSessionKeyHasRageClicks, ReservedSessionKeyIdentified, ReservedSessionKeyIdentifier, ReservedSessionKeyIP, ReservedSessionKeyLength, ReservedSessionKeyNormalness, ReservedSessionKeyOsName, ReservedSessionKeyOsVersion, ReservedSessionKeyPagesVisited, ReservedSessionKeySample, ReservedSessionKeySecureID, ReservedSessionKeyServiceVersion, ReservedSessionKeyState, ReservedSessionKeyViewedByAnyone, ReservedSessionKeyViewedByMe, ReservedSessionKeyWithinBillingQuota, ReservedSessionKeyLocState, ReservedSessionKeyProcessed, ReservedSessionKeyViewed:
+	case ReservedSessionKeyActiveLength, ReservedSessionKeyBrowserName, ReservedSessionKeyBrowserVersion, ReservedSessionKeyCity, ReservedSessionKeyCompleted, ReservedSessionKeyCountry, ReservedSessionKeyEnvironment, ReservedSessionKeyExcluded, ReservedSessionKeyFirstTime, ReservedSessionKeyHasComments, ReservedSessionKeyHasErrors, ReservedSessionKeyHasRageClicks, ReservedSessionKeyIdentified, ReservedSessionKeyIdentifier, ReservedSessionKeyIP, ReservedSessionKeyLength, ReservedSessionKeyNormalness, ReservedSessionKeyOsName, ReservedSessionKeyOsVersion, ReservedSessionKeyPagesVisited, ReservedSessionKeySample, ReservedSessionKeySecureID, ReservedSessionKeyServiceVersion, ReservedSessionKeyState, ReservedSessionKeyViewedByAnyone, ReservedSessionKeyViewedByMe, ReservedSessionKeyWithinBillingQuota, ReservedSessionKeyLocState, ReservedSessionKeyProcessed, ReservedSessionKeyViewed:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1038,7 +1038,6 @@ enum ReservedSessionKey {
 	city
 	completed
 	country
-	device_id
 	environment
 	excluded
 	first_time


### PR DESCRIPTION
## Summary

Fingerprint column was storing an Int32 value which would overflow.
Switch to using the `SessionAttributePairs` searching by `device_id` which was already recorded.
Closes SUP-98

## How did you test this change?

`device_id` filter applies correctly
<img width="1797" alt="Screenshot 2024-08-09 at 15 32 45" src="https://github.com/user-attachments/assets/a4c8cb4b-57ac-4d2d-b53c-53c1194a2481">

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no