### PR TITLE
update identifier search button icon

### DIFF
--- a/frontend/src/pages/Player/MetadataBox/MetadataBox.tsx
+++ b/frontend/src/pages/Player/MetadataBox/MetadataBox.tsx
@@ -1,4 +1,5 @@
 import { Avatar } from '@components/Avatar/Avatar'
+import { Button } from '@components/Button'
 import { useSearchContext } from '@components/Search/SearchContext'
 import { TableList, TableListItem } from '@components/TableList/TableList'
 import { toast } from '@components/Toaster'
@@ -7,8 +8,7 @@ import { GetEnhancedUserDetailsQuery } from '@graph/operations'
 import { Maybe, Session, SocialLink, SocialType } from '@graph/schemas'
 import {
 	Box,
-	ButtonIcon,
-	IconSolidExternalLink,
+	IconSolidCheveronRight,
 	IconSolidQuestionMarkCircle,
 	Tag,
 	Text,
@@ -293,14 +293,16 @@ export const MetadataBox = React.memo(() => {
 						</Box>
 					)}
 				</Box>
-				<ButtonIcon
+				<Button
+					size="small"
 					kind="secondary"
 					emphasis="low"
-					shape="square"
-					size="small"
-					icon={<IconSolidExternalLink />}
+					iconRight={<IconSolidCheveronRight />}
 					onClick={searchIdentifier}
-				/>
+					trackingId="session-metadata-identifier-search"
+				>
+					Sessions
+				</Button>
 			</Box>
 			<Box display="flex" pt="4" pb="8" px="8">
 				<RelatedResourceButtons


### PR DESCRIPTION
## Summary

Updates the user identifier search design to make it more obvious that there is a clickable button.

## How did you test this change?

<img width="346" alt="Screenshot 2024-08-09 at 15 49 50" src="https://github.com/user-attachments/assets/d0dee496-f871-472c-bc1b-1f449084857b">

<img width="346" alt="image" src="https://github.com/user-attachments/assets/ff742e8b-63d4-468b-b837-fe01ae89ab0b">

## Are there any deployment considerations?

no

## Does this work require review from our design team?

@julian-highlight thoughts? i don't know if i love the hover state
