### PR TITLE
Update tutorial copies

### DIFF
--- a/frontend/src/pages/Alerts/Alerts.tsx
+++ b/frontend/src/pages/Alerts/Alerts.tsx
@@ -15,7 +15,6 @@ import {
 	IconSolidLightningBolt,
 	IconSolidLogs,
 	IconSolidMicrosoftTeams,
-	IconSolidPlay,
 	IconSolidPlayCircle,
 	IconSolidPlus,
 	IconSolidRefresh,
@@ -178,7 +177,7 @@ export const ALERT_CONFIGURATIONS: { [key: string]: AlertConfiguration } = {
 		supportsExcludeRules: true,
 	},
 } as const
-const WALKTHROUGH_LINK = 'TODO'
+
 const ALERTS_DOCS_LINK =
 	'https://www.highlight.io/docs/general/product-features/general-features/alerts'
 
@@ -374,7 +373,9 @@ function AlertsPageLoaded({
 						</Heading>
 						<Text weight="medium" size="small" color="default">
 							Manage all the alerts for your currently selected
-							project.
+							project. Get notified when errors occur or important
+							metric conditions are met. Learn more about building
+							alerts <a href={ALERTS_DOCS_LINK}>here</a>.
 						</Text>
 					</Stack>
 					<Stack gap="8" width="full">
@@ -412,29 +413,19 @@ function AlertsPageLoaded({
 							>
 								<Stack gap="16">
 									<Text>
-										Be sure to take a look at the docs, and
-										the walkthrough coming soon!
+										Be sure to take a look at the docs, or
+										watch the walkthrough video!
 									</Text>
-									<Stack flexDirection="row" gap="8">
+									<Box>
 										<LinkButton
 											kind="secondary"
 											emphasis="high"
-											trackingId="alerts-watch-walkthrough"
-											to={WALKTHROUGH_LINK}
-											iconLeft={<IconSolidPlay />}
-											disabled
-										>
-											Watch walkthrough
-										</LinkButton>
-										<LinkButton
 											trackingId="alerts-read-docs"
-											kind="secondary"
-											emphasis="low"
 											to={ALERTS_DOCS_LINK}
 										>
-											Read docs
+											Learn more
 										</LinkButton>
-									</Stack>
+									</Box>
 								</Stack>
 							</Callout>
 						)}

--- a/frontend/src/pages/Graphing/DashboardOverview.tsx
+++ b/frontend/src/pages/Graphing/DashboardOverview.tsx
@@ -9,7 +9,6 @@ import {
 	Heading,
 	IconSolidChartBar,
 	IconSolidDotsHorizontal,
-	IconSolidPlay,
 	IconSolidTrash,
 	Menu,
 	Stack,
@@ -43,7 +42,6 @@ const ITEMS_PER_PAGE = 10
 
 const METRICS_DOCS_LINK =
 	'https://www.highlight.io/docs/general/product-features/metrics/overview'
-const WALKTHROUGH_LINK = 'https://www.youtube.com/watch?v=MzJMCcgf6iU'
 
 export const DashboardOverview: React.FC = () => {
 	const { projectId } = useProjectId()
@@ -123,7 +121,10 @@ export const DashboardOverview: React.FC = () => {
 										color="default"
 									>
 										Metrics allow you to visualize what's
-										happening in your app.
+										happening in your app. Understand error
+										rates, APM trends, and user engagement.
+										Learn more about building dashboards{' '}
+										<a href={METRICS_DOCS_LINK}>here</a>.
 									</Text>
 									{visible && (
 										<Callout
@@ -140,30 +141,16 @@ export const DashboardOverview: React.FC = () => {
 													the docs, or watch the
 													walkthrough video!
 												</Text>
-												<Stack
-													flexDirection="row"
-													gap="8"
-												>
+												<Box>
 													<LinkButton
 														kind="secondary"
 														emphasis="high"
-														trackingId="dashboard-watch-walkthrough"
-														to={WALKTHROUGH_LINK}
-														iconLeft={
-															<IconSolidPlay />
-														}
-													>
-														Watch walkthrough
-													</LinkButton>
-													<LinkButton
 														trackingId="dashboard-read-docs"
-														kind="secondary"
-														emphasis="low"
 														to={METRICS_DOCS_LINK}
 													>
-														Read docs
+														Learn more
 													</LinkButton>
-												</Stack>
+												</Box>
 											</Stack>
 										</Callout>
 									)}


### PR DESCRIPTION
## Summary
Update the metric and alert pages to always have a link to learn more about the feature. Update the callout copies to just link to the documentation (can watch the video on that page)

![Screenshot 2024-08-14 at 6 28 05 PM](https://github.com/user-attachments/assets/eecfeb45-a21e-4a46-a098-b8180a9c9ce6)
![Screenshot 2024-08-14 at 6 27 58 PM](https://github.com/user-attachments/assets/0810af33-6056-493a-b74d-f827aeae4d9f)

## How did you test this change?
1. View the metrics page
- [ ] No copy errors
- [ ] Links work
1. View the errors page
- [ ] No copy errors
- [ ] Links work

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
