### PR TITLE
Only return necessary props in docOptions for smaller payload

### DIFF
--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -68,6 +68,13 @@ export interface DocPath {
 	content: string
 }
 
+type DocLink = {
+	metadata: any
+	simple_path: string
+	array_path: string[]
+	hasContent: boolean
+}
+
 type DocData = {
 	markdownText: MDXRemoteSerializeResult | null
 	markdownTextOG?: string
@@ -75,7 +82,7 @@ type DocData = {
 	quickstartContent?: QuickStartContent
 	slug: string
 	toc: TocEntry
-	docOptions: DocPath[]
+	docOptions: DocLink[]
 	metadata?: {
 		title: string
 		metaTitle?: string
@@ -454,7 +461,14 @@ export const getStaticProps: GetStaticProps<DocData> = async (context) => {
 			slug: currentDoc.simple_path,
 			relPath: currentDoc.rel_path,
 			docIndex: currentDocIndex,
-			docOptions: docPaths,
+			docOptions: docPaths.map((d) => {
+				return {
+					metadata: d.metadata,
+					simple_path: d.simple_path,
+					array_path: d.array_path,
+					hasContent: d.content != '',
+				}
+			}),
 			isSdkDoc: currentDoc.isSdkDoc,
 			toc,
 			redirect,
@@ -633,7 +647,7 @@ const TableOfContents = ({
 	toc: TocEntry
 	openParent: boolean
 	openTopLevel?: boolean
-	docPaths: DocPath[]
+	docPaths: DocLink[]
 	onNavigate?: () => void
 }) => {
 	const hasChildren = !!toc?.children.length
@@ -751,7 +765,7 @@ const TableOfContents = ({
 
 const getBreadcrumbs = (
 	metadata: any,
-	docOptions: DocPath[],
+	docOptions: DocLink[],
 	docIndex: number,
 ) => {
 	const trail: { title: string; path: string; hasContent: boolean }[] = [
@@ -772,7 +786,7 @@ const getBreadcrumbs = (
 			trail.push({
 				title: nextBreadcrumb?.metadata?.title,
 				path: `/docs/${nextBreadcrumb?.simple_path}`,
-				hasContent: nextBreadcrumb?.content != '',
+				hasContent: nextBreadcrumb?.hasContent || false,
 			})
 		})
 	}


### PR DESCRIPTION
## Summary

Only return metadata, simple_path, array_path, hasContent in docOptions for smaller payload

Closes GRO-119

## How did you test this change?

Click through links, see if pages still render correctly, check payload sizes in dev tools

|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/1257413e-c910-4290-86cc-c60862fc36f4)|![image](https://github.com/user-attachments/assets/baea76e0-35ea-4c5e-9fa4-5f04369b7bb2)|

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
