### PR TITLE
Fix metric queries

### DIFF
--- a/backend/clickhouse/metrics.go
+++ b/backend/clickhouse/metrics.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aws/smithy-go/ptr"
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/openlyinc/pointy"
 
@@ -16,6 +17,7 @@ const MetricNamesTable = "trace_metrics"
 var metricsTableConfig = model.TableConfig{
 	AttributesColumn: TracesTableNoDefaultConfig.AttributesColumn,
 	BodyColumn:       TracesTableNoDefaultConfig.BodyColumn,
+	MetricColumn:     ptr.String("MetricValue"),
 	KeysToColumns:    TracesTableNoDefaultConfig.KeysToColumns,
 	ReservedKeys:     TracesTableNoDefaultConfig.ReservedKeys,
 	SelectColumns:    TracesTableNoDefaultConfig.SelectColumns,
@@ -25,6 +27,7 @@ var metricsTableConfig = model.TableConfig{
 var metricsSamplingTableConfig = model.TableConfig{
 	AttributesColumn: metricsTableConfig.AttributesColumn,
 	BodyColumn:       metricsTableConfig.BodyColumn,
+	MetricColumn:     metricsTableConfig.MetricColumn,
 	KeysToColumns:    metricsTableConfig.KeysToColumns,
 	ReservedKeys:     metricsTableConfig.ReservedKeys,
 	SelectColumns:    metricsTableConfig.SelectColumns,

--- a/backend/clickhouse/metrics.go
+++ b/backend/clickhouse/metrics.go
@@ -75,16 +75,16 @@ func (client *Client) ReadWorkspaceMetricCounts(ctx context.Context, projectIDs 
 }
 
 func (client *Client) MetricsKeys(ctx context.Context, projectID int, startDate time.Time, endDate time.Time, query *string, typeArg *modelInputs.KeyType) ([]*modelInputs.QueryKey, error) {
-	table := TraceKeysTable
 	if typeArg != nil && *typeArg == modelInputs.KeyTypeNumeric {
-		table = MetricNamesTable
-	}
-	metricKeys, err := KeysAggregated(ctx, client, table, projectID, startDate, endDate, query, typeArg)
-	if err != nil {
-		return nil, err
+		metricKeys, err := KeysAggregated(ctx, client, MetricNamesTable, projectID, startDate, endDate, query, typeArg)
+		if err != nil {
+			return nil, err
+		}
+
+		return metricKeys, nil
 	}
 
-	return metricKeys, nil
+	return client.TracesKeys(ctx, projectID, startDate, endDate, query, typeArg)
 }
 
 func (client *Client) MetricsKeyValues(ctx context.Context, projectID int, keyName string, startDate time.Time, endDate time.Time, query *string, limit *int) ([]string, error) {

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -781,6 +781,8 @@ func (client *Client) ReadMetrics(ctx context.Context, input ReadMetricsInput) (
 	if !isCountDistinct {
 		if reservedCol, found := keysToColumns[strings.ToLower(input.Column)]; found {
 			metricExpr = fmt.Sprintf("toFloat64(%s)", reservedCol)
+		} else if input.SampleableConfig.tableConfig.MetricColumn != nil {
+			metricExpr = *input.SampleableConfig.tableConfig.MetricColumn
 		} else {
 			metricExpr = fmt.Sprintf("toFloat64OrNull(%s)", col)
 		}

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -2446,6 +2446,7 @@ type TableConfig struct {
 	AttributesColumn string
 	// AttributesList set when AttributesColumn is an array of k,v pairs of attributes
 	AttributesList bool
+	MetricColumn   *string
 	KeysToColumns  map[string]string
 	ReservedKeys   []string
 	SelectColumns  []string

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -796,6 +796,10 @@ const Graph = ({
 		setFetchEnd(moment().toDate())
 	}, [selectedPreset, startDate, endDate])
 
+	const xAxisMetric = bucketByKey !== undefined ? bucketByKey : GROUP_KEY
+	const yAxisMetric = functionType === MetricAggregator.Count ? '' : metric
+	const yAxisFunction = functionType
+
 	// set the fetch dates and poll interval when selected date changes
 	useEffect(() => {
 		rebaseFetchTime()
@@ -829,7 +833,7 @@ const Graph = ({
 					},
 					query: query,
 				},
-				column: metric,
+				column: yAxisMetric,
 				metric_types: [functionType],
 				group_by: groupByKey !== undefined ? [groupByKey] : [],
 				bucket_by:
@@ -868,16 +872,12 @@ const Graph = ({
 		limit,
 		limitFunctionType,
 		limitMetric,
-		metric,
+		yAxisMetric,
 		productType,
 		projectId,
 		queriedBucketCount,
 		query,
 	])
-
-	const xAxisMetric = bucketByKey !== undefined ? bucketByKey : GROUP_KEY
-	const yAxisMetric = functionType === MetricAggregator.Count ? '' : metric
-	const yAxisFunction = functionType
 
 	const data = useGraphData(metrics, xAxisMetric)
 	const series = useGraphSeries(data, xAxisMetric)


### PR DESCRIPTION
## Summary
Fix how metrics are fetched and calculated
- Use correct spot for grabbing metric value out of trace row
- Provide default trace keys to metric search
- Don't use metric column when function is `Count` and there is not option to change

https://www.loom.com/share/f7b41f41c90f4d27b13801e09beaeeb1?sid=642cc4ac-1b33-4ce1-955a-9c95a5fe44cb

## How did you test this change?
- [ ] Able to graph a function of the metric `ScreenWidth`
- [ ] Switch to count and add `metric_name=ScreenHeight` filter

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
