### PR TITLE
Hide autojoin input for not new workspaces

### DIFF
--- a/frontend/src/pages/Auth/AdminForm.tsx
+++ b/frontend/src/pages/Auth/AdminForm.tsx
@@ -201,7 +201,9 @@ export const AdminForm: React.FC = () => {
 			)
 
 			await fetchAdmin() // updates admin in auth context
-			navigate(INVITE_TEAM_ROUTE)
+			navigate(
+				`${INVITE_TEAM_ROUTE}${inWorkspace ? '' : '?new_workspace=1'}`,
+			)
 		} catch (e: any) {
 			if (import.meta.env.DEV) {
 				console.error(e)

--- a/frontend/src/pages/Auth/InviteTeam.tsx
+++ b/frontend/src/pages/Auth/InviteTeam.tsx
@@ -34,6 +34,7 @@ import { getEmailDomain } from '@/util/email'
 
 import * as authRouterStyles from './AuthRouter.css'
 import * as styles from './InviteTeam.css'
+import { BooleanParam, useQueryParam } from 'use-query-params'
 
 const COMMON_EMAIL_PROVIDERS = [
 	'gmail',
@@ -47,6 +48,7 @@ const COMMON_EMAIL_PROVIDERS = [
 export const InviteTeamForm: React.FC = () => {
 	const { setLoadingState } = useAppLoadingContext()
 	const { admin } = useAuthContext()
+	const [new_workspace] = useQueryParam('new_workspace', BooleanParam)
 
 	const navigate = useNavigate()
 	const [error, setError] = React.useState<string>()
@@ -71,15 +73,17 @@ export const InviteTeamForm: React.FC = () => {
 	const authRedirectRoute = authRedirect.get()
 	const redirectRoute = authRedirectRoute ?? setupRoute
 	const workspace = data?.workspaces && data.workspaces[0]
-	const inWorkspace = !!workspace
 
 	const { data: adminRoleData, loading: adminRoleLoading } =
 		useGetAdminRoleQuery({
 			variables: { workspace_id: workspace?.id ?? '' },
-			skip: !inWorkspace,
+			skip: !workspace,
 		})
 	const adminRole = adminRoleData?.admin_role?.role ?? AdminRole.Member
 	const adminProjects = adminRoleData?.admin_role?.projectIds ?? []
+
+	const enableAutoJoinInput =
+		new_workspace && !isCommonEmailDomain && adminRole === AdminRole.Admin
 
 	useEffect(() => {
 		if (adminProjects.length > 0) {
@@ -113,7 +117,7 @@ export const InviteTeamForm: React.FC = () => {
 		analytics.track('Invite team submitted')
 
 		try {
-			if (inWorkspace) {
+			if (!!workspace) {
 				let emails: string[] = [formState.values.inviteEmails]
 				for (let i = 0; i < formState.values.numTeamEmails; i++) {
 					emails.push(
@@ -133,10 +137,7 @@ export const InviteTeamForm: React.FC = () => {
 						},
 					}),
 				)
-				if (
-					adminRole === AdminRole.Admin &&
-					formState.values.autoJoinDomain
-				) {
+				if (enableAutoJoinInput) {
 					promises.push(
 						updateAllowedEmailOrigins({
 							variables: {
@@ -185,7 +186,6 @@ export const InviteTeamForm: React.FC = () => {
 
 	useEffect(() => {
 		if (!loading && !adminRoleLoading) {
-			console.log('setloading')
 			setLoadingState(AppLoadingState.LOADED)
 		}
 	}, [setLoadingState, loading, adminRoleLoading, adminRoleData])
@@ -255,59 +255,54 @@ export const InviteTeamForm: React.FC = () => {
 				<AuthFooter>
 					<Stack gap="12">
 						<Box display="flex" width="full">
-							{!isCommonEmailDomain &&
-								adminRole === AdminRole.Admin && (
-									<Box width="full">
-										<Callout icon={false}>
-											<Stack gap="8">
-												<Box
-													display="flex"
-													alignItems="center"
-													gap="6"
-												>
-													<SwitchButton
-														type="button"
-														size="xxSmall"
-														iconLeft={
-															<IconSolidCheckCircle
-																size={12}
-															/>
-														}
-														checked={autoJoinDomain}
-														onChange={() => {
-															formStore.setValue(
-																formStore.names
-																	.autoJoinDomain,
-																!autoJoinDomain,
-															)
-														}}
-													/>
-													<Text
-														size="small"
-														weight="bold"
-														color="strong"
-													>
-														Allow joining by email
-														domain
-													</Text>
-												</Box>
+							{enableAutoJoinInput && (
+								<Box width="full">
+									<Callout icon={false}>
+										<Stack gap="8">
+											<Box
+												display="flex"
+												alignItems="center"
+												gap="6"
+											>
+												<SwitchButton
+													type="button"
+													size="xxSmall"
+													iconLeft={
+														<IconSolidCheckCircle
+															size={12}
+														/>
+													}
+													checked={autoJoinDomain}
+													onChange={() => {
+														formStore.setValue(
+															formStore.names
+																.autoJoinDomain,
+															!autoJoinDomain,
+														)
+													}}
+												/>
 												<Text
 													size="small"
-													weight="medium"
+													weight="bold"
+													color="strong"
 												>
-													Allow everyone with a{' '}
-													<b>
-														{getEmailDomain(
-															admin?.email,
-														)}
-													</b>{' '}
-													email to join your
-													workspace.
+													Allow joining by email
+													domain
 												</Text>
-											</Stack>
-										</Callout>
-									</Box>
-								)}
+											</Box>
+											<Text size="small" weight="medium">
+												Allow everyone with a{' '}
+												<b>
+													{getEmailDomain(
+														admin?.email,
+													)}
+												</b>{' '}
+												email to join your workspace.
+											</Text>
+										</Stack>
+									</Callout>
+								</Box>
+							)}
 						</Box>
 						<Box display="flex" width="full">
 							<Button

--- a/frontend/src/routers/AppRouter/AppRouter.tsx
+++ b/frontend/src/routers/AppRouter/AppRouter.tsx
@@ -107,6 +107,7 @@ export const AppRouter = () => {
 	const workspaceId = workspaceMatch?.params.workspace_id
 	const workspaceInviteMatch = useMatch('/w/:workspace_id/invite/:invite')
 	const inviteMatch = useMatch('/invite/:invite')
+	const inviteTeamMatch = useMatch(INVITE_TEAM_ROUTE)
 	const joinWorkspaceMatch = useMatch('/join_workspace')
 	const firebaseMatch = useMatch(FIREBASE_CALLBACK_ROUTE)
 	const isFirebasePage = !!firebaseMatch
@@ -168,6 +169,7 @@ export const AppRouter = () => {
 		if (
 			admin &&
 			!admin.about_you_details_filled &&
+			!inviteTeamMatch &&
 			!isVercelIntegrationFlow &&
 			!isInvitePage &&
 			!isFirebasePage &&
@@ -193,6 +195,7 @@ export const AppRouter = () => {
 		isVercelIntegrationFlow,
 		navigate,
 		inviteCode,
+		inviteTeamMatch,
 		isInvitePage,
 		projectId,
 		isJoinWorkspacePage,


### PR DESCRIPTION
## Summary
When an admin user is invited to a workspace, they will overwrite the autojoin email domain field. ONly show this for newly created workspaces.

https://www.loom.com/share/a3cd4544ff55450ba5df5d2ac529f611

## How did you test this change?
1. Create a new user and new project
- [ ] Can see autojoin field
2. Add multiple emails in settings to auto join domain
3. Invite a new user as an admin
4. Sign up as that invited admin
- [ ] Cannot see autojoin field
- [ ] Does not overwrite autojoin field in workspace
5. Delete created users in Firebase (if necessary)

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
