### PR TITLE
Advertise .NET livestream on website banner

### DIFF
--- a/highlight.io/components/common/Navbar/Navbar.tsx
+++ b/highlight.io/components/common/Navbar/Navbar.tsx
@@ -41,15 +41,15 @@ const LaunchWeekBanner = () => {
 const LivestreamBanner = () => {
 	return (
 		<Link
-			href="https://lu.ma/bvnkoy5v"
+			href="https://lu.ma/51zg6p43?utm_source=highlight-banner"
 			target="_blank"
 			rel="noreferrer"
-			className="hidden md:flex justify-center items-center w-full h-[40px] bg-color-primary-200 text-white hover:bg-opacity-90"
+			className="hidden md:flex text-center justify-center items-center w-full py-2.5 px-3 bg-color-primary-200 text-white hover:bg-opacity-90"
 		>
 			<Typography type="copy3">
-				Join our livestream: July 2nd at 1pm PDT on Evaluating LLMs with
-				OpenLLMetry. Register
-				<span className="font-semibold"> here</span>.
+				Join our livestream: Septemper 5th at 1pm PT on Fullstack
+				Monitoring for .NET Applications with OpenTelemetry. Register{' '}
+				<span className="font-semibold underline">here</span>.
 			</Typography>
 		</Link>
 	)
@@ -126,7 +126,7 @@ const Navbar = ({
 				isLaunchWeek ? (
 					<LaunchWeekBanner />
 				) : (
-					<HFSBanner />
+					<LivestreamBanner />
 				)
 			) : null}
 			<div


### PR DESCRIPTION
## Summary

Updates the banner on the website to promote our upcoming .NET livestream.

<img width="1284" alt="Screenshot 2024-08-20 at 3 27 39 PM" src="https://github.com/user-attachments/assets/e2152731-7633-468b-bb5d-79b53a864e68">

## How did you test this change?

Click tested on the website locally.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A