### PR TITLE
make client kill switch less likely to trigger by requiring multiple failures

### DIFF
--- a/.changeset/shaggy-games-flow.md
+++ b/.changeset/shaggy-games-flow.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+make client kill switch less likely to trigger by requiring multiple failures

--- a/sdk/client/src/workers/highlight-client-worker.ts
+++ b/sdk/client/src/workers/highlight-client-worker.ts
@@ -260,6 +260,15 @@ function stringifyProperties(
 		}, 100)
 		try {
 			await Promise.all([pushPayload, pushMetrics])
+			if (
+				numberOfFailedPushPayloads &&
+				performance.now() - requestStart <= UPLOAD_TIMEOUT
+			) {
+				console.warn(
+					`pushPayload succeeded after #${numberOfFailedPushPayloads} failures, resetting stop switch.`,
+				)
+				numberOfFailedPushPayloads = 0
+			}
 		} finally {
 			requestStart = 0
 			clearInterval(int)

--- a/sdk/client/src/workers/highlight-client-worker.ts
+++ b/sdk/client/src/workers/highlight-client-worker.ts
@@ -228,6 +228,7 @@ function stringifyProperties(
 				console.warn(
 					`Uploading pushPayload took too long, stopping recording to avoid OOM.`,
 				)
+				// TODO(vkorolik) multiple failures needed
 				clearInterval(int)
 
 				worker.postMessage({


### PR DESCRIPTION
## Summary

Require multiple PushPayload timeouts before the client stops recording
with the built in kill switch.

## How did you test this change?

locally testing app
https://www.loom.com/share/a5284b3a7f0b45a0aa8c3f394e62b5bd

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
