### PR TITLE
Reduce fetches for errors/sessions histogram

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorFeedHistogram/ErrorFeedHistogram.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorFeedHistogram/ErrorFeedHistogram.tsx
@@ -12,13 +12,18 @@ export const ErrorFeedHistogram: React.FC<{
 }> = React.memo(({ readonly }) => {
 	const { project_id } = useParams<{ project_id: string }>()
 
-	const { query, startDate, endDate, histogramBucketSize, updateSearchTime } =
-		useSearchContext()
+	const {
+		initialQuery,
+		startDate,
+		endDate,
+		histogramBucketSize,
+		updateSearchTime,
+	} = useSearchContext()
 
 	const { loading, data } = useGetErrorsHistogramQuery({
 		variables: {
 			params: {
-				query,
+				query: initialQuery,
 				date_range: {
 					start_date: roundFeedDate(
 						startDate!.toISOString(),

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
@@ -54,7 +54,7 @@ export const SessionsHistogram: React.FC<{ readonly?: boolean }> = React.memo(
 		}>()
 
 		const {
-			query,
+			initialQuery,
 			histogramBucketSize,
 			startDate,
 			endDate,
@@ -65,7 +65,7 @@ export const SessionsHistogram: React.FC<{ readonly?: boolean }> = React.memo(
 			variables: {
 				project_id: project_id!,
 				params: {
-					query,
+					query: initialQuery,
 					date_range: {
 						start_date: roundFeedDate(
 							startDate!.toISOString(),


### PR DESCRIPTION
## Summary
Reduce number of requests sent for errors and sessions histogram -> only refetch when the search executes

## How did you test this change?
1. View sessions
2. Start typing in the search query
- [ ] No searches to fetch sessions histogram
3. Hit enter
- [ ] Search to fetch sessions histogram

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
