### PR TITLE
ensure duplicate tab functionality does not break x-highlight-request header

### DIFF
--- a/.changeset/tough-seahorses-kiss.md
+++ b/.changeset/tough-seahorses-kiss.md
@@ -1,0 +1,6 @@
+---
+'highlight.run': patch
+---
+
+ensure duplicate tab functionality does not break x-highlight-request header
+corrects issue introduced in 9.3.0 with the x-highlight-request missing the session id

--- a/sdk/client/src/utils/sessionStorage/highlightSession.ts
+++ b/sdk/client/src/utils/sessionStorage/highlightSession.ts
@@ -26,8 +26,10 @@ export const getSessionSecureID = (props?: { local?: true }): string => {
 }
 
 export const setSessionSecureID = (secureID: string) => {
-	sessionSecureID = secureID
-	setItem(SESSION_STORAGE_KEYS.SESSION_ID, sessionSecureID)
+	if (secureID) {
+		sessionSecureID = secureID
+		setItem(SESSION_STORAGE_KEYS.SESSION_ID, sessionSecureID)
+	}
 }
 
 const getSessionData = (sessionID: string): SessionData | undefined => {


### PR DESCRIPTION
## Summary

Fixes an issue in highlight.run 9.3.0 where the `x-highlight-request`
would be missing the highlight session id because of the duplicate tab feature
incorrectly interacting with the cookie session propagation.

## How did you test this change?

<img width="732" alt="Screenshot 2024-08-21 at 17 08 02" src="https://github.com/user-attachments/assets/3877522a-9727-48f6-94f4-32d992326e55">


## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
