### PR TITLE
Improve Ruby SDK setup and update docs

### DIFF
--- a/docs-content/getting-started/4_backend-sdk/06_ruby/1_overview.md
+++ b/docs-content/getting-started/4_backend-sdk/06_ruby/1_overview.md
@@ -16,7 +16,4 @@ updatedAt: 2022-04-01T19:52:59.000Z
     <DocsCard title="Other" href="../ruby/other">
         {"Get started without a framework"}
     </DocsCard>
-    <DocsCard title="Ruby OpenTelemetry" href="../../7_native-opentelemetry/2_error-monitoring.md">
-        {"Get started with OpenTelemetry"}
-    </DocsCard>
 </DocsCardGroup>

--- a/docs-content/getting-started/5_backend-logging/04_ruby/1_overview.md
+++ b/docs-content/getting-started/5_backend-logging/04_ruby/1_overview.md
@@ -17,7 +17,4 @@ If you don't see one of your languages / frameworks below, reach out to us in ou
     <DocsCard title="Other Ruby Frameworks" href="./other.md">
         {"Integrate logging in other Ruby Frameworks."}
     </DocsCard>
-    <DocsCard title="Ruby OpenTelemetry" href="../../7_native-opentelemetry/3_logging.md">
-        {"Integrate logging with Native OpenTelemetry."}
-    </DocsCard>
 </DocsCardGroup>

--- a/e2e/ruby/rails/demo/Gemfile
+++ b/e2e/ruby/rails/demo/Gemfile
@@ -72,6 +72,6 @@ group :test do
   gem 'selenium-webdriver'
 end
 
-gem 'highlight_io', path: '../../../../sdk/highlight-ruby/highlight', require: false
+gem 'highlight_io', path: '../../../../sdk/highlight-ruby/highlight'
 
 gem 'rubocop', '~> 1.65'

--- a/e2e/ruby/rails/demo/Gemfile
+++ b/e2e/ruby/rails/demo/Gemfile
@@ -72,6 +72,6 @@ group :test do
   gem 'selenium-webdriver'
 end
 
-gem 'highlight_io', path: '../../../../sdk/highlight-ruby/highlight'
+gem 'highlight_io', path: '../../../../sdk/highlight-ruby/highlight', require: false
 
 gem 'rubocop', '~> 1.65'

--- a/e2e/ruby/rails/demo/Gemfile.lock
+++ b/e2e/ruby/rails/demo/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../../../sdk/highlight-ruby/highlight
   specs:
-    highlight_io (0.3.1)
+    highlight_io (0.4.0)
       grpc (~> 1.65)
       opentelemetry-exporter-otlp (~> 0.28.1)
       opentelemetry-instrumentation-all (~> 0.62.1)

--- a/e2e/ruby/rails/demo/app/controllers/application_controller.rb
+++ b/e2e/ruby/rails/demo/app/controllers/application_controller.rb
@@ -1,9 +1,4 @@
 # frozen_string_literal: true
 
-require 'highlight'
-
 class ApplicationController < ActionController::Base
-  include Highlight::Integrations::Rails
-
-  around_action :with_highlight_context
 end

--- a/e2e/ruby/rails/demo/config/initializers/highlight.rb
+++ b/e2e/ruby/rails/demo/config/initializers/highlight.rb
@@ -2,7 +2,7 @@
 
 require 'highlight'
 
-Highlight::H.new('1jdkoe52', environment: 'dev', otlp_endpoint: 'http://localhost:4318') do |c|
+Highlight.init('1jdkoe52', environment: 'dev', otlp_endpoint: 'http://localhost:4318') do |c|
   c.service_name = 'highlight-ruby-demo-backend'
   c.service_version = '1.0.0'
 end

--- a/highlight.io/components/Products/products.ts
+++ b/highlight.io/components/Products/products.ts
@@ -29,6 +29,21 @@ ReactDOM.render(
 )
 `
 
+const htmlSnippet: string = `
+
+<script src="https://unpkg.com/highlight.run"></script>
+
+H.init(
+    "<YOUR_PROJECT_ID>", // Get your project ID from https://app.highlight.io/setup
+    networkRecording: {
+        enabled: true,
+        recordHeadersAndBody: true,
+    },
+    tracingOrigins: true // Optional configuration of Highlight features
+);
+
+`
+
 const expressSnippet: string = `
 
 import { Handlers } from '@highlight-run/node'
@@ -188,6 +203,18 @@ const svelteSnippet: string = `
 ...
 `
 
+const rubySnipped: string = `
+
+require "highlight"
+
+Highlight.init("<YOUR_PROJECT_ID>", environment: "production") do |c|
+  c.service_name = "my-rails-app"
+end
+
+Rails.logger = Highlight::Logger.new(STDOUT)
+
+`
+
 export const PRODUCTS: { [k: string]: iProduct } = {
 	react: {
 		type: 'frontend',
@@ -239,7 +266,7 @@ export const PRODUCTS: { [k: string]: iProduct } = {
 	},
 	express: {
 		type: 'backend',
-		docsLink: '/docs/getting-started/4_backend-sdk/express',
+		docsLink: '/docs/getting-started/backend-sdk/express',
 		slug: 'express',
 		title: 'Express',
 		types: ['Backend', 'Frontend'],
@@ -248,7 +275,7 @@ export const PRODUCTS: { [k: string]: iProduct } = {
 
 	go: {
 		type: 'backend',
-		docsLink: '/docs/getting-started/4_backend-sdk/go',
+		docsLink: '/docs/getting-started/backend-sdk/go',
 		slug: 'go',
 		title: 'Golang',
 		types: ['Backend', 'Frontend'],
@@ -266,11 +293,20 @@ export const PRODUCTS: { [k: string]: iProduct } = {
 
 	node: {
 		type: 'backend',
-		docsLink: '/docs/getting-started/4_backend-sdk/nodejs',
+		docsLink: '/docs/getting-started/backend-sdk/nodejs',
 		slug: 'node',
 		title: 'Node.js',
 		types: ['Backend', 'Frontend'],
 		snippets: [nodeSnippet, defaultFrontendSnippet],
+	},
+
+	rails: {
+		type: 'backend',
+		docsLink: '/docs/getting-started/backend-sdk/ruby/rails',
+		slug: 'rails',
+		title: 'Rails',
+		types: ['Backend', 'Frontend'],
+		snippets: [rubySnipped, htmlSnippet],
 	},
 }
 

--- a/highlight.io/components/QuickstartContent/backend/ruby/other.tsx
+++ b/highlight.io/components/QuickstartContent/backend/ruby/other.tsx
@@ -3,6 +3,7 @@ import { QuickStartContent } from '../../QuickstartContent'
 import { frontendInstallSnippet } from '../shared-snippets'
 import {
 	customError,
+	customTrace,
 	initializeSdk,
 	installSdk,
 	setUpLogging,
@@ -21,12 +22,12 @@ export const RubyOtherContent: QuickStartContent = {
 		{
 			title: 'Add Highlight tracing.',
 			content:
-				'`trace` will automatically record raised exceptions and send them to Highlight.',
+				'`start_span` will automatically record raised exceptions and send them to Highlight.',
 			code: [
 				{
 					text: `require "highlight"
 
-Highlight::H.instance.trace(nil, nil) do
+Highlight.start_span('my-span') do
   # your code here
 end`,
 					language: 'ruby',
@@ -35,6 +36,7 @@ end`,
 		},
 		verifyErrors,
 		customError,
+		customTrace,
 		setUpLogging('other'),
 	],
 }

--- a/highlight.io/components/QuickstartContent/backend/ruby/other.tsx
+++ b/highlight.io/components/QuickstartContent/backend/ruby/other.tsx
@@ -28,6 +28,7 @@ export const RubyOtherContent: QuickStartContent = {
 					text: `require "highlight"
 
 Highlight.start_span('my-span') do
+  span.add_attribute({ key: "value" })
   # your code here
 end`,
 					language: 'ruby',
@@ -36,7 +37,6 @@ end`,
 		},
 		verifyErrors,
 		customError,
-		customTrace,
 		setUpLogging('other'),
 	],
 }

--- a/highlight.io/components/QuickstartContent/backend/ruby/rails.tsx
+++ b/highlight.io/components/QuickstartContent/backend/ruby/rails.tsx
@@ -3,6 +3,7 @@ import { QuickStartContent } from '../../QuickstartContent'
 import { frontendInstallSnippet } from '../shared-snippets'
 import {
 	customError,
+	customTrace,
 	initializeSdk,
 	installSdk,
 	setUpLogging,
@@ -16,23 +17,6 @@ export const RubyRailsContent: QuickStartContent = {
 		frontendInstallSnippet,
 		installSdk,
 		initializeSdk,
-		{
-			title: 'Add the Highlight controller action.',
-			content:
-				'`with_highlight_context` can be used as a Rails `around_action` to wrap any controller actions to automatically record errors.',
-			code: [
-				{
-					text: `require "highlight"
-
-class ApplicationController < ActionController::Base
-  include Highlight::Integrations::Rails
-
-  around_action :with_highlight_context
-end`,
-					language: 'ruby',
-				},
-			],
-		},
 		{
 			title: 'Verify your errors are being recorded.',
 			content:
@@ -49,6 +33,7 @@ end`,
 			],
 		},
 		customError,
+		customTrace,
 		setUpLogging('rails'),
 	],
 }

--- a/highlight.io/components/QuickstartContent/backend/ruby/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/backend/ruby/shared-snippets.tsx
@@ -17,12 +17,12 @@ bundle install`,
 export const initializeSdk: QuickStartStep = {
 	title: 'Initialize the Highlight Ruby SDK.',
 	content:
-		"`Highlight::H.new` initializes the SDK and allows you to call the singleton `Highlight`. Setting your project ID also lets Highlight record errors for background tasks and processes that aren't associated with a frontend session.",
+		"`Highlight.init` initializes the SDK. Setting your project ID also lets Highlight record errors for background tasks and processes that aren't associated with a frontend session.",
 	code: [
 		{
 			text: `require "highlight"
 
-Highlight::H.new("<YOUR_PROJECT_ID>", environment: "production") do |c|
+Highlight.init("<YOUR_PROJECT_ID>", environment: "production") do |c|
   c.service_name = "my-app"
   c.service_version = "1.0.0"
 end`,

--- a/highlight.io/components/QuickstartContent/backend/ruby/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/backend/ruby/shared-snippets.tsx
@@ -17,7 +17,7 @@ bundle install`,
 export const initializeSdk: QuickStartStep = {
 	title: 'Initialize the Highlight Ruby SDK.',
 	content:
-		"`Highlight::H.new` initializes the SDK and allows you to call the singleton `Highlight::H.instance`. Setting your project ID also lets Highlight record errors for background tasks and processes that aren't associated with a frontend session.",
+		"`Highlight::H.new` initializes the SDK and allows you to call the singleton `Highlight`. Setting your project ID also lets Highlight record errors for background tasks and processes that aren't associated with a frontend session.",
 	code: [
 		{
 			text: `require "highlight"
@@ -34,10 +34,24 @@ end`,
 export const customError: QuickStartStep = {
 	title: 'Record custom errors. (optional)',
 	content:
-		'If you want to explicitly send an error to Highlight, you can use the `record_exception` method within traced code.',
+		'If you want to explicitly send an error to Highlight, you can use the `error` method within traced code.',
 	code: [
 		{
-			text: `Highlight::H.instance.record_exception(e)`,
+			text: `Highlight.error(e)`,
+			language: 'ruby',
+		},
+	],
+}
+
+export const customTrace: QuickStartStep = {
+	title: 'Record custom traces. (optional)',
+	content:
+		'If you want to explicitly send a trace to Highlight, you can use the `start_span` method to wrap any code you want to trace.',
+	code: [
+		{
+			text: `Highlight.start_span('my-span') do |span|
+	# ...
+end`,
 			language: 'ruby',
 		},
 	],

--- a/highlight.io/components/QuickstartContent/logging/ruby/other.tsx
+++ b/highlight.io/components/QuickstartContent/logging/ruby/other.tsx
@@ -16,7 +16,7 @@ export const RubyOtherLogContent: QuickStartContent = {
 				{
 					text: `require "highlight"
 
-Highlight::H.new("<YOUR_PROJECT_ID>", environment: "production") do |c|
+Highlight.init("<YOUR_PROJECT_ID>", environment: "production") do |c|
   c.service_name = "my-ruby-app"
   c.service_version = "git-sha"
 end

--- a/highlight.io/components/QuickstartContent/logging/ruby/rails.tsx
+++ b/highlight.io/components/QuickstartContent/logging/ruby/rails.tsx
@@ -16,7 +16,7 @@ export const RubyRailsLogContent: QuickStartContent = {
 				{
 					text: `require "highlight"
 
-Highlight::H.new("<YOUR_PROJECT_ID>", environment: "production") do |c|
+Highlight.init("<YOUR_PROJECT_ID>", environment: "production") do |c|
   c.service_name = "my-rails-app"
   c.service_version = "git-sha"
 end

--- a/sdk/highlight-ruby/highlight/CHANGELOG.md
+++ b/sdk/highlight-ruby/highlight/CHANGELOG.md
@@ -19,3 +19,9 @@
 ## 0.2.2
 
 - Fix duplicate errors recorded on traces.
+
+## 0.4.0
+
+- Add `H.init` alias
+- Auto instrument Rails requests and eliminate need for `around_action`
+- Fix warning about incompatibility with `ActiveSupport::LoggerSilence`

--- a/sdk/highlight-ruby/highlight/lib/highlight.rb
+++ b/sdk/highlight-ruby/highlight/lib/highlight.rb
@@ -18,6 +18,10 @@ module Highlight
     end
   end
 
+  def self.init(project_id, environment: '', otlp_endpoint: OTLP_HTTP, &block)
+    H.new(project_id, environment: environment, otlp_endpoint: otlp_endpoint, &block)
+  end
+
   def self.start_span(name, attrs = {}, &block)
     if block_given?
       H.instance.start_span(name, attrs, &block)

--- a/sdk/highlight-ruby/highlight/lib/highlight.rb
+++ b/sdk/highlight-ruby/highlight/lib/highlight.rb
@@ -195,6 +195,10 @@ module Highlight
   end
 
   class Logger < ::Logger
+    if defined?(::ActiveSupport::LoggerSilence)
+      include ActiveSupport::LoggerSilence
+    end
+
     def initialize(*args)
       super
       @local_level = nil

--- a/sdk/highlight-ruby/highlight/lib/highlight.rb
+++ b/sdk/highlight-ruby/highlight/lib/highlight.rb
@@ -199,9 +199,7 @@ module Highlight
   end
 
   class Logger < ::Logger
-    if defined?(::ActiveSupport::LoggerSilence)
-      include ActiveSupport::LoggerSilence
-    end
+    include ActiveSupport::LoggerSilence if defined?(::ActiveSupport::LoggerSilence)
 
     def initialize(*args)
       super

--- a/sdk/highlight-ruby/highlight/lib/highlight/version.rb
+++ b/sdk/highlight-ruby/highlight/lib/highlight/version.rb
@@ -1,3 +1,3 @@
 module Highlight
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.4.0'.freeze
 end


### PR DESCRIPTION
## Summary

Updates the Ruby SDK and docs.

* Eliminates the need to set up the `around_action` to instrument requests by adding a `Railtie` and setting up the `around_action` as part of the initialization logic.
* Adds an `init` alias so you can call `Highlight.init` rather than `Highlight::H.new`.
* Fixes an issue where we were seeing warnings about incompatibility with `ActiveSupport::LoggerSilence`.
* Updates the Ruby/Rails documentation.
* Adds a `/for` page for Rails.
* Fixes some broken links on existing `/for` pages.

Closes HIG-4900

## How did you test this change?

Click tested locally in the E2E app + a local instance of the docs site.

## Are there any deployment considerations?

New SDK version going out. Will see if I can get recent articles published about the Ruby SDK updated.

## Does this work require review from our design team?

N/A
