### PR TITLE
Skip large s3 file downloads

### DIFF
--- a/backend/storage/storage.go
+++ b/backend/storage/storage.go
@@ -54,7 +54,7 @@ var (
 const (
 	MIME_TYPE_JSON          = "application/json"
 	CONTENT_ENCODING_BROTLI = "br"
-	MAX_DOWNLOAD_SIZE       = 32 * 1024 * 1024 // 32GB
+	MAX_DOWNLOAD_SIZE       = 32 * 1024 * 1024 // 32MB
 )
 
 type PayloadType string

--- a/backend/storage/storage.go
+++ b/backend/storage/storage.go
@@ -54,7 +54,7 @@ var (
 const (
 	MIME_TYPE_JSON          = "application/json"
 	CONTENT_ENCODING_BROTLI = "br"
-	MAX_DOWNLOAD_SIZE       = 10 * 1024 * 1024 // 10MB
+	MAX_DOWNLOAD_SIZE       = 32 * 1024 * 1024 // 32GB
 )
 
 type PayloadType string

--- a/frontend/src/util/preload.ts
+++ b/frontend/src/util/preload.ts
@@ -15,7 +15,7 @@ import { H } from 'highlight.run'
 
 // Max brotlied resource file allowed. Note that a brotli file with some binary data
 // has a compression ratio of >5x, so unbrotlied this file will take up much more memory.
-const RESOURCE_FILE_SIZE_LIMIT_BYTES = 64 * 1024 * 1024
+const RESOURCE_FILE_SIZE_LIMIT_BYTES = 32 * 1024 * 1024
 
 export const checkResourceLimit = async function (resources_url: string) {
 	const r = await fetch(resources_url, {


### PR DESCRIPTION
## Summary
A session was causing unresponsive pages due to a 50MB file download. Skip large file downloads that are larger than 32MB. This was due to a large network resource file, as session recording are chunked.

## How did you test this change?
N/A - local uses file system client

## Are there any deployment considerations?
1. Test on broken sessiomn
2. Ensure other parts are not broken
3. Create card to look into breaking down network resources

## Does this work require review from our design team?
N/A
