### PR TITLE
Python logging improvements

### DIFF
--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -161,7 +161,7 @@ class H(object):
         )
         self._log_handler = LogHandler(self, level=log_level)
         if instrument_logging:
-            self._instrument_logging()
+            self._instrument_logging(log_level=log_level)
 
         class HighlightSpanProcessor(SpanProcessor):
             def on_start(
@@ -469,12 +469,12 @@ class H(object):
             )
             self.log.emit(r)
 
-    def _instrument_logging(self):
+    def _instrument_logging(self, log_level):
         if H._logging_instrumented:
             return
 
         LoggingInstrumentor().instrument(
-            set_logging_format=True, log_hook=self.log_hook
+            set_logging_format=True, log_hook=self.log_hook, log_level=log_level
         )
         otel_factory = logging.getLogRecordFactory()
 

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -90,7 +90,7 @@ class H(object):
         disabled_integrations: typing.List[str] = None,
         otlp_endpoint: str = "",
         instrument_logging: bool = True,
-        log_level=logging.DEBUG,
+        log_level=logging.INFO,
         service_name: str = "",
         service_version: str = "",
         environment: str = "",
@@ -430,6 +430,7 @@ class H(object):
             attributes[SpanAttributes.CODE_NAMESPACE] = record.module
             attributes[SpanAttributes.CODE_FILEPATH] = record.pathname
             attributes[SpanAttributes.CODE_LINENO] = record.lineno
+            attributes["logger"] = record.name
             attributes["highlight.trace_id"] = request_id
             attributes["highlight.session_id"] = session_id
             if isinstance(record.args, dict):
@@ -474,7 +475,9 @@ class H(object):
             return
 
         LoggingInstrumentor().instrument(
-            set_logging_format=True, log_hook=self.log_hook, log_level=log_level
+            set_logging_format=True,
+            log_hook=self.log_hook,
+            log_level=log_level,
         )
         otel_factory = logging.getLogRecordFactory()
 

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "highlight-io"
-version = "0.8.6"
+version = "0.8.7"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 license = "Apache-2.0"
 authors = [


### PR DESCRIPTION
## Summary
- Respect the log level passed into the Highlight initialization for Python's built in logging.
- Pass in the logger name to the log info

![Screenshot 2024-08-22 at 4 06 27 PM](https://github.com/user-attachments/assets/6a4dbb49-a8f6-4940-bd76-93d49aa0cf48)

## How did you test this change?
1. Start a Python E2E app
2. Create your own logger: `logger = logging.getLogger("pr_test")
3. Add two logs to an endpoint
  a. logging.info("Test info")
  b. logging.error("Test error")
4. Hit the endpoint
- [ ] Info log recorded with logger name
- [ ] Error log recorded with logger name
5. Add `log_level=Logging.Error` into the Python initialization
6. Hit the endpoint
- [ ] Info log not recorded
- [ ] Error log recorded with logger name

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
