### PR TITLE
Add function to filter quickStartContent and use in getStaticProps

### DIFF
--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -491,7 +491,7 @@ export const getStaticProps: GetStaticProps<DocData> = async (context) => {
 						mdxOptions: {
 							remarkPlugins: [remarkGfm],
 						},
-					})
+				  })
 				: null,
 			markdownTextOG: newContent,
 			slug: currentDoc.simple_path,
@@ -882,10 +882,10 @@ export default function DocPage({
 					metadata?.metaTitle?.length
 						? metadata?.metaTitle
 						: metadata?.title?.length
-							? metadata?.title === 'Welcome to Highlight'
-								? 'Documentation'
-								: metadata?.title
-							: ''
+						? metadata?.title === 'Welcome to Highlight'
+							? 'Documentation'
+							: metadata?.title
+						: ''
 				}
 				description={description}
 				absoluteImageUrl={`https://${
@@ -1009,8 +1009,8 @@ export default function DocPage({
 							{metadata?.heading
 								? metadata.heading
 								: metadata?.title
-									? metadata.title
-									: ''}
+								? metadata.title
+								: ''}
 						</h3>
 						{isSdkDoc ? (
 							<DocSection content={markdownTextOG || ''} />
@@ -1101,12 +1101,12 @@ export default function DocPage({
 															<HighlightCodeBlock
 																language={
 																	props.className
-																		? (props.className
+																		? props.className
 																				.split(
 																					'language-',
 																				)
 																				.pop() ??
-																			'js')
+																		  'js'
 																		: 'js'
 																}
 																text={

--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -326,6 +326,34 @@ interface TocEntry {
 	children: TocEntry[]
 }
 
+// Filter quickStartContent to only include the keys that are needed for the current doc
+function getFilteredQuickStartContent(
+	newContent: string,
+	quickStartContent: any,
+) {
+	const regex = /\{(\w+(?:\["[^"]+"\])+)\}/
+	const match = newContent.match(regex)
+
+	if (match) {
+		const keyString = match[1]
+		const quickStartContentMatches = keyString
+			.split(/\["|\"]/)
+			.filter((key) => key && key !== 'quickStartContent')
+
+		const getFilteredValue = (obj: any, keys: string[]) =>
+			keys.reduce((acc, key) => acc?.[key] ?? null, obj)
+
+		const filteredQuickStartContent = quickStartContentMatches.reduceRight(
+			(obj, key) => ({ [key]: obj }),
+			getFilteredValue(quickStartContent, quickStartContentMatches),
+		)
+
+		return filteredQuickStartContent
+	} else {
+		return quickStartContent
+	}
+}
+
 export const getStaticProps: GetStaticProps<DocData> = async (context) => {
 	logger.info(
 		{ params: context?.params },
@@ -449,7 +477,15 @@ export const getStaticProps: GetStaticProps<DocData> = async (context) => {
 				? await serialize(newerContent, {
 						scope: {
 							path: currentDoc.rel_path,
-							quickStartContent,
+							// Only filter quickStartContent if it exists in the markdown
+							quickStartContent: newContent.includes(
+								'quickStartContent',
+							)
+								? getFilteredQuickStartContent(
+										newContent,
+										quickStartContent,
+								  )
+								: null,
 							roadmapData: roadmapData,
 						},
 						mdxOptions: {

--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -484,14 +484,14 @@ export const getStaticProps: GetStaticProps<DocData> = async (context) => {
 								? getFilteredQuickStartContent(
 										newContent,
 										quickStartContent,
-								  )
+									)
 								: null,
 							roadmapData: roadmapData,
 						},
 						mdxOptions: {
 							remarkPlugins: [remarkGfm],
 						},
-				  })
+					})
 				: null,
 			markdownTextOG: newContent,
 			slug: currentDoc.simple_path,
@@ -882,10 +882,10 @@ export default function DocPage({
 					metadata?.metaTitle?.length
 						? metadata?.metaTitle
 						: metadata?.title?.length
-						? metadata?.title === 'Welcome to Highlight'
-							? 'Documentation'
-							: metadata?.title
-						: ''
+							? metadata?.title === 'Welcome to Highlight'
+								? 'Documentation'
+								: metadata?.title
+							: ''
 				}
 				description={description}
 				absoluteImageUrl={`https://${
@@ -1009,8 +1009,8 @@ export default function DocPage({
 							{metadata?.heading
 								? metadata.heading
 								: metadata?.title
-								? metadata.title
-								: ''}
+									? metadata.title
+									: ''}
 						</h3>
 						{isSdkDoc ? (
 							<DocSection content={markdownTextOG || ''} />
@@ -1101,12 +1101,12 @@ export default function DocPage({
 															<HighlightCodeBlock
 																language={
 																	props.className
-																		? props.className
+																		? (props.className
 																				.split(
 																					'language-',
 																				)
 																				.pop() ??
-																		  'js'
+																			'js')
 																		: 'js'
 																}
 																text={


### PR DESCRIPTION
## Summary
Filter out unnecessary Quick Start documentation content with regex, reducing ISR payloads (~50kb to ~15kb)

Fixes GRO-118

## How did you test this change?
|Before|After|
|--|--|
|<img width="795" alt="image" src="https://github.com/user-attachments/assets/e7d543c9-7fd0-4446-9876-876a8e99e976">|<img width="808" alt="image" src="https://github.com/user-attachments/assets/403503bd-f04d-4105-a21c-774356d7451e">|

Click through each quick start doc page

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
