### PR TITLE
Fix drag to resize on side panels

### DIFF
--- a/frontend/src/components/RelatedResources/Panel.tsx
+++ b/frontend/src/components/RelatedResources/Panel.tsx
@@ -1,5 +1,5 @@
 import { Box, Dialog } from '@highlight-run/ui/components'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 import { useRelatedResource } from '@/components/RelatedResources/hooks'
 import {
@@ -26,7 +26,7 @@ type PanelComponent = React.FC<Props> & {
 
 export const Panel: PanelComponent = ({ children, open }) => {
 	const dragHandleRef = useRef<HTMLDivElement>(null)
-	const [dragging, setDragging] = useState(false)
+	const dragging = useRef(false)
 	const { remove, panelWidth, setPanelWidth } = useRelatedResource()
 	const dialogStore = Dialog.useStore({
 		open,
@@ -39,7 +39,7 @@ export const Panel: PanelComponent = ({ children, open }) => {
 
 	const handleMouseMove = useCallback(
 		(e: MouseEvent) => {
-			if (!dragging) {
+			if (!dragging.current) {
 				return
 			}
 
@@ -53,27 +53,24 @@ export const Panel: PanelComponent = ({ children, open }) => {
 				Math.min(Math.max(newWidth, MIN_PANEL_WIDTH), MAX_PANEL_WIDTH),
 			)
 		},
-		[dragging, setPanelWidth],
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[],
 	)
 
 	const handleMouseUp = useCallback(() => {
-		setDragging(false)
+		dragging.current = false
 	}, [])
 
 	useEffect(() => {
-		if (dragging) {
-			window.addEventListener('mousemove', handleMouseMove, true)
-			window.addEventListener('mouseup', handleMouseUp, true)
-		} else {
-			window.removeEventListener('mousemove', handleMouseMove, true)
-			window.removeEventListener('mouseup', handleMouseUp, true)
-		}
+		window.addEventListener('mousemove', handleMouseMove, true)
+		window.addEventListener('mouseup', handleMouseUp, true)
 
 		return () => {
 			window.removeEventListener('mousemove', handleMouseMove, true)
 			window.removeEventListener('mouseup', handleMouseUp, true)
 		}
-	}, [dragging, handleMouseMove, handleMouseUp])
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [])
 
 	return (
 		<Dialog
@@ -93,7 +90,7 @@ export const Panel: PanelComponent = ({ children, open }) => {
 				cssClass={styles.panelDragHandle}
 				onMouseDown={(e) => {
 					e.preventDefault()
-					setDragging(true)
+					dragging.current = true
 				}}
 			/>
 

--- a/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
@@ -143,11 +143,11 @@ export default function ErrorsV2() {
 	const navigation = useErrorPageNavigation(getErrorsData.errorGroupSecureIds)
 
 	const dragHandleRef = useRef<HTMLDivElement>(null)
-	const [dragging, setDragging] = useState(false)
+	const dragging = useRef(false)
 
 	const handleMouseMove = useCallback(
 		(e: MouseEvent) => {
-			if (!dragging) {
+			if (!dragging.current) {
 				return
 			}
 
@@ -158,11 +158,12 @@ export default function ErrorsV2() {
 				Math.min(Math.max(e.clientX, MIN_PANEL_WIDTH), MAX_PANEL_WIDTH),
 			)
 		},
-		[dragging, navigation],
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[],
 	)
 
 	const handleMouseUp = useCallback(() => {
-		setDragging(false)
+		dragging.current = false
 	}, [])
 
 	const onAiSubmit = (aiQuery: string) => {
@@ -195,19 +196,15 @@ export default function ErrorsV2() {
 	}, [aiData])
 
 	useEffect(() => {
-		if (dragging) {
-			window.addEventListener('mousemove', handleMouseMove, true)
-			window.addEventListener('mouseup', handleMouseUp, true)
-		} else {
-			window.removeEventListener('mousemove', handleMouseMove, true)
-			window.removeEventListener('mouseup', handleMouseUp, true)
-		}
+		window.addEventListener('mousemove', handleMouseMove, true)
+		window.addEventListener('mouseup', handleMouseUp, true)
 
 		return () => {
 			window.removeEventListener('mousemove', handleMouseMove, true)
 			window.removeEventListener('mouseup', handleMouseUp, true)
 		}
-	}, [dragging, handleMouseMove, handleMouseUp])
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [])
 
 	useAllHotKeys(navigation)
 
@@ -307,7 +304,7 @@ export default function ErrorsV2() {
 						cssClass={styles.panelDragHandle}
 						onMouseDown={(e) => {
 							e.preventDefault()
-							setDragging(true)
+							dragging.current = true
 						}}
 					/>
 					<SearchPanel />

--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -123,7 +123,7 @@ const PlayerPageBase: React.FC<{ playerRef: RefObject<HTMLDivElement> }> = ({
 	useEffect(() => analytics.page('Session'), [sessionSecureId])
 
 	const dragHandleRef = useRef<HTMLDivElement>(null)
-	const [dragging, setDragging] = useState(false)
+	const dragging = useRef(false)
 
 	const [leftPanelWidth, setLeftPanelWidth] = useLocalStorage(
 		LOCAL_STORAGE_PANEL_WIDTH_KEY,
@@ -132,7 +132,7 @@ const PlayerPageBase: React.FC<{ playerRef: RefObject<HTMLDivElement> }> = ({
 
 	const handleMouseMove = useCallback(
 		(e: MouseEvent) => {
-			if (!dragging) {
+			if (!dragging.current) {
 				return
 			}
 
@@ -143,27 +143,24 @@ const PlayerPageBase: React.FC<{ playerRef: RefObject<HTMLDivElement> }> = ({
 				Math.min(Math.max(e.clientX, MIN_PANEL_WIDTH), MAX_PANEL_WIDTH),
 			)
 		},
-		[dragging, setLeftPanelWidth],
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[],
 	)
 
 	const handleMouseUp = useCallback(() => {
-		setDragging(false)
+		dragging.current = false
 	}, [])
 
 	useEffect(() => {
-		if (dragging) {
-			window.addEventListener('mousemove', handleMouseMove, true)
-			window.addEventListener('mouseup', handleMouseUp, true)
-		} else {
-			window.removeEventListener('mousemove', handleMouseMove, true)
-			window.removeEventListener('mouseup', handleMouseUp, true)
-		}
+		window.addEventListener('mousemove', handleMouseMove, true)
+		window.addEventListener('mouseup', handleMouseUp, true)
 
 		return () => {
 			window.removeEventListener('mousemove', handleMouseMove, true)
 			window.removeEventListener('mouseup', handleMouseUp, true)
 		}
-	}, [dragging, handleMouseMove, handleMouseUp])
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [])
 
 	const showLeftPanel =
 		showLeftPanelPreference && (isLoggedIn || projectId === DEMO_PROJECT_ID)
@@ -184,7 +181,7 @@ const PlayerPageBase: React.FC<{ playerRef: RefObject<HTMLDivElement> }> = ({
 					cssClass={style.panelDragHandle}
 					onMouseDown={(e) => {
 						e.preventDefault()
-						setDragging(true)
+						dragging.current = true
 					}}
 				/>
 				<SessionFeedV3 />


### PR DESCRIPTION
## Summary

Fixes a bug with the side panel resize logic where you could not get out of drag mode after clicking to resize.

https://www.loom.com/share/87f4174444d24cc582cd6db371071734

## How did you test this change?

Click tested locally and in the Reflame PR preview.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A