### PR TITLE
support running backend using iam role for cloud auth

### DIFF
--- a/backend/env/environment.go
+++ b/backend/env/environment.go
@@ -27,16 +27,15 @@ type Configuration struct {
 	AuthJWTAccessToken          string `mapstructure:"JWT_ACCESS_SECRET"`
 	AuthMode                    string `mapstructure:"REACT_APP_AUTH_MODE"`
 	AuthWhitelistedAccount      string `mapstructure:"WHITELISTED_FIREBASE_ACCOUNT"`
-	AwsAccessKeyID              string `mapstructure:"AWS_ACCESS_KEY_ID"`
 	AwsCloudfrontDomain         string `mapstructure:"AWS_CLOUDFRONT_DOMAIN"`
 	AwsCloudfrontPrivateKey     string `mapstructure:"AWS_CLOUDFRONT_PRIVATE_KEY"`
 	AwsCloudfrontPublicKeyID    string `mapstructure:"AWS_CLOUDFRONT_PUBLIC_KEY_ID"`
+	AwsRoleArn                  string `mapstructure:"AWS_ROLE_ARN"`
 	AwsS3BucketName             string `mapstructure:"AWS_S3_BUCKET_NAME_NEW"`
 	AwsS3GithubBucketName       string `mapstructure:"AWS_S3_GITHUB_BUCKET_NAME"`
 	AwsS3ResourcesBucketName    string `mapstructure:"AWS_S3_RESOURCES_BUCKET"`
 	AwsS3SourceMapBucketName    string `mapstructure:"AWS_S3_SOURCE_MAP_BUCKET_NAME_NEW"`
 	AwsS3StagingBucketName      string `mapstructure:"AWS_S3_STAGING_BUCKET_NAME"`
-	AwsSecretAccessKey          string `mapstructure:"AWS_SECRET_ACCESS_KEY"`
 	ClearbitApiKey              string `mapstructure:"CLEARBIT_API_KEY"`
 	ClickUpClientID             string `mapstructure:"CLICKUP_CLIENT_ID"`
 	ClickUpClientSecret         string `mapstructure:"CLICKUP_CLIENT_SECRET"`

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -216,7 +216,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.17.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.26.2
 	github.com/aws/aws-sdk-go-v2/service/sso v1.20.5 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/bwmarrin/discordgo v0.27.1
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/dghubble/sling v1.4.2 // indirect

--- a/backend/storage/storage.go
+++ b/backend/storage/storage.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/cloudfront/sign"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3Types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go/ptr"
 	"github.com/go-chi/chi"
 	"github.com/google/uuid"
@@ -539,6 +540,13 @@ func NewS3Client(ctx context.Context) (*S3Client, error) {
 	clientEast2 := s3.NewFromConfig(cfgEast2, func(o *s3.Options) {
 		o.UsePathStyle = true
 	})
+
+	// Create Amazon S3 API client using path style addressing.
+	stsClient := sts.NewFromConfig(cfgEast2, func(o *sts.Options) {})
+	_, err = stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to validate aws credentials for storage client")
+	}
 
 	return &S3Client{
 		S3ClientEast2:   clientEast2,

--- a/deploy/collector-task.json
+++ b/deploy/collector-task.json
@@ -67,7 +67,7 @@
 		}
 	],
 	"family": "opentelemetry-collector-service",
-	"executionRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
+	"executionRoleArn": "arn:aws:iam::173971919437:role/HighlightAppProd",
 	"networkMode": "awsvpc",
 	"revision": 8,
 	"volumes": [],

--- a/deploy/log-alerts-task.json
+++ b/deploy/log-alerts-task.json
@@ -1,6 +1,6 @@
 {
 	"ipcMode": null,
-	"executionRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
+	"executionRoleArn": "arn:aws:iam::173971919437:role/HighlightAppProd",
 	"containerDefinitions": [
 		{
 			"dnsSearchDomains": null,
@@ -75,7 +75,7 @@
 	],
 	"placementConstraints": [],
 	"memory": "4096",
-	"taskRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
+	"taskRoleArn": "arn:aws:iam::173971919437:role/HighlightAppProd",
 	"compatibilities": ["EC2", "FARGATE"],
 	"taskDefinitionArn": "arn:aws:ecs:us-east-2:173971919437:task-definition/worker-task:40",
 	"family": "log-alerts-task",

--- a/deploy/metric-monitor-task.json
+++ b/deploy/metric-monitor-task.json
@@ -1,6 +1,6 @@
 {
 	"ipcMode": null,
-	"executionRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
+	"executionRoleArn": "arn:aws:iam::173971919437:role/HighlightAppProd",
 	"containerDefinitions": [
 		{
 			"dnsSearchDomains": null,
@@ -75,7 +75,7 @@
 	],
 	"placementConstraints": [],
 	"memory": "4096",
-	"taskRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
+	"taskRoleArn": "arn:aws:iam::173971919437:role/HighlightAppProd",
 	"compatibilities": ["EC2", "FARGATE"],
 	"taskDefinitionArn": "arn:aws:ecs:us-east-2:173971919437:task-definition/worker-task:40",
 	"family": "metric-monitor-task",

--- a/deploy/private-graph-task.json
+++ b/deploy/private-graph-task.json
@@ -55,8 +55,8 @@
 		}
 	],
 	"family": "private-graph-task",
-	"taskRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
-	"executionRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
+	"taskRoleArn": "arn:aws:iam::173971919437:role/HighlightAppProd",
+	"executionRoleArn": "arn:aws:iam::173971919437:role/HighlightAppProd",
 	"networkMode": "bridge",
 	"revision": 1761,
 	"volumes": [],

--- a/deploy/public-graph-task.json
+++ b/deploy/public-graph-task.json
@@ -1,6 +1,6 @@
 {
 	"ipcMode": null,
-	"executionRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
+	"executionRoleArn": "arn:aws:iam::173971919437:role/HighlightAppProd",
 	"containerDefinitions": [
 		{
 			"dnsSearchDomains": null,
@@ -77,7 +77,7 @@
 	],
 	"placementConstraints": [],
 	"memory": "16384",
-	"taskRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
+	"taskRoleArn": "arn:aws:iam::173971919437:role/HighlightAppProd",
 	"compatibilities": ["EC2", "FARGATE"],
 	"taskDefinitionArn": "arn:aws:ecs:us-east-2:173971919437:task-definition/public-graph-task:65",
 	"family": "public-graph-task",

--- a/deploy/public-worker-batched-service.json
+++ b/deploy/public-worker-batched-service.json
@@ -41,8 +41,8 @@
 		}
 	],
 	"family": "public-worker-batched-service",
-	"taskRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
-	"executionRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
+	"taskRoleArn": "arn:aws:iam::173971919437:role/HighlightAppProd",
+	"executionRoleArn": "arn:aws:iam::173971919437:role/HighlightAppProd",
 	"networkMode": "bridge",
 	"revision": 119,
 	"volumes": [],

--- a/deploy/public-worker-datasync-service.json
+++ b/deploy/public-worker-datasync-service.json
@@ -41,8 +41,8 @@
 		}
 	],
 	"family": "public-worker-datasync-service",
-	"taskRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
-	"executionRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
+	"taskRoleArn": "arn:aws:iam::173971919437:role/HighlightAppProd",
+	"executionRoleArn": "arn:aws:iam::173971919437:role/HighlightAppProd",
 	"networkMode": "bridge",
 	"revision": 118,
 	"volumes": [],

--- a/deploy/public-worker-main-service.json
+++ b/deploy/public-worker-main-service.json
@@ -44,8 +44,8 @@
 		}
 	],
 	"family": "public-worker-main-service",
-	"taskRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
-	"executionRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
+	"taskRoleArn": "arn:aws:iam::173971919437:role/HighlightAppProd",
+	"executionRoleArn": "arn:aws:iam::173971919437:role/HighlightAppProd",
 	"networkMode": "bridge",
 	"revision": 408,
 	"volumes": [],

--- a/deploy/public-worker-traces-service.json
+++ b/deploy/public-worker-traces-service.json
@@ -41,8 +41,8 @@
 		}
 	],
 	"family": "public-worker-traces-service",
-	"taskRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
-	"executionRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
+	"taskRoleArn": "arn:aws:iam::173971919437:role/HighlightAppProd",
+	"executionRoleArn": "arn:aws:iam::173971919437:role/HighlightAppProd",
 	"networkMode": "bridge",
 	"revision": 120,
 	"volumes": [],

--- a/deploy/worker-task.json
+++ b/deploy/worker-task.json
@@ -52,8 +52,8 @@
 		}
 	],
 	"family": "worker-task",
-	"taskRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
-	"executionRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
+	"taskRoleArn": "arn:aws:iam::173971919437:role/HighlightAppProd",
+	"executionRoleArn": "arn:aws:iam::173971919437:role/HighlightAppProd",
 	"networkMode": "bridge",
 	"revision": 1679,
 	"volumes": [


### PR DESCRIPTION
## Summary

Support running the highlight backend via an IAM role rather than the AWS ID / secret.

## How did you test this change?

manually deploying to production
locally testing with new IAM role set

## Are there any deployment considerations?

monitoring deploy

## Does this work require review from our design team?

no
