### PR TITLE
improve session events filtering logic

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,7 +73,7 @@
 		"react-virtuoso": "^2.13.1",
 		"recharts": "^2.12.1",
 		"rrweb": "workspace:*",
-		"rudder-sdk-js": "2.20.0",
+		"rudder-sdk-js": "^2.48.17",
 		"subscriptions-transport-ws": "^0.11.0",
 		"use-query-params": "^2.2.0",
 		"validator": "13.7.0",

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -51,6 +51,7 @@ import { OTLP_ENDPOINT, PUBLIC_GRAPH_URI } from '@/constants'
 import { SIGN_IN_ROUTE } from '@/pages/Auth/AuthRouter'
 import { authRedirect } from '@/pages/Auth/utils'
 import { onlyAllowHighlightStaff } from '@/util/authorization/authorizationUtils'
+import { omit } from 'lodash'
 
 document.body.className = 'highlight-light-theme'
 
@@ -366,6 +367,15 @@ const AuthenticationRoleRouter = () => {
 				analytics.identify(adminData.id, {
 					'Project ID': data.project?.id,
 					'Workspace ID': data.project?.workspace?.id,
+					...Object.entries(omit(adminData, ['__typename'])).reduce(
+						(acc, [key, value]) => {
+							if (value) {
+								acc[key] = value.toString()
+							}
+							return acc
+						},
+						{} as Record<string, string>,
+					),
 				})
 			},
 		})

--- a/frontend/src/pages/Player/RightPlayerPanel/components/EventDetails/EventDetails.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/EventDetails/EventDetails.tsx
@@ -40,7 +40,10 @@ const EventDetails = React.memo(({ event }: { event: HighlightEvent }) => {
 		0,
 	)
 	const displayName = getTimelineEventDisplayName(details.title || '')
-	const payload = (event.data as { payload: any }).payload
+	let payload = (event.data as { payload: any }).payload
+	try {
+		payload = JSON.parse(payload)
+	} catch (e) {}
 
 	const eventIdx = eventsForTimelineIndicator.findIndex(
 		(e) => e.identifier === event.identifier,

--- a/frontend/src/pages/Player/StreamElement/StreamElement.tsx
+++ b/frontend/src/pages/Player/StreamElement/StreamElement.tsx
@@ -25,7 +25,11 @@ export const getEventRenderDetails = (
 		details.title = e.data.tag
 		switch (e.data.tag) {
 			case 'Identify':
-				details.displayValue = JSON.parse(payload).user_identifier
+				const identifyPayload = JSON.parse(payload) ?? {}
+				details.displayValue =
+					identifyPayload.email ||
+					identifyPayload.name ||
+					identifyPayload.userIdentifier
 				break
 			case 'Track':
 				try {

--- a/frontend/src/pages/Player/components/EventStreamV2/utils.ts
+++ b/frontend/src/pages/Player/components/EventStreamV2/utils.ts
@@ -42,7 +42,7 @@ export const getFilteredEvents = (
 						/**
 						 * For user properties, we allow for searching by the key.
 						 */
-						const matchedKey = searchTokens.some((searchToken) => {
+						const matchedKey = searchTokens.every((searchToken) => {
 							return keys.some((key) =>
 								key.toLocaleLowerCase().includes(searchToken),
 							)
@@ -52,7 +52,7 @@ export const getFilteredEvents = (
 							matchedKey ||
 							keys.some((key) => {
 								if (typeof userObject[key] === 'string') {
-									return searchTokens.some((searchToken) => {
+									return searchTokens.every((searchToken) => {
 										return userObject[key]
 											.toLowerCase()
 											.includes(searchToken)
@@ -74,7 +74,7 @@ export const getFilteredEvents = (
 						/**
 						 * For track properties, we allow for searching by the key.
 						 */
-						const matchedKey = searchTokens.some((searchToken) => {
+						const matchedKey = searchTokens.every((searchToken) => {
 							return keys.some((key) =>
 								key.toLocaleLowerCase().includes(searchToken),
 							)
@@ -84,7 +84,7 @@ export const getFilteredEvents = (
 							matchedKey ||
 							keys.some((key) => {
 								if (typeof trackProperties[key] === 'string') {
-									return searchTokens.some((searchToken) => {
+									return searchTokens.every((searchToken) => {
 										return trackProperties[key]
 											.toLowerCase()
 											.includes(searchToken)
@@ -105,7 +105,7 @@ export const getFilteredEvents = (
 
 						return keys.some((key) => {
 							if (typeof userObject[key] === 'string') {
-								return searchTokens.some((searchToken) => {
+								return searchTokens.every((searchToken) => {
 									return userObject[key]
 										.toLowerCase()
 										.includes(searchToken)
@@ -123,7 +123,7 @@ export const getFilteredEvents = (
 						viewportPayload,
 					) as (keyof ViewportResizeListenerArgs)[]
 					return keys.some((key) => {
-						return searchTokens.some((searchToken) => {
+						return searchTokens.every((searchToken) => {
 							return (
 								key.toLowerCase().includes(searchToken) ||
 								viewportPayload[key]
@@ -140,7 +140,7 @@ export const getFilteredEvents = (
 						}[]
 					}
 					return vitals.some(({ name, value }) => {
-						return searchTokens.some((searchToken) => {
+						return searchTokens.every((searchToken) => {
 							return (
 								name.toLowerCase().includes(searchToken) ||
 								value.toString().includes(searchToken)
@@ -152,7 +152,7 @@ export const getFilteredEvents = (
 				case 'TabHidden':
 					return true
 				default:
-					return searchTokens.some((searchToken) => {
+					return searchTokens.every((searchToken) => {
 						return (event.data.payload as string)
 							.toLowerCase()
 							.includes(searchToken)

--- a/frontend/src/pages/Player/components/EventStreamV2/utils.ts
+++ b/frontend/src/pages/Player/components/EventStreamV2/utils.ts
@@ -148,9 +148,9 @@ export const getFilteredEvents = (
 						})
 					})
 				case 'RageClicks':
-					return true
+					return false
 				case 'TabHidden':
-					return true
+					return false
 				default:
 					return searchTokens.every((searchToken) => {
 						return (event.data.payload as string)

--- a/frontend/src/routers/AppRouter/AppRouter.tsx
+++ b/frontend/src/routers/AppRouter/AppRouter.tsx
@@ -30,7 +30,6 @@ import { ProjectRouter } from '@routers/ProjectRouter/ProjectRouter'
 import { WorkspaceRouter } from '@routers/ProjectRouter/WorkspaceRouter'
 import analytics from '@util/analytics'
 import log from '@util/log'
-import { omit } from 'lodash'
 import { lazy, Suspense, useEffect } from 'react'
 import {
 	Navigate,
@@ -222,10 +221,7 @@ export const AppRouter = () => {
 				identifyMetadata.avatar = admin.photo_url
 			}
 
-			// `id` is a reserved keyword in rudderstack and it's recommended to use a
-			// static property for the user ID rather than something that could change
-			// over time, like an email address.
-			analytics.identify(admin.id, omit(identifyMetadata, ['id']))
+			analytics.identify(admin.id, identifyMetadata)
 		}
 	}, [admin])
 

--- a/frontend/src/util/analytics.ts
+++ b/frontend/src/util/analytics.ts
@@ -1,7 +1,19 @@
 import { Metadata } from '@highlight-run/client'
 import { H } from 'highlight.run'
 import * as rudderanalytics from 'rudder-sdk-js'
+import { omit } from 'lodash'
 
+// from https://www.rudderstack.com/docs/archive/javascript-sdk/1.1/faq/#what-is-the-reserved-keyword-error
+const rudderstackReserved = [
+	'anonymous_id',
+	'id',
+	'sent_at',
+	'received_at',
+	'timestamp',
+	'original_timestamp',
+	'event_text',
+	'event',
+]
 let rudderstackInitialized = false
 
 const initialize = () => {
@@ -29,7 +41,7 @@ const track = (event: string, metadata?: rudderanalytics.apiObject) => {
 	])
 
 	H.track(event, metadata as Metadata)
-	rudderanalytics.track(event, metadata)
+	rudderanalytics.track(event, omit(metadata, rudderstackReserved))
 }
 
 const identify = (email: string, traits?: rudderanalytics.apiObject) => {
@@ -44,11 +56,14 @@ const identify = (email: string, traits?: rudderanalytics.apiObject) => {
 	hsq.push(['trackPageView'])
 
 	H.identify(email, traits as Metadata)
-	rudderanalytics.identify(email, traits)
+	// `id` is a reserved keyword in rudderstack and it's recommended to use a
+	// static property for the user ID rather than something that could change
+	// over time, like an email address.
+	rudderanalytics.identify(email, omit(traits, rudderstackReserved))
 }
 
 const page = (name: string, properties?: rudderanalytics.apiObject) => {
-	rudderanalytics.page(name, properties)
+	rudderanalytics.page(name, omit(properties, rudderstackReserved))
 }
 
 const analytics = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9959,7 +9959,7 @@ __metadata:
     react-virtuoso: "npm:^2.13.1"
     recharts: "npm:^2.12.1"
     rrweb: "workspace:*"
-    rudder-sdk-js: "npm:2.20.0"
+    rudder-sdk-js: "npm:^2.48.17"
     source-map-explorer: "npm:^2.5.2"
     stylelint: "npm:^14.9.1"
     subscriptions-transport-ws: "npm:^0.11.0"
@@ -49316,10 +49316,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rudder-sdk-js@npm:2.20.0, rudder-sdk-js@npm:^2.20.0":
+"rudder-sdk-js@npm:^2.20.0":
   version: 2.20.0
   resolution: "rudder-sdk-js@npm:2.20.0"
   checksum: 10/a9c0fd8befa7c72df003b7f20ac5e3ae028a8323b1494a973e184684ba628e9b35f32c378ca5a91f6312aebc22c21a7024922746c00315d4c472d410640322dc
+  languageName: node
+  linkType: hard
+
+"rudder-sdk-js@npm:^2.48.17":
+  version: 2.48.17
+  resolution: "rudder-sdk-js@npm:2.48.17"
+  checksum: 10/d381d26ca5d0bab6d190fb2c896bec4a0eac00f4261664b4fa3ebfaf70b432993e872e9c5fdd18b93ae505ccde1dff6fec23311af7831daa08776492bd2e5ab5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -49316,14 +49316,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rudder-sdk-js@npm:^2.20.0":
-  version: 2.20.0
-  resolution: "rudder-sdk-js@npm:2.20.0"
-  checksum: 10/a9c0fd8befa7c72df003b7f20ac5e3ae028a8323b1494a973e184684ba628e9b35f32c378ca5a91f6312aebc22c21a7024922746c00315d4c472d410640322dc
-  languageName: node
-  linkType: hard
-
-"rudder-sdk-js@npm:^2.48.17":
+"rudder-sdk-js@npm:^2.20.0, rudder-sdk-js@npm:^2.48.17":
   version: 2.48.17
   resolution: "rudder-sdk-js@npm:2.48.17"
   checksum: 10/d381d26ca5d0bab6d190fb2c896bec4a0eac00f4261664b4fa3ebfaf70b432993e872e9c5fdd18b93ae505ccde1dff6fec23311af7831daa08776492bd2e5ab5


### PR DESCRIPTION
## Summary

* Fixes filtering logic for session events that would incorrectly include events when a search term was set
* Shows comments in the session events feed supporting filtering
* Uses AND logic for multiple search terms in the events feed
* Fixes rudderanalytics attributes to avoid sending `id` term which was throwing a warning
* Improves frontend `identify` call in our app to report more attributes

## How did you test this change?

https://www.loom.com/share/38ee44b7ded344f690b883ec24ca3ca2

![Screenshot from 2024-08-28 12-27-45](https://github.com/user-attachments/assets/f013defe-e1cb-4429-865d-00d9a031b2c9)


## Are there any deployment considerations?

no

## Does this work require review from our design team?

no