### PR TITLE
make clicktextcontent searchable in right panel session

### DIFF
--- a/.changeset/small-cups-lay.md
+++ b/.changeset/small-cups-lay.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+correctly report clickTextContent as timeline events

--- a/frontend/src/pages/Player/StreamElement/StreamElement.tsx
+++ b/frontend/src/pages/Player/StreamElement/StreamElement.tsx
@@ -52,8 +52,10 @@ export const getEventRenderDetails = (
 			case 'Focus':
 			case 'Segment':
 				try {
-					const keys = Object.keys(JSON.parse(payload))
-					details.displayValue = `{${keys.join(', ')}}`
+					const event = JSON.parse(payload)
+					details.displayValue =
+						event['segment-event'] ??
+						`{${Object.keys(event).join(', ')}}`
 				} catch {
 					details.displayValue = payload
 				}

--- a/frontend/src/pages/Player/StreamElement/StreamElement.tsx
+++ b/frontend/src/pages/Player/StreamElement/StreamElement.tsx
@@ -44,6 +44,11 @@ export const getEventRenderDetails = (
 				break
 			case 'Navigate':
 			case 'Click':
+				details.displayValue =
+					payload.clickTextContent ??
+					payload.clickTarget ??
+					payload.clickSelector
+				break
 			case 'Focus':
 			case 'Segment':
 				try {

--- a/frontend/src/pages/Player/components/EventStreamV2/utils.ts
+++ b/frontend/src/pages/Player/components/EventStreamV2/utils.ts
@@ -147,6 +147,23 @@ export const getFilteredEvents = (
 							)
 						})
 					})
+				case 'Click':
+					const clickPayload = event.data.payload as {
+						clickTextContent?: string
+						clickTarget?: string
+						clickSelector?: string
+					}
+					return searchTokens.every((searchToken) => {
+						return [
+							clickPayload.clickTextContent,
+							clickPayload.clickTarget,
+							clickPayload.clickSelector,
+						].some((clickValue) => {
+							return clickValue
+								? clickValue.toLowerCase().includes(searchToken)
+								: false
+						})
+					})
 				case 'RageClicks':
 					return false
 				case 'TabHidden':

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -938,9 +938,6 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			)
 			this.listeners.push(
 				ClickListener((clickTarget, event) => {
-					if (clickTarget) {
-						this.addCustomEvent('Click', clickTarget)
-					}
 					let selector = null
 					let textContent = null
 					if (event && event.target) {
@@ -952,13 +949,11 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 							textContent = textContent.substring(0, 2000)
 						}
 					}
-					highlightThis.addProperties(
-						{
-							clickTextContent: textContent,
-							clickSelector: selector,
-						},
-						{ type: 'session' },
-					)
+					this.addCustomEvent('Click', {
+						clickTarget,
+						clickTextContent: textContent,
+						clickSelector: selector,
+					})
 				}),
 			)
 			this.listeners.push(

--- a/sdk/client/src/workers/highlight-client-worker.ts
+++ b/sdk/client/src/workers/highlight-client-worker.ts
@@ -308,17 +308,7 @@ function stringifyProperties(
 	const processPropertiesMessage = async (msg: PropertiesMessage) => {
 		const { propertiesObject, propertyType } = msg
 		let eventType: string
-		if (propertiesObject?.clickTextContent !== undefined) {
-			eventType = 'ClickTextContent'
-			// click text content should be searchable on sessions but not part of the timeline indicators
-			await graphqlSDK.addSessionProperties({
-				session_secure_id: sessionSecureID,
-				properties_object: stringifyProperties(
-					propertiesObject,
-					'session',
-				),
-			})
-		} else if (propertyType?.type === 'session') {
+		if (propertyType?.type === 'session') {
 			eventType = 'Session'
 			// Session properties are custom properties that the Highlight snippet adds (visited-url, referrer, etc.)
 			// These should be searchable but not part of `Track` timeline indicators
@@ -333,14 +323,12 @@ function stringifyProperties(
 			// Track properties are properties that users define; rn, either through segment or manually.
 			if (propertyType?.source === 'segment') {
 				eventType = 'Segment'
-				addCustomEvent<string>(
-					'Segment Track',
-					stringify(propertiesObject),
-				)
 			} else {
 				eventType = 'Track'
-				addCustomEvent<string>(eventType, stringify(propertiesObject))
 			}
+		}
+		if (eventType !== 'Session') {
+			addCustomEvent<string>(eventType, stringify(propertiesObject))
 		}
 		logger.log(
 			`Adding ${eventType} Properties to session (${sessionSecureID}) w/ obj: ${JSON.stringify(


### PR DESCRIPTION
## Summary

Click events would not properly report the clickTextContent as a searchable attribute in the sessions feed.
Update the client to report the events correctly and ensure 

Builds on events feed changes in https://github.com/highlight/highlight/pull/9227 (to be merged first)

## How did you test this change?

locally building client
https://www.loom.com/share/4f4d046659aa4f4a8ed326b412c062cb
![Screenshot from 2024-08-28 12-14-30](https://github.com/user-attachments/assets/059c6d19-ca14-490d-9d48-eab18738e784)


## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
