### PR TITLE
Speed up yarn install on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,5 @@
 	"github": {
 		"silent": true
 	},
-	"installCommand": "yarn workspaces focus highlight.io --production"
+	"installCommand": "yarn install --production"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
 	"github": {
 		"silent": true
-	}
+	},
+	"installCommand": "yarn workspaces focus highlight.io --production"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,5 @@
 	"github": {
 		"silent": true
 	},
-	"installCommand": "yarn workspaces focus --all --production"
+	"installCommand": "VERCEL_FORCE_NO_BUILD_CACHE=1 yarn workspaces focus highlight.io --production"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,5 @@
 	"github": {
 		"silent": true
 	},
-	"installCommand": "yarn install --production"
+	"installCommand": "yarn workspaces focus --all --production"
 }


### PR DESCRIPTION
## Summary

Only install the dependencies needed for a production build of highlight.io when installing NPM deps in Vercel.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
