### PR TITLE
Fix livestream banner typo

### DIFF
--- a/highlight.io/components/common/Navbar/Navbar.tsx
+++ b/highlight.io/components/common/Navbar/Navbar.tsx
@@ -47,7 +47,7 @@ const LivestreamBanner = () => {
 			className="hidden md:flex text-center justify-center items-center w-full py-2.5 px-3 bg-color-primary-200 text-white hover:bg-opacity-90"
 		>
 			<Typography type="copy3">
-				Join our livestream: Septemper 5th at 1pm PT on Fullstack
+				Join our livestream: September 5th at 1pm PT on Fullstack
 				Monitoring for .NET Applications with OpenTelemetry. Register{' '}
 				<span className="font-semibold underline">here</span>.
 			</Typography>

--- a/highlight.io/components/common/Navbar/Navbar.tsx
+++ b/highlight.io/components/common/Navbar/Navbar.tsx
@@ -47,7 +47,7 @@ const LivestreamBanner = () => {
 			className="hidden md:flex text-center justify-center items-center w-full py-2.5 px-3 bg-color-primary-200 text-white hover:bg-opacity-90"
 		>
 			<Typography type="copy3">
-				Join our livestream: September 5th at 1pm PT on Fullstack
+				Join our livestream: Septemper 5th at 1pm PT on Fullstack
 				Monitoring for .NET Applications with OpenTelemetry. Register{' '}
 				<span className="font-semibold underline">here</span>.
 			</Typography>


### PR DESCRIPTION
## Summary

- Change month from "Septemper" to "September"
- Fixes GRO-129

## How did you test this change?

Visual check:
| Before | After |
|--|--|
|<img width="1020" alt="image" src="https://github.com/user-attachments/assets/e4d31a75-11fa-4f3a-bddc-e9d0a0beac28">|<img width="1020" alt="image" src="https://github.com/user-attachments/assets/54692df4-b0f2-4af4-a162-d6adfb064e92">|

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No