### PR TITLE
fix python sdk install docs

### DIFF
--- a/highlight.io/components/QuickstartContent/backend/python/django.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/django.tsx
@@ -13,7 +13,7 @@ export const PythonDjangoContext: QuickStartContent = {
 	logoUrl: siteUrl('/images/quickstart/django.svg'),
 	entries: [
 		setupFrontendSnippet,
-		downloadSnippet('Django'),
+		downloadSnippet(),
 		{
 			title: 'Initialize the Highlight SDK.',
 			content:

--- a/highlight.io/components/QuickstartContent/backend/python/fastapi.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/fastapi.tsx
@@ -14,7 +14,7 @@ export const PythonFastAPIContext: QuickStartContent = {
 	logoUrl: siteUrl('/images/quickstart/fastapi.svg'),
 	entries: [
 		setupFrontendSnippet,
-		downloadSnippet('FastAPI'),
+		downloadSnippet(),
 		{
 			title: 'Initialize the Highlight SDK.',
 			content: 'Setup the SDK to with the FastAPI integration.',

--- a/highlight.io/components/QuickstartContent/backend/python/flask.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/flask.tsx
@@ -13,7 +13,7 @@ export const PythonFlaskContext: QuickStartContent = {
 	logoUrl: siteUrl('/images/quickstart/flask.svg'),
 	entries: [
 		setupFrontendSnippet,
-		downloadSnippet('Flask'),
+		downloadSnippet(),
 		{
 			title: 'Initialize the Highlight SDK.',
 			content: 'Setup the SDK to with the Flask integration.',

--- a/highlight.io/components/QuickstartContent/traces/python/django.tsx
+++ b/highlight.io/components/QuickstartContent/traces/python/django.tsx
@@ -12,7 +12,7 @@ export const PythonDjangoTracesContent: QuickStartContent = {
 	logoUrl: siteUrl('/images/quickstart/django.svg'),
 	entries: [
 		setupFrontendSnippet,
-		downloadSnippet('Django'),
+		downloadSnippet(),
 		{
 			title: 'Initialize the Highlight SDK.',
 			content:

--- a/highlight.io/components/QuickstartContent/traces/python/fastapi.tsx
+++ b/highlight.io/components/QuickstartContent/traces/python/fastapi.tsx
@@ -13,7 +13,7 @@ export const PythonFastAPITracesContent: QuickStartContent = {
 	logoUrl: siteUrl('/images/quickstart/fastapi.svg'),
 	entries: [
 		setupFrontendSnippet,
-		downloadSnippet('FastAPI'),
+		downloadSnippet(),
 		{
 			title: 'Initialize the Highlight SDK.',
 			content: 'Setup the SDK to with the FastAPI integration.',

--- a/highlight.io/components/QuickstartContent/traces/python/flask.tsx
+++ b/highlight.io/components/QuickstartContent/traces/python/flask.tsx
@@ -12,7 +12,7 @@ export const PythonFlaskTracesContent: QuickStartContent = {
 	logoUrl: siteUrl('/images/quickstart/flask.svg'),
 	entries: [
 		setupFrontendSnippet,
-		downloadSnippet('Flask'),
+		downloadSnippet(),
 		{
 			title: 'Initialize the Highlight SDK.',
 			content: 'Setup the SDK to with the Flask integration.',


### PR DESCRIPTION
## Summary

Python install docs were using the `[framework]` instasll flavors which are no longer relevant.

## How did you test this change?

CI

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
