### PR TITLE
revert rudderstack upgrade

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,7 +73,7 @@
 		"react-virtuoso": "^2.13.1",
 		"recharts": "^2.12.1",
 		"rrweb": "workspace:*",
-		"rudder-sdk-js": "^2.48.17",
+		"rudder-sdk-js": "2.20.0",
 		"subscriptions-transport-ws": "^0.11.0",
 		"use-query-params": "^2.2.0",
 		"validator": "13.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9959,7 +9959,7 @@ __metadata:
     react-virtuoso: "npm:^2.13.1"
     recharts: "npm:^2.12.1"
     rrweb: "workspace:*"
-    rudder-sdk-js: "npm:^2.48.17"
+    rudder-sdk-js: "npm:2.20.0"
     source-map-explorer: "npm:^2.5.2"
     stylelint: "npm:^14.9.1"
     subscriptions-transport-ws: "npm:^0.11.0"
@@ -49316,7 +49316,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rudder-sdk-js@npm:^2.20.0, rudder-sdk-js@npm:^2.48.17":
+"rudder-sdk-js@npm:2.20.0":
+  version: 2.20.0
+  resolution: "rudder-sdk-js@npm:2.20.0"
+  checksum: 10/a9c0fd8befa7c72df003b7f20ac5e3ae028a8323b1494a973e184684ba628e9b35f32c378ca5a91f6312aebc22c21a7024922746c00315d4c472d410640322dc
+  languageName: node
+  linkType: hard
+
+"rudder-sdk-js@npm:^2.20.0":
   version: 2.48.17
   resolution: "rudder-sdk-js@npm:2.48.17"
   checksum: 10/d381d26ca5d0bab6d190fb2c896bec4a0eac00f4261664b4fa3ebfaf70b432993e872e9c5fdd18b93ae505ccde1dff6fec23311af7831daa08776492bd2e5ab5


### PR DESCRIPTION
## Summary

Remove rudderstack sdk update which sets up bugsnag.
Bugsnag causing a memory leak / OOM in our app.

## How did you test this change?

reflame preview

before
<img width="1010" alt="image" src="https://github.com/user-attachments/assets/37c2e27f-bb9f-4f8c-a3b3-eb2c816ff62b">

after
<img width="1214" alt="Screenshot 2024-09-04 at 15 46 48" src="https://github.com/user-attachments/assets/fd70ba25-13e8-4a9f-9bb1-8682e8cde894">

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
