### PR TITLE
fix related trace query for session network requests

### DIFF
--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
@@ -181,8 +181,8 @@ function NetworkResourceDetails({
 	const timestamp = useMemo(() => {
 		// startTime used in highlight.run <8.8.0 for websocket events and <7.5.4 for requests
 		return resource.startTimeAbs
-			? resource.startTimeAbs - startTime
-			: new Date(resource.startTime).getTime()
+			? resource.startTimeAbs
+			: startTime + resource.startTime
 	}, [resource.startTime, resource.startTimeAbs, startTime])
 
 	useHotkeys(


### PR DESCRIPTION
## Summary

Correctly query time range for session related traces.

## How did you test this change?

before
<img width="1618" alt="Screenshot 2024-09-05 at 15 20 11" src="https://github.com/user-attachments/assets/3ee0819f-8f10-4762-b464-1c28199218fe">

after
<img width="1385" alt="image" src="https://github.com/user-attachments/assets/7f15c4b2-e10e-4124-8b4e-ba3756896b5d">

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
