### PR TITLE
turn on enterprise features on self hosted enterprise deployments

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -226,7 +226,8 @@ func main() {
 	// setup highlight logrus hook
 	hlog.Init()
 
-	if err := enterprise.Start(ctx); err != nil {
+	isEnterprise, err := enterprise.Start(ctx)
+	if err != nil {
 		log.WithContext(ctx).WithError(err).Fatal("Failed to start highlight enterprise license checker.")
 	}
 
@@ -254,6 +255,14 @@ func main() {
 
 		if err != nil {
 			log.WithContext(ctx).Fatalf("Error migrating DB: %v", err)
+		}
+	}
+
+	if isEnterprise {
+		if err := model.EnableAllWorkspaceSettings(ctx, db); err != nil {
+			log.WithContext(ctx).
+				WithError(err).
+				Error("failed to enable all workspace settings for enterprise deploy")
 		}
 	}
 

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -2441,6 +2441,29 @@ func SendWelcomeSlackMessage(ctx context.Context, obj IAlert, input *SendWelcome
 	return nil
 }
 
+// EnableAllWorkspaceSettings updates all rows to enable enterprise workspace features
+func EnableAllWorkspaceSettings(ctx context.Context, db *gorm.DB) error {
+	if err := db.WithContext(ctx).
+		Model(&AllWorkspaceSettings{}).
+		Where("1 = 1").
+		Updates(&AllWorkspaceSettings{
+			StoreIP:                   true,
+			CanShowBillingIssueBanner: false,
+			EnableUnlimitedDashboards: true,
+			EnableUnlimitedProjects:   true,
+			EnableUnlimitedRetention:  true,
+			EnableUnlimitedSeats:      true,
+			EnableBillingLimits:       true,
+			EnableGrafanaDashboard:    true,
+			EnableIngestSampling:      true,
+			EnableProjectLevelAccess:  true,
+			EnableSessionExport:       true,
+		}).Error; err != nil {
+		return e.Wrap(err, "failed to enable all workspace settings")
+	}
+	return nil
+}
+
 type TableConfig struct {
 	TableName        string
 	BodyColumn       string


### PR DESCRIPTION
## Summary

Self hosted deployments would not set up certain business tier features
even with an enterprise license. 
Configure feature flags accordingly based on the enterprise configuration.

## How did you test this change?

<img width="901" alt="Screenshot 2024-09-06 at 18 27 46" src="https://github.com/user-attachments/assets/ebb7296c-36fc-4f98-9e7b-5fdf481b8294">

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
