### PR TITLE
correctly update rewrites for /highlight-events proxy when existing rewrites are defined

### DIFF
--- a/.changeset/cool-papayas-compete.md
+++ b/.changeset/cool-papayas-compete.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/next': patch
+---
+
+correctly update rewrites for /highlight-events proxy when existing rewrites are defined

--- a/e2e/nextjs/next.config.mjs
+++ b/e2e/nextjs/next.config.mjs
@@ -3,7 +3,7 @@ import { withHighlightConfig } from '@highlight-run/next/config'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-	productionBrowserSourceMaps: true,
+	productionBrowserSourceMaps: false,
 	experimental: {
 		serverComponentsExternalPackages: ['pino', 'pino-pretty'],
 	},
@@ -16,6 +16,11 @@ const nextConfig = {
 		}
 		return config
 	},
+	rewrites: async () => [
+		{ source: '/example', destination: 'https://www.google.com' },
+	],
 }
 
-export default withHighlightConfig(nextConfig)
+export default withHighlightConfig(nextConfig, {
+	apiKey: 'abc123',
+})

--- a/sdk/highlight-next/src/util/with-highlight-config.ts
+++ b/sdk/highlight-next/src/util/with-highlight-config.ts
@@ -120,7 +120,13 @@ const getHighlightConfig = async (
 	let newRewrites = config.rewrites
 	if (defaultOpts.uploadSourceMaps || defaultOpts.configureHighlightProxy) {
 		newRewrites = async () => {
-			let re
+			let re:
+				| Rewrite[]
+				| {
+						beforeFiles: Rewrite[]
+						afterFiles: Rewrite[]
+						fallback: Rewrite[]
+				  }
 			if (!config.rewrites) {
 				re = new Array<Rewrite>()
 			} else {
@@ -134,19 +140,18 @@ const getHighlightConfig = async (
 
 			const highlightRewrite = {
 				source: '/highlight-events',
-				destination: 'https://pub.highlight.run',
+				destination: 'https://pub.highlight.io',
 			}
 
 			if (!re || Array.isArray(re)) {
-				return {
-					beforeFiles: defaultOpts.uploadSourceMaps
-						? [sourcemapRewrite]
-						: [],
-					afterFiles: defaultOpts.configureHighlightProxy
-						? (re ?? []).concat(highlightRewrite)
-						: [],
-					fallback: [],
+				re = re ?? []
+				if (defaultOpts.uploadSourceMaps) {
+					re.push(sourcemapRewrite)
 				}
+				if (defaultOpts.configureHighlightProxy) {
+					re.push(highlightRewrite)
+				}
+				return re
 			} else {
 				return {
 					beforeFiles: defaultOpts.uploadSourceMaps


### PR DESCRIPTION
## Summary

When next.js rewrites are defined, update existing ones correctly
rather than replacing when the definition is a `Rewrite[]`.

## How did you test this change?

local debugger

before
<img width="779" alt="Screenshot 2024-09-06 at 18 56 50" src="https://github.com/user-attachments/assets/f081bf3f-4c9c-42ca-a69d-70ead28f910a">

after
<img width="697" alt="Screenshot 2024-09-06 at 18 55 36" src="https://github.com/user-attachments/assets/3edf3f12-cc23-4a2d-9185-dc3f78f4e945">


## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
