### PR TITLE
Add Google analytics conversion events

### DIFF
--- a/frontend/src/@types/window.d.ts
+++ b/frontend/src/@types/window.d.ts
@@ -1,6 +1,7 @@
 // eslint-disable @typescript-eslint/no-explicit-any
 interface Window {
 	analytics: any
+	dataLayer: any
 	H: any
 	_highlightFirebaseConfig: any
 	_highlightFirebaseConfigString: any

--- a/frontend/src/components/DemoModal/DemoModal.tsx
+++ b/frontend/src/components/DemoModal/DemoModal.tsx
@@ -65,6 +65,7 @@ export const DemoModal = () => {
 			...attribution,
 		})
 		analytics.track('demo-email-submit', { email, ...attribution })
+		analytics.trackGaEvent('demo_email_submit', { email, ...attribution })
 		setVisible(false)
 	}
 

--- a/frontend/src/pages/Auth/SignUp.tsx
+++ b/frontend/src/pages/Auth/SignUp.tsx
@@ -87,6 +87,11 @@ export const SignUp: React.FC = () => {
 					provider: additionalUserInfo.providerId,
 				})
 
+				analytics.trackGaEvent('sign_up', {
+					email: user.email!,
+					provider: additionalUserInfo.providerId,
+				})
+
 				if (!user?.emailVerified) {
 					auth.currentUser?.sendEmailVerification()
 				}

--- a/frontend/src/util/analytics.ts
+++ b/frontend/src/util/analytics.ts
@@ -78,6 +78,7 @@ const identify = (email: string, traits?: rudderanalytics.apiObject) => {
 		},
 	])
 	hsq.push(['trackPageView'])
+
 	// `id` is a reserved keyword in rudderstack and it's recommended to use a
 	// static property for the user ID rather than something that could change
 	// over time, like an email address.
@@ -93,11 +94,21 @@ const page = (name: string, properties?: rudderanalytics.apiObject) => {
 	rudderanalytics.page(name, omit(properties, rudderstackReserved))
 }
 
+const trackGaEvent = (event: string, properties?: Record<string, any>) => {
+	if (window.dataLayer) {
+		window.dataLayer.push({
+			event,
+			...properties,
+		})
+	}
+}
+
 const analytics = {
 	initialize,
 	track,
 	identify,
 	page,
+	trackGaEvent,
 }
 
 export default analytics

--- a/frontend/src/util/integrated.tsx
+++ b/frontend/src/util/integrated.tsx
@@ -297,8 +297,8 @@ export const useAlertsIntegration = () => {
 				(data?.user_properties_alerts?.length ?? 0) >
 			0
 		) {
-			analytics.track('integrated-logs', { id: projectId })
-			analytics.trackGaEvent('integrated_logs')
+			analytics.track('integrated-alerts', { id: projectId })
+			analytics.trackGaEvent('integrated_alerts')
 
 			setLocalStorageIntegrated({
 				loading: false,

--- a/frontend/src/util/integrated.tsx
+++ b/frontend/src/util/integrated.tsx
@@ -73,6 +73,7 @@ export const useClientIntegration = () => {
 				data?.clientIntegration.integrated
 			) {
 				analytics.track('integrated-client', { id: projectId })
+				analytics.trackGaEvent('integrated_client')
 			}
 
 			setLocalStorageIntegrated({
@@ -127,6 +128,7 @@ export const useServerIntegration = () => {
 				data?.serverIntegration.integrated
 			) {
 				analytics.track('integrated-server', { id: projectId })
+				analytics.trackGaEvent('integrated_server')
 			}
 
 			setLocalStorageIntegrated({
@@ -181,6 +183,7 @@ export const useLogsIntegration = () => {
 				data?.logsIntegration.integrated
 			) {
 				analytics.track('integrated-logs', { id: projectId })
+				analytics.trackGaEvent('integrated_logs')
 			}
 
 			setLocalStorageIntegrated({
@@ -235,6 +238,7 @@ export const useTracesIntegration = () => {
 				data?.tracesIntegration.integrated
 			) {
 				analytics.track('integrated-traces', { id: projectId })
+				analytics.trackGaEvent('integrated_traces')
 			}
 
 			setLocalStorageIntegrated({
@@ -294,6 +298,7 @@ export const useAlertsIntegration = () => {
 			0
 		) {
 			analytics.track('integrated-logs', { id: projectId })
+			analytics.trackGaEvent('integrated_logs')
 
 			setLocalStorageIntegrated({
 				loading: false,
@@ -355,6 +360,7 @@ export const useTeamIntegration = () => {
 	useEffect(() => {
 		if ((data?.admins.length ?? 0) > 1) {
 			analytics.track('integrated-team', { id: projectId })
+			analytics.trackGaEvent('integrated_team')
 
 			setLocalStorageIntegrated({
 				loading: false,


### PR DESCRIPTION
## Summary

Adds GA tracking for some key events.

## How did you test this change?

Ran through some of the conversion events and checked that they appeared in `window.dataLayer` correctly + showed up in the event stream for tag manager on the preview deploy.

<img width="875" alt="Screenshot 2024-09-10 at 8 43 32 AM" src="https://github.com/user-attachments/assets/607bea2a-30af-4d92-b35d-1c0f335d29aa">

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A