### PR TITLE
Fix client reporting screen oreintation

### DIFF
--- a/.changeset/wicked-spiders-think.md
+++ b/.changeset/wicked-spiders-think.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+Fix type error reporting screen orientation

--- a/sdk/client/src/listeners/viewport-resize-listener.tsx
+++ b/sdk/client/src/listeners/viewport-resize-listener.tsx
@@ -18,7 +18,7 @@ export const ViewportResizeListener = (
 				availWidth: window.screen.availWidth,
 				colorDepth: window.screen.colorDepth,
 				pixelDepth: window.screen.pixelDepth,
-				orientation: window.screen.orientation.angle,
+				orientation: window.screen.orientation?.angle ?? 0,
 			})
 		}, DELAY)
 	}


### PR DESCRIPTION
## Summary
User reported error: `TypeError: undefined is not an object (evaluating 'window.screen.orientation.angle')`

Default to 0 when orientation not available.

## How did you test this change?
N/A

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A