### PR TITLE
Disable flame graph interactions when clicked

### DIFF
--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -122,9 +122,11 @@ export const TraceFlameGraphNode = memo<Props>(
 				<g
 					transform={`translate(${offsetX}, ${offsetY})`}
 					onClick={() => setSelectedSpan(span)}
-					onMouseOver={() => setHoveredSpan(span)}
+					onMouseOver={(e) => e.buttons === 0 && setHoveredSpan(span)}
+					onMouseMove={(e) =>
+						e.buttons === 0 && setTooltipCoordinates(e)
+					}
 					onMouseOut={() => setHoveredSpan(undefined)}
-					onMouseMove={(e) => setTooltipCoordinates(e)}
 				>
 					<rect
 						key={span.spanID}


### PR DESCRIPTION
## Summary

Fixes a bug where the flame graph tooltip could be shown when clicking and dragging to resize the side panel or dragging to select an area of the span to zoom in on.

## How did you test this change?

Click tested locally by:

1. Dragging the resize panel quickly back and forth over an area where a span is displayed on the flame graph and ensuring the tooltip is not rendered.
2. Hovering over a span then clicking and dragging on the graph to zoom in, ensuring the tooltip is not rendered.

## Are there any deployment considerations?

N/A - only a bit of UI polish ✨ 

## Does this work require review from our design team?

N/A
