### PR TITLE
Include email in GA integration events

### DIFF
--- a/frontend/src/util/integrated.tsx
+++ b/frontend/src/util/integrated.tsx
@@ -67,7 +67,7 @@ export const useClientIntegration = () => {
 	])
 
 	useEffect(() => {
-		if (data?.clientIntegration !== undefined) {
+		if (data?.clientIntegration !== undefined && admin?.email) {
 			if (
 				!localStorageIntegrated.integrated &&
 				data?.clientIntegration.integrated
@@ -125,7 +125,7 @@ export const useServerIntegration = () => {
 	])
 
 	useEffect(() => {
-		if (data?.serverIntegration !== undefined) {
+		if (data?.serverIntegration !== undefined && admin?.email) {
 			if (
 				!localStorageIntegrated.integrated &&
 				data?.serverIntegration.integrated
@@ -183,7 +183,7 @@ export const useLogsIntegration = () => {
 	])
 
 	useEffect(() => {
-		if (data?.logsIntegration !== undefined) {
+		if (data?.logsIntegration !== undefined && admin?.email) {
 			if (
 				!localStorageIntegrated.integrated &&
 				data?.logsIntegration.integrated
@@ -241,7 +241,7 @@ export const useTracesIntegration = () => {
 	])
 
 	useEffect(() => {
-		if (data?.tracesIntegration !== undefined) {
+		if (data?.tracesIntegration !== undefined && admin?.email) {
 			if (
 				!localStorageIntegrated.integrated &&
 				data?.tracesIntegration.integrated
@@ -299,16 +299,7 @@ export const useAlertsIntegration = () => {
 	])
 
 	useEffect(() => {
-		if (
-			(data?.log_alerts?.length ?? 0) +
-				(data?.error_alerts?.length ?? 0) +
-				(data?.new_session_alerts?.length ?? 0) +
-				(data?.rage_click_alerts?.length ?? 0) +
-				(data?.new_user_alerts?.length ?? 0) +
-				(data?.track_properties_alerts?.length ?? 0) +
-				(data?.user_properties_alerts?.length ?? 0) >
-			0
-		) {
+		if (admin?.email && (data?.alerts?.length ?? 0) > 0) {
 			analytics.track('integrated-alerts', { id: projectId })
 			analytics.trackGaEvent('integrated_alerts', {
 				email: admin?.email,
@@ -322,13 +313,7 @@ export const useAlertsIntegration = () => {
 		}
 	}, [
 		admin?.email,
-		data?.error_alerts?.length,
-		data?.log_alerts?.length,
-		data?.new_session_alerts?.length,
-		data?.new_user_alerts?.length,
-		data?.rage_click_alerts?.length,
-		data?.track_properties_alerts?.length,
-		data?.user_properties_alerts?.length,
+		data?.alerts?.length,
 		localStorageIntegrated.integrated,
 		projectId,
 		setLocalStorageIntegrated,
@@ -373,7 +358,7 @@ export const useTeamIntegration = () => {
 	])
 
 	useEffect(() => {
-		if ((data?.admins.length ?? 0) > 1) {
+		if (admin?.email && (data?.admins.length ?? 0) > 1) {
 			analytics.track('integrated-team', { id: projectId })
 			analytics.trackGaEvent('integrated_team', {
 				email: admin?.email,

--- a/frontend/src/util/integrated.tsx
+++ b/frontend/src/util/integrated.tsx
@@ -37,7 +37,7 @@ export type LocalStorageIntegrationData = {
 } & IntegrationStatus
 
 export const useClientIntegration = () => {
-	const { isLoggedIn } = useAuthContext()
+	const { admin, isLoggedIn } = useAuthContext()
 	const { projectId } = useNumericProjectId()
 	const [localStorageIntegrated, setLocalStorageIntegrated] =
 		useIntegratedLocalStorage(projectId!, 'client')
@@ -73,7 +73,9 @@ export const useClientIntegration = () => {
 				data?.clientIntegration.integrated
 			) {
 				analytics.track('integrated-client', { id: projectId })
-				analytics.trackGaEvent('integrated_client')
+				analytics.trackGaEvent('integrated_client', {
+					email: admin?.email,
+				})
 			}
 
 			setLocalStorageIntegrated({
@@ -82,6 +84,7 @@ export const useClientIntegration = () => {
 			})
 		}
 	}, [
+		admin?.email,
 		data?.clientIntegration,
 		localStorageIntegrated.integrated,
 		projectId,
@@ -92,7 +95,7 @@ export const useClientIntegration = () => {
 }
 
 export const useServerIntegration = () => {
-	const { isLoggedIn } = useAuthContext()
+	const { admin, isLoggedIn } = useAuthContext()
 	const { projectId } = useNumericProjectId()
 	const [localStorageIntegrated, setLocalStorageIntegrated] =
 		useIntegratedLocalStorage(projectId!, 'server')
@@ -128,7 +131,9 @@ export const useServerIntegration = () => {
 				data?.serverIntegration.integrated
 			) {
 				analytics.track('integrated-server', { id: projectId })
-				analytics.trackGaEvent('integrated_server')
+				analytics.trackGaEvent('integrated_server', {
+					email: admin?.email,
+				})
 			}
 
 			setLocalStorageIntegrated({
@@ -137,6 +142,7 @@ export const useServerIntegration = () => {
 			})
 		}
 	}, [
+		admin?.email,
 		data?.serverIntegration,
 		localStorageIntegrated.integrated,
 		projectId,
@@ -147,7 +153,7 @@ export const useServerIntegration = () => {
 }
 
 export const useLogsIntegration = () => {
-	const { isLoggedIn } = useAuthContext()
+	const { admin, isLoggedIn } = useAuthContext()
 	const { projectId } = useNumericProjectId()
 	const [localStorageIntegrated, setLocalStorageIntegrated] =
 		useIntegratedLocalStorage(projectId!, 'logs')
@@ -183,7 +189,9 @@ export const useLogsIntegration = () => {
 				data?.logsIntegration.integrated
 			) {
 				analytics.track('integrated-logs', { id: projectId })
-				analytics.trackGaEvent('integrated_logs')
+				analytics.trackGaEvent('integrated_logs', {
+					email: admin?.email,
+				})
 			}
 
 			setLocalStorageIntegrated({
@@ -192,6 +200,7 @@ export const useLogsIntegration = () => {
 			})
 		}
 	}, [
+		admin?.email,
 		data?.logsIntegration,
 		localStorageIntegrated.integrated,
 		projectId,
@@ -202,7 +211,7 @@ export const useLogsIntegration = () => {
 }
 
 export const useTracesIntegration = () => {
-	const { isLoggedIn } = useAuthContext()
+	const { admin, isLoggedIn } = useAuthContext()
 	const { projectId } = useNumericProjectId()
 	const [localStorageIntegrated, setLocalStorageIntegrated] =
 		useIntegratedLocalStorage(projectId!, 'traces')
@@ -238,7 +247,9 @@ export const useTracesIntegration = () => {
 				data?.tracesIntegration.integrated
 			) {
 				analytics.track('integrated-traces', { id: projectId })
-				analytics.trackGaEvent('integrated_traces')
+				analytics.trackGaEvent('integrated_traces', {
+					email: admin?.email,
+				})
 			}
 
 			setLocalStorageIntegrated({
@@ -247,6 +258,7 @@ export const useTracesIntegration = () => {
 			})
 		}
 	}, [
+		admin?.email,
 		data?.tracesIntegration,
 		localStorageIntegrated.integrated,
 		projectId,
@@ -257,7 +269,7 @@ export const useTracesIntegration = () => {
 }
 
 export const useAlertsIntegration = () => {
-	const { isLoggedIn } = useAuthContext()
+	const { isLoggedIn, admin } = useAuthContext()
 	const { projectId } = useNumericProjectId()
 	const [localStorageIntegrated, setLocalStorageIntegrated] =
 		useIntegratedLocalStorage(projectId!, 'alerts')
@@ -298,7 +310,9 @@ export const useAlertsIntegration = () => {
 			0
 		) {
 			analytics.track('integrated-alerts', { id: projectId })
-			analytics.trackGaEvent('integrated_alerts')
+			analytics.trackGaEvent('integrated_alerts', {
+				email: admin?.email,
+			})
 
 			setLocalStorageIntegrated({
 				loading: false,
@@ -307,6 +321,7 @@ export const useAlertsIntegration = () => {
 			})
 		}
 	}, [
+		admin?.email,
 		data?.error_alerts?.length,
 		data?.log_alerts?.length,
 		data?.new_session_alerts?.length,
@@ -323,7 +338,7 @@ export const useAlertsIntegration = () => {
 }
 
 export const useTeamIntegration = () => {
-	const { isLoggedIn } = useAuthContext()
+	const { admin, isLoggedIn } = useAuthContext()
 	const { projectId } = useNumericProjectId()
 	const [localStorageIntegrated, setLocalStorageIntegrated] =
 		useIntegratedLocalStorage(projectId!, 'team')
@@ -360,7 +375,9 @@ export const useTeamIntegration = () => {
 	useEffect(() => {
 		if ((data?.admins.length ?? 0) > 1) {
 			analytics.track('integrated-team', { id: projectId })
-			analytics.trackGaEvent('integrated_team')
+			analytics.trackGaEvent('integrated_team', {
+				email: admin?.email,
+			})
 
 			setLocalStorageIntegrated({
 				loading: false,
@@ -369,6 +386,7 @@ export const useTeamIntegration = () => {
 			})
 		}
 	}, [
+		admin?.email,
 		data?.admins.length,
 		localStorageIntegrated.integrated,
 		projectId,


### PR DESCRIPTION
## Summary

Per the request of Nathan, include the `email` attribute in our `integrated_*` events we send to Google.

## How did you test this change?

Click tested with a new account to confirm the data was present in `window.dataLayer`.

<img width="597" alt="Screenshot 2024-09-11 at 5 36 17 PM" src="https://github.com/user-attachments/assets/ecf6eaa8-ae22-4609-bcef-266bb91331ab">

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A