### PR TITLE
Fix log page ordering

### DIFF
--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -186,11 +186,10 @@ func makeSelectBuilder(
 			return nil, err
 		}
 
-		sb.Where(sb.GreaterEqualThan("Timestamp", params.DateRange.StartDate))
-
 		// See https://dba.stackexchange.com/a/206811
 		if pagination.Direction == modelInputs.SortDirectionAsc {
 			sb.Where(sb.GreaterEqualThan("Timestamp", timestamp)).
+				Where(sb.LessEqualThan("Timestamp", params.DateRange.EndDate)).
 				Where(
 					sb.Or(
 						sb.GreaterThan("Timestamp", timestamp),
@@ -199,6 +198,7 @@ func makeSelectBuilder(
 				)
 		} else {
 			sb.Where(sb.LessEqualThan("Timestamp", timestamp)).
+				Where(sb.GreaterEqualThan("Timestamp", params.DateRange.StartDate)).
 				Where(
 					sb.Or(
 						sb.LessThan("Timestamp", timestamp),
@@ -221,11 +221,10 @@ func makeSelectBuilder(
 			return nil, err
 		}
 
-		sb.LessEqualThan("Timestamp", params.DateRange.EndDate)
-
 		// See https://dba.stackexchange.com/a/206811
 		if pagination.Direction == modelInputs.SortDirectionAsc {
 			sb.Where(sb.LessEqualThan("Timestamp", timestamp)).
+				Where(sb.GreaterEqualThan("Timestamp", params.DateRange.StartDate)).
 				Where(
 					sb.Or(
 						sb.LessThan("Timestamp", timestamp),
@@ -234,6 +233,7 @@ func makeSelectBuilder(
 				)
 		} else {
 			sb.Where(sb.GreaterEqualThan("Timestamp", timestamp)).
+				Where(sb.LessEqualThan("Timestamp", params.DateRange.EndDate)).
 				Where(
 					sb.Or(
 						sb.GreaterThan("Timestamp", timestamp),

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -186,15 +186,28 @@ func makeSelectBuilder(
 			return nil, err
 		}
 
+		sb.Where(sb.GreaterEqualThan("Timestamp", params.DateRange.StartDate))
+
 		// See https://dba.stackexchange.com/a/206811
-		sb.Where(sb.LessEqualThan("Timestamp", timestamp)).
-			Where(sb.GreaterEqualThan("Timestamp", params.DateRange.StartDate)).
-			Where(
-				sb.Or(
-					sb.LessThan("Timestamp", timestamp),
-					sb.LessThan("UUID", uuid),
-				),
-			).OrderBy(orderForward)
+		if pagination.Direction == modelInputs.SortDirectionAsc {
+			sb.Where(sb.GreaterEqualThan("Timestamp", timestamp)).
+				Where(
+					sb.Or(
+						sb.GreaterThan("Timestamp", timestamp),
+						sb.GreaterThan("UUID", uuid),
+					),
+				)
+		} else {
+			sb.Where(sb.LessEqualThan("Timestamp", timestamp)).
+				Where(
+					sb.Or(
+						sb.LessThan("Timestamp", timestamp),
+						sb.LessThan("UUID", uuid),
+					),
+				)
+		}
+
+		sb.OrderBy(orderForward)
 	} else if pagination.At != nil && len(*pagination.At) > 1 {
 		timestamp, uuid, err := decodeCursor(*pagination.At)
 		if err != nil {
@@ -208,15 +221,28 @@ func makeSelectBuilder(
 			return nil, err
 		}
 
-		sb.Where(sb.GreaterEqualThan("Timestamp", timestamp)).
-			Where(sb.LessEqualThan("Timestamp", params.DateRange.EndDate)).
-			Where(
-				sb.Or(
-					sb.GreaterThan("Timestamp", timestamp),
-					sb.GreaterThan("UUID", uuid),
-				),
-			).
-			OrderBy(orderBackward)
+		sb.LessEqualThan("Timestamp", params.DateRange.EndDate)
+
+		// See https://dba.stackexchange.com/a/206811
+		if pagination.Direction == modelInputs.SortDirectionAsc {
+			sb.Where(sb.LessEqualThan("Timestamp", timestamp)).
+				Where(
+					sb.Or(
+						sb.LessThan("Timestamp", timestamp),
+						sb.LessThan("UUID", uuid),
+					),
+				)
+		} else {
+			sb.Where(sb.GreaterEqualThan("Timestamp", timestamp)).
+				Where(
+					sb.Or(
+						sb.GreaterThan("Timestamp", timestamp),
+						sb.GreaterThan("UUID", uuid),
+					),
+				)
+		}
+
+		sb.OrderBy(orderBackward)
 	} else {
 		sb.Where(sb.LessEqualThan("Timestamp", params.DateRange.EndDate)).
 			Where(sb.GreaterEqualThan("Timestamp", params.DateRange.StartDate))
@@ -1156,7 +1182,6 @@ func getSortOrders(
 	backwardDirection := "ASC"
 	if paginationDirection == modelInputs.SortDirectionAsc || sortDirection == modelInputs.SortDirectionAsc {
 		forwardDirection = "ASC"
-	} else {
 		backwardDirection = "DESC"
 	}
 

--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -161,38 +161,43 @@ export const useGetLogs = ({
 
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	const fetchMoreForward = useCallback(
-		debounce(async () => {
-			const { hasNextPage, endCursor } = data?.logs.pageInfo || {}
-			if (!hasNextPage || loadingAfter || !endCursor) {
-				return
-			}
+		debounce(
+			async () => {
+				const { hasNextPage, endCursor } = data?.logs.pageInfo || {}
+				if (!hasNextPage || loadingAfter || !endCursor) {
+					return
+				}
 
-			setLoadingAfter(true)
+				setLoadingAfter(true)
 
-			await fetchMore({
-				variables: { after: endCursor },
-				updateQuery: (prevResult, { fetchMoreResult }) => {
-					return {
-						logs: {
-							...prevResult.logs,
-							edges: [
-								...prevResult.logs.edges,
-								...fetchMoreResult.logs.edges,
-							],
-							pageInfo: {
-								...prevResult.logs.pageInfo,
-								hasNextPage:
-									fetchMoreResult.logs.pageInfo.hasNextPage,
-								endCursor:
-									fetchMoreResult.logs.pageInfo.endCursor,
+				await fetchMore({
+					variables: { after: endCursor },
+					updateQuery: (prevResult, { fetchMoreResult }) => {
+						return {
+							logs: {
+								...prevResult.logs,
+								edges: [
+									...prevResult.logs.edges,
+									...fetchMoreResult.logs.edges,
+								],
+								pageInfo: {
+									...prevResult.logs.pageInfo,
+									hasNextPage:
+										fetchMoreResult.logs.pageInfo
+											.hasNextPage,
+									endCursor:
+										fetchMoreResult.logs.pageInfo.endCursor,
+								},
 							},
-						},
-					}
-				},
-			})
+						}
+					},
+				})
 
-			setLoadingAfter(false)
-		}, 500),
+				setLoadingAfter(false)
+			},
+			500,
+			{ leading: true },
+		),
 		[data, fetchMore, loadingAfter],
 	)
 

--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -160,18 +160,11 @@ export const useGetLogs = ({
 	})
 
 	// eslint-disable-next-line react-hooks/exhaustive-deps
-	const fetchMoreForward = useCallback(
+	const fetchMoreLogs = useCallback(
 		debounce(
-			async () => {
-				const { hasNextPage, endCursor } = data?.logs.pageInfo || {}
-				if (!hasNextPage || loadingAfter || !endCursor) {
-					return
-				}
-
-				setLoadingAfter(true)
-
+			async (cursor: string) => {
 				await fetchMore({
-					variables: { after: endCursor },
+					variables: { after: cursor },
 					updateQuery: (prevResult, { fetchMoreResult }) => {
 						return {
 							logs: {
@@ -195,11 +188,22 @@ export const useGetLogs = ({
 
 				setLoadingAfter(false)
 			},
-			500,
-			{ leading: true },
+			300,
+			{ leading: true, trailing: false },
 		),
-		[data, fetchMore, loadingAfter],
+		[fetchMore],
 	)
+
+	const fetchMoreForward = useCallback(async () => {
+		const { hasNextPage, endCursor } = data?.logs.pageInfo || {}
+		if (!hasNextPage || loadingAfter || !endCursor) {
+			return
+		}
+
+		setLoadingAfter(true)
+		await fetchMoreLogs(endCursor)
+		setLoadingAfter(false)
+	}, [data?.logs.pageInfo, fetchMoreLogs, loadingAfter])
 
 	const existingTraceSet = new Set(logRelatedResources?.existing_logs_traces)
 

--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -105,7 +105,7 @@ export const useGetLogs = ({
 		GetLogsQueryVariables
 	>({
 		maxResults: MAX_LOGS,
-		skip: disablePolling || true,
+		skip: disablePolling,
 		variableFn: useCallback(
 			() => ({
 				project_id: project_id!,

--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -5,10 +5,11 @@ import {
 } from '@graph/hooks'
 import { GetLogsQuery, GetLogsQueryVariables } from '@graph/operations'
 import * as Types from '@graph/schemas'
-import { LogEdge, PageInfo } from '@graph/schemas'
+import { LogEdge } from '@graph/schemas'
 import { usePollQuery } from '@util/search'
 import moment from 'moment'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { debounce } from 'lodash'
 
 import { TIME_FORMAT } from '@/components/Search/SearchForm/constants'
 
@@ -20,13 +21,6 @@ export type LogEdgeWithResources = LogEdge & {
 	traceExist?: boolean
 }
 
-const initialWindowInfo: PageInfo = {
-	hasNextPage: true,
-	hasPreviousPage: true,
-	startCursor: '', // unused but needed for typedef
-	endCursor: '', // unused but needed for typedef
-}
-
 export const MAX_LOGS = 50
 
 export const useGetLogs = ({
@@ -36,6 +30,8 @@ export const useGetLogs = ({
 	startDate,
 	endDate,
 	disablePolling,
+	sortColumn = 'timestamp',
+	sortDirection = Types.SortDirection.Desc,
 }: {
 	query: string
 	project_id: string | undefined
@@ -43,33 +39,25 @@ export const useGetLogs = ({
 	startDate: Date
 	endDate: Date
 	disablePolling?: boolean
+	sortColumn?: string
+	sortDirection?: Types.SortDirection
 }) => {
-	// The backend can only tell us page info about a single page.
-	// It has no idea what pages have already been loaded.
-	//
-	// For example: say we make the initial request for 100 logs and hasNextPage=true and hasPreviousPage=false
-	// That means that we should not make any requests when going backwards.
-	//
-	// If the user scrolls forward to get the next 100 logs, the server will say that hasPreviousPage is `true` since we're on page 2.
-	// Hence, we track the initial information (where "window" is effectively multiple pages) to ensure we aren't making requests unnecessarily.
-	const [windowInfo, setWindowInfo] = useState<PageInfo>(initialWindowInfo)
 	const [loadingAfter, setLoadingAfter] = useState(false)
-	const [loadingBefore, setLoadingBefore] = useState(false)
-
-	useEffect(() => {
-		setWindowInfo(initialWindowInfo)
-	}, [query, startDate, endDate])
 
 	const { data, loading, error, refetch, fetchMore } = useGetLogsQuery({
 		variables: {
 			project_id: project_id!,
 			at: logCursor,
-			direction: Types.SortDirection.Desc,
+			direction: sortDirection,
 			params: {
 				query,
 				date_range: {
 					start_date: moment(startDate).format(TIME_FORMAT),
 					end_date: moment(endDate).format(TIME_FORMAT),
+				},
+				sort: {
+					column: sortColumn,
+					direction: sortDirection,
 				},
 			},
 		},
@@ -117,12 +105,12 @@ export const useGetLogs = ({
 		GetLogsQueryVariables
 	>({
 		maxResults: MAX_LOGS,
-		skip: disablePolling,
+		skip: disablePolling || true,
 		variableFn: useCallback(
 			() => ({
 				project_id: project_id!,
 				at: logCursor,
-				direction: Types.SortDirection.Desc,
+				direction: sortDirection,
 				params: {
 					query,
 					date_range: {
@@ -131,9 +119,20 @@ export const useGetLogs = ({
 							.format(TIME_FORMAT),
 						end_date: moment().format(TIME_FORMAT),
 					},
+					sort: {
+						column: sortColumn,
+						direction: sortDirection,
+					},
 				},
 			}),
-			[logCursor, logResultMetadata.endDate, project_id, query],
+			[
+				logCursor,
+				logResultMetadata.endDate,
+				project_id,
+				query,
+				sortColumn,
+				sortDirection,
+			],
 		),
 		moreDataQuery,
 		getResultCount: useCallback((result) => {
@@ -160,74 +159,42 @@ export const useGetLogs = ({
 		skip: !data?.logs.edges.length,
 	})
 
-	const fetchMoreForward = useCallback(async () => {
-		if (!windowInfo.hasNextPage || loadingAfter) {
-			return
-		}
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	const fetchMoreForward = useCallback(
+		debounce(async () => {
+			const { hasNextPage, endCursor } = data?.logs.pageInfo || {}
+			if (!hasNextPage || loadingAfter || !endCursor) {
+				return
+			}
 
-		const lastItem = data && data.logs.edges[data.logs.edges.length - 1]
-		const lastCursor = lastItem?.cursor
+			setLoadingAfter(true)
 
-		if (!lastCursor) {
-			return
-		}
+			await fetchMore({
+				variables: { after: endCursor },
+				updateQuery: (prevResult, { fetchMoreResult }) => {
+					return {
+						logs: {
+							...prevResult.logs,
+							edges: [
+								...prevResult.logs.edges,
+								...fetchMoreResult.logs.edges,
+							],
+							pageInfo: {
+								...prevResult.logs.pageInfo,
+								hasNextPage:
+									fetchMoreResult.logs.pageInfo.hasNextPage,
+								endCursor:
+									fetchMoreResult.logs.pageInfo.endCursor,
+							},
+						},
+					}
+				},
+			})
 
-		setLoadingAfter(true)
-
-		await fetchMore({
-			variables: { after: lastCursor },
-			updateQuery: (prevResult, { fetchMoreResult }) => {
-				const newData = fetchMoreResult.logs.edges
-				setWindowInfo({
-					...windowInfo,
-					hasNextPage: fetchMoreResult.logs.pageInfo.hasNextPage,
-				})
-				setLoadingAfter(false)
-				return {
-					logs: {
-						...prevResult.logs,
-						edges: [...prevResult.logs.edges, ...newData],
-						pageInfo: fetchMoreResult.logs.pageInfo,
-					},
-				}
-			},
-		})
-	}, [data, fetchMore, loadingAfter, windowInfo])
-
-	const fetchMoreBackward = useCallback(async () => {
-		if (!windowInfo.hasPreviousPage || loadingBefore) {
-			return
-		}
-
-		const firstItem = data && data.logs.edges[0]
-		const firstCursor = firstItem?.cursor
-
-		if (!firstCursor) {
-			return
-		}
-
-		setLoadingBefore(true)
-
-		await fetchMore({
-			variables: { before: firstCursor },
-			updateQuery: (prevResult, { fetchMoreResult }) => {
-				const newData = fetchMoreResult.logs.edges
-				setWindowInfo({
-					...windowInfo,
-					hasPreviousPage:
-						fetchMoreResult.logs.pageInfo.hasPreviousPage,
-				})
-				setLoadingBefore(false)
-				return {
-					logs: {
-						...prevResult.logs,
-						edges: [...prevResult.logs.edges, ...newData],
-						pageInfo: fetchMoreResult.logs.pageInfo,
-					},
-				}
-			},
-		})
-	}, [data, fetchMore, loadingBefore, windowInfo])
+			setLoadingAfter(false)
+		}, 500),
+		[data, fetchMore, loadingAfter],
+	)
 
 	const existingTraceSet = new Set(logRelatedResources?.existing_logs_traces)
 
@@ -253,10 +220,8 @@ export const useGetLogs = ({
 		pollingExpired,
 		loading,
 		loadingAfter,
-		loadingBefore,
 		error,
 		fetchMoreForward,
-		fetchMoreBackward,
 		refetch,
 	}
 }

--- a/frontend/src/pages/Traces/TracesPage.tsx
+++ b/frontend/src/pages/Traces/TracesPage.tsx
@@ -108,7 +108,7 @@ export const TracesPage: React.FC = () => {
 		startDate: searchTimeContext.startDate,
 		endDate: searchTimeContext.endDate,
 		skipPolling,
-		sortColumn,
+		sortColumn: sortColumn || undefined,
 		sortDirection: sortDirection as SortDirection,
 	})
 

--- a/frontend/src/pages/Traces/useGetTraces.ts
+++ b/frontend/src/pages/Traces/useGetTraces.ts
@@ -96,7 +96,7 @@ export const useGetTraces = ({
 		GetTracesQueryVariables
 	>({
 		maxResults: MAX_TRACES,
-		skip: skipPolling || true,
+		skip: skipPolling,
 		variableFn: useCallback(
 			() => ({
 				project_id: projectId!,

--- a/frontend/src/pages/Traces/useGetTraces.ts
+++ b/frontend/src/pages/Traces/useGetTraces.ts
@@ -1,19 +1,13 @@
 import { useGetTracesLazyQuery, useGetTracesQuery } from '@graph/hooks'
 import { GetTracesQuery, GetTracesQueryVariables } from '@graph/operations'
 import * as Types from '@graph/schemas'
-import { PageInfo, TraceEdge } from '@graph/schemas'
+import { TraceEdge } from '@graph/schemas'
 import { usePollQuery } from '@util/search'
 import moment from 'moment'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { debounce } from 'lodash'
 
 import { TIME_FORMAT } from '@/components/Search/SearchForm/constants'
-
-export const initialWindowInfo: PageInfo = {
-	hasNextPage: true,
-	hasPreviousPage: true,
-	startCursor: '', // unused but needed for typedef
-	endCursor: '', // unused but needed for typedef
-}
 
 export const MAX_TRACES = 50
 
@@ -24,8 +18,8 @@ export const useGetTraces = ({
 	startDate,
 	endDate,
 	skipPolling,
-	sortColumn,
-	sortDirection,
+	sortColumn = 'timestamp',
+	sortDirection = Types.SortDirection.Desc,
 	skip,
 }: {
 	query: string
@@ -34,31 +28,17 @@ export const useGetTraces = ({
 	startDate: Date
 	endDate: Date
 	skipPolling?: boolean
-	sortColumn?: string | null | undefined
-	sortDirection?: Types.SortDirection | null | undefined
+	sortColumn?: string
+	sortDirection?: Types.SortDirection
 	skip?: boolean
 }) => {
-	// The backend can only tell us page info about a single page.
-	// It has no idea what pages have already been loaded.
-	//
-	// For example: say we make the initial request for 100 traces and hasNextPage=true and hasPreviousPage=false
-	// That means that we should not make any requests when going backwards.
-	//
-	// If the user scrolls forward to get the next 100 traces, the server will say that hasPreviousPage is `true` since we're on page 2.
-	// Hence, we track the initial information (where "window" is effectively multiple pages) to ensure we aren't making requests unnecessarily.
-	const [windowInfo, setWindowInfo] = useState<PageInfo>(initialWindowInfo)
 	const [loadingAfter, setLoadingAfter] = useState(false)
-	const [loadingBefore, setLoadingBefore] = useState(false)
-
-	useEffect(() => {
-		setWindowInfo(initialWindowInfo)
-	}, [query, startDate, endDate])
 
 	const { data, loading, error, refetch, fetchMore } = useGetTracesQuery({
 		variables: {
 			project_id: projectId!,
 			at: traceCursor,
-			direction: Types.SortDirection.Desc,
+			direction: sortDirection,
 			params: {
 				query,
 				date_range: {
@@ -66,8 +46,8 @@ export const useGetTraces = ({
 					end_date: moment(endDate).format(TIME_FORMAT),
 				},
 				sort: {
-					column: sortColumn ?? 'timestamp',
-					direction: sortDirection ?? Types.SortDirection.Desc,
+					column: sortColumn,
+					direction: sortDirection,
 				},
 			},
 		},
@@ -116,12 +96,12 @@ export const useGetTraces = ({
 		GetTracesQueryVariables
 	>({
 		maxResults: MAX_TRACES,
-		skip: skipPolling,
+		skip: skipPolling || true,
 		variableFn: useCallback(
 			() => ({
 				project_id: projectId!,
 				at: traceCursor,
-				direction: Types.SortDirection.Desc,
+				direction: sortDirection,
 				params: {
 					query,
 					date_range: {
@@ -131,8 +111,8 @@ export const useGetTraces = ({
 						end_date: moment().format(TIME_FORMAT),
 					},
 					sort: {
-						column: sortColumn ?? 'timestamp',
-						direction: sortDirection ?? Types.SortDirection.Desc,
+						column: sortColumn,
+						direction: sortDirection,
 					},
 				},
 			}),
@@ -153,74 +133,42 @@ export const useGetTraces = ({
 		}, []),
 	})
 
-	const fetchMoreForward = useCallback(async () => {
-		if (!windowInfo.hasNextPage || loadingAfter) {
-			return
-		}
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	const fetchMoreForward = useCallback(
+		debounce(async () => {
+			const { hasNextPage, endCursor } = data?.traces.pageInfo || {}
+			if (!hasNextPage || loadingAfter || !endCursor) {
+				return
+			}
 
-		const lastItem = data && data.traces.edges[data.traces.edges.length - 1]
-		const lastCursor = lastItem?.cursor
+			setLoadingAfter(true)
 
-		if (!lastCursor) {
-			return
-		}
+			await fetchMore({
+				variables: { after: endCursor },
+				updateQuery: (prevResult, { fetchMoreResult }) => {
+					return {
+						traces: {
+							...prevResult.traces,
+							edges: [
+								...prevResult.traces.edges,
+								...fetchMoreResult.traces.edges,
+							],
+							pageInfo: {
+								...prevResult.traces.pageInfo,
+								hasNextPage:
+									fetchMoreResult.traces.pageInfo.hasNextPage,
+								endCursor:
+									fetchMoreResult.traces.pageInfo.endCursor,
+							},
+						},
+					}
+				},
+			})
 
-		setLoadingAfter(true)
-
-		await fetchMore({
-			variables: { after: lastCursor },
-			updateQuery: (prevResult, { fetchMoreResult }) => {
-				const newData = fetchMoreResult.traces.edges
-				setWindowInfo({
-					...windowInfo,
-					hasNextPage: fetchMoreResult.traces.pageInfo.hasNextPage,
-				})
-				setLoadingAfter(false)
-				return {
-					traces: {
-						...prevResult.traces,
-						edges: [...prevResult.traces.edges, ...newData],
-						pageInfo: fetchMoreResult.traces.pageInfo,
-					},
-				}
-			},
-		})
-	}, [data, fetchMore, loadingAfter, windowInfo])
-
-	const fetchMoreBackward = useCallback(async () => {
-		if (!windowInfo.hasPreviousPage || loadingBefore) {
-			return
-		}
-
-		const firstItem = data && data.traces.edges[0]
-		const firstCursor = firstItem?.cursor
-
-		if (!firstCursor) {
-			return
-		}
-
-		setLoadingBefore(true)
-
-		await fetchMore({
-			variables: { before: firstCursor },
-			updateQuery: (prevResult, { fetchMoreResult }) => {
-				const newData = fetchMoreResult.traces.edges
-				setWindowInfo({
-					...windowInfo,
-					hasPreviousPage:
-						fetchMoreResult.traces.pageInfo.hasPreviousPage,
-				})
-				setLoadingBefore(false)
-				return {
-					traces: {
-						...prevResult.traces,
-						edges: [...prevResult.traces.edges, ...newData],
-						pageInfo: fetchMoreResult.traces.pageInfo,
-					},
-				}
-			},
-		})
-	}, [data, fetchMore, loadingBefore, windowInfo])
+			setLoadingAfter(false)
+		}, 500),
+		[data, fetchMore, loadingAfter],
+	)
 
 	return {
 		traceEdges: (data?.traces.edges || []) as TraceEdge[],
@@ -229,10 +177,8 @@ export const useGetTraces = ({
 		clearMoreTraces: reset,
 		loading,
 		loadingAfter,
-		loadingBefore,
 		error,
 		fetchMoreForward,
-		fetchMoreBackward,
 		refetch,
 		sampled: data?.traces.sampled,
 	}

--- a/frontend/src/pages/Traces/useGetTraces.ts
+++ b/frontend/src/pages/Traces/useGetTraces.ts
@@ -134,18 +134,11 @@ export const useGetTraces = ({
 	})
 
 	// eslint-disable-next-line react-hooks/exhaustive-deps
-	const fetchMoreForward = useCallback(
+	const fetchMoreTraces = useCallback(
 		debounce(
-			async () => {
-				const { hasNextPage, endCursor } = data?.traces.pageInfo || {}
-				if (!hasNextPage || loadingAfter || !endCursor) {
-					return
-				}
-
-				setLoadingAfter(true)
-
+			async (cursor: string) => {
 				await fetchMore({
-					variables: { after: endCursor },
+					variables: { after: cursor },
 					updateQuery: (prevResult, { fetchMoreResult }) => {
 						return {
 							traces: {
@@ -167,14 +160,23 @@ export const useGetTraces = ({
 						}
 					},
 				})
-
-				setLoadingAfter(false)
 			},
-			500,
-			{ leading: true },
+			300,
+			{ leading: true, trailing: false },
 		),
-		[data, fetchMore, loadingAfter],
+		[fetchMore],
 	)
+
+	const fetchMoreForward = useCallback(async () => {
+		const { hasNextPage, endCursor } = data?.traces.pageInfo || {}
+		if (!hasNextPage || loadingAfter || !endCursor) {
+			return
+		}
+
+		setLoadingAfter(true)
+		await fetchMoreTraces(endCursor)
+		setLoadingAfter(false)
+	}, [data?.traces.pageInfo, fetchMoreTraces, loadingAfter])
 
 	return {
 		traceEdges: (data?.traces.edges || []) as TraceEdge[],

--- a/frontend/src/pages/Traces/useGetTraces.ts
+++ b/frontend/src/pages/Traces/useGetTraces.ts
@@ -135,38 +135,44 @@ export const useGetTraces = ({
 
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	const fetchMoreForward = useCallback(
-		debounce(async () => {
-			const { hasNextPage, endCursor } = data?.traces.pageInfo || {}
-			if (!hasNextPage || loadingAfter || !endCursor) {
-				return
-			}
+		debounce(
+			async () => {
+				const { hasNextPage, endCursor } = data?.traces.pageInfo || {}
+				if (!hasNextPage || loadingAfter || !endCursor) {
+					return
+				}
 
-			setLoadingAfter(true)
+				setLoadingAfter(true)
 
-			await fetchMore({
-				variables: { after: endCursor },
-				updateQuery: (prevResult, { fetchMoreResult }) => {
-					return {
-						traces: {
-							...prevResult.traces,
-							edges: [
-								...prevResult.traces.edges,
-								...fetchMoreResult.traces.edges,
-							],
-							pageInfo: {
-								...prevResult.traces.pageInfo,
-								hasNextPage:
-									fetchMoreResult.traces.pageInfo.hasNextPage,
-								endCursor:
-									fetchMoreResult.traces.pageInfo.endCursor,
+				await fetchMore({
+					variables: { after: endCursor },
+					updateQuery: (prevResult, { fetchMoreResult }) => {
+						return {
+							traces: {
+								...prevResult.traces,
+								edges: [
+									...prevResult.traces.edges,
+									...fetchMoreResult.traces.edges,
+								],
+								pageInfo: {
+									...prevResult.traces.pageInfo,
+									hasNextPage:
+										fetchMoreResult.traces.pageInfo
+											.hasNextPage,
+									endCursor:
+										fetchMoreResult.traces.pageInfo
+											.endCursor,
+								},
 							},
-						},
-					}
-				},
-			})
+						}
+					},
+				})
 
-			setLoadingAfter(false)
-		}, 500),
+				setLoadingAfter(false)
+			},
+			500,
+			{ leading: true },
+		),
 		[data, fetchMore, loadingAfter],
 	)
 


### PR DESCRIPTION
## Summary
There is a race condition that causing use to double fetch logs on the infinite scroll. Fix this by adding a debounce and cleaning up some of the outdated code

https://www.loom.com/share/be2c80f36b6140deac8e384651168989

## How did you test this change?
1. Log the logs page
2. Scroll to the bottom of the table
- [ ] Only one request sent
- [ ] No duplicate logs in table
4. Repeat for traces
- [ ] Only one request sent
- [ ] No duplicate traces in table

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
