### PR TITLE
Only alert OPEN errors

### DIFF
--- a/backend/alerts/v2/destinations/slack/messages.go
+++ b/backend/alerts/v2/destinations/slack/messages.go
@@ -224,15 +224,15 @@ func sendErrorAlert(ctx context.Context, slackAccessToken string, alertInput *de
 	var stackTraceBlock *slack.TextBlockObject
 
 	if err := json.Unmarshal([]byte(alertInput.ErrorInput.Stacktrace), &stackTrace); err == nil {
-		firstTrace := stackTrace[0]
+		fileLocation := "File unknown"
 
-		var fileLocation string
-		if firstTrace.LineNumber != nil {
-			fileLocation = fmt.Sprintf("%s:%d", *firstTrace.FileName, *firstTrace.LineNumber)
-		} else if firstTrace.FileName != nil {
-			fileLocation = *firstTrace.FileName
-		} else {
-			fileLocation = "File unknown"
+		if len(stackTrace) > 0 {
+			firstTrace := stackTrace[0]
+			if firstTrace.LineNumber != nil {
+				fileLocation = fmt.Sprintf("%s:%d", *firstTrace.FileName, *firstTrace.LineNumber)
+			} else if firstTrace.FileName != nil {
+				fileLocation = *firstTrace.FileName
+			}
 		}
 
 		if len(fileLocation) > ERROR_STACKTRACE_FILE_NAME_LENGTH_LIMIT {

--- a/backend/jobs/metric-alerts/metric-alerts.go
+++ b/backend/jobs/metric-alerts/metric-alerts.go
@@ -28,7 +28,7 @@ const maxWorkers = 40
 const alertEvalFreq = time.Minute
 
 var defaultAlertFilters = map[modelInputs.ProductType]string{
-	modelInputs.ProductTypeErrors: "status=OPEN",
+	modelInputs.ProductTypeErrors: "status=OPEN ",
 }
 
 func WatchMetricAlerts(ctx context.Context, DB *gorm.DB, MailClient *sendgrid.Client, rh *resthooks.Resthook, redis *redis.Client, ccClient *clickhouse.Client, lambdaClient *lambda.Client) {

--- a/backend/jobs/metric-alerts/metric-alerts.go
+++ b/backend/jobs/metric-alerts/metric-alerts.go
@@ -27,6 +27,10 @@ import (
 const maxWorkers = 40
 const alertEvalFreq = time.Minute
 
+var defaultAlertFilters = map[modelInputs.ProductType]string{
+	modelInputs.ProductTypeErrors: "status=OPEN",
+}
+
 func WatchMetricAlerts(ctx context.Context, DB *gorm.DB, MailClient *sendgrid.Client, rh *resthooks.Resthook, redis *redis.Client, ccClient *clickhouse.Client, lambdaClient *lambda.Client) {
 	log.WithContext(ctx).Info("Starting to watch metric alerts")
 
@@ -103,9 +107,9 @@ func processMetricAlert(ctx context.Context, DB *gorm.DB, MailClient *sendgrid.C
 		return errors.Errorf("Unknown product type: %s", alert.ProductType)
 	}
 
-	query := ""
+	query := defaultAlertFilters[alert.ProductType]
 	if alert.Query != nil {
-		query = *alert.Query
+		query += *alert.Query
 	}
 
 	column := ""

--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -76,7 +76,7 @@ const ALERT_PRODUCT_INFO = {
 	[ProductType.Sessions]:
 		"Alerts once for every session that matches the condition's filters.",
 	[ProductType.Errors]:
-		'Alerts every time an error group matches the specified conditions.',
+		'Alerts every time an open error matches the specified conditions.',
 	[ProductType.Logs]: false,
 	[ProductType.Traces]: false,
 	[ProductType.Metrics]: false,


### PR DESCRIPTION
## Summary
Error alerts send notifications for errors that are ignored. Add a default filter to only alert OPEN errors.

Note: Resolved errors should be reopened in a different process.

## How did you test this change?
1. Create an error alert
2. Cause an error
- [ ] Notification received
3. Ignore the error
4. Cause the error again
- [ ] No notification received

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A