### PR TITLE
host frontend on s3

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -69,8 +69,6 @@ jobs:
               run: doppler run -- yarn build:frontend
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_RENDER_SECRET }}
-                  GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-                  PREVIEW: ${{ github.event.pull_request.head.repo.full_name == 'highlight/highlight' && github.ref != 'refs/heads/main' }}
 
             - name: Build render
               # does not work for open source builds as doppler is required
@@ -87,9 +85,10 @@ jobs:
                   APP_VERSION: ${{ github.event.pull_request.head.sha || github.sha }}
 
             - name: Upload frontend code
-              # TODO(vkorolik)
-              # if: github.ref == 'refs/heads/main'
               run: yarn publish:frontend
+              env:
+                  GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+                  PREVIEW: ${{ github.event.pull_request.head.repo.full_name == 'highlight/highlight' && github.ref != 'refs/heads/main' }}
 
             - name: Configure yarn npm registry credentials
               if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -87,6 +87,7 @@ jobs:
                   APP_VERSION: ${{ github.event.pull_request.head.sha || github.sha }}
 
             - name: Upload frontend code
+              # TODO(vkorolik)
               # if: github.ref == 'refs/heads/main'
               run: yarn publish:frontend
 

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -63,6 +63,15 @@ jobs:
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
                   REACT_APP_COMMIT_SHA: ${{ github.sha }}
 
+            - name: Build production frontend
+              # does not work for open source builds as doppler is required
+              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main' || github.event_name == 'release'
+              run: doppler run -- yarn build:frontend
+              env:
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_RENDER_SECRET }}
+                  GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+                  PREVIEW: ${{ github.event.pull_request.head.repo.full_name == 'highlight/highlight' && github.ref != 'refs/heads/main' }}
+
             - name: Build render
               # does not work for open source builds as doppler is required
               if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -78,7 +78,7 @@ jobs:
                   APP_VERSION: ${{ github.event.pull_request.head.sha || github.sha }}
 
             - name: Upload frontend code
-              if: github.ref == 'refs/heads/main'
+              # if: github.ref == 'refs/heads/main'
               run: yarn publish:frontend
 
             - name: Configure yarn npm registry credentials

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -90,7 +90,7 @@ jobs:
               run: yarn publish:frontend
               env:
                   GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-                  PREVIEW: ${{ github.event.pull_request.head.repo.full_name == 'highlight/highlight' && github.ref != 'refs/heads/main' }}
+                  # PREVIEW: ${{ github.event.pull_request.head.repo.full_name == 'highlight/highlight' && github.ref != 'refs/heads/main' }}
 
             - name: Configure yarn npm registry credentials
               if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -90,7 +90,7 @@ jobs:
               run: yarn publish:frontend
               env:
                   GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-                  # PREVIEW: ${{ github.event.pull_request.head.repo.full_name == 'highlight/highlight' && github.ref != 'refs/heads/main' }}
+                  PREVIEW: ${{ github.event.pull_request.head.repo.full_name == 'highlight/highlight' && github.ref != 'refs/heads/main' }}
 
             - name: Configure yarn npm registry credentials
               if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -23,22 +23,6 @@ jobs:
                   submodules: recursive
                   fetch-depth: 0
 
-            - uses: dorny/paths-filter@v2
-              id: filter
-              with:
-                  filters: |
-                      npm-changed:
-                        - 'sdk/client/**'
-                        - 'sdk/firstload/**'
-                        - 'sdk/highlight-apollo/**'
-                        - 'sdk/highlight-cloudflare/**'
-                        - 'sdk/highlight-nest/**'
-                        - 'sdk/highlight-next/**'
-                        - 'sdk/highlight-node/**'
-                        - 'sdk/highlight-react/**'
-                        - 'sdk/highlight-remix/**'
-                        - 'sdk/opentelemetry-sdk-workers/packages/opentelemetry-sdk-workers/**'
-
             # automatically caches dependencies based on yarn.lock
             - name: Setup Node.js environment
               uses: actions/setup-node@v4
@@ -49,7 +33,7 @@ jobs:
             - name: Install js dependencies
               run: yarn
 
-            - name: Check check for duplicate deps
+            - name: Check yarn for duplicate deps
               run: yarn dedupe --check
 
             - name: Check generated files for Reflame
@@ -92,6 +76,10 @@ jobs:
               env:
                   HIGHLIGHT_API_KEY: ${{ secrets.HIGHLIGHT_SOURCEMAP_API_KEY }}
                   APP_VERSION: ${{ github.event.pull_request.head.sha || github.sha }}
+
+            - name: Upload frontend code
+              if: github.ref == 'refs/heads/main'
+              run: yarn publish:frontend
 
             - name: Configure yarn npm registry credentials
               if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -61,7 +61,7 @@ jobs:
               env:
                   GRAPHCMS_TOKEN: ${{ secrets.GRAPHCMS_TOKEN }}
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
-                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
+                  REACT_APP_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
             - name: Build production frontend
               # does not work for open source builds as doppler is required
@@ -76,6 +76,7 @@ jobs:
               run: doppler run -- yarn build:render
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_RENDER_SECRET }}
+                  REACT_APP_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
             - name: Upload frontend sourcemaps
               if: github.ref == 'refs/heads/main'

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -69,6 +69,7 @@ jobs:
               run: doppler run -- yarn build:frontend
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_RENDER_SECRET }}
+                  REACT_APP_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
             - name: Build render
               # does not work for open source builds as doppler is required

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -89,6 +89,7 @@
 		"dev:reflame": "node scripts/reflame.mjs --watch",
 		"dev:tsm": "tsm src -w --logLevel=error",
 		"dev:gql": "graphql-codegen --config --watch codegen.yml",
+		"publish": "aws s3 cp --recursive . arn:aws:s3:::highlight-frontend/",
 		"reflame": "yarn dev:reflame",
 		"reflame-build": "node scripts/reflame.mjs",
 		"lint": "eslint ./src",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -89,7 +89,7 @@
 		"dev:reflame": "node scripts/reflame.mjs --watch",
 		"dev:tsm": "tsm src -w --logLevel=error",
 		"dev:gql": "graphql-codegen --config --watch codegen.yml",
-		"publish": "aws s3 cp --recursive . arn:aws:s3:::highlight-frontend/",
+		"publish": "aws s3 cp --recursive build s3://highlight-frontend",
 		"reflame": "yarn dev:reflame",
 		"reflame-build": "node scripts/reflame.mjs",
 		"lint": "eslint ./src",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -89,7 +89,7 @@
 		"dev:reflame": "node scripts/reflame.mjs --watch",
 		"dev:tsm": "tsm src -w --logLevel=error",
 		"dev:gql": "graphql-codegen --config --watch codegen.yml",
-		"publish": "aws s3 cp --recursive build s3://highlight-frontend",
+		"publish": "node scripts/publish.mjs",
 		"reflame": "yarn dev:reflame",
 		"reflame-build": "node scripts/reflame.mjs",
 		"lint": "eslint ./src",

--- a/frontend/scripts/publish.mjs
+++ b/frontend/scripts/publish.mjs
@@ -5,14 +5,20 @@ const exec = util.promisify(execAsync)
 const isPreview = process.env['PREVIEW'] === 'true'
 const gitSHA = process.env['GIT_SHA']
 
-try {
-	let path = `s3://highlight-frontend`
-	if (isPreview) {
-		path = `${path}/preview/${gitSHA}`
+const paths = [`s3://highlight-frontend`]
+if (isPreview) {
+	paths.push(`s3://highlight-frontend/preview/${gitSHA}`)
+}
+
+for (const path of paths) {
+	try {
+		console.log('Publishing frontend bundle', { isPreview, gitSHA, path })
+		const { stdout, stderr } = await exec(
+			`aws s3 cp --recursive build ${path}`,
+		)
+		console.log('Published', { stdout, stderr })
+	} catch (e) {
+		console.error(e)
+		process.exit(1)
 	}
-	console.log('Publishing frontend bundle', { isPreview, gitSHA, path })
-	await exec(`aws s3 cp --recursive build ${path}`)
-} catch (e) {
-	console.error(e)
-	process.exit(1)
 }

--- a/frontend/scripts/publish.mjs
+++ b/frontend/scripts/publish.mjs
@@ -1,0 +1,18 @@
+import { exec as execAsync } from 'child_process'
+import * as util from 'util'
+const exec = util.promisify(execAsync)
+
+const isPreview = process.env['PREVIEW'] === 'true'
+const gitSHA = process.env['GIT_SHA']
+
+try {
+	let path = `s3://highlight-frontend`
+	if (isPreview) {
+		path = `${path}/preview/${gitSHA}`
+	}
+	console.log('Publishing frontend bundle', { isPreview, gitSHA, path })
+	await exec(`aws s3 cp --recursive build ${path}`)
+} catch (e) {
+	console.error(e)
+	process.exit(1)
+}

--- a/frontend/scripts/publish.mjs
+++ b/frontend/scripts/publish.mjs
@@ -2,7 +2,7 @@ import { exec as execAsync } from 'child_process'
 import * as util from 'util'
 const exec = util.promisify(execAsync)
 
-const BUCKET = ''
+const BUCKET = 'highlight-frontend'
 const DISTRIBUTION = 'ERPS6ET782WO1'
 
 const isPreview = process.env['PREVIEW'] === 'true'

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
 		"public-gen": "cd backend && make public-gen",
 		"publish:ai": "yarn workspace @highlight-run/ai publish",
 		"publish:client": "yarn workspace scripts publish:client",
+		"publish:frontend": "yarn workspace @highlight-run/frontend publish",
 		"publish:react-email-templates": "yarn workspace emails publish",
 		"publish:render": "yarn workspace render publish",
 		"publish:turbo": "yarn workspaces foreach -R --no-private --from '@highlight-run/*' npm publish --access public --tolerate-republish && yarn workspace highlight.run npm publish --access public --tolerate-republish && yarn workspace @highlight-run/opentelemetry-sdk-workers npm publish --access public --tolerate-republish",


### PR DESCRIPTION
## Summary

* Deploys the frontend from github actions to an S3 bucket which is used to host app.highlight.io
* For branch PR previews, deploys the frontend from github actions to a `/preview/<sha>/index.html` path as well.
The previews currently do not load due to the app redirecting from that URL, but we use reflame for previews anyway.
The preview uploads can be used to quickly revert the prod build by copying the output to the top level.

## How did you test this change?

running deploy to prod, app.highlight.io now hosted from CloudFront that points to this s3 bucket

test upload to prod from [this job](https://github.com/highlight/highlight/actions/runs/12285836160/job/34284726719)
![Screenshot from 2024-12-11 22-56-40](https://github.com/user-attachments/assets/dfb4ebe4-4f13-45c0-99c7-b072b7da7910)
![Screenshot from 2024-12-11 22-56-36](https://github.com/user-attachments/assets/f2f59024-cbb4-49ce-afea-71211f4460c3)


## Are there any deployment considerations?

allows for further cloudfront configuration such as WAF. turned off billing for render.com

## Does this work require review from our design team?

no
