### PR TITLE
chunk network resources

### DIFF
--- a/.changeset/shiny-buckets-sparkle.md
+++ b/.changeset/shiny-buckets-sparkle.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+record pri.highlight.io requests

--- a/__generated/rr/rrweb/rr.js
+++ b/__generated/rr/rrweb/rr.js
@@ -1,11 +1,17 @@
 // ../rrweb/packages/rrweb/dist/rrweb.js
 var __defProp = Object.defineProperty;
 var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
-var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+var __publicField = (obj, key, value) => {
+  __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
 var _a;
 var __defProp$1 = Object.defineProperty;
 var __defNormalProp$1 = (obj, key, value) => key in obj ? __defProp$1(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
-var __publicField$1 = (obj, key, value) => __defNormalProp$1(obj, typeof key !== "symbol" ? key + "" : key, value);
+var __publicField$1 = (obj, key, value) => {
+  __defNormalProp$1(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
 var NodeType$2 = /* @__PURE__ */ ((NodeType2) => {
   NodeType2[NodeType2["Document"] = 0] = "Document";
   NodeType2[NodeType2["DocumentType"] = 1] = "DocumentType";
@@ -209,13 +215,9 @@ function stringifyStylesheet(s2) {
     if (!rules2) {
       return null;
     }
-    let sheetHref = s2.href;
-    if (!sheetHref && s2.ownerNode && s2.ownerNode.ownerDocument) {
-      sheetHref = s2.ownerNode.ownerDocument.location.href;
-    }
     const stringifiedRules = Array.from(
       rules2,
-      (rule) => stringifyRule(rule, sheetHref)
+      (rule) => stringifyRule(rule, s2.href)
     ).join("");
     return fixBrowserCompatibilityIssuesInCSS(stringifiedRules);
   } catch (error) {
@@ -450,43 +452,9 @@ function absolutifyURLs(cssText, href) {
     }
   );
 }
-function normalizeCssString(cssText) {
-  return cssText.replace(/(\/\*[^*]*\*\/)|[\s;]/g, "");
-}
-function splitCssText(cssText, style) {
-  const childNodes2 = Array.from(style.childNodes);
-  const splits = [];
-  if (childNodes2.length > 1 && cssText && typeof cssText === "string") {
-    const cssTextNorm = normalizeCssString(cssText);
-    for (let i2 = 1; i2 < childNodes2.length; i2++) {
-      if (childNodes2[i2].textContent && typeof childNodes2[i2].textContent === "string") {
-        const textContentNorm = normalizeCssString(childNodes2[i2].textContent);
-        for (let j = 3; j < textContentNorm.length; j++) {
-          const bit = textContentNorm.substring(0, j);
-          if (cssTextNorm.split(bit).length === 2) {
-            const splitNorm = cssTextNorm.indexOf(bit);
-            for (let k = splitNorm; k < cssText.length; k++) {
-              if (normalizeCssString(cssText.substring(0, k)).length === splitNorm) {
-                splits.push(cssText.substring(0, k));
-                cssText = cssText.substring(k);
-                break;
-              }
-            }
-            break;
-          }
-        }
-      }
-    }
-  }
-  splits.push(cssText);
-  return splits;
-}
-function markCssSplits(cssText, style) {
-  return splitCssText(cssText, style).join("/* rr_split */");
-}
 function obfuscateText(text) {
   text = text.replace(/[^ -~]+/g, "");
-  text = (text == null ? void 0 : text.split(" ").map((word) => Math.random().toString(20).substring(2, word.length)).join(" ")) || "";
+  text = (text == null ? void 0 : text.split(" ").map((word) => Math.random().toString(20).substr(2, word.length)).join(" ")) || "";
   return text;
 }
 function isElementSrcBlocked(tagName) {
@@ -797,7 +765,6 @@ function serializeNode(n2, options) {
     recordCanvas,
     keepIframeSrcFn,
     newlyAddedElement = false,
-    cssCaptured = false,
     privacySetting
   } = options;
   const rootId = getRootId(doc, mirror2);
@@ -847,8 +814,7 @@ function serializeNode(n2, options) {
         needsMask,
         maskTextFn,
         privacySetting,
-        rootId,
-        cssCaptured
+        rootId
       });
     case n2.CDATA_SECTION_NODE:
       return {
@@ -873,28 +839,48 @@ function getRootId(doc, mirror2) {
   return docId === 1 ? void 0 : docId;
 }
 function serializeTextNode(n2, options) {
-  var _a2;
-  const { needsMask, maskTextFn, privacySetting, rootId, cssCaptured } = options;
+  var _a2, _b;
+  const {
+    needsMask,
+    maskTextFn,
+    privacySetting,
+    rootId
+  } = options;
   const parent = index$1.parentNode(n2);
   const parentTagName = parent && parent.tagName;
-  let textContent2 = "";
+  let text = index$1.textContent(n2);
   const isStyle = parentTagName === "STYLE" ? true : void 0;
   const isScript = parentTagName === "SCRIPT" ? true : void 0;
-  if (isScript) {
-    textContent2 = "SCRIPT_PLACEHOLDER";
-  } else if (!cssCaptured) {
-    textContent2 = index$1.textContent(n2);
-    if (isStyle && textContent2) {
-      textContent2 = absolutifyURLs(textContent2, getHref(options.doc));
+  let textContentHandled = false;
+  if (isStyle && text) {
+    try {
+      if (n2.nextSibling || n2.previousSibling) {
+      } else if ((_a2 = parent.sheet) == null ? void 0 : _a2.cssRules) {
+        text = stringifyStylesheet(parent.sheet);
+      }
+    } catch (err) {
+      console.warn(
+        `Cannot get CSS styles from text's parentNode. Error: ${err}`,
+        n2
+      );
     }
+    text = absolutifyURLs(text, getHref(options.doc));
+    textContentHandled = true;
   }
-  if (!isStyle && !isScript && textContent2 && needsMask) {
-    textContent2 = maskTextFn ? maskTextFn(textContent2, index$1.parentElement(n2)) : textContent2.replace(/[\S]/g, "*");
+  if (isScript) {
+    text = "SCRIPT_PLACEHOLDER";
+    textContentHandled = true;
+  } else if (parentTagName === "NOSCRIPT") {
+    text = "";
+    textContentHandled = true;
+  }
+  if (!isStyle && !isScript && text && needsMask) {
+    text = maskTextFn ? maskTextFn(text, index$1.parentElement(n2)) : text.replace(/[\S]/g, "*");
   }
   const enableStrictPrivacy = privacySetting === "strict";
-  const highlightOverwriteRecord = (_a2 = n2.parentElement) == null ? void 0 : _a2.getAttribute("data-hl-record");
-  const obfuscateDefaultPrivacy = privacySetting === "default" && shouldObfuscateTextByDefault(textContent2);
-  if ((enableStrictPrivacy || obfuscateDefaultPrivacy) && !highlightOverwriteRecord && parentTagName) {
+  const highlightOverwriteRecord = (_b = n2.parentElement) == null ? void 0 : _b.getAttribute("data-hl-record");
+  const obfuscateDefaultPrivacy = privacySetting === "default" && shouldObfuscateTextByDefault(text);
+  if ((enableStrictPrivacy || obfuscateDefaultPrivacy) && !highlightOverwriteRecord && !textContentHandled && parentTagName) {
     const IGNORE_TAG_NAMES = /* @__PURE__ */ new Set([
       "HEAD",
       "TITLE",
@@ -904,13 +890,14 @@ function serializeTextNode(n2, options) {
       "BODY",
       "NOSCRIPT"
     ]);
-    if (!IGNORE_TAG_NAMES.has(parentTagName) && textContent2) {
-      textContent2 = obfuscateText(textContent2);
+    if (!IGNORE_TAG_NAMES.has(parentTagName) && text) {
+      text = obfuscateText(text);
     }
   }
   return {
     type: NodeType$2.Text,
-    textContent: textContent2 || "",
+    textContent: text || "",
+    isStyle,
     rootId
   };
 }
@@ -962,14 +949,12 @@ function serializeElementNode(n2, options) {
       attributes._cssText = cssText;
     }
   }
-  if (tagName === "style" && n2.sheet) {
-    let cssText = stringifyStylesheet(
+  if (tagName === "style" && n2.sheet && // TODO: Currently we only try to get dynamic stylesheet when it is an empty style element
+  !(n2.innerText || index$1.textContent(n2) || "").trim().length) {
+    const cssText = stringifyStylesheet(
       n2.sheet
     );
     if (cssText) {
-      if (n2.childNodes.length > 1) {
-        cssText = markCssSplits(cssText, n2);
-      }
       attributes._cssText = cssText;
     }
   }
@@ -1202,7 +1187,6 @@ function serializeNodeWithId(n2, options) {
     stylesheetLoadTimeout = 5e3,
     keepIframeSrcFn = () => false,
     newlyAddedElement = false,
-    cssCaptured = false,
     privacySetting
   } = options;
   let { needsMask } = options;
@@ -1232,7 +1216,6 @@ function serializeNodeWithId(n2, options) {
     recordCanvas,
     keepIframeSrcFn,
     newlyAddedElement,
-    cssCaptured,
     privacySetting
   });
   if (!_serializedNode) {
@@ -1242,7 +1225,7 @@ function serializeNodeWithId(n2, options) {
   let id;
   if (mirror2.hasNode(n2)) {
     id = mirror2.getId(n2);
-  } else if (slimDOMExcluded(_serializedNode, slimDOMOptions) || !preserveWhiteSpace && _serializedNode.type === NodeType$2.Text && !_serializedNode.textContent.replace(/^\s+|\s+$/gm, "").length) {
+  } else if (slimDOMExcluded(_serializedNode, slimDOMOptions) || !preserveWhiteSpace && _serializedNode.type === NodeType$2.Text && !_serializedNode.isStyle && !_serializedNode.textContent.replace(/^\s+|\s+$/gm, "").length) {
     id = IGNORED_NODE;
   } else {
     id = genId();
@@ -1301,15 +1284,11 @@ function serializeNodeWithId(n2, options) {
       onStylesheetLoad,
       stylesheetLoadTimeout,
       keepIframeSrcFn,
-      cssCaptured: false,
       privacySetting: overwrittenPrivacySetting
     };
     if (serializedNode.type === NodeType$2.Element && serializedNode.tagName === "textarea" && serializedNode.attributes.value !== void 0)
       ;
     else {
-      if (serializedNode.type === NodeType$2.Element && serializedNode.attributes._cssText !== void 0 && typeof serializedNode.attributes._cssText === "string") {
-        bypassOptions.cssCaptured = true;
-      }
       for (const childN of Array.from(index$1.childNodes(n2))) {
         const serializedChildNode = serializeNodeWithId(childN, bypassOptions);
         if (serializedChildNode) {
@@ -2110,36 +2089,6 @@ function createCache() {
     stylesWithHoverClass
   };
 }
-function applyCssSplits(n2, cssText, hackCss, cache) {
-  const childTextNodes = [];
-  for (const scn of n2.childNodes) {
-    if (scn.type === NodeType$2.Text) {
-      childTextNodes.push(scn);
-    }
-  }
-  const cssTextSplits = cssText.split("/* rr_split */");
-  while (cssTextSplits.length > 1 && cssTextSplits.length > childTextNodes.length) {
-    cssTextSplits.splice(-2, 2, cssTextSplits.slice(-2).join(""));
-  }
-  for (let i2 = 0; i2 < childTextNodes.length; i2++) {
-    const childTextNode = childTextNodes[i2];
-    const cssTextSection = cssTextSplits[i2];
-    if (childTextNode && cssTextSection) {
-      childTextNode.textContent = hackCss ? adaptCssForReplay(cssTextSection, cache) : cssTextSection;
-    }
-  }
-}
-function buildStyleNode(n2, styleEl, cssText, options) {
-  const { doc, hackCss, cache } = options;
-  if (n2.childNodes.length) {
-    applyCssSplits(n2, cssText, hackCss, cache);
-  } else {
-    if (hackCss) {
-      cssText = adaptCssForReplay(cssText, cache);
-    }
-    styleEl.appendChild(doc.createTextNode(cssText));
-  }
-}
 function buildNode(n2, options) {
   var _a2;
   const { doc, hackCss, cache } = options;
@@ -2189,12 +2138,12 @@ function buildNode(n2, options) {
           specialAttributes[name] = value;
           continue;
         }
-        if (typeof value !== "string")
-          ;
-        else if (tagName === "style" && name === "_cssText") {
-          buildStyleNode(n2, node, value, options);
-          continue;
-        } else if (tagName === "textarea" && name === "value") {
+        const isTextarea = tagName === "textarea" && name === "value";
+        const isRemoteOrDynamicCss = tagName === "style" && name === "_cssText";
+        if (isRemoteOrDynamicCss && hackCss && typeof value === "string") {
+          value = adaptCssForReplay(value, cache);
+        }
+        if ((isTextarea || isRemoteOrDynamicCss) && typeof value === "string") {
           node.appendChild(doc.createTextNode(value));
           n2.childNodes = [];
           continue;
@@ -2289,10 +2238,9 @@ function buildNode(n2, options) {
       return node;
     }
     case NodeType$2.Text:
-      if (n2.isStyle && hackCss) {
-        return doc.createTextNode(adaptCssForReplay(n2.textContent, cache));
-      }
-      return doc.createTextNode(n2.textContent);
+      return doc.createTextNode(
+        n2.isStyle && hackCss ? adaptCssForReplay(n2.textContent, cache) : n2.textContent
+      );
     case NodeType$2.CDATA:
       return doc.createCDATASection(n2.textContent);
     case NodeType$2.Comment:
@@ -2436,10 +2384,16 @@ function rebuild(n2, options) {
 }
 var __defProp2 = Object.defineProperty;
 var __defNormalProp2 = (obj, key, value) => key in obj ? __defProp2(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
-var __publicField2 = (obj, key, value) => __defNormalProp2(obj, typeof key !== "symbol" ? key + "" : key, value);
+var __publicField2 = (obj, key, value) => {
+  __defNormalProp2(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
 var __defProp22 = Object.defineProperty;
 var __defNormalProp22 = (obj, key, value) => key in obj ? __defProp22(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
-var __publicField22 = (obj, key, value) => __defNormalProp22(obj, typeof key !== "symbol" ? key + "" : key, value);
+var __publicField22 = (obj, key, value) => {
+  __defNormalProp22(obj, typeof key !== "symbol" ? key + "" : key, value);
+  return value;
+};
 var NodeType$1 = /* @__PURE__ */ ((NodeType2) => {
   NodeType2[NodeType2["Document"] = 0] = "Document";
   NodeType2[NodeType2["DocumentType"] = 1] = "DocumentType";
@@ -3291,13 +3245,8 @@ function diffProps(oldTree, newTree, rrnodeMirror) {
       };
     } else if (newTree.tagName === "IFRAME" && name === "srcdoc")
       continue;
-    else {
-      try {
-        oldTree.setAttribute(name, newValue);
-      } catch (err) {
-        console.warn(err);
-      }
-    }
+    else
+      oldTree.setAttribute(name, newValue);
   }
   for (const { name } of Array.from(oldAttributes))
     if (!(name in newAttributes))
@@ -4600,17 +4549,8 @@ var MutationBuffer = class {
       };
       const pushAdd = (n2) => {
         const parent = index.parentNode(n2);
-        if (!parent || !inDom(n2)) {
+        if (!parent || !inDom(n2) || parent.tagName === "TEXTAREA") {
           return;
-        }
-        let cssCaptured = false;
-        if (n2.nodeType === Node.TEXT_NODE) {
-          const parentTag = parent.tagName;
-          if (parentTag === "TEXTAREA") {
-            return;
-          } else if (parentTag === "STYLE" && this.addedSet.has(parent)) {
-            cssCaptured = true;
-          }
         }
         const parentId = isShadowRoot(parent) ? this.mirror.getId(getShadowHost(n2)) : this.mirror.getId(parent);
         const nextId = getNextId(n2);
@@ -4654,8 +4594,7 @@ var MutationBuffer = class {
           },
           onStylesheetLoad: (link, childSn) => {
             this.stylesheetManager.attachLinkElement(link, childSn);
-          },
-          cssCaptured
+          }
         });
         if (sn) {
           adds.push({
@@ -6868,7 +6807,7 @@ function initCanvasWebGLMutationObserver(cb, win, blockClass, blockSelector) {
     handlers.forEach((h) => h());
   };
 }
-var encodedJs = "KGZ1bmN0aW9uKCkgewogICJ1c2Ugc3RyaWN0IjsKICB2YXIgY2hhcnMgPSAiQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ejAxMjM0NTY3ODkrLyI7CiAgdmFyIGxvb2t1cCA9IHR5cGVvZiBVaW50OEFycmF5ID09PSAidW5kZWZpbmVkIiA/IFtdIDogbmV3IFVpbnQ4QXJyYXkoMjU2KTsKICBmb3IgKHZhciBpID0gMDsgaSA8IGNoYXJzLmxlbmd0aDsgaSsrKSB7CiAgICBsb29rdXBbY2hhcnMuY2hhckNvZGVBdChpKV0gPSBpOwogIH0KICB2YXIgZW5jb2RlID0gZnVuY3Rpb24oYXJyYXlidWZmZXIpIHsKICAgIHZhciBieXRlcyA9IG5ldyBVaW50OEFycmF5KGFycmF5YnVmZmVyKSwgaTIsIGxlbiA9IGJ5dGVzLmxlbmd0aCwgYmFzZTY0ID0gIiI7CiAgICBmb3IgKGkyID0gMDsgaTIgPCBsZW47IGkyICs9IDMpIHsKICAgICAgYmFzZTY0ICs9IGNoYXJzW2J5dGVzW2kyXSA+PiAyXTsKICAgICAgYmFzZTY0ICs9IGNoYXJzWyhieXRlc1tpMl0gJiAzKSA8PCA0IHwgYnl0ZXNbaTIgKyAxXSA+PiA0XTsKICAgICAgYmFzZTY0ICs9IGNoYXJzWyhieXRlc1tpMiArIDFdICYgMTUpIDw8IDIgfCBieXRlc1tpMiArIDJdID4+IDZdOwogICAgICBiYXNlNjQgKz0gY2hhcnNbYnl0ZXNbaTIgKyAyXSAmIDYzXTsKICAgIH0KICAgIGlmIChsZW4gJSAzID09PSAyKSB7CiAgICAgIGJhc2U2NCA9IGJhc2U2NC5zdWJzdHJpbmcoMCwgYmFzZTY0Lmxlbmd0aCAtIDEpICsgIj0iOwogICAgfSBlbHNlIGlmIChsZW4gJSAzID09PSAxKSB7CiAgICAgIGJhc2U2NCA9IGJhc2U2NC5zdWJzdHJpbmcoMCwgYmFzZTY0Lmxlbmd0aCAtIDIpICsgIj09IjsKICAgIH0KICAgIHJldHVybiBiYXNlNjQ7CiAgfTsKICBjb25zdCBsYXN0QmxvYk1hcCA9IC8qIEBfX1BVUkVfXyAqLyBuZXcgTWFwKCk7CiAgY29uc3QgdHJhbnNwYXJlbnRCbG9iTWFwID0gLyogQF9fUFVSRV9fICovIG5ldyBNYXAoKTsKICBhc3luYyBmdW5jdGlvbiBnZXRUcmFuc3BhcmVudEJsb2JGb3Iod2lkdGgsIGhlaWdodCwgZGF0YVVSTE9wdGlvbnMpIHsKICAgIGNvbnN0IGlkID0gYCR7d2lkdGh9LSR7aGVpZ2h0fWA7CiAgICBpZiAoIk9mZnNjcmVlbkNhbnZhcyIgaW4gZ2xvYmFsVGhpcykgewogICAgICBpZiAodHJhbnNwYXJlbnRCbG9iTWFwLmhhcyhpZCkpIHJldHVybiB0cmFuc3BhcmVudEJsb2JNYXAuZ2V0KGlkKTsKICAgICAgY29uc3Qgb2Zmc2NyZWVuID0gbmV3IE9mZnNjcmVlbkNhbnZhcyh3aWR0aCwgaGVpZ2h0KTsKICAgICAgb2Zmc2NyZWVuLmdldENvbnRleHQoIjJkIik7CiAgICAgIGNvbnN0IGJsb2IgPSBhd2FpdCBvZmZzY3JlZW4uY29udmVydFRvQmxvYihkYXRhVVJMT3B0aW9ucyk7CiAgICAgIGNvbnN0IGFycmF5QnVmZmVyID0gYXdhaXQgYmxvYi5hcnJheUJ1ZmZlcigpOwogICAgICBjb25zdCBiYXNlNjQgPSBlbmNvZGUoYXJyYXlCdWZmZXIpOwogICAgICB0cmFuc3BhcmVudEJsb2JNYXAuc2V0KGlkLCBiYXNlNjQpOwogICAgICByZXR1cm4gYmFzZTY0OwogICAgfSBlbHNlIHsKICAgICAgcmV0dXJuICIiOwogICAgfQogIH0KICBjb25zdCB3b3JrZXIgPSBzZWxmOwogIGxldCBsb2dEZWJ1ZyA9IGZhbHNlOwogIGNvbnN0IGRlYnVnID0gKC4uLmFyZ3MpID0+IHsKICAgIGlmIChsb2dEZWJ1ZykgewogICAgICBjb25zb2xlLmRlYnVnKC4uLmFyZ3MpOwogICAgfQogIH07CiAgd29ya2VyLm9ubWVzc2FnZSA9IGFzeW5jIGZ1bmN0aW9uKGUpIHsKICAgIGxvZ0RlYnVnID0gISFlLmRhdGEubG9nRGVidWc7CiAgICBpZiAoIk9mZnNjcmVlbkNhbnZhcyIgaW4gZ2xvYmFsVGhpcykgewogICAgICBjb25zdCB7IGlkLCBiaXRtYXAsIHdpZHRoLCBoZWlnaHQsIGR4LCBkeSwgZHcsIGRoLCBkYXRhVVJMT3B0aW9ucyB9ID0gZS5kYXRhOwogICAgICBjb25zdCB0cmFuc3BhcmVudEJhc2U2NCA9IGdldFRyYW5zcGFyZW50QmxvYkZvcigKICAgICAgICB3aWR0aCwKICAgICAgICBoZWlnaHQsCiAgICAgICAgZGF0YVVSTE9wdGlvbnMKICAgICAgKTsKICAgICAgY29uc3Qgb2Zmc2NyZWVuID0gbmV3IE9mZnNjcmVlbkNhbnZhcyh3aWR0aCwgaGVpZ2h0KTsKICAgICAgY29uc3QgY3R4ID0gb2Zmc2NyZWVuLmdldENvbnRleHQoIjJkIik7CiAgICAgIGN0eC5kcmF3SW1hZ2UoYml0bWFwLCAwLCAwLCB3aWR0aCwgaGVpZ2h0KTsKICAgICAgYml0bWFwLmNsb3NlKCk7CiAgICAgIGNvbnN0IGJsb2IgPSBhd2FpdCBvZmZzY3JlZW4uY29udmVydFRvQmxvYihkYXRhVVJMT3B0aW9ucyk7CiAgICAgIGNvbnN0IHR5cGUgPSBibG9iLnR5cGU7CiAgICAgIGNvbnN0IGFycmF5QnVmZmVyID0gYXdhaXQgYmxvYi5hcnJheUJ1ZmZlcigpOwogICAgICBjb25zdCBiYXNlNjQgPSBlbmNvZGUoYXJyYXlCdWZmZXIpOwogICAgICBpZiAoIWxhc3RCbG9iTWFwLmhhcyhpZCkgJiYgYXdhaXQgdHJhbnNwYXJlbnRCYXNlNjQgPT09IGJhc2U2NCkgewogICAgICAgIGRlYnVnKCJbaGlnaGxpZ2h0LXdvcmtlcl0gY2FudmFzIGJpdG1hcCBpcyB0cmFuc3BhcmVudCIsIHsKICAgICAgICAgIGlkLAogICAgICAgICAgYmFzZTY0CiAgICAgICAgfSk7CiAgICAgICAgbGFzdEJsb2JNYXAuc2V0KGlkLCBiYXNlNjQpOwogICAgICAgIHJldHVybiB3b3JrZXIucG9zdE1lc3NhZ2UoeyBpZCwgc3RhdHVzOiAidHJhbnNwYXJlbnQiIH0pOwogICAgICB9CiAgICAgIGlmIChsYXN0QmxvYk1hcC5nZXQoaWQpID09PSBiYXNlNjQpIHsKICAgICAgICBkZWJ1ZygiW2hpZ2hsaWdodC13b3JrZXJdIGNhbnZhcyBiaXRtYXAgaXMgdW5jaGFuZ2VkIiwgewogICAgICAgICAgaWQsCiAgICAgICAgICBiYXNlNjQKICAgICAgICB9KTsKICAgICAgICByZXR1cm4gd29ya2VyLnBvc3RNZXNzYWdlKHsgaWQsIHN0YXR1czogInVuY2hhbmdlZCIgfSk7CiAgICAgIH0KICAgICAgY29uc3QgbXNnID0gewogICAgICAgIGlkLAogICAgICAgIHR5cGUsCiAgICAgICAgYmFzZTY0LAogICAgICAgIHdpZHRoLAogICAgICAgIGhlaWdodCwKICAgICAgICBkeCwKICAgICAgICBkeSwKICAgICAgICBkdywKICAgICAgICBkaAogICAgICB9OwogICAgICBkZWJ1ZygiW2hpZ2hsaWdodC13b3JrZXJdIGNhbnZhcyBiaXRtYXAgcHJvY2Vzc2VkIiwgbXNnKTsKICAgICAgd29ya2VyLnBvc3RNZXNzYWdlKG1zZyk7CiAgICAgIGxhc3RCbG9iTWFwLnNldChpZCwgYmFzZTY0KTsKICAgIH0gZWxzZSB7CiAgICAgIGRlYnVnKCJbaGlnaGxpZ2h0LXdvcmtlcl0gbm8gb2Zmc2NyZWVuY2FudmFzIHN1cHBvcnQiLCB7CiAgICAgICAgaWQ6IGUuZGF0YS5pZAogICAgICB9KTsKICAgICAgcmV0dXJuIHdvcmtlci5wb3N0TWVzc2FnZSh7IGlkOiBlLmRhdGEuaWQsIHN0YXR1czogInVuc3VwcG9ydGVkIiB9KTsKICAgIH0KICB9Owp9KSgpOwovLyMgc291cmNlTWFwcGluZ1VSTD1pbWFnZS1iaXRtYXAtZGF0YS11cmwtd29ya2VyLUJpWEpSZjQ3LmpzLm1hcAo=";
+var encodedJs = "KGZ1bmN0aW9uKCkgewogICJ1c2Ugc3RyaWN0IjsKICB2YXIgY2hhcnMgPSAiQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ejAxMjM0NTY3ODkrLyI7CiAgdmFyIGxvb2t1cCA9IHR5cGVvZiBVaW50OEFycmF5ID09PSAidW5kZWZpbmVkIiA/IFtdIDogbmV3IFVpbnQ4QXJyYXkoMjU2KTsKICBmb3IgKHZhciBpID0gMDsgaSA8IGNoYXJzLmxlbmd0aDsgaSsrKSB7CiAgICBsb29rdXBbY2hhcnMuY2hhckNvZGVBdChpKV0gPSBpOwogIH0KICB2YXIgZW5jb2RlID0gZnVuY3Rpb24oYXJyYXlidWZmZXIpIHsKICAgIHZhciBieXRlcyA9IG5ldyBVaW50OEFycmF5KGFycmF5YnVmZmVyKSwgaTIsIGxlbiA9IGJ5dGVzLmxlbmd0aCwgYmFzZTY0ID0gIiI7CiAgICBmb3IgKGkyID0gMDsgaTIgPCBsZW47IGkyICs9IDMpIHsKICAgICAgYmFzZTY0ICs9IGNoYXJzW2J5dGVzW2kyXSA+PiAyXTsKICAgICAgYmFzZTY0ICs9IGNoYXJzWyhieXRlc1tpMl0gJiAzKSA8PCA0IHwgYnl0ZXNbaTIgKyAxXSA+PiA0XTsKICAgICAgYmFzZTY0ICs9IGNoYXJzWyhieXRlc1tpMiArIDFdICYgMTUpIDw8IDIgfCBieXRlc1tpMiArIDJdID4+IDZdOwogICAgICBiYXNlNjQgKz0gY2hhcnNbYnl0ZXNbaTIgKyAyXSAmIDYzXTsKICAgIH0KICAgIGlmIChsZW4gJSAzID09PSAyKSB7CiAgICAgIGJhc2U2NCA9IGJhc2U2NC5zdWJzdHJpbmcoMCwgYmFzZTY0Lmxlbmd0aCAtIDEpICsgIj0iOwogICAgfSBlbHNlIGlmIChsZW4gJSAzID09PSAxKSB7CiAgICAgIGJhc2U2NCA9IGJhc2U2NC5zdWJzdHJpbmcoMCwgYmFzZTY0Lmxlbmd0aCAtIDIpICsgIj09IjsKICAgIH0KICAgIHJldHVybiBiYXNlNjQ7CiAgfTsKICBjb25zdCBsYXN0QmxvYk1hcCA9IC8qIEBfX1BVUkVfXyAqLyBuZXcgTWFwKCk7CiAgY29uc3QgdHJhbnNwYXJlbnRCbG9iTWFwID0gLyogQF9fUFVSRV9fICovIG5ldyBNYXAoKTsKICBhc3luYyBmdW5jdGlvbiBnZXRUcmFuc3BhcmVudEJsb2JGb3Iod2lkdGgsIGhlaWdodCwgZGF0YVVSTE9wdGlvbnMpIHsKICAgIGNvbnN0IGlkID0gYCR7d2lkdGh9LSR7aGVpZ2h0fWA7CiAgICBpZiAoIk9mZnNjcmVlbkNhbnZhcyIgaW4gZ2xvYmFsVGhpcykgewogICAgICBpZiAodHJhbnNwYXJlbnRCbG9iTWFwLmhhcyhpZCkpCiAgICAgICAgcmV0dXJuIHRyYW5zcGFyZW50QmxvYk1hcC5nZXQoaWQpOwogICAgICBjb25zdCBvZmZzY3JlZW4gPSBuZXcgT2Zmc2NyZWVuQ2FudmFzKHdpZHRoLCBoZWlnaHQpOwogICAgICBvZmZzY3JlZW4uZ2V0Q29udGV4dCgiMmQiKTsKICAgICAgY29uc3QgYmxvYiA9IGF3YWl0IG9mZnNjcmVlbi5jb252ZXJ0VG9CbG9iKGRhdGFVUkxPcHRpb25zKTsKICAgICAgY29uc3QgYXJyYXlCdWZmZXIgPSBhd2FpdCBibG9iLmFycmF5QnVmZmVyKCk7CiAgICAgIGNvbnN0IGJhc2U2NCA9IGVuY29kZShhcnJheUJ1ZmZlcik7CiAgICAgIHRyYW5zcGFyZW50QmxvYk1hcC5zZXQoaWQsIGJhc2U2NCk7CiAgICAgIHJldHVybiBiYXNlNjQ7CiAgICB9IGVsc2UgewogICAgICByZXR1cm4gIiI7CiAgICB9CiAgfQogIGNvbnN0IHdvcmtlciA9IHNlbGY7CiAgbGV0IGxvZ0RlYnVnID0gZmFsc2U7CiAgY29uc3QgZGVidWcgPSAoLi4uYXJncykgPT4gewogICAgaWYgKGxvZ0RlYnVnKSB7CiAgICAgIGNvbnNvbGUuZGVidWcoLi4uYXJncyk7CiAgICB9CiAgfTsKICB3b3JrZXIub25tZXNzYWdlID0gYXN5bmMgZnVuY3Rpb24oZSkgewogICAgbG9nRGVidWcgPSAhIWUuZGF0YS5sb2dEZWJ1ZzsKICAgIGlmICgiT2Zmc2NyZWVuQ2FudmFzIiBpbiBnbG9iYWxUaGlzKSB7CiAgICAgIGNvbnN0IHsgaWQsIGJpdG1hcCwgd2lkdGgsIGhlaWdodCwgZHgsIGR5LCBkdywgZGgsIGRhdGFVUkxPcHRpb25zIH0gPSBlLmRhdGE7CiAgICAgIGNvbnN0IHRyYW5zcGFyZW50QmFzZTY0ID0gZ2V0VHJhbnNwYXJlbnRCbG9iRm9yKAogICAgICAgIHdpZHRoLAogICAgICAgIGhlaWdodCwKICAgICAgICBkYXRhVVJMT3B0aW9ucwogICAgICApOwogICAgICBjb25zdCBvZmZzY3JlZW4gPSBuZXcgT2Zmc2NyZWVuQ2FudmFzKHdpZHRoLCBoZWlnaHQpOwogICAgICBjb25zdCBjdHggPSBvZmZzY3JlZW4uZ2V0Q29udGV4dCgiMmQiKTsKICAgICAgY3R4LmRyYXdJbWFnZShiaXRtYXAsIDAsIDAsIHdpZHRoLCBoZWlnaHQpOwogICAgICBiaXRtYXAuY2xvc2UoKTsKICAgICAgY29uc3QgYmxvYiA9IGF3YWl0IG9mZnNjcmVlbi5jb252ZXJ0VG9CbG9iKGRhdGFVUkxPcHRpb25zKTsKICAgICAgY29uc3QgdHlwZSA9IGJsb2IudHlwZTsKICAgICAgY29uc3QgYXJyYXlCdWZmZXIgPSBhd2FpdCBibG9iLmFycmF5QnVmZmVyKCk7CiAgICAgIGNvbnN0IGJhc2U2NCA9IGVuY29kZShhcnJheUJ1ZmZlcik7CiAgICAgIGlmICghbGFzdEJsb2JNYXAuaGFzKGlkKSAmJiBhd2FpdCB0cmFuc3BhcmVudEJhc2U2NCA9PT0gYmFzZTY0KSB7CiAgICAgICAgZGVidWcoIltoaWdobGlnaHQtd29ya2VyXSBjYW52YXMgYml0bWFwIGlzIHRyYW5zcGFyZW50IiwgewogICAgICAgICAgaWQsCiAgICAgICAgICBiYXNlNjQKICAgICAgICB9KTsKICAgICAgICBsYXN0QmxvYk1hcC5zZXQoaWQsIGJhc2U2NCk7CiAgICAgICAgcmV0dXJuIHdvcmtlci5wb3N0TWVzc2FnZSh7IGlkLCBzdGF0dXM6ICJ0cmFuc3BhcmVudCIgfSk7CiAgICAgIH0KICAgICAgaWYgKGxhc3RCbG9iTWFwLmdldChpZCkgPT09IGJhc2U2NCkgewogICAgICAgIGRlYnVnKCJbaGlnaGxpZ2h0LXdvcmtlcl0gY2FudmFzIGJpdG1hcCBpcyB1bmNoYW5nZWQiLCB7CiAgICAgICAgICBpZCwKICAgICAgICAgIGJhc2U2NAogICAgICAgIH0pOwogICAgICAgIHJldHVybiB3b3JrZXIucG9zdE1lc3NhZ2UoeyBpZCwgc3RhdHVzOiAidW5jaGFuZ2VkIiB9KTsKICAgICAgfQogICAgICBjb25zdCBtc2cgPSB7CiAgICAgICAgaWQsCiAgICAgICAgdHlwZSwKICAgICAgICBiYXNlNjQsCiAgICAgICAgd2lkdGgsCiAgICAgICAgaGVpZ2h0LAogICAgICAgIGR4LAogICAgICAgIGR5LAogICAgICAgIGR3LAogICAgICAgIGRoCiAgICAgIH07CiAgICAgIGRlYnVnKCJbaGlnaGxpZ2h0LXdvcmtlcl0gY2FudmFzIGJpdG1hcCBwcm9jZXNzZWQiLCBtc2cpOwogICAgICB3b3JrZXIucG9zdE1lc3NhZ2UobXNnKTsKICAgICAgbGFzdEJsb2JNYXAuc2V0KGlkLCBiYXNlNjQpOwogICAgfSBlbHNlIHsKICAgICAgZGVidWcoIltoaWdobGlnaHQtd29ya2VyXSBubyBvZmZzY3JlZW5jYW52YXMgc3VwcG9ydCIsIHsKICAgICAgICBpZDogZS5kYXRhLmlkCiAgICAgIH0pOwogICAgICByZXR1cm4gd29ya2VyLnBvc3RNZXNzYWdlKHsgaWQ6IGUuZGF0YS5pZCwgc3RhdHVzOiAidW5zdXBwb3J0ZWQiIH0pOwogICAgfQogIH07Cn0pKCk7Ci8vIyBzb3VyY2VNYXBwaW5nVVJMPWltYWdlLWJpdG1hcC1kYXRhLXVybC13b3JrZXItS0tvQ2VrWjEuanMubWFwCg==";
 var decodeBase64 = (base64) => Uint8Array.from(atob(base64), (c2) => c2.charCodeAt(0));
 var blob = typeof window !== "undefined" && window.Blob && new Blob([decodeBase64(encodedJs)], { type: "text/javascript;charset=utf-8" });
 function WorkerWrapper(options) {
@@ -9896,9 +9835,6 @@ var Replayer = class {
         "html.rrweb-paused *, html.rrweb-paused *:before, html.rrweb-paused *:after { animation-play-state: paused !important; }"
       );
     }
-    if (!injectStylesRules.length) {
-      return;
-    }
     if (this.usingVirtualDom) {
       const styleEl = this.virtualDom.createElement("style");
       this.virtualDom.mirror.add(
@@ -10582,12 +10518,7 @@ var Replayer = class {
         }
         return this.warnNodeNotFound(d, mutation.id);
       }
-      const parentEl = target.parentElement;
-      if (mutation.value && parentEl && parentEl.tagName === "STYLE") {
-        target.textContent = adaptCssForReplay(mutation.value, this.cache);
-      } else {
-        target.textContent = mutation.value;
-      }
+      target.textContent = mutation.value;
       if (this.usingVirtualDom) {
         const parent = target.parentNode;
         if (((_a2 = parent == null ? void 0 : parent.rules) == null ? void 0 : _a2.length) > 0)

--- a/__generated/rr/rrweb/rr.min.css
+++ b/__generated/rr/rrweb/rr.min.css
@@ -18,7 +18,7 @@
   display: inline-block;
   width: 20px;
   height: 20px;
-  background: rgb(73, 80, 246);
+  background: #4950f6;
   border-radius: 100%;
   transform: translate(-50%, -50%);
   opacity: .3;
@@ -84,7 +84,7 @@
 }
 .rr-player {
   position: relative;
-  background: white;
+  background: #fff;
   float: left;
   border-radius: 5px;
   box-shadow: 0 24px 48px #11103e1f;

--- a/__generated/rr/rrweb/rr.min.css
+++ b/__generated/rr/rrweb/rr.min.css
@@ -18,7 +18,7 @@
   display: inline-block;
   width: 20px;
   height: 20px;
-  background: #4950f6;
+  background: rgb(73, 80, 246);
   border-radius: 100%;
   transform: translate(-50%, -50%);
   opacity: .3;
@@ -84,7 +84,7 @@
 }
 .rr-player {
   position: relative;
-  background: #fff;
+  background: white;
   float: left;
   border-radius: 5px;
   box-shadow: 0 24px 48px #11103e1f;

--- a/backend/clickhouse/cursor.go
+++ b/backend/clickhouse/cursor.go
@@ -23,6 +23,11 @@ type Connection[T interface{}] struct {
 }
 
 func getConnection[T interface{}](edges []*Edge[T], pagination Pagination) *Connection[T] {
+	limit := LogsLimit
+	if pagination.Limit != nil {
+		limit = *pagination.Limit
+	}
+
 	var (
 		endCursor       string
 		startCursor     string
@@ -36,31 +41,31 @@ func getConnection[T interface{}](edges []*Edge[T], pagination Pagination) *Conn
 		beforeCount := idx
 		afterCount := len(edges) - idx - 1
 
-		if beforeCount == LogsLimit/2+1 { // has backwards pagination
+		if beforeCount == limit/2+1 { // has backwards pagination
 			hasPreviousPage = true
 			edges = edges[1:] // remove first
 		}
 
-		if afterCount == LogsLimit/2+1 { // has forward pagination
+		if afterCount == limit/2+1 { // has forward pagination
 			hasNextPage = true
 			edges = edges[:len(edges)-1] // remove last
 		}
 	} else if pagination.After != nil && len(*pagination.After) > 1 {
 		hasPreviousPage = true // implicitly true because the passed in cursor should match
-		if len(edges) >= LogsLimit+1 {
+		if len(edges) >= limit+1 {
 			hasNextPage = true
 			edges = edges[:len(edges)-1]
 		}
 	} else if pagination.Before != nil && len(*pagination.Before) > 1 {
 		hasNextPage = true // implicitly true because the passed in cursor should match
-		if len(edges) >= LogsLimit+1 {
+		if len(edges) >= limit+1 {
 			hasPreviousPage = true
 			edges = edges[1 : len(edges)-1]
 		}
 	} else {
-		if len(edges) >= LogsLimit+1 { // has forward page
-			hasNextPage = len(edges) == LogsLimit+1
-			edges = edges[:LogsLimit]
+		if len(edges) >= limit+1 { // has forward page
+			hasNextPage = len(edges) == limit+1
+			edges = edges[:limit]
 		}
 	}
 

--- a/backend/clickhouse/cursor_test.go
+++ b/backend/clickhouse/cursor_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestGetConnectionAfter(t *testing.T) {
+	limit := 123_456
 	zeroEdges := []*Edge[modelInputs.Log]{}
 	oneEdge := []*Edge[modelInputs.Log]{
 		{
@@ -20,7 +21,7 @@ func TestGetConnectionAfter(t *testing.T) {
 	}
 
 	manyEdges := []*Edge[modelInputs.Log]{}
-	for i := 1; i <= LogsLimit+1; i++ {
+	for i := 1; i <= limit+1; i++ {
 		manyEdges = append(manyEdges, &Edge[modelInputs.Log]{
 			Cursor: "cursor",
 		})
@@ -30,6 +31,7 @@ func TestGetConnectionAfter(t *testing.T) {
 
 	conn := getConnection(zeroEdges, Pagination{
 		After: ptr.String("cursor"),
+		Limit: ptr.Int(limit),
 	})
 
 	assert.Equal(t, &lc{
@@ -61,7 +63,7 @@ func TestGetConnectionAfter(t *testing.T) {
 	})
 
 	assert.Equal(t, &lc{
-		Edges: manyEdges[:LogsLimit],
+		Edges: manyEdges[:limit],
 		PageInfo: &modelInputs.PageInfo{
 			HasNextPage:     true,
 			HasPreviousPage: true,
@@ -132,9 +134,10 @@ func TestGetConnectionBefore(t *testing.T) {
 }
 
 func TestGetConnectionNoPagination(t *testing.T) {
+	limit := 123_456
 	zeroEdges := []*Edge[modelInputs.Log]{}
 	manyEdges := []*Edge[modelInputs.Log]{}
-	for i := 1; i <= LogsLimit+1; i++ {
+	for i := 1; i <= limit+1; i++ {
 		manyEdges = append(manyEdges, &Edge[modelInputs.Log]{
 			Cursor: "cursor",
 		})
@@ -142,7 +145,9 @@ func TestGetConnectionNoPagination(t *testing.T) {
 
 	type lc = Connection[modelInputs.Log]
 
-	connection := getConnection(zeroEdges, Pagination{})
+	connection := getConnection(zeroEdges, Pagination{
+		Limit: ptr.Int(limit),
+	})
 
 	assert.Equal(t, &lc{
 		Edges: zeroEdges,
@@ -154,10 +159,12 @@ func TestGetConnectionNoPagination(t *testing.T) {
 		},
 	}, connection)
 
-	connection = getConnection(manyEdges, Pagination{})
+	connection = getConnection(manyEdges, Pagination{
+		Limit: ptr.Int(limit),
+	})
 
 	assert.Equal(t, &lc{
-		Edges: manyEdges[:LogsLimit],
+		Edges: manyEdges[:limit],
 		PageInfo: &modelInputs.PageInfo{
 			HasNextPage:     true,
 			HasPreviousPage: false,

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -134,6 +134,7 @@ type Pagination struct {
 	At        *string
 	Direction modelInputs.SortDirection
 	CountOnly bool
+	Limit     *int
 }
 
 func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelInputs.QueryInput, pagination Pagination) (*modelInputs.LogConnection, error) {

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -119,7 +119,7 @@ func (client *Client) BatchWriteLogRows(ctx context.Context, logRows []*LogRow) 
 	return batch.Send()
 }
 
-const LogsLimit int = 1000
+const LogsLimit int = 50
 const KeyValuesLimit int = 50
 
 const OrderBackwardNatural = "Timestamp ASC, UUID ASC"

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -119,7 +119,7 @@ func (client *Client) BatchWriteLogRows(ctx context.Context, logRows []*LogRow) 
 	return batch.Send()
 }
 
-const LogsLimit int = 50
+const LogsLimit int = 1000
 const KeyValuesLimit int = 50
 
 const OrderBackwardNatural = "Timestamp ASC, UUID ASC"

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -1130,7 +1130,7 @@ type ComplexityRoot struct {
 		TimelineIndicatorEvents          func(childComplexity int, sessionSecureID string) int
 		TopUsers                         func(childComplexity int, projectID int, lookbackDays float64) int
 		Trace                            func(childComplexity int, projectID int, traceID string, timestamp time.Time, sessionSecureID *string) int
-		Traces                           func(childComplexity int, projectID int, params model.QueryInput, after *string, before *string, at *string, direction model.SortDirection) int
+		Traces                           func(childComplexity int, projectID int, params model.QueryInput, after *string, before *string, at *string, direction model.SortDirection, limit *int) int
 		TracesIntegration                func(childComplexity int, projectID int) int
 		TracesKeyValues                  func(childComplexity int, projectID int, keyName string, dateRange model.DateRangeRequiredInput, query *string, count *int) int
 		TracesKeys                       func(childComplexity int, projectID int, dateRange model.DateRangeRequiredInput, query *string, typeArg *model.KeyType) int
@@ -1992,7 +1992,7 @@ type QueryResolver interface {
 	ErrorTags(ctx context.Context) ([]*model1.ErrorTag, error)
 	MatchErrorTag(ctx context.Context, query string) ([]*model.MatchedErrorTag, error)
 	Trace(ctx context.Context, projectID int, traceID string, timestamp time.Time, sessionSecureID *string) (*model.TracePayload, error)
-	Traces(ctx context.Context, projectID int, params model.QueryInput, after *string, before *string, at *string, direction model.SortDirection) (*model.TraceConnection, error)
+	Traces(ctx context.Context, projectID int, params model.QueryInput, after *string, before *string, at *string, direction model.SortDirection, limit *int) (*model.TraceConnection, error)
 	TracesMetrics(ctx context.Context, projectID int, params model.QueryInput, column string, metricTypes []model.MetricAggregator, groupBy []string, bucketBy *string, bucketCount *int, bucketWindow *int, limit *int, limitAggregator *model.MetricAggregator, limitColumn *string) (*model.MetricsBuckets, error)
 	TracesKeys(ctx context.Context, projectID int, dateRange model.DateRangeRequiredInput, query *string, typeArg *model.KeyType) ([]*model.QueryKey, error)
 	TracesKeyValues(ctx context.Context, projectID int, keyName string, dateRange model.DateRangeRequiredInput, query *string, count *int) ([]string, error)
@@ -8665,7 +8665,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Traces(childComplexity, args["project_id"].(int), args["params"].(model.QueryInput), args["after"].(*string), args["before"].(*string), args["at"].(*string), args["direction"].(model.SortDirection)), true
+		return e.complexity.Query.Traces(childComplexity, args["project_id"].(int), args["params"].(model.QueryInput), args["after"].(*string), args["before"].(*string), args["at"].(*string), args["direction"].(model.SortDirection), args["limit"].(*int)), true
 
 	case "Query.tracesIntegration":
 		if e.complexity.Query.TracesIntegration == nil {
@@ -13981,6 +13981,7 @@ type Query {
 		before: String
 		at: String
 		direction: SortDirection!
+		limit: Int
 	): TraceConnection!
 	traces_metrics(
 		project_id: ID!
@@ -22261,6 +22262,15 @@ func (ec *executionContext) field_Query_traces_args(ctx context.Context, rawArgs
 		}
 	}
 	args["direction"] = arg5
+	var arg6 *int
+	if tmp, ok := rawArgs["limit"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("limit"))
+		arg6, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["limit"] = arg6
 	return args, nil
 }
 
@@ -63860,7 +63870,7 @@ func (ec *executionContext) _Query_traces(ctx context.Context, field graphql.Col
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Traces(rctx, fc.Args["project_id"].(int), fc.Args["params"].(model.QueryInput), fc.Args["after"].(*string), fc.Args["before"].(*string), fc.Args["at"].(*string), fc.Args["direction"].(model.SortDirection))
+		return ec.resolvers.Query().Traces(rctx, fc.Args["project_id"].(int), fc.Args["params"].(model.QueryInput), fc.Args["after"].(*string), fc.Args["before"].(*string), fc.Args["at"].(*string), fc.Args["direction"].(model.SortDirection), fc.Args["limit"].(*int))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -2392,6 +2392,7 @@ type Query {
 		before: String
 		at: String
 		direction: SortDirection!
+		limit: Int
 	): TraceConnection!
 	traces_metrics(
 		project_id: ID!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -9305,7 +9305,7 @@ func (r *queryResolver) Trace(ctx context.Context, projectID int, traceID string
 }
 
 // Traces is the resolver for the traces field.
-func (r *queryResolver) Traces(ctx context.Context, projectID int, params modelInputs.QueryInput, after *string, before *string, at *string, direction modelInputs.SortDirection) (*modelInputs.TraceConnection, error) {
+func (r *queryResolver) Traces(ctx context.Context, projectID int, params modelInputs.QueryInput, after *string, before *string, at *string, direction modelInputs.SortDirection, limit *int) (*modelInputs.TraceConnection, error) {
 	project, err := r.isUserInProjectOrDemoProject(ctx, projectID)
 	if err != nil {
 		return nil, err
@@ -9316,6 +9316,7 @@ func (r *queryResolver) Traces(ctx context.Context, projectID int, params modelI
 		Before:    before,
 		At:        at,
 		Direction: direction,
+		Limit:     limit,
 	})
 }
 

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -3285,6 +3285,7 @@ func (r *Resolver) submitFrontendWebsocketMetric(sessionObj *model.Session, even
 			attribute.String(highlight.SessionIDAttribute, sessionObj.SecureID),
 			attribute.String(highlight.RequestIDAttribute, event.SocketID),
 			attribute.String(highlight.TraceKeyAttribute, event.Name),
+			attribute.String("ws.type", event.Type),
 			semconv.DeploymentEnvironmentKey.String(sessionObj.Environment),
 			semconv.ServiceNameKey.String(sessionObj.ServiceName),
 			semconv.ServiceVersionKey.String(ptr.ToString(sessionObj.AppVersion)),

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -3248,13 +3248,13 @@ func (r *Resolver) submitFrontendNetworkMetric(ctx context.Context, sessionObj *
 		for requestHeader, requestHeaderValue := range requestHeaders {
 			str, ok := requestHeaderValue.(string)
 			if ok {
-				attributes = append(attributes, attribute.String(fmt.Sprintf("http.request.header.%s", requestHeader), str))
+				attributes = append(attributes, attribute.String(fmt.Sprintf("http.request.headers.%s", requestHeader), str))
 			}
 		}
 		for responseHeader, responseHeaderValue := range responseHeaders {
 			str, ok := responseHeaderValue.(string)
 			if ok {
-				attributes = append(attributes, attribute.String(fmt.Sprintf("http.response.header.%s", responseHeader), str))
+				attributes = append(attributes, attribute.String(fmt.Sprintf("http.response.headers.%s", responseHeader), str))
 			}
 		}
 		requestBodyJson := make(map[string]interface{})

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -3197,7 +3197,7 @@ func (r *Resolver) submitFrontendNetworkMetric(ctx context.Context, sessionObj *
 		responseHeaders, _ := re.RequestResponsePairs.Response.HeadersRaw.(map[string]interface{})
 		userAgent, _ := requestHeaders["User-Agent"].(string)
 		requestBody, ok := re.RequestResponsePairs.Request.Body.(string)
-		if !ok {
+		if re.RequestResponsePairs.Request.Body != nil && !ok {
 			bdBytes, err := json.Marshal(requestBody)
 			if err != nil {
 				log.WithContext(ctx).WithError(err).WithField("sessionID", sessionObj.ID).Error("failed to serialize network request body as json")
@@ -3206,7 +3206,7 @@ func (r *Resolver) submitFrontendNetworkMetric(ctx context.Context, sessionObj *
 			}
 		}
 		responseBody, ok := re.RequestResponsePairs.Response.Body.(string)
-		if !ok {
+		if re.RequestResponsePairs.Response.Body != nil && !ok {
 			bdBytes, err := json.Marshal(responseBody)
 			if err != nil {
 				log.WithContext(ctx).WithError(err).WithField("sessionID", sessionObj.ID).Error("failed to serialize network response body as json")
@@ -3224,6 +3224,7 @@ func (r *Resolver) submitFrontendNetworkMetric(ctx context.Context, sessionObj *
 			semconv.ServiceName(sessionObj.ServiceName),
 			semconv.ServiceVersion(ptr.ToString(sessionObj.AppVersion)),
 			semconv.HTTPURL(re.Name),
+			attribute.Bool("http.blocked", re.RequestResponsePairs.URLBlocked),
 			attribute.String("http.request.body", requestBody),
 			attribute.String("http.response.body", responseBody),
 			attribute.Float64("http.response.encoded.size", re.EncodedBodySize),

--- a/frontend/src/components/Header/CommandBar/CommandBarCommands.tsx
+++ b/frontend/src/components/Header/CommandBar/CommandBarCommands.tsx
@@ -135,12 +135,6 @@ export const usePlayerCommands = (
 			},
 			name: `Download events`,
 		},
-		{
-			command: () => {
-				document.location.search = 'downloadresources=1'
-			},
-			name: `Download resources (navigate to network tab first)`,
-		},
 	] as const
 
 	const [, , routeName, sessionId] = location.pathname.split('/')

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -14663,6 +14663,7 @@ export const GetTracesDocument = gql`
 		$before: String
 		$at: String
 		$direction: SortDirection!
+		$limit: Int
 	) {
 		traces(
 			project_id: $project_id
@@ -14671,6 +14672,7 @@ export const GetTracesDocument = gql`
 			before: $before
 			at: $at
 			direction: $direction
+			limit: $limit
 		) {
 			edges {
 				cursor
@@ -14728,6 +14730,7 @@ export const GetTracesDocument = gql`
  *      before: // value for 'before'
  *      at: // value for 'at'
  *      direction: // value for 'direction'
+ *      limit: // value for 'limit'
  *   },
  * });
  */

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -5013,6 +5013,7 @@ export type GetTracesQueryVariables = Types.Exact<{
 	before?: Types.Maybe<Types.Scalars['String']>
 	at?: Types.Maybe<Types.Scalars['String']>
 	direction: Types.SortDirection
+	limit?: Types.Maybe<Types.Scalars['Int']>
 }>
 
 export type GetTracesQuery = { __typename?: 'Query' } & {

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2926,6 +2926,7 @@ export type QueryTracesArgs = {
 	at?: InputMaybe<Scalars['String']>
 	before?: InputMaybe<Scalars['String']>
 	direction: SortDirection
+	limit?: InputMaybe<Scalars['Int']>
 	params: QueryInput
 	project_id: Scalars['ID']
 }

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2436,6 +2436,7 @@ query GetTraces(
 	$before: String
 	$at: String
 	$direction: SortDirection!
+	$limit: Int
 ) {
 	traces(
 		project_id: $project_id
@@ -2444,6 +2445,7 @@ query GetTraces(
 		before: $before
 		at: $at
 		direction: $direction
+		limit: $limit
 	) {
 		edges {
 			cursor

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -73,6 +73,11 @@ const clientDebug = window.localStorage.getItem(clientDebugKey)
 if (!clientDebug) {
 	window.localStorage.setItem(clientDebugKey, 'false')
 }
+const clientOtelKey = 'highlight-client-otel'
+const clientOtel = window.localStorage.getItem(clientOtelKey)
+if (!clientOtel) {
+	window.localStorage.setItem(clientOtelKey, 'true')
+}
 const shouldDebugLog = clientDebug === 'true'
 const options: HighlightOptions = {
 	debug: shouldDebugLog
@@ -123,7 +128,7 @@ const options: HighlightOptions = {
 	sessionShortcut: 'alt+1,command+`,alt+esc',
 	version: import.meta.env.REACT_APP_COMMIT_SHA ?? '1.0.0',
 	serviceName: 'frontend',
-	enableOtelTracing: true,
+	enableOtelTracing: clientOtel !== 'false',
 	otlpEndpoint: OTLP_ENDPOINT,
 }
 const favicon = document.querySelector("link[rel~='icon']") as any

--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -185,6 +185,8 @@ export const useResources = (
 		sortDirection: SortDirection.Asc,
 		sortColumn: 'timestamp',
 		skip: !session?.secure_id,
+		skipPolling: true,
+		loadAll: true,
 	})
 
 	const [resources, setResources] = useState<NetworkResourceWithID[]>([])

--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -71,8 +71,9 @@ const buildResources = (traces: TraceEdge[]) => {
 				trace.node.traceAttributes.http?.response?.body
 					? 'fetch'
 					: 'other'),
-			transferSize:
-				trace.node.traceAttributes.http?.response?.transfer?.size ?? 0,
+			transferSize: Number(
+				trace.node.traceAttributes.http?.response?.transfer?.size,
+			),
 			requestResponsePairs: {
 				request: {
 					id: trace.node.traceID,
@@ -85,9 +86,13 @@ const buildResources = (traces: TraceEdge[]) => {
 				response: {
 					body: trace.node.traceAttributes.http?.response?.body,
 					headers: responseHeaders,
-					status: trace.node.traceAttributes.http?.status_code,
-					size: trace.node.traceAttributes.http?.response?.transfer
-						?.size,
+					status:
+						trace.node.traceAttributes.http?.status_code ||
+						'Unknown',
+					size: Number(
+						trace.node.traceAttributes.http?.response?.transfer
+							?.size,
+					),
 				},
 				urlBlocked: trace.node.traceAttributes.http?.blocked,
 			},

--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -186,7 +186,7 @@ export const useResources = (
 		sortColumn: 'timestamp',
 		skip: !session?.secure_id,
 		skipPolling: true,
-		loadAll: true,
+		limit: 1_000,
 	})
 
 	const [resources, setResources] = useState<NetworkResourceWithID[]>([])

--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -87,8 +87,9 @@ const buildResources = (traces: TraceEdge[]) => {
 					body: trace.node.traceAttributes.http?.response?.body,
 					headers: responseHeaders,
 					status:
-						trace.node.traceAttributes.http?.status_code ||
-						'Unknown',
+						trace.node.traceAttributes.http?.status_code === '0'
+							? 'Unknown'
+							: trace.node.traceAttributes.http?.status_code,
 					size: Number(
 						trace.node.traceAttributes.http?.response?.transfer
 							?.size,

--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -1,26 +1,23 @@
-import { useGetResourcesQuery } from '@graph/hooks'
-import { Session } from '@graph/schemas'
+import { Session, SortDirection, TraceEdge } from '@graph/schemas'
 import { RequestResponsePair } from '@highlight-run/client'
 import { RequestType } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
 import { getGraphQLResolverName } from '@pages/Player/utils/utils'
 import { createContext } from '@util/context/context'
-import { indexedDBFetch } from '@util/db'
-import { checkResourceLimit } from '@util/preload'
-import { H } from 'highlight.run'
-import { useCallback, useEffect, useState } from 'react'
-import { BooleanParam, useQueryParam } from 'use-query-params'
+import { useEffect, useState } from 'react'
 
-import { useSessionParams } from '@/pages/Sessions/utils'
 import { ApolloError } from '@apollo/client'
+import { useGetTraces } from '@pages/Traces/useGetTraces'
+import { useProjectId } from '@hooks/useProjectId'
+import moment from 'moment'
 
 export enum LoadingError {
-	NetworkResourcesTooLarge = 'payload too large.',
 	NetworkResourcesFetchFailed = 'failed to fetch.',
 }
 
 interface ResourcesContext {
 	resourcesLoading: boolean
-	loadResources: () => void
+	loadingAfter: boolean
+	fetchMoreForward: () => Promise<void>
 	resources: NetworkResourceWithID[]
 	error?: LoadingError | ApolloError
 }
@@ -38,11 +35,42 @@ interface NetworkResource extends PerformanceResourceTiming {
 
 export type NetworkResourceWithID = { id: number } & NetworkResource
 
-const buildResources = (resources: NetworkResource[]) => {
+const buildResources = (traces: TraceEdge[]) => {
 	const indexResources = [] as NetworkResourceWithID[]
 	const webSocketHash = {} as { [key: string]: NetworkResource }
 
-	resources?.forEach((resource: NetworkResource) => {
+	traces?.forEach((trace: TraceEdge) => {
+		const start = moment(trace.node.startTime)
+		const resource = {
+			startTimeAbs: start.toDate().getTime(),
+			responseEndAbs:
+				start.toDate().getTime() + trace.node.duration / 1e6,
+			decodedBodySize: Number(
+				trace.node.traceAttributes.http?.response_content_length,
+			),
+			name: trace.node.traceAttributes.http?.url,
+			initiatorType: trace.node.traceAttributes.initiator_type,
+			transferSize:
+				trace.node.traceAttributes.http?.response?.transfer?.size,
+			requestResponsePairs: {
+				request: {
+					sessionSecureID: trace.node.secureSessionID,
+					id: trace.node.traceAttributes.traceID,
+					url: trace.node.traceAttributes.http?.url,
+					verb: trace.node.traceAttributes.http?.method,
+					body: trace.node.traceAttributes.http?.request?.body,
+					headers: trace.node.traceAttributes.http?.request?.headers,
+				},
+				response: {
+					status: trace.node.traceAttributes.http?.status_code,
+					body: trace.node.traceAttributes.http?.response?.body,
+					headers: trace.node.traceAttributes.http?.response?.headers,
+					size: trace.node.traceAttributes.http?.response?.transfer
+						?.size,
+				},
+				urlBlocked: trace.node.traceAttributes.http?.blocked,
+			},
+		} as unknown as NetworkResource
 		if (
 			resource.initiatorType === RequestType.WebSocket &&
 			resource.socketId
@@ -77,19 +105,23 @@ const buildResources = (resources: NetworkResource[]) => {
 		.map((resource: NetworkResourceWithID) => {
 			const resolverName = getGraphQLResolverName(resource)
 
-			const updatedResource = { ...resource }
+			let updatedResource = { ...resource }
 
 			if (resolverName) {
 				updatedResource.displayName = `${resolverName} (${resource.name})`
 			}
 
 			if (resource.startTimeAbs && resource.responseEndAbs) {
-				updatedResource.duration =
-					resource.responseEndAbs - resource.startTimeAbs
+				updatedResource = {
+					...updatedResource,
+					duration: resource.responseEndAbs - resource.startTimeAbs,
+				}
 			} else if (resource.responseEnd && resource.startTime) {
 				// used in highlight.run <8.8.0 for websocket events and <7.5.4 for requests
-				updatedResource.duration =
-					resource.responseEnd - resource.startTime
+				updatedResource = {
+					...updatedResource,
+					duration: resource.responseEnd - resource.startTime,
+				}
 			}
 
 			return updatedResource
@@ -98,112 +130,46 @@ const buildResources = (resources: NetworkResource[]) => {
 
 export const useResources = (
 	session: Session | undefined,
-): ResourcesContext => {
-	const { sessionSecureId: session_secure_id } = useSessionParams()
-	const [sessionSecureId, setSessionSecureId] = useState<string>()
-	const [s3Error, setS3Error] = useState<LoadingError>()
-	const [downloadResources] = useQueryParam('downloadresources', BooleanParam)
-
-	const [resourcesLoading, setResourcesLoading] = useState(false)
-	const skipQuery =
-		sessionSecureId === undefined ||
-		session === undefined ||
-		!!session?.resources_url
+): {
+	error: ApolloError | undefined
+	fetchMoreForward: () => Promise<void>
+	loadingAfter: boolean
+	resources: NetworkResourceWithID[]
+	resourcesLoading: boolean
+} => {
+	const { projectId } = useProjectId()
 
 	const {
-		data,
-		loading: queryLoading,
-		error: redisError,
-	} = useGetResourcesQuery({
-		variables: {
-			session_secure_id: sessionSecureId ?? '',
-		},
-		fetchPolicy: 'cache-and-network',
-		skip: skipQuery,
+		traceEdges,
+		loading: resourcesLoading,
+		error: dataError,
+		loadingAfter,
+		fetchMoreForward,
+	} = useGetTraces({
+		query: `secure_session_id=${session?.secure_id} AND highlight.type=http.request`,
+		projectId,
+		startDate: moment(session?.created_at).toDate(),
+		endDate: moment(session?.created_at).add(4, 'hours').toDate(),
+		traceCursor: undefined,
+		sortDirection: SortDirection.Asc,
+		sortColumn: 'timestamp',
+		skip: !session?.secure_id,
 	})
 
-	useEffect(() => {
-		if (!skipQuery) {
-			setResourcesLoading(queryLoading && data === undefined)
-		}
-	}, [data, queryLoading, skipQuery])
-
 	const [resources, setResources] = useState<NetworkResourceWithID[]>([])
-	useEffect(() => {
-		setS3Error(undefined)
-		setResources(buildResources(data?.resources as NetworkResource[]))
-	}, [data?.resources])
 
 	useEffect(() => {
-		if (downloadResources && resources.length > 0) {
-			const a = document.createElement('a')
-			const file = new Blob([JSON.stringify(resources)], {
-				type: 'application/json',
-			})
-
-			a.href = URL.createObjectURL(file)
-			a.download = `session-${sessionSecureId}-resources.json`
-			a.click()
-
-			URL.revokeObjectURL(a.href)
+		if (session && traceEdges.length) {
+			setResources(buildResources(traceEdges))
 		}
-	}, [downloadResources, resources, sessionSecureId])
-
-	// If sessionSecureId is set and equals the current session's (ensures effect is run once)
-	// and resources url is defined, fetch using resources url
-	useEffect(() => {
-		if (
-			sessionSecureId === session?.secure_id &&
-			!!session?.resources_url
-		) {
-			setResourcesLoading(true)
-			;(async () => {
-				if (!session.resources_url) return
-				const limit = await checkResourceLimit(session.resources_url)
-				if (limit) {
-					setS3Error(LoadingError.NetworkResourcesTooLarge)
-					H.consumeError(new Error(limit.error), undefined, {
-						fileSize: limit.fileSize.toString(),
-						limit: limit.sizeLimit.toString(),
-						sessionSecureID: session?.secure_id,
-					})
-					return
-				}
-				let response
-				for await (const r of indexedDBFetch(session.resources_url)) {
-					response = r
-				}
-				if (response) {
-					response
-						.json()
-						.then((data) => {
-							setS3Error(undefined)
-							setResources(buildResources(data))
-						})
-						.catch((e) => {
-							setS3Error(LoadingError.NetworkResourcesFetchFailed)
-							setResources([])
-							H.consumeError(
-								e,
-								'Error direct downloading resources',
-							)
-						})
-						.finally(() => setResourcesLoading(false))
-				}
-			})()
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [sessionSecureId, session?.secure_id])
-
-	const loadResources = useCallback(() => {
-		setSessionSecureId(session_secure_id)
-	}, [session_secure_id])
+	}, [session, traceEdges])
 
 	return {
-		loadResources,
 		resources,
 		resourcesLoading,
-		error: redisError ?? s3Error,
+		error: dataError,
+		loadingAfter,
+		fetchMoreForward,
 	}
 }
 

--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -70,7 +70,7 @@ const buildResources = (traces: TraceEdge[]) => {
 				trace.node.traceAttributes.http?.response?.transfer?.size ?? 0,
 			requestResponsePairs: {
 				request: {
-					id: trace.node.traceAttributes.traceID,
+					id: trace.node.traceID,
 					body: trace.node.traceAttributes.http?.request?.body,
 					headers: requestHeaders,
 					sessionSecureID: trace.node.secureSessionID,

--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -40,7 +40,7 @@ const buildResources = (traces: TraceEdge[]) => {
 	const webSocketHash = {} as { [key: string]: NetworkResource }
 
 	traces?.forEach((trace: TraceEdge) => {
-		const start = moment(trace.node.startTime)
+		const start = moment(trace.node.timestamp)
 		const resource = {
 			startTimeAbs: start.toDate().getTime(),
 			responseEndAbs:
@@ -49,7 +49,7 @@ const buildResources = (traces: TraceEdge[]) => {
 				trace.node.traceAttributes.http?.response_content_length,
 			),
 			name: trace.node.traceAttributes.http?.url,
-			initiatorType: trace.node.traceAttributes.initiator_type,
+			initiatorType: trace.node.traceAttributes.initiator_type || 'fetch',
 			transferSize:
 				trace.node.traceAttributes.http?.response?.transfer?.size,
 			requestResponsePairs: {
@@ -70,6 +70,10 @@ const buildResources = (traces: TraceEdge[]) => {
 				},
 				urlBlocked: trace.node.traceAttributes.http?.blocked,
 			},
+			socketId: trace.node.traceID,
+			type:
+				trace.node.traceAttributes.ws?.type ||
+				trace.node.traceAttributes.http?.type,
 		} as unknown as NetworkResource
 		if (
 			resource.initiatorType === RequestType.WebSocket &&

--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -42,7 +42,8 @@ const buildResources = (traces: TraceEdge[]) => {
 	traces?.forEach((trace: TraceEdge) => {
 		const start = moment(trace.node.timestamp)
 		const transferSize = Number(
-			trace.node.traceAttributes.http?.response?.transfer?.size ??
+			trace.node.traceAttributes.http?.response?.encoded?.size ??
+				trace.node.traceAttributes.http?.response?.transfer?.size ??
 				trace.node.traceAttributes.http?.response_content_length,
 		)
 		const requestBody =

--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -65,7 +65,12 @@ const buildResources = (traces: TraceEdge[]) => {
 				trace.node.traceAttributes.http?.response_content_length,
 			),
 			name: trace.node.traceAttributes.http?.url,
-			initiatorType: trace.node.traceAttributes.initiator_type || 'fetch',
+			initiatorType:
+				trace.node.traceAttributes.initiator_type ||
+				(trace.node.traceAttributes.http?.request?.body ||
+				trace.node.traceAttributes.http?.response?.body
+					? 'fetch'
+					: 'other'),
 			transferSize:
 				trace.node.traceAttributes.http?.response?.transfer?.size ?? 0,
 			requestResponsePairs: {

--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -67,7 +67,7 @@ const buildResources = (traces: TraceEdge[]) => {
 			name: trace.node.traceAttributes.http?.url,
 			initiatorType: trace.node.traceAttributes.initiator_type || 'fetch',
 			transferSize:
-				trace.node.traceAttributes.http?.response?.transfer?.size,
+				trace.node.traceAttributes.http?.response?.transfer?.size ?? 0,
 			requestResponsePairs: {
 				request: {
 					id: trace.node.traceAttributes.traceID,

--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -41,6 +41,22 @@ const buildResources = (traces: TraceEdge[]) => {
 
 	traces?.forEach((trace: TraceEdge) => {
 		const start = moment(trace.node.timestamp)
+		let requestHeaders =
+				trace.node.traceAttributes.http?.request?.headers ??
+				trace.node.traceAttributes.http?.request?.header,
+			responseHeaders =
+				trace.node.traceAttributes.http?.response?.headers ??
+				trace.node.traceAttributes.http?.response?.header
+		try {
+			if (typeof requestHeaders === 'string') {
+				requestHeaders = JSON.parse(requestHeaders)
+			}
+		} catch (e) {}
+		try {
+			if (typeof responseHeaders === 'string') {
+				responseHeaders = JSON.parse(responseHeaders)
+			}
+		} catch (e) {}
 		const resource = {
 			startTimeAbs: start.toDate().getTime(),
 			responseEndAbs:
@@ -54,17 +70,17 @@ const buildResources = (traces: TraceEdge[]) => {
 				trace.node.traceAttributes.http?.response?.transfer?.size,
 			requestResponsePairs: {
 				request: {
-					sessionSecureID: trace.node.secureSessionID,
 					id: trace.node.traceAttributes.traceID,
+					body: trace.node.traceAttributes.http?.request?.body,
+					headers: requestHeaders,
+					sessionSecureID: trace.node.secureSessionID,
 					url: trace.node.traceAttributes.http?.url,
 					verb: trace.node.traceAttributes.http?.method,
-					body: trace.node.traceAttributes.http?.request?.body,
-					headers: trace.node.traceAttributes.http?.request?.headers,
 				},
 				response: {
-					status: trace.node.traceAttributes.http?.status_code,
 					body: trace.node.traceAttributes.http?.response?.body,
-					headers: trace.node.traceAttributes.http?.response?.headers,
+					headers: responseHeaders,
+					status: trace.node.traceAttributes.http?.status_code,
 					size: trace.node.traceAttributes.http?.response?.transfer
 						?.size,
 				},

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
@@ -308,10 +308,18 @@ function NetworkResourceDetails({
 			>
 				<Tabs.List px="8" gap="12">
 					<Tabs.Tab id={NetworkRequestTabs.Info}>Info</Tabs.Tab>
-					<Tabs.Tab id={NetworkRequestTabs.Errors}>Errors</Tabs.Tab>
-					<Tabs.Tab id={NetworkRequestTabs.Logs}>Logs</Tabs.Tab>
 					{isNetworkRequest && (
-						<Tabs.Tab id={NetworkRequestTabs.Trace}>Trace</Tabs.Tab>
+						<>
+							<Tabs.Tab id={NetworkRequestTabs.Errors}>
+								Errors
+							</Tabs.Tab>
+							<Tabs.Tab id={NetworkRequestTabs.Logs}>
+								Logs
+							</Tabs.Tab>
+							<Tabs.Tab id={NetworkRequestTabs.Trace}>
+								Trace
+							</Tabs.Tab>
+						</>
 					)}
 				</Tabs.List>
 				<Tabs.Panel id={NetworkRequestTabs.Info} scrollable>

--- a/frontend/src/pages/Player/TimelineIndicatorsContext/TimelineIndicatorsContext.tsx
+++ b/frontend/src/pages/Player/TimelineIndicatorsContext/TimelineIndicatorsContext.tsx
@@ -2,7 +2,6 @@ import { useGetTimelineIndicatorEventsQuery } from '@graph/hooks'
 import { Session, TimelineIndicatorEvent } from '@graph/schemas'
 import { LoadingError } from '@pages/Player/ResourcesContext/ResourcesContext'
 import { indexedDBFetch } from '@util/db'
-import { checkResourceLimit } from '@util/preload'
 import { H } from 'highlight.run'
 import { useEffect, useState } from 'react'
 
@@ -56,18 +55,6 @@ export const useTimelineIndicators = (
 			setLoading(true)
 			;(async () => {
 				if (!session.timeline_indicators_url) return
-				const limit = await checkResourceLimit(
-					session.timeline_indicators_url,
-				)
-				if (limit) {
-					setError(LoadingError.NetworkResourcesTooLarge)
-					H.consumeError(new Error(limit.error), undefined, {
-						fileSize: limit.fileSize.toString(),
-						limit: limit.sizeLimit.toString(),
-						sessionSecureID: session?.secure_id,
-					})
-					return
-				}
 				let response
 				for await (const r of indexedDBFetch(
 					session.timeline_indicators_url,

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -207,9 +207,10 @@ export const NetworkPage = ({
 	)
 
 	const fetchMoreWhenScrolled = useCallback(
-		async (e: React.UIEventHandler<'div'>) => {
+		async (e: React.UIEvent<'div'>) => {
 			if (!loadingAfter) {
-				const { scrollHeight, scrollTop, clientHeight } = e.target
+				const { scrollHeight, scrollTop, clientHeight } =
+					e.target as HTMLDivElement
 				//once the user has scrolled within 100px of the bottom of the table, fetch more data if there is any
 				if (scrollHeight - scrollTop - clientHeight < 100) {
 					await fetchMoreForward()

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -39,7 +39,6 @@ import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
 
 import { ErrorObject } from '@/graph/generated/schemas'
 import { useActiveNetworkResourceId } from '@/hooks/useActiveNetworkResourceId'
-import { useSessionParams } from '@/pages/Sessions/utils'
 import { styledVerticalScrollbar } from '@/style/common.css'
 import analytics from '@/util/analytics'
 
@@ -67,20 +66,16 @@ export const NetworkPage = ({
 	const startTime = sessionMetadata.startTime
 	const { showPlayerAbsoluteTime } = usePlayerConfiguration()
 	const { setActiveNetworkResourceId } = useActiveNetworkResourceId()
-	const { sessionSecureId } = useSessionParams()
 
 	const virtuoso = useRef<VirtuosoHandle>(null)
 
 	const {
 		resources: parsedResources,
-		loadResources,
 		resourcesLoading: loading,
 		error: resourceLoadingError,
+		loadingAfter,
+		fetchMoreForward,
 	} = useResourcesContext()
-	useEffect(() => {
-		loadResources()
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [sessionSecureId])
 
 	const networkRange = useMemo(() => {
 		if (parsedResources.length > 0) {
@@ -264,6 +259,9 @@ export const NetworkPage = ({
 								exit: (v) => v < 128,
 							}}
 							data={resourcesToRender}
+							onScroll={() =>
+								loadingAfter ? null : fetchMoreForward()
+							}
 							itemContent={(index, resource) => {
 								const requestId =
 									getHighlightRequestId(resource)

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -73,8 +73,6 @@ export const NetworkPage = ({
 		resources: parsedResources,
 		resourcesLoading: loading,
 		error: resourceLoadingError,
-		loadingAfter,
-		fetchMoreForward,
 	} = useResourcesContext()
 
 	const networkRange = useMemo(() => {
@@ -259,9 +257,6 @@ export const NetworkPage = ({
 								exit: (v) => v < 128,
 							}}
 							data={resourcesToRender}
-							onScroll={() =>
-								loadingAfter ? null : fetchMoreForward()
-							}
 							itemContent={(index, resource) => {
 								const requestId =
 									getHighlightRequestId(resource)

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -73,6 +73,8 @@ export const NetworkPage = ({
 		resources: parsedResources,
 		resourcesLoading: loading,
 		error: resourceLoadingError,
+		fetchMoreForward,
+		loadingAfter,
 	} = useResourcesContext()
 
 	const networkRange = useMemo(() => {
@@ -204,6 +206,20 @@ export const NetworkPage = ({
 		[],
 	)
 
+	const fetchMoreWhenScrolled = useCallback(
+		async (e: React.UIEventHandler<'div'>) => {
+			if (!loadingAfter) {
+				const { scrollHeight, scrollTop, clientHeight } = e.target
+				//once the user has scrolled within 100px of the bottom of the table, fetch more data if there is any
+				if (scrollHeight - scrollTop - clientHeight < 100) {
+					console.log('vadim', 'fetching more')
+					await fetchMoreForward()
+				}
+			}
+		},
+		[fetchMoreForward, loadingAfter],
+	)
+
 	useLayoutEffect(() => {
 		if (autoScroll && state === ReplayerState.Playing) {
 			scrollFunction(currentResourceIdx)
@@ -252,6 +268,7 @@ export const NetworkPage = ({
 									/>
 								),
 							}}
+							onScroll={fetchMoreWhenScrolled}
 							scrollSeekConfiguration={{
 								enter: (v) => v > 512,
 								exit: (v) => v < 128,

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -212,7 +212,6 @@ export const NetworkPage = ({
 				const { scrollHeight, scrollTop, clientHeight } = e.target
 				//once the user has scrolled within 100px of the bottom of the table, fetch more data if there is any
 				if (scrollHeight - scrollTop - clientHeight < 100) {
-					console.log('vadim', 'fetching more')
 					await fetchMoreForward()
 				}
 			}

--- a/frontend/src/pages/Player/WebSocketContext/WebSocketContext.tsx
+++ b/frontend/src/pages/Player/WebSocketContext/WebSocketContext.tsx
@@ -2,7 +2,6 @@ import { useGetWebSocketEventsQuery } from '@graph/hooks'
 import { Session, WebSocketEvent } from '@graph/schemas'
 import { LoadingError } from '@pages/Player/ResourcesContext/ResourcesContext'
 import { indexedDBFetch } from '@util/db'
-import { checkResourceLimit } from '@util/preload'
 import { H } from 'highlight.run'
 import { useEffect, useState } from 'react'
 
@@ -56,18 +55,6 @@ export const useWebSocket = (
 			setLoading(true)
 			;(async () => {
 				if (!session.web_socket_events_url) return
-				const limit = await checkResourceLimit(
-					session.web_socket_events_url,
-				)
-				if (limit) {
-					setError(LoadingError.NetworkResourcesTooLarge)
-					H.consumeError(new Error(limit.error), undefined, {
-						fileSize: limit.fileSize.toString(),
-						limit: limit.sizeLimit.toString(),
-						sessionSecureID: session?.secure_id,
-					})
-					return
-				}
 				let response
 				for await (const r of indexedDBFetch(
 					session.web_socket_events_url,

--- a/frontend/src/pages/Traces/useGetTraces.ts
+++ b/frontend/src/pages/Traces/useGetTraces.ts
@@ -4,7 +4,7 @@ import * as Types from '@graph/schemas'
 import { TraceEdge } from '@graph/schemas'
 import { usePollQuery } from '@util/search'
 import moment from 'moment'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { debounce } from 'lodash'
 
 import { TIME_FORMAT } from '@/components/Search/SearchForm/constants'
@@ -18,10 +18,10 @@ export const useGetTraces = ({
 	startDate,
 	endDate,
 	skipPolling,
-	loadAll,
 	sortColumn = 'timestamp',
 	sortDirection = Types.SortDirection.Desc,
 	skip,
+	limit,
 }: {
 	query: string
 	projectId: string | undefined
@@ -29,10 +29,10 @@ export const useGetTraces = ({
 	startDate: Date
 	endDate: Date
 	skipPolling?: boolean
-	loadAll?: boolean
 	sortColumn?: string
 	sortDirection?: Types.SortDirection
 	skip?: boolean
+	limit?: number
 }) => {
 	const [loadingAfter, setLoadingAfter] = useState(false)
 
@@ -41,6 +41,7 @@ export const useGetTraces = ({
 			project_id: projectId!,
 			at: traceCursor,
 			direction: sortDirection,
+			limit,
 			params: {
 				query,
 				date_range: {
@@ -171,6 +172,7 @@ export const useGetTraces = ({
 
 	const fetchMoreForward = useCallback(async () => {
 		const { hasNextPage, endCursor } = data?.traces.pageInfo || {}
+		console.log('vadim', 'fetchMoreForward', { hasNextPage, endCursor })
 		if (!hasNextPage || loadingAfter || !endCursor) {
 			return
 		}
@@ -179,12 +181,6 @@ export const useGetTraces = ({
 		await fetchMoreTraces(endCursor)
 		setLoadingAfter(false)
 	}, [data?.traces.pageInfo, fetchMoreTraces, loadingAfter])
-
-	useEffect(() => {
-		if (loadAll && !loadingAfter) {
-			fetchMoreForward()
-		}
-	}, [fetchMoreForward, loadAll, loadingAfter])
 
 	return {
 		traceEdges: (data?.traces.edges || []) as TraceEdge[],

--- a/frontend/src/pages/Traces/useGetTraces.ts
+++ b/frontend/src/pages/Traces/useGetTraces.ts
@@ -172,7 +172,6 @@ export const useGetTraces = ({
 
 	const fetchMoreForward = useCallback(async () => {
 		const { hasNextPage, endCursor } = data?.traces.pageInfo || {}
-		console.log('vadim', 'fetchMoreForward', { hasNextPage, endCursor })
 		if (!hasNextPage || loadingAfter || !endCursor) {
 			return
 		}

--- a/frontend/src/pages/Traces/useGetTraces.ts
+++ b/frontend/src/pages/Traces/useGetTraces.ts
@@ -4,7 +4,7 @@ import * as Types from '@graph/schemas'
 import { TraceEdge } from '@graph/schemas'
 import { usePollQuery } from '@util/search'
 import moment from 'moment'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { debounce } from 'lodash'
 
 import { TIME_FORMAT } from '@/components/Search/SearchForm/constants'
@@ -18,6 +18,7 @@ export const useGetTraces = ({
 	startDate,
 	endDate,
 	skipPolling,
+	loadAll,
 	sortColumn = 'timestamp',
 	sortDirection = Types.SortDirection.Desc,
 	skip,
@@ -28,6 +29,7 @@ export const useGetTraces = ({
 	startDate: Date
 	endDate: Date
 	skipPolling?: boolean
+	loadAll?: boolean
 	sortColumn?: string
 	sortDirection?: Types.SortDirection
 	skip?: boolean
@@ -177,6 +179,12 @@ export const useGetTraces = ({
 		await fetchMoreTraces(endCursor)
 		setLoadingAfter(false)
 	}, [data?.traces.pageInfo, fetchMoreTraces, loadingAfter])
+
+	useEffect(() => {
+		if (loadAll && !loadingAfter) {
+			fetchMoreForward()
+		}
+	}, [fetchMoreForward, loadAll, loadingAfter])
 
 	return {
 		traceEdges: (data?.traces.edges || []) as TraceEdge[],

--- a/sdk/client/src/listeners/network-listener/utils/utils.ts
+++ b/sdk/client/src/listeners/network-listener/utils/utils.ts
@@ -251,9 +251,10 @@ const isHighlightNetworkResourceFilter = (name: string, backendUrl: string) =>
 	name
 		.toLocaleLowerCase()
 		.includes(
-			import.meta.env.REACT_APP_PUBLIC_GRAPH_URI ?? 'highlight.io',
+			import.meta.env.REACT_APP_PUBLIC_GRAPH_URI ?? 'pub.highlight.io',
 		) ||
-	name.toLocaleLowerCase().includes('highlight.io') ||
+	name.toLocaleLowerCase().includes('pub.highlight.io') ||
+	name.toLocaleLowerCase().includes('otel.highlight.io') ||
 	name.toLocaleLowerCase().includes(backendUrl)
 
 export const shouldNetworkRequestBeRecorded = (


### PR DESCRIPTION
## Summary

Updates the session dev tools `network` page to load data from `Traces`.
Updates the Resource context to use traces to load session network data across the product.
Doesn't yet switch to the new traces table to render network resources, but should make it easy to do so in the future.

## How did you test this change?

* tested with otel frontend traces
* tested with frontend network requests recorded as traces

https://www.loom.com/share/3a252f8576e84405aa5ac6ded29868dd

## Are there any deployment considerations?

monitoring in prod, will follow up to clean up network request files

## Does this work require review from our design team?

no
