### PR TITLE
Fix metric graph scroll

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -8088,7 +8088,7 @@ body {
   height: 40px;
 }
 .gw96js1 {
-  height: 100%;
+  height: calc(100% - 40px);
 }
 .gw96js2 {
   width: calc(100%);

--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -342,7 +342,7 @@ export const AlertForm: React.FC = () => {
 						py="6"
 					>
 						<Text size="small" weight="medium">
-							Create alert
+							{isEdit ? 'Edit' : 'Create'} alert
 						</Text>
 						<Box display="flex" gap="4">
 							<DateRangePicker

--- a/frontend/src/pages/Graphing/GraphingEditor.css.ts
+++ b/frontend/src/pages/Graphing/GraphingEditor.css.ts
@@ -6,7 +6,7 @@ export const editGraphHeader = style({
 })
 
 export const editGraphPanel = style({
-	height: '100%',
+	height: 'calc(100% - 40px)',
 })
 
 export const previewWindow = style({

--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -482,7 +482,7 @@ export const GraphingEditor: React.FC = () => {
 						display="flex"
 						flexDirection="row"
 						justifyContent="space-between"
-						height="full"
+						cssClass={style.editGraphPanel}
 					>
 						<GraphBackgroundWrapper>
 							<Graph


### PR DESCRIPTION
## Summary
Not able to scroll the metric form to the bottom of the screen when necessary
![Screenshot 2024-09-16 at 12 50 48 PM](https://github.com/user-attachments/assets/8bec888b-f294-4b72-9094-807b5d10b7e7)


## How did you test this change?
1. Create a metric
2. Cut off the form so scroll is necessary
- [ ] Able to access all inputs by scrolling

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A