### PR TITLE
Fix Next.js build warnings and broken links

### DIFF
--- a/highlight.io/next.config.js
+++ b/highlight.io/next.config.js
@@ -101,7 +101,6 @@ const nextConfig = {
 					'/docs/getting-started/backend-logging/python/other',
 				permanent: true,
 			},
-			ighl,
 		]
 	},
 	async headers() {

--- a/highlight.io/next.config.js
+++ b/highlight.io/next.config.js
@@ -62,6 +62,46 @@ const nextConfig = {
 				destination: 'https://github.com/highlight/highlight',
 				permanent: false,
 			},
+			{
+				source: '/docs/product-features/comments',
+				destination:
+					'/docs/general/product-features/general-features/comments',
+				permanent: true,
+			},
+			{
+				source: '/docs/general/company/product-philosphy',
+				destination: '/docs/general/company/product-philosophy',
+				permanent: true,
+			},
+			{
+				source: '/docs/general/product-features/session-replay/privacy',
+				destination:
+					'/docs/getting-started/client-sdk/replay-configuration/privacy',
+				permanent: true,
+			},
+			{
+				source: '/docs/reference',
+				destination: '/docs',
+				permanent: true,
+			},
+			{
+				source: '/blog/post/opensearch-for-a-write-heavy-workload',
+				destination: '/blog/opensearch-for-a-write-heavy-workload',
+				permanent: true,
+			},
+			{
+				source: '/docs/general/getting-started/backend-sdk/cloudflare',
+				destination:
+					'/docs/getting-started/backend-logging/js/cloudflare',
+				permanent: true,
+			},
+			{
+				source: '/docs/general/getting-started/backend-sdk/python',
+				destination:
+					'/docs/getting-started/backend-logging/python/other',
+				permanent: true,
+			},
+			ighl,
 		]
 	},
 	async headers() {

--- a/highlight.io/pages/_app.tsx
+++ b/highlight.io/pages/_app.tsx
@@ -9,7 +9,6 @@ import { SpeedInsights } from '@vercel/speed-insights/next'
 import { H } from 'highlight.run'
 import type { AppProps } from 'next/app'
 import Head from 'next/head'
-import { SSRProvider } from 'react-aria'
 import Analytics from '../components/Analytics'
 import { Meta } from '../components/common/Head/Meta'
 import MetaImage from '../public/images/meta-image.jpg'
@@ -36,7 +35,7 @@ H.init('4d7k1xeo', {
 
 function MyApp({ Component, pageProps }: AppProps) {
 	return (
-		<SSRProvider>
+		<>
 			<Head>
 				<title>
 					highlight.io: The open source monitoring platform.
@@ -57,7 +56,7 @@ function MyApp({ Component, pageProps }: AppProps) {
 			<Component {...pageProps} />
 			<SpeedInsights />
 			<Analytics />
-		</SSRProvider>
+		</>
 	)
 }
 

--- a/highlight.io/pages/api/og/blog/[slug].tsx
+++ b/highlight.io/pages/api/og/blog/[slug].tsx
@@ -67,7 +67,7 @@ const handler = async function (req: NextRequest) {
 						width={650}
 						height={650}
 						src={`data:image/png;base64,${backDropBase64}`}
-					></Image>
+					/>
 					<svg
 						width="68"
 						height="68"

--- a/highlight.io/pages/api/og/blog/[slug].tsx
+++ b/highlight.io/pages/api/og/blog/[slug].tsx
@@ -2,6 +2,7 @@ import { ImageResponse } from '@vercel/og'
 import { NextRequest, URLPattern } from 'next/server'
 import { withEdgeRouterHighlight } from '../../../../highlight.edge.config'
 import { backdrop, font, fontLight } from '../util'
+import Image from 'next/image'
 
 export const config = {
 	runtime: 'edge',
@@ -56,7 +57,7 @@ const handler = async function (req: NextRequest) {
 						paddingBottom: 50,
 					}}
 				>
-					<img
+					<Image
 						alt={'backdrop'}
 						style={{
 							position: 'absolute',
@@ -66,7 +67,7 @@ const handler = async function (req: NextRequest) {
 						width={650}
 						height={650}
 						src={`data:image/png;base64,${backDropBase64}`}
-					></img>
+					></Image>
 					<svg
 						width="68"
 						height="68"

--- a/highlight.io/pages/api/og/customer/[slug].tsx
+++ b/highlight.io/pages/api/og/customer/[slug].tsx
@@ -67,7 +67,7 @@ const handler = async function (req: NextRequest) {
 						width={650}
 						height={650}
 						src={`data:image/png;base64,${backDropBase64}`}
-					></Image>
+					/>
 					<svg
 						width="68"
 						height="68"

--- a/highlight.io/pages/api/og/customer/[slug].tsx
+++ b/highlight.io/pages/api/og/customer/[slug].tsx
@@ -2,6 +2,7 @@ import { ImageResponse } from '@vercel/og'
 import { NextRequest, URLPattern } from 'next/server'
 import { withEdgeRouterHighlight } from '../../../../highlight.edge.config'
 import { backdrop, font, fontLight } from '../util'
+import Image from 'next/image'
 
 export const config = {
 	runtime: 'edge',
@@ -56,7 +57,7 @@ const handler = async function (req: NextRequest) {
 						paddingBottom: 50,
 					}}
 				>
-					<img
+					<Image
 						alt={'backdrop'}
 						style={{
 							position: 'absolute',
@@ -66,7 +67,7 @@ const handler = async function (req: NextRequest) {
 						width={650}
 						height={650}
 						src={`data:image/png;base64,${backDropBase64}`}
-					></img>
+					></Image>
 					<svg
 						width="68"
 						height="68"

--- a/highlight.io/pages/api/og/doc/[[...doc]].tsx
+++ b/highlight.io/pages/api/og/doc/[[...doc]].tsx
@@ -1,5 +1,6 @@
 import { ImageResponse } from '@vercel/og'
 import 'fs'
+import Image from 'next/image'
 import { NextRequest, URLPattern } from 'next/server'
 import { withEdgeRouterHighlight } from '../../../../highlight.edge.config'
 import { bug1, bug2, font, fontLight, logoOnDark } from '../util'
@@ -61,7 +62,7 @@ const handler = withEdgeRouterHighlight(async function (req: NextRequest) {
 					backgroundColor: '#0D0225',
 				}}
 			>
-				<img
+				<Image
 					alt={'logo'}
 					style={{
 						marginTop: 40,
@@ -70,7 +71,7 @@ const handler = withEdgeRouterHighlight(async function (req: NextRequest) {
 					width={180}
 					height={180}
 					src={`data:image/png;base64,${logoBase64}`}
-				/>
+				></Image>
 				<div
 					style={{
 						display: 'flex',
@@ -107,7 +108,7 @@ const handler = withEdgeRouterHighlight(async function (req: NextRequest) {
 						{title || 'Highlight Documentation'}
 					</div>
 				</div>
-				<img
+				<Image
 					alt={'bug1'}
 					style={{
 						position: 'absolute',
@@ -117,8 +118,8 @@ const handler = withEdgeRouterHighlight(async function (req: NextRequest) {
 					width={207.98 * 1.1}
 					height={255.91 * 1.1}
 					src={`data:image/png;base64,${bug1Base64}`}
-				/>
-				<img
+				></Image>
+				<Image
 					alt={'bug2'}
 					style={{
 						position: 'absolute',
@@ -128,7 +129,7 @@ const handler = withEdgeRouterHighlight(async function (req: NextRequest) {
 					width={308.49 * 1.2}
 					height={235.58 * 1.2}
 					src={`data:image/png;base64,${bug2Base64}`}
-				/>
+				></Image>
 			</div>
 		),
 		{

--- a/highlight.io/pages/api/og/doc/[[...doc]].tsx
+++ b/highlight.io/pages/api/og/doc/[[...doc]].tsx
@@ -9,6 +9,8 @@ export const config = {
 	runtime: 'edge',
 }
 
+// Used for generating og images for docs pages. Example usage:
+// https://highlight.io/api/og/doc/docs/getting-started/introduction/test
 const handler = withEdgeRouterHighlight(async function (req: NextRequest) {
 	const fontData = await font
 	const fontLightData = await fontLight

--- a/highlight.io/pages/api/og/doc/[[...doc]].tsx
+++ b/highlight.io/pages/api/og/doc/[[...doc]].tsx
@@ -71,7 +71,7 @@ const handler = withEdgeRouterHighlight(async function (req: NextRequest) {
 					width={180}
 					height={180}
 					src={`data:image/png;base64,${logoBase64}`}
-				></Image>
+				/>
 				<div
 					style={{
 						display: 'flex',
@@ -118,7 +118,7 @@ const handler = withEdgeRouterHighlight(async function (req: NextRequest) {
 					width={207.98 * 1.1}
 					height={255.91 * 1.1}
 					src={`data:image/png;base64,${bug1Base64}`}
-				></Image>
+				/>
 				<Image
 					alt={'bug2'}
 					style={{
@@ -129,7 +129,7 @@ const handler = withEdgeRouterHighlight(async function (req: NextRequest) {
 					width={308.49 * 1.2}
 					height={235.58 * 1.2}
 					src={`data:image/png;base64,${bug2Base64}`}
-				></Image>
+				/>
 			</div>
 		),
 		{

--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -46,6 +46,7 @@ import logger from '../../highlight.logger'
 import ChevronDown from '../../public/images/ChevronDownIcon'
 import Minus from '../../public/images/MinusIcon'
 import { readMarkdown, removeOrderingPrefix } from '../../shared/doc'
+import Image from 'next/image'
 
 const DOCS_CONTENT_PATH = path.join(process.cwd(), '../docs-content')
 const DOCS_GITHUB_LINK = `github.com/highlight/highlight/blob/main/docs-content`
@@ -1148,9 +1149,20 @@ export default function DocPage({
 												img: (props) => {
 													return (
 														<picture>
-															<img
+															<Image
 																{...props}
-																alt={props.alt}
+																width={Number(
+																	props.width,
+																)}
+																height={Number(
+																	props.height,
+																)}
+																src={String(
+																	props.src,
+																)}
+																alt={String(
+																	props.alt,
+																)}
 																className="border rounded-lg border-divider-on-dark"
 															/>
 														</picture>


### PR DESCRIPTION
## Summary

Addresses the following warnings we were seeing in our build logs:

```sh
In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.
In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.
In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.
In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.
In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.
In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.
In React 18, SSRProvider is not necessary and is a noop. You can remove it from your app.
```

```sh
59:6  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
```

Also fixes some broken backlinks by adding redirects to the relevant page:

<img width="337" alt="Screenshot 2024-09-17 at 9 48 24 AM" src="https://github.com/user-attachments/assets/30e4218d-565e-4a4b-a933-fd2aa1d6feaf">

## How did you test this change?

Click tested locally and in the PR preview to ensure the images are still rendered correctly in the following areas:

* Loading customer og images (e.g. https://highlight.io/api/og/customer/highlight-launch-week-day-5?title=Day+5%3A+Our+Partners+%26+Supporters&fname=Vadim&lname=Korolik&role=Co-Founder+%26+CTO)
* Loading an og docs image (e.g. https://highlight.io/api/og/doc/docs/getting-started/introduction/test)
* Loading images via the Markdown image syntax (`![]()`) (e.g. https://www.highlight.io/blog/5-best-python-logging-libraries)
* Tested the pages we are redirecting to:
  * https://highlight.io/docs/general/product-features/general-features/comments
  * https://highlight.io/docs/general/company/product-philosophy
  * https://highlight.io/docs/getting-started/client-sdk/replay-configuration/privacy
  * https://highlight.io/docs
  * https://highlight.io/blog/opensearch-for-a-write-heavy-workload
  * https://highlight.io/docs/getting-started/backend-logging/js/cloudflare
  * https://highlight.io/docs/getting-started/backend-logging/python/other

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A