### PR TITLE
remove span around admin fetch

### DIFF
--- a/.reflame.config.jsonc
+++ b/.reflame.config.jsonc
@@ -376,10 +376,8 @@
     "highlight.run": {
       "version": "9.3.4"
     },
-    // TODO: create a library for this
-    // Might need a shim entry point for .css?
     "@highlight-run/react": {
-      "version": "^3.2.0",
+      "version": "5.0.4"
     },
     "antd": {
       "entryPoints": [

--- a/.reflame.config.jsonc
+++ b/.reflame.config.jsonc
@@ -374,7 +374,7 @@
       ],
     },
     "highlight.run": {
-      "version": "^9.1.0"
+      "version": "9.3.4"
     },
     // TODO: create a library for this
     // Might need a shim entry point for .css?

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -308,24 +308,22 @@ const AuthenticationRoleRouter = () => {
 	)
 
 	const fetchAdmin = useCallback(async () => {
-		H.startSpan('adminFetch', async () => {
-			if (loading || !user) {
-				return
-			}
+		if (loading || !user) {
+			return
+		}
 
-			const variables: any = {}
-			if (workspaceId) {
-				variables.workspace_id = workspaceId
-			} else if (projectId) {
-				variables.project_id = projectId
-			}
+		const variables: any = {}
+		if (workspaceId) {
+			variables.workspace_id = workspaceId
+		} else if (projectId) {
+			variables.project_id = projectId
+		}
 
-			if (!called) {
-				await getAdminQuery({ variables })
-			} else {
-				await refetch!()
-			}
-		})
+		if (!called) {
+			await getAdminQuery({ variables })
+		} else {
+			await refetch!()
+		}
 	}, [called, getAdminQuery, loading, projectId, refetch, user, workspaceId])
 
 	useEffect(() => {


### PR DESCRIPTION
## Summary

Improve app startup performance when slow loading of the highlight.run client
causes the firebase login flow to be blocked (because `H.startSpan` cannot execute)

## How did you test this change?

https://www.loom.com/share/a76a392b816a438a9d83c865625e7146

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
