### PR TITLE
New default alerts

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1954,6 +1954,7 @@ type Alert struct {
 	Disabled          bool                `gorm:"default:false"`
 	LastAdminToEditID int                 `gorm:"last_admin_to_edit_id"`
 	Destinations      []*AlertDestination `gorm:"foreignKey:AlertID"`
+	Default           bool                `gorm:"default:false"` // alert created during setup flow
 
 	// fields for threshold alert
 	BelowThreshold    *bool

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -845,20 +845,17 @@ type ComplexityRoot struct {
 		ChangeAdminRole                       func(childComplexity int, workspaceID int, adminID int, newRole string) int
 		ChangeProjectMembership               func(childComplexity int, workspaceID int, adminID int, projectIds []int) int
 		CreateAdmin                           func(childComplexity int) int
-		CreateAlert                           func(childComplexity int, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, belowThreshold *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int, destinations []*model.AlertDestinationInput) int
+		CreateAlert                           func(childComplexity int, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, belowThreshold *bool, defaultArg *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int, destinations []*model.AlertDestinationInput) int
 		CreateCloudflareProxy                 func(childComplexity int, workspaceID int, proxySubdomain string) int
-		CreateErrorAlert                      func(childComplexity int, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, query string, regexGroups []*string, frequency int, defaultArg *bool) int
 		CreateErrorComment                    func(childComplexity int, projectID int, errorGroupSecureID string, text string, textForEmail string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, errorURL string, authorName string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
 		CreateErrorCommentForExistingIssue    func(childComplexity int, projectID int, errorGroupSecureID string, text string, textForEmail string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, errorURL string, authorName string, issueURL string, issueTitle string, issueID string, integrations []*model.IntegrationType) int
 		CreateErrorTag                        func(childComplexity int, title string, description string) int
 		CreateIssueForErrorComment            func(childComplexity int, projectID int, errorURL string, errorCommentID int, authorName string, textForAttachment string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
 		CreateIssueForSessionComment          func(childComplexity int, projectID int, sessionURL string, sessionCommentID int, authorName string, textForAttachment string, time float64, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
-		CreateLogAlert                        func(childComplexity int, input model.LogAlertInput) int
 		CreateMetricMonitor                   func(childComplexity int, projectID int, name string, aggregator model.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, filters []*model.MetricTagFilterInput) int
 		CreateOrUpdateStripeSubscription      func(childComplexity int, workspaceID int) int
 		CreateProject                         func(childComplexity int, name string, workspaceID int) int
 		CreateSavedSegment                    func(childComplexity int, projectID int, name string, entityType model.SavedSegmentEntityType, query string) int
-		CreateSessionAlert                    func(childComplexity int, input model.SessionAlertInput) int
 		CreateSessionComment                  func(childComplexity int, projectID int, sessionSecureID string, sessionTimestamp int, text string, textForEmail string, xCoordinate float64, yCoordinate float64, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, sessionURL string, time float64, authorName string, sessionImage *string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType, tags []*model.SessionCommentTagInput, additionalContext *string) int
 		CreateSessionCommentWithExistingIssue func(childComplexity int, projectID int, sessionSecureID string, sessionTimestamp int, text string, textForEmail string, xCoordinate float64, yCoordinate float64, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, sessionURL string, time float64, authorName string, sessionImage *string, tags []*model.SessionCommentTagInput, integrations []*model.IntegrationType, issueTitle *string, issueURL string, issueID string, additionalContext *string) int
 		CreateWorkspace                       func(childComplexity int, name string, promoCode *string) int
@@ -1805,11 +1802,10 @@ type MutationResolver interface {
 	SyncSlackIntegration(ctx context.Context, projectID int) (*model.SlackSyncResponse, error)
 	CreateMetricMonitor(ctx context.Context, projectID int, name string, aggregator model.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
 	UpdateMetricMonitor(ctx context.Context, metricMonitorID int, projectID int, name *string, aggregator *model.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, disabled *bool, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
-	CreateAlert(ctx context.Context, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, belowThreshold *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int, destinations []*model.AlertDestinationInput) (*model1.Alert, error)
+	CreateAlert(ctx context.Context, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, belowThreshold *bool, defaultArg *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int, destinations []*model.AlertDestinationInput) (*model1.Alert, error)
 	UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *model.ProductType, functionType *model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, belowThreshold *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int, destinations []*model.AlertDestinationInput) (*model1.Alert, error)
 	UpdateAlertDisabled(ctx context.Context, projectID int, alertID int, disabled bool) (bool, error)
 	DeleteAlert(ctx context.Context, projectID int, alertID int) (bool, error)
-	CreateErrorAlert(ctx context.Context, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, query string, regexGroups []*string, frequency int, defaultArg *bool) (*model1.ErrorAlert, error)
 	UpdateErrorAlert(ctx context.Context, projectID int, name *string, errorAlertID int, countThreshold *int, thresholdWindow *int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, query string, regexGroups []*string, frequency *int, disabled *bool) (*model1.ErrorAlert, error)
 	DeleteErrorAlert(ctx context.Context, projectID int, errorAlertID int) (*model1.ErrorAlert, error)
 	DeleteMetricMonitor(ctx context.Context, projectID int, metricMonitorID int) (*model1.MetricMonitor, error)
@@ -1817,10 +1813,8 @@ type MutationResolver interface {
 	UpdateErrorAlertIsDisabled(ctx context.Context, id int, projectID int, disabled bool) (*model1.ErrorAlert, error)
 	UpdateMetricMonitorIsDisabled(ctx context.Context, id int, projectID int, disabled bool) (*model1.MetricMonitor, error)
 	UpdateSessionAlert(ctx context.Context, id int, input model.SessionAlertInput) (*model1.SessionAlert, error)
-	CreateSessionAlert(ctx context.Context, input model.SessionAlertInput) (*model1.SessionAlert, error)
 	DeleteSessionAlert(ctx context.Context, projectID int, sessionAlertID int) (*model1.SessionAlert, error)
 	UpdateLogAlert(ctx context.Context, id int, input model.LogAlertInput) (*model1.LogAlert, error)
-	CreateLogAlert(ctx context.Context, input model.LogAlertInput) (*model1.LogAlert, error)
 	DeleteLogAlert(ctx context.Context, projectID int, id int) (*model1.LogAlert, error)
 	UpdateLogAlertIsDisabled(ctx context.Context, id int, projectID int, disabled bool) (*model1.LogAlert, error)
 	UpdateSessionIsPublic(ctx context.Context, sessionSecureID string, isPublic bool) (*model1.Session, error)
@@ -5733,7 +5727,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.CreateAlert(childComplexity, args["project_id"].(int), args["name"].(string), args["product_type"].(model.ProductType), args["function_type"].(model.MetricAggregator), args["function_column"].(*string), args["query"].(*string), args["group_by_key"].(*string), args["below_threshold"].(*bool), args["threshold_value"].(*float64), args["threshold_window"].(*int), args["threshold_cooldown"].(*int), args["destinations"].([]*model.AlertDestinationInput)), true
+		return e.complexity.Mutation.CreateAlert(childComplexity, args["project_id"].(int), args["name"].(string), args["product_type"].(model.ProductType), args["function_type"].(model.MetricAggregator), args["function_column"].(*string), args["query"].(*string), args["group_by_key"].(*string), args["below_threshold"].(*bool), args["default"].(*bool), args["threshold_value"].(*float64), args["threshold_window"].(*int), args["threshold_cooldown"].(*int), args["destinations"].([]*model.AlertDestinationInput)), true
 
 	case "Mutation.createCloudflareProxy":
 		if e.complexity.Mutation.CreateCloudflareProxy == nil {
@@ -5746,18 +5740,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.CreateCloudflareProxy(childComplexity, args["workspace_id"].(int), args["proxy_subdomain"].(string)), true
-
-	case "Mutation.createErrorAlert":
-		if e.complexity.Mutation.CreateErrorAlert == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_createErrorAlert_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.CreateErrorAlert(childComplexity, args["project_id"].(int), args["name"].(string), args["count_threshold"].(int), args["threshold_window"].(int), args["slack_channels"].([]*model.SanitizedSlackChannelInput), args["discord_channels"].([]*model.DiscordChannelInput), args["microsoft_teams_channels"].([]*model.MicrosoftTeamsChannelInput), args["webhook_destinations"].([]*model.WebhookDestinationInput), args["emails"].([]*string), args["query"].(string), args["regex_groups"].([]*string), args["frequency"].(int), args["default"].(*bool)), true
 
 	case "Mutation.createErrorComment":
 		if e.complexity.Mutation.CreateErrorComment == nil {
@@ -5819,18 +5801,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.CreateIssueForSessionComment(childComplexity, args["project_id"].(int), args["session_url"].(string), args["session_comment_id"].(int), args["author_name"].(string), args["text_for_attachment"].(string), args["time"].(float64), args["issue_title"].(*string), args["issue_description"].(*string), args["issue_team_id"].(*string), args["issue_type_id"].(*string), args["integrations"].([]*model.IntegrationType)), true
 
-	case "Mutation.createLogAlert":
-		if e.complexity.Mutation.CreateLogAlert == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_createLogAlert_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.CreateLogAlert(childComplexity, args["input"].(model.LogAlertInput)), true
-
 	case "Mutation.createMetricMonitor":
 		if e.complexity.Mutation.CreateMetricMonitor == nil {
 			break
@@ -5878,18 +5848,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.CreateSavedSegment(childComplexity, args["project_id"].(int), args["name"].(string), args["entity_type"].(model.SavedSegmentEntityType), args["query"].(string)), true
-
-	case "Mutation.createSessionAlert":
-		if e.complexity.Mutation.CreateSessionAlert == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_createSessionAlert_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.CreateSessionAlert(childComplexity, args["input"].(model.SessionAlertInput)), true
 
 	case "Mutation.createSessionComment":
 		if e.complexity.Mutation.CreateSessionComment == nil {
@@ -14485,6 +14443,7 @@ type Mutation {
 		query: String
 		group_by_key: String
 		below_threshold: Boolean
+		default: Boolean
 		threshold_value: Float
 		threshold_window: Int
 		threshold_cooldown: Int
@@ -14511,21 +14470,6 @@ type Mutation {
 		disabled: Boolean!
 	): Boolean!
 	deleteAlert(project_id: ID!, alert_id: ID!): Boolean!
-	createErrorAlert(
-		project_id: ID!
-		name: String!
-		count_threshold: Int!
-		threshold_window: Int!
-		slack_channels: [SanitizedSlackChannelInput]!
-		discord_channels: [DiscordChannelInput!]!
-		microsoft_teams_channels: [MicrosoftTeamsChannelInput!]!
-		webhook_destinations: [WebhookDestinationInput!]!
-		emails: [String]!
-		query: String!
-		regex_groups: [String]!
-		frequency: Int!
-		default: Boolean
-	): ErrorAlert
 	updateErrorAlert(
 		project_id: ID!
 		name: String
@@ -14561,10 +14505,8 @@ type Mutation {
 	): MetricMonitor
 
 	updateSessionAlert(id: ID!, input: SessionAlertInput!): SessionAlert
-	createSessionAlert(input: SessionAlertInput!): SessionAlert
 	deleteSessionAlert(project_id: ID!, session_alert_id: ID!): SessionAlert
 	updateLogAlert(id: ID!, input: LogAlertInput!): LogAlert
-	createLogAlert(input: LogAlertInput!): LogAlert
 	deleteLogAlert(project_id: ID!, id: ID!): LogAlert
 	updateLogAlertIsDisabled(
 		id: ID!
@@ -14898,42 +14840,51 @@ func (ec *executionContext) field_Mutation_createAlert_args(ctx context.Context,
 		}
 	}
 	args["below_threshold"] = arg7
-	var arg8 *float64
+	var arg8 *bool
+	if tmp, ok := rawArgs["default"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("default"))
+		arg8, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["default"] = arg8
+	var arg9 *float64
 	if tmp, ok := rawArgs["threshold_value"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_value"))
-		arg8, err = ec.unmarshalOFloat2ᚖfloat64(ctx, tmp)
+		arg9, err = ec.unmarshalOFloat2ᚖfloat64(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["threshold_value"] = arg8
-	var arg9 *int
+	args["threshold_value"] = arg9
+	var arg10 *int
 	if tmp, ok := rawArgs["threshold_window"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_window"))
-		arg9, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["threshold_window"] = arg9
-	var arg10 *int
-	if tmp, ok := rawArgs["threshold_cooldown"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_cooldown"))
 		arg10, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["threshold_cooldown"] = arg10
-	var arg11 []*model.AlertDestinationInput
-	if tmp, ok := rawArgs["destinations"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("destinations"))
-		arg11, err = ec.unmarshalNAlertDestinationInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐAlertDestinationInputᚄ(ctx, tmp)
+	args["threshold_window"] = arg10
+	var arg11 *int
+	if tmp, ok := rawArgs["threshold_cooldown"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_cooldown"))
+		arg11, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["destinations"] = arg11
+	args["threshold_cooldown"] = arg11
+	var arg12 []*model.AlertDestinationInput
+	if tmp, ok := rawArgs["destinations"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("destinations"))
+		arg12, err = ec.unmarshalNAlertDestinationInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐAlertDestinationInputᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["destinations"] = arg12
 	return args, nil
 }
 
@@ -14958,129 +14909,6 @@ func (ec *executionContext) field_Mutation_createCloudflareProxy_args(ctx contex
 		}
 	}
 	args["proxy_subdomain"] = arg1
-	return args, nil
-}
-
-func (ec *executionContext) field_Mutation_createErrorAlert_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 int
-	if tmp, ok := rawArgs["project_id"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
-		arg0, err = ec.unmarshalNID2int(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["project_id"] = arg0
-	var arg1 string
-	if tmp, ok := rawArgs["name"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
-		arg1, err = ec.unmarshalNString2string(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["name"] = arg1
-	var arg2 int
-	if tmp, ok := rawArgs["count_threshold"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("count_threshold"))
-		arg2, err = ec.unmarshalNInt2int(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["count_threshold"] = arg2
-	var arg3 int
-	if tmp, ok := rawArgs["threshold_window"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("threshold_window"))
-		arg3, err = ec.unmarshalNInt2int(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["threshold_window"] = arg3
-	var arg4 []*model.SanitizedSlackChannelInput
-	if tmp, ok := rawArgs["slack_channels"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("slack_channels"))
-		arg4, err = ec.unmarshalNSanitizedSlackChannelInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSanitizedSlackChannelInput(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["slack_channels"] = arg4
-	var arg5 []*model.DiscordChannelInput
-	if tmp, ok := rawArgs["discord_channels"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("discord_channels"))
-		arg5, err = ec.unmarshalNDiscordChannelInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐDiscordChannelInputᚄ(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["discord_channels"] = arg5
-	var arg6 []*model.MicrosoftTeamsChannelInput
-	if tmp, ok := rawArgs["microsoft_teams_channels"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("microsoft_teams_channels"))
-		arg6, err = ec.unmarshalNMicrosoftTeamsChannelInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐMicrosoftTeamsChannelInputᚄ(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["microsoft_teams_channels"] = arg6
-	var arg7 []*model.WebhookDestinationInput
-	if tmp, ok := rawArgs["webhook_destinations"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("webhook_destinations"))
-		arg7, err = ec.unmarshalNWebhookDestinationInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐWebhookDestinationInputᚄ(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["webhook_destinations"] = arg7
-	var arg8 []*string
-	if tmp, ok := rawArgs["emails"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("emails"))
-		arg8, err = ec.unmarshalNString2ᚕᚖstring(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["emails"] = arg8
-	var arg9 string
-	if tmp, ok := rawArgs["query"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
-		arg9, err = ec.unmarshalNString2string(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["query"] = arg9
-	var arg10 []*string
-	if tmp, ok := rawArgs["regex_groups"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("regex_groups"))
-		arg10, err = ec.unmarshalNString2ᚕᚖstring(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["regex_groups"] = arg10
-	var arg11 int
-	if tmp, ok := rawArgs["frequency"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("frequency"))
-		arg11, err = ec.unmarshalNInt2int(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["frequency"] = arg11
-	var arg12 *bool
-	if tmp, ok := rawArgs["default"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("default"))
-		arg12, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["default"] = arg12
 	return args, nil
 }
 
@@ -15546,21 +15374,6 @@ func (ec *executionContext) field_Mutation_createIssueForSessionComment_args(ctx
 	return args, nil
 }
 
-func (ec *executionContext) field_Mutation_createLogAlert_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 model.LogAlertInput
-	if tmp, ok := rawArgs["input"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
-		arg0, err = ec.unmarshalNLogAlertInput2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogAlertInput(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["input"] = arg0
-	return args, nil
-}
-
 func (ec *executionContext) field_Mutation_createMetricMonitor_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -15753,21 +15566,6 @@ func (ec *executionContext) field_Mutation_createSavedSegment_args(ctx context.C
 		}
 	}
 	args["query"] = arg3
-	return args, nil
-}
-
-func (ec *executionContext) field_Mutation_createSessionAlert_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 model.SessionAlertInput
-	if tmp, ok := rawArgs["input"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
-		arg0, err = ec.unmarshalNSessionAlertInput2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSessionAlertInput(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["input"] = arg0
 	return args, nil
 }
 
@@ -49388,7 +49186,7 @@ func (ec *executionContext) _Mutation_createAlert(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["product_type"].(model.ProductType), fc.Args["function_type"].(model.MetricAggregator), fc.Args["function_column"].(*string), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["below_threshold"].(*bool), fc.Args["threshold_value"].(*float64), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int), fc.Args["destinations"].([]*model.AlertDestinationInput))
+		return ec.resolvers.Mutation().CreateAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["product_type"].(model.ProductType), fc.Args["function_type"].(model.MetricAggregator), fc.Args["function_column"].(*string), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["below_threshold"].(*bool), fc.Args["default"].(*bool), fc.Args["threshold_value"].(*float64), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int), fc.Args["destinations"].([]*model.AlertDestinationInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -49650,96 +49448,6 @@ func (ec *executionContext) fieldContext_Mutation_deleteAlert(ctx context.Contex
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_deleteAlert_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Mutation_createErrorAlert(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_createErrorAlert(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateErrorAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["count_threshold"].(int), fc.Args["threshold_window"].(int), fc.Args["slack_channels"].([]*model.SanitizedSlackChannelInput), fc.Args["discord_channels"].([]*model.DiscordChannelInput), fc.Args["microsoft_teams_channels"].([]*model.MicrosoftTeamsChannelInput), fc.Args["webhook_destinations"].([]*model.WebhookDestinationInput), fc.Args["emails"].([]*string), fc.Args["query"].(string), fc.Args["regex_groups"].([]*string), fc.Args["frequency"].(int), fc.Args["default"].(*bool))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model1.ErrorAlert)
-	fc.Result = res
-	return ec.marshalOErrorAlert2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐErrorAlert(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Mutation_createErrorAlert(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Mutation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_ErrorAlert_id(ctx, field)
-			case "updated_at":
-				return ec.fieldContext_ErrorAlert_updated_at(ctx, field)
-			case "Name":
-				return ec.fieldContext_ErrorAlert_Name(ctx, field)
-			case "ChannelsToNotify":
-				return ec.fieldContext_ErrorAlert_ChannelsToNotify(ctx, field)
-			case "DiscordChannelsToNotify":
-				return ec.fieldContext_ErrorAlert_DiscordChannelsToNotify(ctx, field)
-			case "MicrosoftTeamsChannelsToNotify":
-				return ec.fieldContext_ErrorAlert_MicrosoftTeamsChannelsToNotify(ctx, field)
-			case "WebhookDestinations":
-				return ec.fieldContext_ErrorAlert_WebhookDestinations(ctx, field)
-			case "EmailsToNotify":
-				return ec.fieldContext_ErrorAlert_EmailsToNotify(ctx, field)
-			case "Query":
-				return ec.fieldContext_ErrorAlert_Query(ctx, field)
-			case "CountThreshold":
-				return ec.fieldContext_ErrorAlert_CountThreshold(ctx, field)
-			case "ThresholdWindow":
-				return ec.fieldContext_ErrorAlert_ThresholdWindow(ctx, field)
-			case "LastAdminToEditID":
-				return ec.fieldContext_ErrorAlert_LastAdminToEditID(ctx, field)
-			case "Type":
-				return ec.fieldContext_ErrorAlert_Type(ctx, field)
-			case "RegexGroups":
-				return ec.fieldContext_ErrorAlert_RegexGroups(ctx, field)
-			case "Frequency":
-				return ec.fieldContext_ErrorAlert_Frequency(ctx, field)
-			case "DailyFrequency":
-				return ec.fieldContext_ErrorAlert_DailyFrequency(ctx, field)
-			case "disabled":
-				return ec.fieldContext_ErrorAlert_disabled(ctx, field)
-			case "default":
-				return ec.fieldContext_ErrorAlert_default(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type ErrorAlert", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_createErrorAlert_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -50368,98 +50076,6 @@ func (ec *executionContext) fieldContext_Mutation_updateSessionAlert(ctx context
 	return fc, nil
 }
 
-func (ec *executionContext) _Mutation_createSessionAlert(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_createSessionAlert(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateSessionAlert(rctx, fc.Args["input"].(model.SessionAlertInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model1.SessionAlert)
-	fc.Result = res
-	return ec.marshalOSessionAlert2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionAlert(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Mutation_createSessionAlert(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Mutation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_SessionAlert_id(ctx, field)
-			case "updated_at":
-				return ec.fieldContext_SessionAlert_updated_at(ctx, field)
-			case "Name":
-				return ec.fieldContext_SessionAlert_Name(ctx, field)
-			case "ChannelsToNotify":
-				return ec.fieldContext_SessionAlert_ChannelsToNotify(ctx, field)
-			case "DiscordChannelsToNotify":
-				return ec.fieldContext_SessionAlert_DiscordChannelsToNotify(ctx, field)
-			case "MicrosoftTeamsChannelsToNotify":
-				return ec.fieldContext_SessionAlert_MicrosoftTeamsChannelsToNotify(ctx, field)
-			case "WebhookDestinations":
-				return ec.fieldContext_SessionAlert_WebhookDestinations(ctx, field)
-			case "EmailsToNotify":
-				return ec.fieldContext_SessionAlert_EmailsToNotify(ctx, field)
-			case "ExcludedEnvironments":
-				return ec.fieldContext_SessionAlert_ExcludedEnvironments(ctx, field)
-			case "CountThreshold":
-				return ec.fieldContext_SessionAlert_CountThreshold(ctx, field)
-			case "TrackProperties":
-				return ec.fieldContext_SessionAlert_TrackProperties(ctx, field)
-			case "UserProperties":
-				return ec.fieldContext_SessionAlert_UserProperties(ctx, field)
-			case "ThresholdWindow":
-				return ec.fieldContext_SessionAlert_ThresholdWindow(ctx, field)
-			case "LastAdminToEditID":
-				return ec.fieldContext_SessionAlert_LastAdminToEditID(ctx, field)
-			case "Type":
-				return ec.fieldContext_SessionAlert_Type(ctx, field)
-			case "ExcludeRules":
-				return ec.fieldContext_SessionAlert_ExcludeRules(ctx, field)
-			case "DailyFrequency":
-				return ec.fieldContext_SessionAlert_DailyFrequency(ctx, field)
-			case "disabled":
-				return ec.fieldContext_SessionAlert_disabled(ctx, field)
-			case "default":
-				return ec.fieldContext_SessionAlert_default(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type SessionAlert", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_createSessionAlert_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Mutation_deleteSessionAlert(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_deleteSessionAlert(ctx, field)
 	if err != nil {
@@ -50634,94 +50250,6 @@ func (ec *executionContext) fieldContext_Mutation_updateLogAlert(ctx context.Con
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_updateLogAlert_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Mutation_createLogAlert(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_createLogAlert(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateLogAlert(rctx, fc.Args["input"].(model.LogAlertInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model1.LogAlert)
-	fc.Result = res
-	return ec.marshalOLogAlert2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐLogAlert(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Mutation_createLogAlert(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Mutation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_LogAlert_id(ctx, field)
-			case "updated_at":
-				return ec.fieldContext_LogAlert_updated_at(ctx, field)
-			case "Name":
-				return ec.fieldContext_LogAlert_Name(ctx, field)
-			case "ChannelsToNotify":
-				return ec.fieldContext_LogAlert_ChannelsToNotify(ctx, field)
-			case "DiscordChannelsToNotify":
-				return ec.fieldContext_LogAlert_DiscordChannelsToNotify(ctx, field)
-			case "MicrosoftTeamsChannelsToNotify":
-				return ec.fieldContext_LogAlert_MicrosoftTeamsChannelsToNotify(ctx, field)
-			case "WebhookDestinations":
-				return ec.fieldContext_LogAlert_WebhookDestinations(ctx, field)
-			case "EmailsToNotify":
-				return ec.fieldContext_LogAlert_EmailsToNotify(ctx, field)
-			case "CountThreshold":
-				return ec.fieldContext_LogAlert_CountThreshold(ctx, field)
-			case "ThresholdWindow":
-				return ec.fieldContext_LogAlert_ThresholdWindow(ctx, field)
-			case "LastAdminToEditID":
-				return ec.fieldContext_LogAlert_LastAdminToEditID(ctx, field)
-			case "Type":
-				return ec.fieldContext_LogAlert_Type(ctx, field)
-			case "DailyFrequency":
-				return ec.fieldContext_LogAlert_DailyFrequency(ctx, field)
-			case "disabled":
-				return ec.fieldContext_LogAlert_disabled(ctx, field)
-			case "query":
-				return ec.fieldContext_LogAlert_query(ctx, field)
-			case "BelowThreshold":
-				return ec.fieldContext_LogAlert_BelowThreshold(ctx, field)
-			case "default":
-				return ec.fieldContext_LogAlert_default(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type LogAlert", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_createLogAlert_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -91570,10 +91098,6 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "createErrorAlert":
-			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_createErrorAlert(ctx, field)
-			})
 		case "updateErrorAlert":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_updateErrorAlert(ctx, field)
@@ -91602,10 +91126,6 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_updateSessionAlert(ctx, field)
 			})
-		case "createSessionAlert":
-			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_createSessionAlert(ctx, field)
-			})
 		case "deleteSessionAlert":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_deleteSessionAlert(ctx, field)
@@ -91613,10 +91133,6 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "updateLogAlert":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_updateLogAlert(ctx, field)
-			})
-		case "createLogAlert":
-			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_createLogAlert(ctx, field)
 			})
 		case "deleteLogAlert":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -2856,6 +2856,7 @@ type Mutation {
 		query: String
 		group_by_key: String
 		below_threshold: Boolean
+		default: Boolean
 		threshold_value: Float
 		threshold_window: Int
 		threshold_cooldown: Int
@@ -2882,21 +2883,6 @@ type Mutation {
 		disabled: Boolean!
 	): Boolean!
 	deleteAlert(project_id: ID!, alert_id: ID!): Boolean!
-	createErrorAlert(
-		project_id: ID!
-		name: String!
-		count_threshold: Int!
-		threshold_window: Int!
-		slack_channels: [SanitizedSlackChannelInput]!
-		discord_channels: [DiscordChannelInput!]!
-		microsoft_teams_channels: [MicrosoftTeamsChannelInput!]!
-		webhook_destinations: [WebhookDestinationInput!]!
-		emails: [String]!
-		query: String!
-		regex_groups: [String]!
-		frequency: Int!
-		default: Boolean
-	): ErrorAlert
 	updateErrorAlert(
 		project_id: ID!
 		name: String
@@ -2932,10 +2918,8 @@ type Mutation {
 	): MetricMonitor
 
 	updateSessionAlert(id: ID!, input: SessionAlertInput!): SessionAlert
-	createSessionAlert(input: SessionAlertInput!): SessionAlert
 	deleteSessionAlert(project_id: ID!, session_alert_id: ID!): SessionAlert
 	updateLogAlert(id: ID!, input: LogAlertInput!): LogAlert
-	createLogAlert(input: LogAlertInput!): LogAlert
 	deleteLogAlert(project_id: ID!, id: ID!): LogAlert
 	updateLogAlertIsDisabled(
 		id: ID!

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -3016,108 +3016,6 @@ export type ReplyToErrorCommentMutationOptions = Apollo.BaseMutationOptions<
 	Types.ReplyToErrorCommentMutation,
 	Types.ReplyToErrorCommentMutationVariables
 >
-export const CreateErrorAlertDocument = gql`
-	mutation CreateErrorAlert(
-		$project_id: ID!
-		$name: String!
-		$count_threshold: Int!
-		$threshold_window: Int!
-		$slack_channels: [SanitizedSlackChannelInput]!
-		$discord_channels: [DiscordChannelInput!]!
-		$webhook_destinations: [WebhookDestinationInput!]!
-		$microsoft_teams_channels: [MicrosoftTeamsChannelInput!]!
-		$emails: [String]!
-		$regex_groups: [String]!
-		$frequency: Int!
-		$default: Boolean
-		$query: String!
-	) {
-		createErrorAlert(
-			project_id: $project_id
-			count_threshold: $count_threshold
-			name: $name
-			slack_channels: $slack_channels
-			discord_channels: $discord_channels
-			microsoft_teams_channels: $microsoft_teams_channels
-			webhook_destinations: $webhook_destinations
-			emails: $emails
-			threshold_window: $threshold_window
-			regex_groups: $regex_groups
-			frequency: $frequency
-			default: $default
-			query: $query
-		) {
-			id
-			ChannelsToNotify {
-				webhook_channel
-				webhook_channel_id
-			}
-			EmailsToNotify
-			Name
-			CountThreshold
-			ThresholdWindow
-			LastAdminToEditID
-			RegexGroups
-			Frequency
-			disabled
-			Query
-		}
-	}
-`
-export type CreateErrorAlertMutationFn = Apollo.MutationFunction<
-	Types.CreateErrorAlertMutation,
-	Types.CreateErrorAlertMutationVariables
->
-
-/**
- * __useCreateErrorAlertMutation__
- *
- * To run a mutation, you first call `useCreateErrorAlertMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useCreateErrorAlertMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [createErrorAlertMutation, { data, loading, error }] = useCreateErrorAlertMutation({
- *   variables: {
- *      project_id: // value for 'project_id'
- *      name: // value for 'name'
- *      count_threshold: // value for 'count_threshold'
- *      threshold_window: // value for 'threshold_window'
- *      slack_channels: // value for 'slack_channels'
- *      discord_channels: // value for 'discord_channels'
- *      webhook_destinations: // value for 'webhook_destinations'
- *      microsoft_teams_channels: // value for 'microsoft_teams_channels'
- *      emails: // value for 'emails'
- *      regex_groups: // value for 'regex_groups'
- *      frequency: // value for 'frequency'
- *      default: // value for 'default'
- *      query: // value for 'query'
- *   },
- * });
- */
-export function useCreateErrorAlertMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.CreateErrorAlertMutation,
-		Types.CreateErrorAlertMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.CreateErrorAlertMutation,
-		Types.CreateErrorAlertMutationVariables
-	>(CreateErrorAlertDocument, baseOptions)
-}
-export type CreateErrorAlertMutationHookResult = ReturnType<
-	typeof useCreateErrorAlertMutation
->
-export type CreateErrorAlertMutationResult =
-	Apollo.MutationResult<Types.CreateErrorAlertMutation>
-export type CreateErrorAlertMutationOptions = Apollo.BaseMutationOptions<
-	Types.CreateErrorAlertMutation,
-	Types.CreateErrorAlertMutationVariables
->
 export const CreateMetricMonitorDocument = gql`
 	mutation CreateMetricMonitor(
 		$project_id: ID!
@@ -3395,6 +3293,7 @@ export const CreateAlertDocument = gql`
 		$function_column: String
 		$query: String
 		$group_by_key: String
+		$default: Boolean
 		$below_threshold: Boolean
 		$threshold_value: Float
 		$threshold_window: Int
@@ -3409,6 +3308,7 @@ export const CreateAlertDocument = gql`
 			function_column: $function_column
 			query: $query
 			group_by_key: $group_by_key
+			default: $default
 			below_threshold: $below_threshold
 			threshold_value: $threshold_value
 			threshold_window: $threshold_window
@@ -3446,6 +3346,7 @@ export type CreateAlertMutationFn = Apollo.MutationFunction<
  *      function_column: // value for 'function_column'
  *      query: // value for 'query'
  *      group_by_key: // value for 'group_by_key'
+ *      default: // value for 'default'
  *      below_threshold: // value for 'below_threshold'
  *      threshold_value: // value for 'threshold_value'
  *      threshold_window: // value for 'threshold_window'
@@ -4039,55 +3940,6 @@ export type UpdateLogAlertMutationOptions = Apollo.BaseMutationOptions<
 	Types.UpdateLogAlertMutation,
 	Types.UpdateLogAlertMutationVariables
 >
-export const CreateLogAlertDocument = gql`
-	mutation CreateLogAlert($input: LogAlertInput!) {
-		createLogAlert(input: $input) {
-			id
-		}
-	}
-`
-export type CreateLogAlertMutationFn = Apollo.MutationFunction<
-	Types.CreateLogAlertMutation,
-	Types.CreateLogAlertMutationVariables
->
-
-/**
- * __useCreateLogAlertMutation__
- *
- * To run a mutation, you first call `useCreateLogAlertMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useCreateLogAlertMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [createLogAlertMutation, { data, loading, error }] = useCreateLogAlertMutation({
- *   variables: {
- *      input: // value for 'input'
- *   },
- * });
- */
-export function useCreateLogAlertMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.CreateLogAlertMutation,
-		Types.CreateLogAlertMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.CreateLogAlertMutation,
-		Types.CreateLogAlertMutationVariables
-	>(CreateLogAlertDocument, baseOptions)
-}
-export type CreateLogAlertMutationHookResult = ReturnType<
-	typeof useCreateLogAlertMutation
->
-export type CreateLogAlertMutationResult =
-	Apollo.MutationResult<Types.CreateLogAlertMutation>
-export type CreateLogAlertMutationOptions = Apollo.BaseMutationOptions<
-	Types.CreateLogAlertMutation,
-	Types.CreateLogAlertMutationVariables
->
 export const DeleteLogAlertDocument = gql`
 	mutation DeleteLogAlert($project_id: ID!, $id: ID!) {
 		deleteLogAlert(project_id: $project_id, id: $id) {
@@ -4378,66 +4230,6 @@ export type UpdateErrorAlertIsDisabledMutationOptions =
 		Types.UpdateErrorAlertIsDisabledMutation,
 		Types.UpdateErrorAlertIsDisabledMutationVariables
 	>
-export const CreateSessionAlertDocument = gql`
-	mutation CreateSessionAlert($input: SessionAlertInput!) {
-		createSessionAlert(input: $input) {
-			id
-			ChannelsToNotify {
-				webhook_channel
-				webhook_channel_id
-			}
-			EmailsToNotify
-			Name
-			ExcludedEnvironments
-			CountThreshold
-			ThresholdWindow
-			LastAdminToEditID
-			disabled
-		}
-	}
-`
-export type CreateSessionAlertMutationFn = Apollo.MutationFunction<
-	Types.CreateSessionAlertMutation,
-	Types.CreateSessionAlertMutationVariables
->
-
-/**
- * __useCreateSessionAlertMutation__
- *
- * To run a mutation, you first call `useCreateSessionAlertMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useCreateSessionAlertMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [createSessionAlertMutation, { data, loading, error }] = useCreateSessionAlertMutation({
- *   variables: {
- *      input: // value for 'input'
- *   },
- * });
- */
-export function useCreateSessionAlertMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.CreateSessionAlertMutation,
-		Types.CreateSessionAlertMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.CreateSessionAlertMutation,
-		Types.CreateSessionAlertMutationVariables
-	>(CreateSessionAlertDocument, baseOptions)
-}
-export type CreateSessionAlertMutationHookResult = ReturnType<
-	typeof useCreateSessionAlertMutation
->
-export type CreateSessionAlertMutationResult =
-	Apollo.MutationResult<Types.CreateSessionAlertMutation>
-export type CreateSessionAlertMutationOptions = Apollo.BaseMutationOptions<
-	Types.CreateSessionAlertMutation,
-	Types.CreateSessionAlertMutationVariables
->
 export const UpdateSessionAlertDocument = gql`
 	mutation UpdateSessionAlert($id: ID!, $input: SessionAlertInput!) {
 		updateSessionAlert(id: $id, input: $input) {

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -824,61 +824,6 @@ export type ReplyToErrorCommentMutation = { __typename?: 'Mutation' } & {
 	>
 }
 
-export type CreateErrorAlertMutationVariables = Types.Exact<{
-	project_id: Types.Scalars['ID']
-	name: Types.Scalars['String']
-	count_threshold: Types.Scalars['Int']
-	threshold_window: Types.Scalars['Int']
-	slack_channels:
-		| Array<Types.Maybe<Types.SanitizedSlackChannelInput>>
-		| Types.Maybe<Types.SanitizedSlackChannelInput>
-	discord_channels:
-		| Array<Types.DiscordChannelInput>
-		| Types.DiscordChannelInput
-	webhook_destinations:
-		| Array<Types.WebhookDestinationInput>
-		| Types.WebhookDestinationInput
-	microsoft_teams_channels:
-		| Array<Types.MicrosoftTeamsChannelInput>
-		| Types.MicrosoftTeamsChannelInput
-	emails:
-		| Array<Types.Maybe<Types.Scalars['String']>>
-		| Types.Maybe<Types.Scalars['String']>
-	regex_groups:
-		| Array<Types.Maybe<Types.Scalars['String']>>
-		| Types.Maybe<Types.Scalars['String']>
-	frequency: Types.Scalars['Int']
-	default?: Types.Maybe<Types.Scalars['Boolean']>
-	query: Types.Scalars['String']
-}>
-
-export type CreateErrorAlertMutation = { __typename?: 'Mutation' } & {
-	createErrorAlert?: Types.Maybe<
-		{ __typename?: 'ErrorAlert' } & Pick<
-			Types.ErrorAlert,
-			| 'id'
-			| 'EmailsToNotify'
-			| 'Name'
-			| 'CountThreshold'
-			| 'ThresholdWindow'
-			| 'LastAdminToEditID'
-			| 'RegexGroups'
-			| 'Frequency'
-			| 'disabled'
-			| 'Query'
-		> & {
-				ChannelsToNotify: Array<
-					Types.Maybe<
-						{ __typename?: 'SanitizedSlackChannel' } & Pick<
-							Types.SanitizedSlackChannel,
-							'webhook_channel' | 'webhook_channel_id'
-						>
-					>
-				>
-			}
-	>
-}
-
 export type CreateMetricMonitorMutationVariables = Types.Exact<{
 	project_id: Types.Scalars['ID']
 	name: Types.Scalars['String']
@@ -1025,6 +970,7 @@ export type CreateAlertMutationVariables = Types.Exact<{
 	function_column?: Types.Maybe<Types.Scalars['String']>
 	query?: Types.Maybe<Types.Scalars['String']>
 	group_by_key?: Types.Maybe<Types.Scalars['String']>
+	default?: Types.Maybe<Types.Scalars['Boolean']>
 	below_threshold?: Types.Maybe<Types.Scalars['Boolean']>
 	threshold_value?: Types.Maybe<Types.Scalars['Float']>
 	threshold_window?: Types.Maybe<Types.Scalars['Int']>
@@ -1213,16 +1159,6 @@ export type UpdateLogAlertMutation = { __typename?: 'Mutation' } & {
 	>
 }
 
-export type CreateLogAlertMutationVariables = Types.Exact<{
-	input: Types.LogAlertInput
-}>
-
-export type CreateLogAlertMutation = { __typename?: 'Mutation' } & {
-	createLogAlert?: Types.Maybe<
-		{ __typename?: 'LogAlert' } & Pick<Types.LogAlert, 'id'>
-	>
-}
-
 export type DeleteLogAlertMutationVariables = Types.Exact<{
 	project_id: Types.Scalars['ID']
 	id: Types.Scalars['ID']
@@ -1283,35 +1219,6 @@ export type UpdateErrorAlertIsDisabledMutationVariables = Types.Exact<{
 export type UpdateErrorAlertIsDisabledMutation = { __typename?: 'Mutation' } & {
 	updateErrorAlertIsDisabled?: Types.Maybe<
 		{ __typename?: 'ErrorAlert' } & Pick<Types.ErrorAlert, 'id'>
-	>
-}
-
-export type CreateSessionAlertMutationVariables = Types.Exact<{
-	input: Types.SessionAlertInput
-}>
-
-export type CreateSessionAlertMutation = { __typename?: 'Mutation' } & {
-	createSessionAlert?: Types.Maybe<
-		{ __typename?: 'SessionAlert' } & Pick<
-			Types.SessionAlert,
-			| 'id'
-			| 'EmailsToNotify'
-			| 'Name'
-			| 'ExcludedEnvironments'
-			| 'CountThreshold'
-			| 'ThresholdWindow'
-			| 'LastAdminToEditID'
-			| 'disabled'
-		> & {
-				ChannelsToNotify: Array<
-					Types.Maybe<
-						{ __typename?: 'SanitizedSlackChannel' } & Pick<
-							Types.SanitizedSlackChannel,
-							'webhook_channel' | 'webhook_channel_id'
-						>
-					>
-				>
-			}
 	>
 }
 
@@ -5551,7 +5458,6 @@ export const namedOperations = {
 		MuteErrorCommentThread: 'MuteErrorCommentThread' as const,
 		RemoveErrorIssue: 'RemoveErrorIssue' as const,
 		ReplyToErrorComment: 'ReplyToErrorComment' as const,
-		CreateErrorAlert: 'CreateErrorAlert' as const,
 		CreateMetricMonitor: 'CreateMetricMonitor' as const,
 		UpdateMetricMonitor: 'UpdateMetricMonitor' as const,
 		DeleteMetricMonitor: 'DeleteMetricMonitor' as const,
@@ -5565,13 +5471,11 @@ export const namedOperations = {
 		DeleteErrorAlert: 'DeleteErrorAlert' as const,
 		DeleteSessionAlert: 'DeleteSessionAlert' as const,
 		UpdateLogAlert: 'UpdateLogAlert' as const,
-		CreateLogAlert: 'CreateLogAlert' as const,
 		DeleteLogAlert: 'DeleteLogAlert' as const,
 		UpdateLogAlertIsDisabled: 'UpdateLogAlertIsDisabled' as const,
 		UpdateSessionAlertIsDisabled: 'UpdateSessionAlertIsDisabled' as const,
 		UpdateMetricMonitorIsDisabled: 'UpdateMetricMonitorIsDisabled' as const,
 		UpdateErrorAlertIsDisabled: 'UpdateErrorAlertIsDisabled' as const,
-		CreateSessionAlert: 'CreateSessionAlert' as const,
 		UpdateSessionAlert: 'UpdateSessionAlert' as const,
 		UpdateSessionIsPublic: 'UpdateSessionIsPublic' as const,
 		UpdateErrorGroupIsPublic: 'UpdateErrorGroupIsPublic' as const,

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1192,18 +1192,15 @@ export type Mutation = {
 	createAdmin: Admin
 	createAlert?: Maybe<Alert>
 	createCloudflareProxy: Scalars['String']
-	createErrorAlert?: Maybe<ErrorAlert>
 	createErrorComment?: Maybe<ErrorComment>
 	createErrorCommentForExistingIssue?: Maybe<ErrorComment>
 	createErrorTag: ErrorTag
 	createIssueForErrorComment?: Maybe<ErrorComment>
 	createIssueForSessionComment?: Maybe<SessionComment>
-	createLogAlert?: Maybe<LogAlert>
 	createMetricMonitor?: Maybe<MetricMonitor>
 	createOrUpdateStripeSubscription?: Maybe<Scalars['String']>
 	createProject?: Maybe<Project>
 	createSavedSegment?: Maybe<SavedSegment>
-	createSessionAlert?: Maybe<SessionAlert>
 	createSessionComment?: Maybe<SessionComment>
 	createSessionCommentWithExistingIssue?: Maybe<SessionComment>
 	createWorkspace?: Maybe<Workspace>
@@ -1311,6 +1308,7 @@ export type MutationChangeProjectMembershipArgs = {
 
 export type MutationCreateAlertArgs = {
 	below_threshold?: InputMaybe<Scalars['Boolean']>
+	default?: InputMaybe<Scalars['Boolean']>
 	destinations: Array<AlertDestinationInput>
 	function_column?: InputMaybe<Scalars['String']>
 	function_type: MetricAggregator
@@ -1327,22 +1325,6 @@ export type MutationCreateAlertArgs = {
 export type MutationCreateCloudflareProxyArgs = {
 	proxy_subdomain: Scalars['String']
 	workspace_id: Scalars['ID']
-}
-
-export type MutationCreateErrorAlertArgs = {
-	count_threshold: Scalars['Int']
-	default?: InputMaybe<Scalars['Boolean']>
-	discord_channels: Array<DiscordChannelInput>
-	emails: Array<InputMaybe<Scalars['String']>>
-	frequency: Scalars['Int']
-	microsoft_teams_channels: Array<MicrosoftTeamsChannelInput>
-	name: Scalars['String']
-	project_id: Scalars['ID']
-	query: Scalars['String']
-	regex_groups: Array<InputMaybe<Scalars['String']>>
-	slack_channels: Array<InputMaybe<SanitizedSlackChannelInput>>
-	threshold_window: Scalars['Int']
-	webhook_destinations: Array<WebhookDestinationInput>
 }
 
 export type MutationCreateErrorCommentArgs = {
@@ -1408,10 +1390,6 @@ export type MutationCreateIssueForSessionCommentArgs = {
 	time: Scalars['Float']
 }
 
-export type MutationCreateLogAlertArgs = {
-	input: LogAlertInput
-}
-
 export type MutationCreateMetricMonitorArgs = {
 	aggregator: MetricAggregator
 	discord_channels: Array<DiscordChannelInput>
@@ -1441,10 +1419,6 @@ export type MutationCreateSavedSegmentArgs = {
 	name: Scalars['String']
 	project_id: Scalars['ID']
 	query: Scalars['String']
-}
-
-export type MutationCreateSessionAlertArgs = {
-	input: SessionAlertInput
 }
 
 export type MutationCreateSessionCommentArgs = {

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -804,53 +804,6 @@ mutation ReplyToErrorComment(
 	}
 }
 
-mutation CreateErrorAlert(
-	$project_id: ID!
-	$name: String!
-	$count_threshold: Int!
-	$threshold_window: Int!
-	$slack_channels: [SanitizedSlackChannelInput]!
-	$discord_channels: [DiscordChannelInput!]!
-	$webhook_destinations: [WebhookDestinationInput!]!
-	$microsoft_teams_channels: [MicrosoftTeamsChannelInput!]!
-	$emails: [String]!
-	$regex_groups: [String]!
-	$frequency: Int!
-	$default: Boolean
-	$query: String!
-) {
-	createErrorAlert(
-		project_id: $project_id
-		count_threshold: $count_threshold
-		name: $name
-		slack_channels: $slack_channels
-		discord_channels: $discord_channels
-		microsoft_teams_channels: $microsoft_teams_channels
-		webhook_destinations: $webhook_destinations
-		emails: $emails
-		threshold_window: $threshold_window
-		regex_groups: $regex_groups
-		frequency: $frequency
-		default: $default
-		query: $query
-	) {
-		id
-		ChannelsToNotify {
-			webhook_channel
-			webhook_channel_id
-		}
-		EmailsToNotify
-		Name
-		CountThreshold
-		ThresholdWindow
-		LastAdminToEditID
-		RegexGroups
-		Frequency
-		disabled
-		Query
-	}
-}
-
 mutation CreateMetricMonitor(
 	$project_id: ID!
 	$name: String!
@@ -973,6 +926,7 @@ mutation CreateAlert(
 	$function_column: String
 	$query: String
 	$group_by_key: String
+	$default: Boolean
 	$below_threshold: Boolean
 	$threshold_value: Float
 	$threshold_window: Int
@@ -987,6 +941,7 @@ mutation CreateAlert(
 		function_column: $function_column
 		query: $query
 		group_by_key: $group_by_key
+		default: $default
 		below_threshold: $below_threshold
 		threshold_value: $threshold_value
 		threshold_window: $threshold_window
@@ -1141,12 +1096,6 @@ mutation UpdateLogAlert($id: ID!, $input: LogAlertInput!) {
 	}
 }
 
-mutation CreateLogAlert($input: LogAlertInput!) {
-	createLogAlert(input: $input) {
-		id
-	}
-}
-
 mutation DeleteLogAlert($project_id: ID!, $id: ID!) {
 	deleteLogAlert(project_id: $project_id, id: $id) {
 		id
@@ -1205,23 +1154,6 @@ mutation UpdateErrorAlertIsDisabled(
 		disabled: $disabled
 	) {
 		id
-	}
-}
-
-mutation CreateSessionAlert($input: SessionAlertInput!) {
-	createSessionAlert(input: $input) {
-		id
-		ChannelsToNotify {
-			webhook_channel
-			webhook_channel_id
-		}
-		EmailsToNotify
-		Name
-		ExcludedEnvironments
-		CountThreshold
-		ThresholdWindow
-		LastAdminToEditID
-		disabled
 	}
 }
 

--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -68,9 +68,12 @@ const FREQUENCY_OPTIONS = FREQUENCIES.filter((freq) => Number(freq.value) >= 60)
 const MINUTE = 60
 const WEEK = 7 * 24 * 60 * MINUTE
 
-const DEFAULT_THRESHOLD = 1
-const DEFAULT_WINDOW = MINUTE * 30
-const DEFAULT_COOLDOWN = MINUTE * 30
+export const SESSION_WINDOW = MINUTE
+export const SESSION_COOLDOWN = WEEK
+
+export const DEFAULT_THRESHOLD = 1
+export const DEFAULT_WINDOW = MINUTE * 30
+export const DEFAULT_COOLDOWN = MINUTE * 30
 
 const ALERT_PRODUCT_INFO = {
 	[ProductType.Sessions]:
@@ -164,8 +167,8 @@ export const AlertForm: React.FC = () => {
 			setGroupByEnabled(true)
 			setGroupByKey('secure_id')
 			// only alert once per session
-			setThresholdWindow(MINUTE)
-			setThresholdCooldown(WEEK)
+			setThresholdWindow(SESSION_WINDOW)
+			setThresholdCooldown(SESSION_COOLDOWN)
 		} else if (productType === ProductType.Errors) {
 			// locked error settings -> group by secure_id
 			setGroupByEnabled(true)

--- a/frontend/src/pages/Alerts/AlertsRouter.tsx
+++ b/frontend/src/pages/Alerts/AlertsRouter.tsx
@@ -51,30 +51,9 @@ const AlertsRouter = () => {
 					element={<Navigate to={`/${project_id}/alerts`} replace />}
 				/>
 				<Route
-					path="new/logs"
-					element={
-						<Navigate
-							to={`/${project_id}/alerts/logs/new`}
-							replace
-						/>
-					}
-				/>
-
-				<Route
-					path="new/errors"
-					element={
-						<Navigate
-							to={`/${project_id}/alerts/errors/new`}
-							replace
-						/>
-					}
-				/>
-				<Route path="session/new" element={<SessionAlertPage />} />
-				<Route
 					path="session/:alert_id"
 					element={<SessionAlertPage />}
 				/>
-				<Route path="errors/new" element={<ErrorAlertPage />} />
 				<Route path="errors/:alert_id" element={<ErrorAlertPage />} />
 			</Routes>
 		</AlertsContextProvider>

--- a/frontend/src/pages/Alerts/ErrorAlert/ErrorAlertPage.tsx
+++ b/frontend/src/pages/Alerts/ErrorAlert/ErrorAlertPage.tsx
@@ -2,7 +2,6 @@ import { Button } from '@components/Button'
 import Select from '@components/Select/Select'
 import { toast } from '@components/Toaster'
 import {
-	useCreateErrorAlertMutation,
 	useDeleteErrorAlertMutation,
 	useUpdateErrorAlertMutation,
 } from '@graph/hooks'
@@ -32,7 +31,6 @@ import {
 	getFrequencyOption,
 } from '@pages/Alerts/utils/AlertsUtils'
 import { useParams } from '@util/react-router/useParams'
-import { capitalize } from 'lodash'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { StringParam, useQueryParam } from 'use-query-params'
@@ -58,9 +56,6 @@ export const ErrorAlertPage = () => {
 	const { alert_id } = useParams<{
 		alert_id: string
 	}>()
-
-	const isCreate = alert_id === undefined
-	const createStr = isCreate ? 'create' : 'update'
 
 	const { alertsPayload } = useAlertsContext()
 	const alert = alert_id
@@ -134,13 +129,10 @@ export const ErrorAlertPage = () => {
 	}, [alert])
 
 	useEffect(() => {
-		analytics.page('Error Alert', { isCreate })
-	}, [isCreate])
+		analytics.page('Error Alert')
+	}, [])
 
 	const [updateErrorAlertMutation] = useUpdateErrorAlertMutation({
-		refetchQueries: [namedOperations.Query.GetAlertsPagePayload],
-	})
-	const [createErrorAlertMutation] = useCreateErrorAlertMutation({
 		refetchQueries: [namedOperations.Query.GetAlertsPagePayload],
 	})
 	const [deleteErrorAlertMutation] = useDeleteErrorAlertMutation({
@@ -175,31 +167,29 @@ export const ErrorAlertPage = () => {
 				>
 					Cancel
 				</Button>
-				{!isCreate && (
-					<Button
-						kind="danger"
-						size="small"
-						emphasis="low"
-						trackingId="deleteErrorAlert"
-						onClick={() => {
-							deleteErrorAlertMutation({
-								variables: {
-									project_id: project_id ?? '',
-									error_alert_id: alert_id,
-								},
+				<Button
+					kind="danger"
+					size="small"
+					emphasis="low"
+					trackingId="deleteErrorAlert"
+					onClick={() => {
+						deleteErrorAlertMutation({
+							variables: {
+								project_id: project_id ?? '',
+								error_alert_id: alert_id!,
+							},
+						})
+							.then(() => {
+								toast.success(`Error alert deleted!`)
+								navigate(`/${project_id}/alerts`)
 							})
-								.then(() => {
-									toast.success(`Error alert deleted!`)
-									navigate(`/${project_id}/alerts`)
-								})
-								.catch(() => {
-									toast.error(`Failed to delete error alert!`)
-								})
-						}}
-					>
-						Delete Alert
-					</Button>
-				)}
+							.catch(() => {
+								toast.error(`Failed to delete error alert!`)
+							})
+					}}
+				>
+					Delete Alert
+				</Button>
 				<Button
 					kind="primary"
 					size="small"
@@ -277,45 +267,28 @@ export const ErrorAlertPage = () => {
 							return
 						}
 
-						if (isCreate) {
-							createErrorAlertMutation({
-								variables: input,
+						updateErrorAlertMutation({
+							variables: {
+								...input,
+								error_alert_id: alert_id!,
+							},
+						})
+							.then(() => {
+								toast.success(`Error alert updated!`)
+								navigate(`/${project_id}/alerts`)
 							})
-								.then(() => {
-									toast.success(`Error alert ${createStr}d!`)
-									navigate(`/${project_id}/alerts`)
-								})
-								.catch(() => {
-									toast.error(
-										`Failed to ${createStr} error alert!`,
-									)
-								})
-						} else {
-							updateErrorAlertMutation({
-								variables: {
-									...input,
-									error_alert_id: alert_id,
-								},
+							.catch(() => {
+								toast.error(`Failed to update error alert!`)
 							})
-								.then(() => {
-									toast.success(`Error alert ${createStr}d!`)
-									navigate(`/${project_id}/alerts`)
-								})
-								.catch(() => {
-									toast.error(
-										`Failed to ${createStr} error alert!`,
-									)
-								})
-						}
 					}}
 				>
-					{capitalize(createStr)} alert
+					Update alert
 				</Button>
 			</Box>
 		</Box>
 	)
 
-	const isLoading = !isCreate && !formValues.loaded
+	const isLoading = !formValues.loaded
 
 	return (
 		<Box width="full" background="raised" p="8">
@@ -394,7 +367,6 @@ export const ErrorAlertPage = () => {
 									>
 										<ErrorAlertForm
 											hideRegexExpression={
-												isCreate ||
 												!alert?.RegexGroups?.length
 											}
 										/>

--- a/frontend/src/pages/Alerts/LogAlert/LogAlertRouter.tsx
+++ b/frontend/src/pages/Alerts/LogAlert/LogAlertRouter.tsx
@@ -28,7 +28,6 @@ const LogAlertsRouter = () => {
 				<title>Log Alerts</title>
 			</Helmet>
 			<Routes>
-				<Route path="new" element={<LogAlertPage />} />
 				<Route path=":alert_id" element={<LogAlertPage />} />
 			</Routes>
 		</LogAlertsContextProvider>


### PR DESCRIPTION
## Summary
In the setup page, we create old default alerts for the new user if they request. Update these to be the new alerts.

Three alerts:
- New user sessions
- Error alerts
- Error logs

Additional notes
- Also removes being able to create legacy alerts.
- Removes routes from router

## How did you test this change?
1. Create a new user/workspace
2. Sign up for the new alerts via the alert menu option
- [ ] Alerts created successfully in db (note that settings in UI may not be visible -> fix in https://github.com/highlight/highlight/pull/9336)
- [ ] Alert is denoted with `default: true`
- [ ] Correct destinations created
3. Create a manual alert
- [ ] Alert successfully created
- [ ] Alert is denoted with `default: false`

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
