### PR TITLE
race condition when playing sessions causing pausing

### DIFF
--- a/.changeset/giant-penguins-watch.md
+++ b/.changeset/giant-penguins-watch.md
@@ -1,5 +1,0 @@
----
-'highlight.run': patch
----
-
-update client startSpan methods to pass callback return

--- a/.changeset/giant-penguins-watch.md
+++ b/.changeset/giant-penguins-watch.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+update client startSpan methods to pass callback return

--- a/frontend/src/hooks/useFeatureFlag/useFeatureFlag.ts
+++ b/frontend/src/hooks/useFeatureFlag/useFeatureFlag.ts
@@ -28,7 +28,6 @@ export const FeatureConfig: { [key: number]: Config } = {
 	[Feature.PlayerNoChunkRemoval]: {
 		workspace: true,
 		percent: 0,
-		workspaceOverride: new Set<string>(['13623', '95052']),
 	},
 } as const
 

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -501,7 +501,7 @@ export const usePlayer = (
 						chunks: chunkEventsRef.current,
 					},
 				)
-				dispatchAction(undefined, blockingLoad.current)
+				dispatchAction(startTime, blockingLoad.current)
 				blockingLoad.current = undefined
 			}
 		},

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -684,16 +684,25 @@ export const usePlayer = (
 	useEffect(() => {
 		resetPlayer()
 		if (sessionSecureId && eventChunksData?.event_chunks?.length) {
-			loadEventChunk(0).then(() => {
-				dispatch({
-					type: PlayerActionType.onChunksLoad,
-					showPlayerMouseTail,
-					time: 0,
-					action: ReplayerState.Paused,
-					playerRef,
+			loadEventChunk(0)
+				.then(() => {
+					dispatch({
+						type: PlayerActionType.onChunksLoad,
+						showPlayerMouseTail,
+						time: 0,
+						action: ReplayerState.Paused,
+						playerRef,
+					})
+					log('PlayerHook.tsx', 'initial chunk complete')
 				})
-				log('PlayerHook.tsx', 'initial chunk complete')
-			})
+				.then(() => {
+					const nextChunk = eventChunksData.event_chunks.at(1)
+					if (nextChunk) {
+						loadEventChunk(nextChunk.chunk_index).then(() => {
+							log('PlayerHook.tsx', 'next chunk load complete')
+						})
+					}
+				})
 		}
 	}, [
 		projectId,

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -314,13 +314,19 @@ export const usePlayer = (
 
 	const dispatchAction = useCallback(
 		(time: number, action: ReplayerState) => {
-			dispatch({
-				type: PlayerActionType.onChunksLoad,
-				showPlayerMouseTail,
-				time,
-				action: action,
-				playerRef,
-			})
+			H.startSpan(
+				'dispatchAction',
+				{ attributes: { time, action } },
+				() => {
+					dispatch({
+						type: PlayerActionType.onChunksLoad,
+						showPlayerMouseTail,
+						time,
+						action: action,
+						playerRef,
+					})
+				},
+			)
 		},
 		[playerRef, showPlayerMouseTail],
 	)

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -413,6 +413,18 @@ export const usePlayer = (
 						'waiting for loading chunk',
 						i,
 					)
+					// signal that we are loading chunks once
+					if (!blockingLoad && forceBlockingLoad) {
+						log(
+							'PlayerHook.tsx:ensureChunksLoaded',
+							'needs blocking load for chunk, forced blocking load',
+							i,
+						)
+						blockingLoad = true
+						dispatch({
+							type: PlayerActionType.startChunksLoad,
+						})
+					}
 				} else {
 					// signal that we are loading chunks once
 					if (!blockingLoad) {

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -169,7 +169,6 @@ export const usePlayer = (
 
 	const unsubscribeSessionPayloadFn = useRef<(() => void) | null>()
 	const animationFrameID = useRef<number>(0)
-	const lookaheadLoading = useRef<boolean>(false)
 
 	const [
 		chunkEventsRef,
@@ -944,14 +943,6 @@ export const usePlayer = (
 	// ensures we skip over inactivity periods
 	useEffect(() => {
 		;(async () => {
-			if (lookaheadLoading.current) {
-				log(
-					'PlayerHook.tsx',
-					'skipping lookahead due to concurrent loading',
-				)
-				return
-			}
-			lookaheadLoading.current = true
 			if (
 				state.sessionMetadata.startTime === 0 ||
 				state.replayerState !== ReplayerState.Playing ||
@@ -981,7 +972,7 @@ export const usePlayer = (
 				undefined,
 				getLastLoadedEventTimestamp() - state.time < LOOKAHEAD_MS,
 			)
-		})().finally(() => (lookaheadLoading.current = false))
+		})()
 	}, [
 		state.time,
 		ensureChunksLoaded,

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -684,25 +684,16 @@ export const usePlayer = (
 	useEffect(() => {
 		resetPlayer()
 		if (sessionSecureId && eventChunksData?.event_chunks?.length) {
-			loadEventChunk(0)
-				.then(() => {
-					dispatch({
-						type: PlayerActionType.onChunksLoad,
-						showPlayerMouseTail,
-						time: 0,
-						action: ReplayerState.Paused,
-						playerRef,
-					})
-					log('PlayerHook.tsx', 'initial chunk complete')
+			loadEventChunk(0).then(() => {
+				dispatch({
+					type: PlayerActionType.onChunksLoad,
+					showPlayerMouseTail,
+					time: 0,
+					action: ReplayerState.Paused,
+					playerRef,
 				})
-				.then(() => {
-					const nextChunk = eventChunksData.event_chunks.at(1)
-					if (nextChunk) {
-						loadEventChunk(nextChunk.chunk_index).then(() => {
-							log('PlayerHook.tsx', 'next chunk load complete')
-						})
-					}
-				})
+				log('PlayerHook.tsx', 'initial chunk complete')
+			})
 		}
 	}, [
 		projectId,

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -397,7 +397,7 @@ export const usePlayer = (
 			log(
 				'PlayerHook.tsx:ensureChunksLoaded',
 				'checking chunk loaded status range',
-				{ action, startIdx, endIdx },
+				{ action, startIdx, endIdx, forceLoadNext, forceBlockingLoad },
 			)
 			for (let i = startIdx; i <= endIdx; i++) {
 				log('PlayerHook.tsx:ensureChunksLoaded', 'has', i, {

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -501,7 +501,7 @@ export const usePlayer = (
 						chunks: chunkEventsRef.current,
 					},
 				)
-				dispatchAction(startTime, blockingLoad.current)
+				dispatchAction(undefined, blockingLoad.current)
 				blockingLoad.current = undefined
 			}
 		},

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -491,7 +491,11 @@ export const usePlayer = (
 					},
 				)
 				dispatchAction(startTime, action)
-			} else if (blockingLoad.current && state.replayerState) {
+			} else if (
+				promises.length &&
+				blockingLoad.current &&
+				state.replayerState
+			) {
 				log(
 					'PlayerHook.tsx:ensureChunksLoaded',
 					'calling dispatchAction due to blockingLoad',

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -320,7 +320,6 @@ export const usePlayer = (
 						action: action,
 						playerRef,
 					})
-					blockingLoad.current = false
 				},
 			)
 		},
@@ -414,7 +413,6 @@ export const usePlayer = (
 						'waiting for loading chunk',
 						i,
 					)
-					// signal that we are loading chunks once
 					if (!blockingLoad.current && forceBlockingLoad) {
 						log(
 							'PlayerHook.tsx:ensureChunksLoaded',
@@ -427,19 +425,19 @@ export const usePlayer = (
 						})
 					}
 				} else {
-					// signal that we are loading chunks once
-					if (!blockingLoad.current) {
-						if (forceBlockingLoad || i == startIdx) {
-							log(
-								'PlayerHook.tsx:ensureChunksLoaded',
-								'needs blocking load for chunk',
-								i,
-							)
-							blockingLoad.current = true
-							dispatch({
-								type: PlayerActionType.startChunksLoad,
-							})
-						}
+					if (
+						(!blockingLoad.current && forceBlockingLoad) ||
+						i == startIdx
+					) {
+						log(
+							'PlayerHook.tsx:ensureChunksLoaded',
+							'needs blocking load for chunk',
+							i,
+						)
+						blockingLoad.current = true
+						dispatch({
+							type: PlayerActionType.startChunksLoad,
+						})
 					}
 					promises.push(loadEventChunk(i))
 				}
@@ -504,6 +502,7 @@ export const usePlayer = (
 					},
 				)
 				dispatchAction(startTime, state.replayerState)
+				blockingLoad.current = false
 			}
 		},
 		[

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -433,6 +433,15 @@ export const usePlayer = (
 					}
 					promises.push(loadEventChunk(i))
 				}
+
+				if (promises.length > MAX_CHUNK_COUNT) {
+					console.warn('large number of chunks requested', {
+						startIdx,
+						endIdx,
+						current: chunkEventsRef.current,
+					})
+					break
+				}
 			}
 			log(
 				'PlayerHook.tsx:ensureChunksLoaded',

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -68,8 +68,8 @@ export const FRAME_MS = 1000 / 120
 export const THROTTLED_UPDATE_MS = FRAME_MS * 30
 
 export const CHUNKING_DISABLED_PROJECTS: string[] = []
-export const LOOKAHEAD_MS = 1000 * 30
-export const MAX_CHUNK_COUNT = 50
+export const LOOKAHEAD_MS = 1000 * 60
+export const MAX_CHUNK_COUNT = 8
 
 export enum SessionViewability {
 	VIEWABLE,

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -64,12 +64,13 @@ const PROJECTS_WITH_CSS_ANIMATIONS: string[] = ['1', '1020', '1021', '102751']
 
 // assuming 120 fps
 export const FRAME_MS = 1000 / 120
-// update every 30 frames
-export const THROTTLED_UPDATE_MS = FRAME_MS * 30
+// update every 15 frames
+export const THROTTLED_UPDATE_MS = FRAME_MS * 15
 
 export const CHUNKING_DISABLED_PROJECTS: string[] = []
-export const LOOKAHEAD_MS = 1000 * 60
-export const MAX_CHUNK_COUNT = 8
+export const LOOKAHEAD_MS = 1000 * 30
+export const BUFFER_MS = 1000 * 3
+export const MAX_CHUNK_COUNT = 5
 
 export enum SessionViewability {
 	VIEWABLE,

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -64,7 +64,7 @@ const PROJECTS_WITH_CSS_ANIMATIONS: string[] = ['1', '1020', '1021', '102751']
 
 // assuming 120 fps
 export const FRAME_MS = 1000 / 120
-// update every 15 frames
+// update every N frames
 export const THROTTLED_UPDATE_MS = FRAME_MS * 15
 
 export const CHUNKING_DISABLED_PROJECTS: string[] = []

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -444,7 +444,7 @@ export const PlayerReducer = (
 				PlayerActionType.startChunksLoad,
 				s,
 				ReplayerState.Paused,
-				getTimeFromReplayer(s.replayer, s.sessionMetadata),
+				undefined,
 				true,
 			)
 			break

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -239,7 +239,7 @@ interface startChunksLoad {
 interface onChunksLoad {
 	type: PlayerActionType.onChunksLoad
 	showPlayerMouseTail: boolean
-	time: number
+	time: number | undefined
 	playerRef: RefObject<HTMLDivElement>
 	action: ReplayerState
 }

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -68,8 +68,8 @@ export const FRAME_MS = 1000 / 120
 export const THROTTLED_UPDATE_MS = FRAME_MS * 30
 
 export const CHUNKING_DISABLED_PROJECTS: string[] = []
-export const LOOKAHEAD_MS = 1000 * 60
-export const MAX_CHUNK_COUNT = 8
+export const LOOKAHEAD_MS = 1000 * 30
+export const MAX_CHUNK_COUNT = 50
 
 export enum SessionViewability {
 	VIEWABLE,


### PR DESCRIPTION
## Summary

Fixes a race condition that has been around in the session player for a while
causing the replay to freeze when chunks were being loaded.

## How did you test this change?

https://www.loom.com/share/86b09c571b554b3695d2ab19f9e757db?from_recorder=1&focus_title=1

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
