### PR TITLE
block tracing via x-highlight-request header via urlblocklist

### DIFF
--- a/.changeset/slimy-pots-greet.md
+++ b/.changeset/slimy-pots-greet.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+block tracing via x-highlight-request header via urlblocklist

--- a/sdk/client/src/listeners/network-listener/utils/fetch-listener.ts
+++ b/sdk/client/src/listeners/network-listener/utils/fetch-listener.ts
@@ -40,7 +40,7 @@ export const FetchListener = (
 		}
 
 		const [sessionSecureID, requestId] = createNetworkRequestId(otelEnabled)
-		if (shouldNetworkRequestBeTraced(url, tracingOrigins)) {
+		if (shouldNetworkRequestBeTraced(url, tracingOrigins, urlBlocklist)) {
 			init = init || {}
 			// Pre-existing headers could be one of three different formats; this reads all of them.
 			let headers = new Headers(init.headers)

--- a/sdk/client/src/listeners/network-listener/utils/utils.test.ts
+++ b/sdk/client/src/listeners/network-listener/utils/utils.test.ts
@@ -1,4 +1,8 @@
-import { normalizeUrl } from './utils'
+import {
+	normalizeUrl,
+	shouldNetworkRequestBeRecorded,
+	shouldNetworkRequestBeTraced,
+} from './utils'
 
 describe('normalizeUrl', () => {
 	vi.stubGlobal('location', {
@@ -19,4 +23,58 @@ describe('normalizeUrl', () => {
 	])('normalizeUrl(%s, %s) -> %s', (url, expected) => {
 		expect(normalizeUrl(url)).toBe(expected)
 	})
+})
+
+describe('shouldNetworkRequestBeTraced/shouldNetworkRequestBeRecorded', () => {
+	vi.stubGlobal('location', {
+		origin: 'https://pub.highlight.run',
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	test.each([
+		['https://example.com/api/todo/create', true, [], true],
+		['https://pub.example.com/api/todo/create', ['example.com'], [], true],
+		[
+			'https://pub.example.com/api/todo/create',
+			['foo.example.com'],
+			[],
+			false,
+		],
+		[
+			'https://pub.example.com/api/todo/create',
+			[/.*example\.com.*/],
+			[],
+			true,
+		],
+		[
+			'https://pub.example.com/api/todo/create',
+			[/.*example\.com.*/],
+			['https://pub.example.com/my/api'],
+			true,
+		],
+		[
+			'https://pub.example.com/api/todo/create',
+			[/.*example\.com.*/],
+			['https://pub.example.com/api'],
+			false,
+		],
+	])(
+		'shouldNetworkRequestBeTraced(%s, %b, %s, %b) -> %s',
+		(url, tracingOrigins, urlBlocklist, expected) => {
+			window.location.host = 'example.com'
+			expect(
+				shouldNetworkRequestBeTraced(url, tracingOrigins, urlBlocklist),
+			).toBe(expected)
+			expect(
+				shouldNetworkRequestBeRecorded(
+					url,
+					'https://pub.highlight.io',
+					tracingOrigins,
+				),
+			).toBe(true)
+		},
+	)
 })

--- a/sdk/client/src/listeners/network-listener/utils/utils.ts
+++ b/sdk/client/src/listeners/network-listener/utils/utils.ts
@@ -263,14 +263,22 @@ export const shouldNetworkRequestBeRecorded = (
 ) => {
 	return (
 		!isHighlightNetworkResourceFilter(url, highlightBackendUrl) ||
-		shouldNetworkRequestBeTraced(url, tracingOrigins)
+		shouldNetworkRequestBeTraced(url, tracingOrigins ?? [], [])
 	)
 }
 
 export const shouldNetworkRequestBeTraced = (
 	url: string,
-	tracingOrigins?: boolean | (string | RegExp)[],
+	tracingOrigins: boolean | (string | RegExp)[],
+	urlBlocklist: string[],
 ) => {
+	if (
+		urlBlocklist.some((blockedUrl) =>
+			url.toLowerCase().includes(blockedUrl),
+		)
+	) {
+		return false
+	}
 	let patterns: (string | RegExp)[] = []
 	if (tracingOrigins === true) {
 		patterns = ['localhost', /^\//]

--- a/sdk/client/src/listeners/network-listener/utils/xhr-listener.ts
+++ b/sdk/client/src/listeners/network-listener/utils/xhr-listener.ts
@@ -80,7 +80,13 @@ export const XHRListener = (
 		}
 
 		const [sessionSecureID, requestId] = createNetworkRequestId(otelEnabled)
-		if (shouldNetworkRequestBeTraced(this._url, tracingOrigins)) {
+		if (
+			shouldNetworkRequestBeTraced(
+				this._url,
+				tracingOrigins,
+				urlBlocklist,
+			)
+		) {
 			this.setRequestHeader(
 				HIGHLIGHT_REQUEST_HEADER,
 				getHighlightRequestHeader(sessionSecureID, requestId),

--- a/sdk/client/src/otel/index.ts
+++ b/sdk/client/src/otel/index.ts
@@ -384,7 +384,7 @@ const shouldRecordRequest = (
 		return false
 	}
 
-	return shouldNetworkRequestBeTraced(url, tracingOrigins)
+	return shouldNetworkRequestBeTraced(url, tracingOrigins ?? [], urlBlocklist)
 }
 
 const assignDocumentDurations = (span: api.Span) => {


### PR DESCRIPTION
## Summary

* Apply the `urlBlocklist` as a denylist to the tracing logic to avoid adding `x-highlight-request` to blocked APIs in scenarios where it is easier to block out a list of URLs rather than include all in the `tracingOrigins`

## How did you test this change?

unit test

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
