### PR TITLE
address performance issues with canvas recording during snapshot

### DIFF
--- a/.changeset/bright-frogs-crash.md
+++ b/.changeset/bright-frogs-crash.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+fix full snapshot error when failing to starting rrweb recording

--- a/.changeset/hungry-peas-live.md
+++ b/.changeset/hungry-peas-live.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+improve canvas serialization performance and support shadow dom canvases

--- a/.changeset/rare-rocks-beam.md
+++ b/.changeset/rare-rocks-beam.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+fix rrweb replay breaking on invalid inlined css

--- a/__generated/rr/rrweb/rr.js
+++ b/__generated/rr/rrweb/rr.js
@@ -1002,12 +1002,8 @@ function serializeElementNode(n2, options) {
   }
   if (tagName === "canvas" && recordCanvas) {
     if (n2.__context === "2d") {
-      if (!is2DCanvasBlank(n2)) {
-        attributes.rr_dataURL = n2.toDataURL(
-          dataURLOptions.type,
-          dataURLOptions.quality
-        );
-      }
+      if (!is2DCanvasBlank(n2))
+        ;
     } else if (!("__context" in n2)) {
       const canvasDataURL = n2.toDataURL(
         dataURLOptions.type,
@@ -1115,7 +1111,9 @@ function serializeElementNode(n2, options) {
         height,
         rr_width: `${width}px`,
         rr_height: `${height}px`,
-        rr_inlined_video: true
+        rr_inlined_video: true,
+        class: attributes.class,
+        style: attributes.style
       };
       tagName = "canvas";
       const blankCanvas = doc.createElement("canvas");
@@ -2125,7 +2123,11 @@ function applyCssSplits(n2, cssText, hackCss, cache) {
     const childTextNode = childTextNodes[i2];
     const cssTextSection = cssTextSplits[i2];
     if (childTextNode && cssTextSection) {
-      childTextNode.textContent = hackCss ? adaptCssForReplay(cssTextSection, cache) : cssTextSection;
+      try {
+        childTextNode.textContent = hackCss ? adaptCssForReplay(cssTextSection, cache) : cssTextSection;
+      } catch (err) {
+        console.warn(`Highlight failed to set rrweb css ${err}`);
+      }
     }
   }
 }
@@ -7114,9 +7116,21 @@ var CanvasManager = class {
     let lastSnapshotTime = 0;
     let rafId;
     const elementFoundTime = /* @__PURE__ */ new Map();
+    const querySelectorAll2 = (node, selector) => {
+      const nodes = [];
+      node.querySelectorAll(selector).forEach((n2) => nodes.push(n2));
+      const nodeIterator = document.createNodeIterator(node, Node.ELEMENT_NODE);
+      let currentNode;
+      while (currentNode = nodeIterator.nextNode()) {
+        if (currentNode == null ? void 0 : currentNode.shadowRoot) {
+          nodes.push(...querySelectorAll2(currentNode.shadowRoot, selector));
+        }
+      }
+      return nodes;
+    };
     const getCanvas = (timestamp) => {
       const matchedCanvas = [];
-      win.document.querySelectorAll("canvas").forEach((canvas) => {
+      querySelectorAll2(win.document, "canvas").forEach((canvas) => {
         if (!isBlocked(canvas, blockClass, blockSelector, true)) {
           this.debug(canvas, "discovered canvas");
           matchedCanvas.push(canvas);
@@ -7131,7 +7145,7 @@ var CanvasManager = class {
     const getVideos = (timestamp) => {
       const matchedVideos = [];
       if (recordVideos) {
-        win.document.querySelectorAll("video").forEach((video) => {
+        querySelectorAll2(win.document, "video").forEach((video) => {
           if (video.src !== "" && video.src.indexOf("blob:") === -1)
             return;
           if (!isBlocked(video, blockClass, blockSelector, true)) {
@@ -7186,10 +7200,14 @@ var CanvasManager = class {
               actualHeight: video.videoHeight
             };
             const maxDim = Math.max(actualWidth, actualHeight);
-            if (video.width === 0 || video.height === 0 || actualWidth === 0 || actualHeight === 0 || boxWidth === 0 || boxHeight === 0) {
+            if (actualWidth === 0 || actualHeight === 0 || boxWidth === 0 || boxHeight === 0) {
               this.debug(video, "not yet ready", {
                 width: video.width,
-                height: video.height
+                height: video.height,
+                actualWidth,
+                actualHeight,
+                boxWidth,
+                boxHeight
               });
               return;
             }

--- a/__generated/rr/rrweb/rr.js
+++ b/__generated/rr/rrweb/rr.js
@@ -2198,7 +2198,13 @@ function buildNode(n2, options) {
           continue;
         } else if (tagName === "textarea" && name === "value") {
           node.appendChild(doc.createTextNode(value));
-          n2.childNodes = [];
+          try {
+            n2.childNodes = [];
+          } catch (err) {
+            console.warn(
+              `Highlight failed to set rrweb text area child nodes ${err}`
+            );
+          }
           continue;
         }
         try {

--- a/__generated/rr/rrweb/rr.js
+++ b/__generated/rr/rrweb/rr.js
@@ -7200,7 +7200,7 @@ var CanvasManager = class {
               actualHeight: video.videoHeight
             };
             const maxDim = Math.max(actualWidth, actualHeight);
-            if (actualWidth === 0 || actualHeight === 0 || boxWidth === 0 || boxHeight === 0) {
+            if (maxDim === 0) {
               this.debug(video, "not yet ready", {
                 width: video.width,
                 height: video.height,
@@ -8932,7 +8932,7 @@ var MediaManager = class {
   syncAllMediaElements(options = { pause: false }) {
     this.mediaMap.forEach((_mediaState, target) => {
       this.syncTargetWithState(target);
-      if (options.pause) {
+      if (options.pause && target.pause) {
         target.pause();
       }
     });

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -1402,6 +1402,10 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 	}
 
 	private takeFullSnapshot() {
+		if (!this._recordStop) {
+			this.logger.log(`skipping full snapshot as rrweb is not running`)
+			return
+		}
 		this.logger.log(`taking full snapshot`, {
 			bytesSinceSnapshot: this._eventBytesSinceSnapshot,
 			lastSnapshotTime: this._lastSnapshotTime,


### PR DESCRIPTION
## Summary

* Fixes video element recording and replay dimensions
* Improves performance issues with canvas recording during snapshot due to lack of resizing
* Support shadow DOM canvas element recording with efficient webworker serialization
See rrweb changes

Closes SUP-76

## How did you test this change?

https://preview.highlight.io/1/sessions/K2IaqbpSLUS8dTMOOTp7zPpVoiEZ?%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201J8G8RQTEMGG5CMPDXVYDR944%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22sup-123-performance-issues-with-canvas-recording-during-highlight%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D

https://app.highlight.io/56881/sessions/gQm9vhNqjSfocYU7gMSZGYtBL8is
https://app.highlight.io/56881/sessions/SAuoYsMJTkrHx8TrPamC6I7t3Q57

![Screenshot from 2024-09-23 15-28-38](https://github.com/user-attachments/assets/e19b12bf-809a-4361-a08e-df0c95c9d81e)


## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
