### PR TITLE
Upgrade go to v1.23.1

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/highlight-run/highlight/backend
 
-go 1.22.2
+go 1.23.1
 
 replace golang.org/x/crypto => golang.org/x/crypto v0.17.0
 

--- a/e2e/go/Dockerfile
+++ b/e2e/go/Dockerfile
@@ -1,9 +1,11 @@
 ARG IMAGE_BASE_NAME="ghcr.io/highlight/e2e:latest"
 FROM ${IMAGE_BASE_NAME}
 
+ARG GO_VERSION=1.23.1
+
 WORKDIR /opt/go
-RUN wget https://go.dev/dl/go1.23.0.linux-amd64.tar.gz
-RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.23.0.linux-amd64.tar.gz
+RUN wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz
+RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
 ENV PATH=/usr/local/go/bin:${PATH}
 
 WORKDIR /highlight/e2e/go

--- a/e2e/go/go.mod
+++ b/e2e/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/highlight/highlight/e2e/go
 
-go 1.22.2
+go 1.23.1
 
 replace github.com/highlight/highlight/sdk/highlight-go => ../../sdk/highlight-go
 

--- a/e2e/nextjs/go-service/go.mod
+++ b/e2e/nextjs/go-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/deltaespilon/distributed-tracing
 
-go 1.22.2
+go 1.23.1
 
 require (
 	github.com/go-chi/chi/v5 v5.0.12

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.22.2
+go 1.23.1
 
 use ./backend
 

--- a/sdk/highlight-go/go.mod
+++ b/sdk/highlight-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/highlight/highlight/sdk/highlight-go
 
-go 1.22.2
+go 1.23.1
 
 require (
 	github.com/99designs/gqlgen v0.17.45

--- a/sdk/highlightinc-highlight-datasource/go.mod
+++ b/sdk/highlightinc-highlight-datasource/go.mod
@@ -1,6 +1,6 @@
 module github.com/highlight/highlightinc-highlight-datasource
 
-go 1.22.2
+go 1.23.1
 
 require (
 	github.com/grafana/grafana-plugin-sdk-go v0.250.0

--- a/sdk/highlightinc-highlight-datasource/go.sum
+++ b/sdk/highlightinc-highlight-datasource/go.sum
@@ -40,6 +40,7 @@ github.com/elazarl/goproxy/ext v0.0.0-20220115173737-adb46da277ac h1:9yrT5tmn9Zc
 github.com/elazarl/goproxy/ext v0.0.0-20220115173737-adb46da277ac/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
+github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -87,6 +88,7 @@ github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/E
 github.com/gobwas/ws v1.2.1 h1:F2aeBZrm2NDsc7vbovKrWSogd4wvfAxg0FQ89/iqOTk=
 github.com/gobwas/ws v1.2.1/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/KY=
 github.com/goccy/go-json v0.10.3 h1:KZ5WoDbxAIgm2HNbYckL0se1fHD6rz5j4ywS6ebzDqA=
+github.com/goccy/go-json v0.10.3/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
@@ -373,7 +375,9 @@ gonum.org/v1/gonum v0.12.0/go.mod h1:73TDxJfAAHeA8Mk9mf8NlIppyhQNo5GLTcYeqgo2lvY
 google.golang.org/genproto/googleapis/api v0.0.0-20240822170219-fc7c04adadcd h1:BBOTEWLuuEGQy9n1y9MhVJ9Qt0BDu21X8qZs71/uPZo=
 google.golang.org/genproto/googleapis/api v0.0.0-20240822170219-fc7c04adadcd/go.mod h1:fO8wJzT2zbQbAjbIoos1285VfEIYKDDY+Dt+WpTkh6g=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 h1:pPJltXNxVzT4pK9yD8vR9X75DaWYYmLGMsEvBfFQZzQ=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1/go.mod h1:UqMtugtsSgubUsoxbuAoiCXvqvErP7Gf0so0mK9tHxU=
 google.golang.org/grpc v1.66.2 h1:3QdXkuq3Bkh7w+ywLdLvM56cmGvQHUMZpiCzt6Rqaoo=
+google.golang.org/grpc v1.66.2/go.mod h1:s3/l6xSSCURdVfAnL+TqCNMyTDAGN6+lZeVxnZR128Y=
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary

Was investigating [an error I was seeing locally](https://highlightcorp.slack.com/archives/C02CJANPHQS/p1727195920289109) running the backend and saw somewhere upgrading Go might resolve the issue. It does seem to have fixed my local build, and didn't see any harm in upgrading so thought I'd propose the change.

Also updates our Go E2E app to use the same version of Go as everywhere else.

## How did you test this change?

Local backend build using `make start` from `./backend` and then click tested locally. Also ran the go E2E app to ensure that worked too.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A