### PR TITLE
Fix all sessions for user link

### DIFF
--- a/frontend/src/pages/Player/MetadataBox/MetadataBox.tsx
+++ b/frontend/src/pages/Player/MetadataBox/MetadataBox.tsx
@@ -17,9 +17,9 @@ import {
 import usePlayerConfiguration from '@pages/Player/PlayerHook/utils/usePlayerConfiguration'
 import { sessionIsBackfilled } from '@pages/Player/utils/utils'
 import {
-	getDisplayName,
 	getDisplayNameAndField,
 	getIdentifiedUserProfileImage,
+	getIdentifier,
 } from '@pages/Sessions/SessionsFeedV3/MinimalSessionCard/utils/utils'
 import { useParams } from '@util/react-router/useParams'
 import { copyToClipboard, validateEmail } from '@util/string'
@@ -41,6 +41,7 @@ import { RelatedResourceButtons } from '@/pages/Player/MetadataBox/RelatedResour
 import { useReplayerContext } from '../ReplayerContext'
 import * as style from './MetadataBox.css'
 import { getAbsoluteUrl, getMajorVersion } from './utils/utils'
+import { quoteQueryValue } from '@/components/Search/SearchForm/utils'
 
 export const MetadataBox = React.memo(() => {
 	const { session_secure_id } = useParams<{ session_secure_id: string }>()
@@ -198,17 +199,15 @@ export const MetadataBox = React.memo(() => {
 
 		let newQueryParts = []
 		if (session.identified) {
-			const displayName = getDisplayName(session)
-			const userParam = validateEmail(displayName)
-				? 'email'
-				: 'identifier'
+			const identifier = getIdentifier(session)
+			const userParam = validateEmail(identifier) ? 'email' : 'identifier'
 
 			newQueryParts = queryParts.filter((part) => part.key !== userParam)
 			newQueryParts.push({
 				key: userParam,
 				operator: '=',
-				value: displayName,
-				text: `${userParam}=${displayName}`,
+				value: identifier,
+				text: `${userParam}=${quoteQueryValue(identifier)}`,
 			} as SearchExpression)
 		} else {
 			newQueryParts = queryParts.filter(

--- a/frontend/src/pages/Player/MetadataBox/MetadataBox.tsx
+++ b/frontend/src/pages/Player/MetadataBox/MetadataBox.tsx
@@ -19,10 +19,10 @@ import { sessionIsBackfilled } from '@pages/Player/utils/utils'
 import {
 	getDisplayNameAndField,
 	getIdentifiedUserProfileImage,
-	getIdentifier,
+	getUserProperties,
 } from '@pages/Sessions/SessionsFeedV3/MinimalSessionCard/utils/utils'
 import { useParams } from '@util/react-router/useParams'
-import { copyToClipboard, validateEmail } from '@util/string'
+import { copyToClipboard } from '@util/string'
 import clsx from 'clsx'
 import { capitalize } from 'lodash'
 import React, { useCallback, useEffect, useMemo } from 'react'
@@ -199,15 +199,23 @@ export const MetadataBox = React.memo(() => {
 
 		let newQueryParts = []
 		if (session.identified) {
-			const identifier = getIdentifier(session)
-			const userParam = validateEmail(identifier) ? 'email' : 'identifier'
+			const { email } = getUserProperties(session.user_properties)
+			const { identifier } = session
 
-			newQueryParts = queryParts.filter((part) => part.key !== userParam)
+			if (!email && !identifier) {
+				return
+			}
+
+			const { key, value } = email
+				? { key: 'email', value: email }
+				: { key: 'identifier', value: identifier }
+
+			newQueryParts = queryParts.filter((part) => part.key !== key)
 			newQueryParts.push({
-				key: userParam,
+				key,
 				operator: '=',
-				value: identifier,
-				text: `${userParam}=${quoteQueryValue(identifier)}`,
+				value,
+				text: `${key}=${quoteQueryValue(value)}`,
 			} as SearchExpression)
 		} else {
 			newQueryParts = queryParts.filter(

--- a/frontend/src/pages/Sessions/SessionsFeedV3/MinimalSessionCard/utils/utils.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/MinimalSessionCard/utils/utils.ts
@@ -65,19 +65,3 @@ export const getDisplayName = (
 ): string => {
 	return getDisplayNameAndField(session)[0]
 }
-
-export const getIdentifier = (
-	session?: Maybe<SessionWithIdentityInformation>,
-): string => {
-	const userProperties = getUserProperties(session?.user_properties)
-
-	if (userProperties?.email) {
-		return userProperties?.email
-	} else if (session?.identifier && session.identifier !== 'null') {
-		return session.identifier
-	} else if (session?.fingerprint) {
-		return `${session?.fingerprint}`
-	} else {
-		return 'unidentified'
-	}
-}

--- a/frontend/src/pages/Sessions/SessionsFeedV3/MinimalSessionCard/utils/utils.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/MinimalSessionCard/utils/utils.ts
@@ -65,3 +65,19 @@ export const getDisplayName = (
 ): string => {
 	return getDisplayNameAndField(session)[0]
 }
+
+export const getIdentifier = (
+	session?: Maybe<SessionWithIdentityInformation>,
+): string => {
+	const userProperties = getUserProperties(session?.user_properties)
+
+	if (userProperties?.email) {
+		return userProperties?.email
+	} else if (session?.identifier && session.identifier !== 'null') {
+		return session.identifier
+	} else if (session?.fingerprint) {
+		return `${session?.fingerprint}`
+	} else {
+		return 'unidentified'
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the link to see all sessions for a user by:

1. Updating the logic for finding the identifier
2. Ensure values are quoted if necessary (had some users saying their identifier was first/last name including spaces)

## How did you test this change?

Click tested locally and in PR preview by:

1. Going to a session
2. Opening the user metadata panel
3. Clicking the "Sessions >" button
4. Confirming results look correct in the sidebar with the filters applied

I tested this on some of our project's settings and on the session that was reported as problematic (see Linear ticket for details).

## Are there any deployment considerations?

N/A - just need to report back to users who have said this isn't working.

## Does this work require review from our design team?

N/A