### PR TITLE
fix errors sort order

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5311,7 +5311,6 @@ func (r *queryResolver) ErrorGroups(ctx context.Context, projectID int, count in
 		Joins("ErrorTag").
 		Where("error_groups.id in ?", ids).
 		Where("error_groups.project_id = ?", project.ID).
-		Order("error_groups.updated_at DESC").
 		Find(&results).Error; err != nil {
 		return nil, err
 	}
@@ -5321,6 +5320,18 @@ func (r *queryResolver) ErrorGroups(ctx context.Context, projectID int, count in
 			return nil, err
 		}
 	}
+
+	// Sort results by LastOccurrence, descending
+	sort.Slice(results, func(i, j int) bool {
+		var timeA, timeB time.Time
+		if results[i].LastOccurrence != nil {
+			timeA = *results[i].LastOccurrence
+		}
+		if results[j].LastOccurrence != nil {
+			timeB = *results[j].LastOccurrence
+		}
+		return timeA.After(timeB)
+	})
 
 	return &model.ErrorResults{
 		ErrorGroups: lo.Map(results, func(eg *model.ErrorGroup, idx int) model.ErrorGroup { return *eg }),


### PR DESCRIPTION
## Summary
- after clickhouse query, there was also an order by for the sql query
- remove that and replace with in-memory sort according to `LastOccurrence`
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
