### PR TITLE
cleanup raw events as part of session deletion job

### DIFF
--- a/backend/lambda-functions/deleteSessions/handlers/handlers.go
+++ b/backend/lambda-functions/deleteSessions/handlers/handlers.go
@@ -219,7 +219,6 @@ func (h *handlers) DeleteSessions(ctx context.Context, projectId int, startDate 
 
 	if err := h.storageClient.CleanupRawEvents(ctx, projectId); err != nil {
 		log.WithContext(ctx).Error(err)
-		return
 	}
 
 	if len(batches) == 0 {

--- a/backend/lambda-functions/deleteSessions/handlers/handlers.go
+++ b/backend/lambda-functions/deleteSessions/handlers/handlers.go
@@ -217,6 +217,11 @@ func (h *handlers) DeleteSessions(ctx context.Context, projectId int, startDate 
 		return
 	}
 
+	if err := h.storageClient.CleanupRawEvents(ctx, projectId); err != nil {
+		log.WithContext(ctx).Error(err)
+		return
+	}
+
 	if len(batches) == 0 {
 		log.WithContext(ctx).Warnf("SessionDeleteJob - no sessions to delete for projectId %d, continuing", projectId)
 		return

--- a/backend/storage/storage.go
+++ b/backend/storage/storage.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -53,8 +54,9 @@ var (
 )
 
 const (
-	MIME_TYPE_JSON          = "application/json"
-	CONTENT_ENCODING_BROTLI = "br"
+	MIME_TYPE_JSON           = "application/json"
+	CONTENT_ENCODING_BROTLI  = "br"
+	RAW_EVENT_RETENTION_DAYS = 1
 )
 
 type PayloadType string
@@ -99,6 +101,7 @@ type Client interface {
 	ReadGitHubFile(ctx context.Context, repoPath string, fileName string, version string) ([]byte, error)
 	PushGitHubFile(ctx context.Context, repoPath string, fileName string, version string, fileBytes []byte) (*int64, error)
 	DeleteSessionData(ctx context.Context, projectId int, sessionId int) error
+	CleanupRawEvents(ctx context.Context, projectId int) error
 }
 
 type FilesystemClient struct {
@@ -515,6 +518,37 @@ func (s *S3Client) DeleteSessionData(ctx context.Context, projectId int, session
 		}
 	}
 
+	return nil
+}
+
+func (f *FilesystemClient) CleanupRawEvents(ctx context.Context, projectId int) error {
+	if f.fsRoot == "" {
+		return errors.New("f.fsRoot cannot be empty")
+	}
+
+	basePath := fmt.Sprintf("%s/raw-events/%d", f.fsRoot, projectId)
+	startDate := time.Now().AddDate(0, 0, -1*RAW_EVENT_RETENTION_DAYS)
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		fileInfo, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if fileInfo.ModTime().Before(startDate) {
+			os.RemoveAll(path.Join(basePath, entry.Name()))
+		}
+	}
+
+	return nil
+}
+
+func (f *S3Client) CleanupRawEvents(ctx context.Context, projectId int) error {
 	return nil
 }
 

--- a/backend/storage/storage.go
+++ b/backend/storage/storage.go
@@ -529,6 +529,9 @@ func (f *FilesystemClient) CleanupRawEvents(ctx context.Context, projectId int) 
 	basePath := fmt.Sprintf("%s/raw-events/%d", f.fsRoot, projectId)
 	startDate := time.Now().AddDate(0, 0, -1*RAW_EVENT_RETENTION_DAYS)
 	entries, err := os.ReadDir(basePath)
+	if os.IsNotExist(err) {
+		return nil
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- enforces raw event cleanup by removing any folders in the `raw-events` directory > 1 day old
- applies only when the `SESSION_RETENTION_DAYS` env var is set
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran locally + debugged
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
