### PR TITLE
Hide mouse cursor until replayer is ready

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6059,6 +6059,9 @@ body {
   position: relative;
   width: 100%;
 }
+.hide-mouse-cursor .replayer-mouse {
+  display: none;
+}
 ._1gpgayi5 iframe {
   border-radius: 4px;
   border: var(--_1pyqka9k) solid 1px;

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -40,6 +40,7 @@ import {
 } from '@pages/Player/SessionLevelBar/utils/utils'
 import {
 	customEvent,
+	IncrementalSource,
 	metaEvent,
 	playerMetaData,
 	SessionInterval,
@@ -576,6 +577,24 @@ const initReplayer = (
 			warn: throttle(console.warn, 100),
 		},
 	})
+
+	// Hide the mouse cursor until we get a movement event and know where to place it.
+	playerMountingRoot.classList.add('hide-mouse-cursor')
+	const mouseMoveEvents = [
+		IncrementalSource.MouseMove,
+		IncrementalSource.TouchMove,
+		IncrementalSource.Drag,
+	]
+	const castEventHandler = (event: any) => {
+		const source = event.data.source
+		const isMouseMove = mouseMoveEvents.includes(source)
+
+		if (isMouseMove) {
+			playerMountingRoot.classList.remove('hide-mouse-cursor')
+			s.replayer?.off('event-cast', castEventHandler)
+		}
+	}
+	s.replayer.on('event-cast', castEventHandler)
 
 	s.browserExtensionScriptURLs = getBrowserExtensionScriptURLs(events)
 

--- a/frontend/src/pages/Player/styles.css.ts
+++ b/frontend/src/pages/Player/styles.css.ts
@@ -53,6 +53,10 @@ export const rrwebPlayerWrapper = style({
 	width: '100%',
 })
 
+globalStyle('.hide-mouse-cursor .replayer-mouse', {
+	display: 'none',
+})
+
 export const rrwebInnerWrapper = style({})
 globalStyle(`${rrwebInnerWrapper} iframe`, {
 	borderRadius: 4,

--- a/frontend/src/pages/Player/utils/utils.ts
+++ b/frontend/src/pages/Player/utils/utils.ts
@@ -157,18 +157,6 @@ export const useResizePlayer = (
 		setScale(scale)
 	}, [playerWrapperRef, replayer?.wrapper, setScale, viewport])
 
-	// This adjusts the dimensions (i.e. scale()) of the iframe when the page loads.
-	useEffect(() => {
-		const i = window.setInterval(() => {
-			if (replayer && resizePlayer()) {
-				clearInterval(i)
-			}
-		}, 1000 / 15)
-		return () => {
-			i && clearInterval(i)
-		}
-	}, [resizePlayer, replayer])
-
 	// On any change to replayer, 'sizes', refresh the size of the player.
 	useEffect(() => {
 		replayer && resizePlayer()

--- a/frontend/src/pages/Player/utils/utils.ts
+++ b/frontend/src/pages/Player/utils/utils.ts
@@ -5,6 +5,7 @@ import useResizeAware from 'react-resize-aware'
 import { Replayer } from 'rrweb'
 
 import * as playerStyles from '@/pages/Player/styles.css'
+import { useReplayerContext } from '@/pages/Player/ReplayerContext'
 
 export enum SessionPageSearchParams {
 	/** Automatically sets the date range for the current segment based on the value. */
@@ -121,6 +122,7 @@ export const useResizePlayer = (
 	playerWrapperRef: React.RefObject<HTMLDivElement>,
 	setScale: React.Dispatch<React.SetStateAction<number>>,
 ) => {
+	const { viewport } = useReplayerContext()
 	const [centerColumnResizeListener, centerColumnSize] = useResizeAware()
 	const [resizeListener, sizes] = useResizeAware()
 
@@ -131,66 +133,54 @@ export const useResizePlayer = (
 			)
 		: 0
 
-	const resizePlayer = useCallback(
-		(replayer: Replayer): boolean => {
-			const width = replayer?.wrapper?.getBoundingClientRect().width
-			const height = replayer?.wrapper?.getBoundingClientRect().height
-			const targetWidth = playerWrapperRef.current?.clientWidth
-			const targetHeight = playerWrapperRef.current?.clientHeight
-			if (!targetWidth || !targetHeight) {
-				return false
+	const resizePlayer = useCallback((): void => {
+		const { width, height } = viewport ?? {}
+		const targetWidth = playerWrapperRef.current?.clientWidth
+		const targetHeight = playerWrapperRef.current?.clientHeight
+		if (!targetWidth || !targetHeight || !width || !height) {
+			return
+		}
+
+		const widthScale = (targetWidth - playerStyles.PLAYER_PADDING_X) / width
+		const heightScale =
+			(targetHeight - playerStyles.PLAYER_PADDING_Y) / height
+		const scale = Math.min(heightScale, widthScale)
+
+		if (scale <= 0 || !Number.isFinite(scale)) {
+			return
+		}
+
+		replayer?.wrapper?.setAttribute(
+			'style',
+			`transform: scale(${scale}) translate(-50%, -50%)`,
+		)
+		setScale(scale)
+	}, [playerWrapperRef, replayer?.wrapper, setScale, viewport])
+
+	// This adjusts the dimensions (i.e. scale()) of the iframe when the page loads.
+	useEffect(() => {
+		const i = window.setInterval(() => {
+			if (replayer && resizePlayer()) {
+				clearInterval(i)
 			}
-			const widthScale =
-				(targetWidth - playerStyles.PLAYER_PADDING_X) / width
-			const heightScale =
-				(targetHeight - playerStyles.PLAYER_PADDING_Y) / height
-			let scale = Math.min(heightScale, widthScale)
-			// If calculated scale is close enough to 1, return to avoid
-			// infinite looping caused by small floating point math differences
-			if (scale >= 0.9999 && scale <= 1.0001) {
-				return false
-			}
-
-			let retry = false
-			if (scale <= 0 || !Number.isFinite(scale)) {
-				retry = true
-				scale = 1
-			}
-
-			setScale((s) => {
-				const replayerScale = s * scale
-
-				replayer?.wrapper?.setAttribute(
-					'style',
-					`transform: scale(${replayerScale}) translate(-50%, -50%)`,
-				)
-				replayer?.wrapper?.setAttribute(
-					'class',
-					`replayer-wrapper ${playerStyles.rrwebInnerWrapper}`,
-				)
-
-				return replayerScale
-			})
-			return !retry
-		},
-		[playerWrapperRef, setScale],
-	)
-
-	const playerBoundingClientRectWidth =
-		replayer?.wrapper?.getBoundingClientRect().width
-	const playerBoundingClientRectHeight =
-		replayer?.wrapper?.getBoundingClientRect().height
+		}, 1000 / 15)
+		return () => {
+			i && clearInterval(i)
+		}
+	}, [resizePlayer, replayer])
 
 	// On any change to replayer, 'sizes', refresh the size of the player.
 	useEffect(() => {
-		replayer && resizePlayer(replayer)
+		replayer && resizePlayer()
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [
-		sizes,
-		replayer,
-		playerBoundingClientRectWidth,
-		playerBoundingClientRectHeight,
-	])
+	}, [sizes, replayer, viewport?.width, viewport?.height])
+
+	useEffect(() => {
+		replayer?.wrapper?.setAttribute(
+			'class',
+			`replayer-wrapper ${playerStyles.rrwebInnerWrapper}`,
+		)
+	}, [replayer?.wrapper])
 
 	return {
 		resizeListener,


### PR DESCRIPTION
## Summary

Fixes an issue where the mouse would be shown initially very large and in the center of the replayer, then reposition to the top left corner once the replayer's size was adjusted. This PR hides the cursor until we get a mouse event that which contains positioning data for the mouse to display it in the correct spot on the replayer.

## How did you test this change?

* On production, view a session and click around playing different sessions. Note the flicker on the replayer where you see the cursor incorrectly positioned briefly.
* Perform the same test on the PR preview and ensure the behavior looks better.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A