### PR TITLE
Update select options

### DIFF
--- a/packages/ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/src/components/Select/Select.stories.tsx
@@ -145,6 +145,40 @@ const users: User[] = OPTIONS.map((name, i) => ({
 	name,
 	value: i + 1,
 }))
+export const SingleSelectDynamicOptionsAndCustomTypes = () => {
+	const [options, setOptions] = useState<User[]>(users)
+	const [value, setValue] = useState<User>()
+
+	return (
+		<Stack gap="10">
+			<pre style={{ whiteSpace: 'pre-wrap' }}>
+				{JSON.stringify(options)}
+			</pre>
+
+			<Select<User>
+				value={value}
+				options={options}
+				placeholder="Select a user..."
+				onValueChange={(newValue) => {
+					setValue(newValue)
+				}}
+			/>
+
+			<Button
+				onClick={() => {
+					const number = options.length + 1
+					setOptions((prev) => [
+						...prev,
+						{ name: `New User ${number}`, value: number },
+					])
+				}}
+			>
+				Add Option
+			</Button>
+		</Stack>
+	)
+}
+
 export const DynamicOptionsAndCustomTypes = () => {
 	const [options, setOptions] = useState<User[]>(users)
 	const [value, setValue] = useState<User[]>([])

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -245,18 +245,24 @@ export const Select = <T,>({
 			const { value } = store.getState()
 			let newOptions = valueToOptions(optionsProp) as SelectOption[]
 
-			if (Array.isArray(newOptions) && Array.isArray(value)) {
-				const missingOptions = value
-					.filter(
-						(v) =>
-							!newOptions.some((option) =>
-								optionsMatch(option, v),
-							),
-					)
-					.map((v) => ({ name: v, value: v }))
+			if (Array.isArray(newOptions)) {
+				if (Array.isArray(value)) {
+					const missingOptions = value
+						.filter(
+							(v) =>
+								!newOptions.some((option) =>
+									optionsMatch(option, v),
+								),
+						)
+						.map((v) => ({ name: v, value: v }))
 
-				if (missingOptions.length) {
-					newOptions = [...newOptions, ...missingOptions]
+					if (missingOptions.length) {
+						newOptions = [...newOptions, ...missingOptions]
+					}
+				} else if (
+					!newOptions.some((option) => optionsMatch(option, value))
+				) {
+					newOptions = [...newOptions, { name: value, value }]
 				}
 
 				setOptions(newOptions)


### PR DESCRIPTION
## Summary
We only update the options state when the select is a multiselect. Move the `setOptions` out of the value array check.

Note: also adds created value to options for non-array case

## How did you test this change?
1. Start story book
2. Naviage to the `[Single Select Dynamic Options And Custom Types](http://localhost:6006/?path=/story/components-select--single-select-dynamic-options-and-custom-types)` select
- [ ] Able to select added option

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
