### PR TITLE
Some small fixes

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsoleTable/index.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsoleTable/index.tsx
@@ -44,6 +44,10 @@ import { SearchExpression } from '@/components/Search/Parser/listener'
 import { LogEdge } from '@/graph/generated/schemas'
 import { LogDetails } from '@/pages/LogsPage/LogsTable/LogDetails'
 import { THROTTLED_UPDATE_MS } from '@/pages/Player/PlayerHook/PlayerState'
+import {
+	ReplayerState,
+	useReplayerContext,
+} from '@/pages/Player/ReplayerContext'
 import analytics from '@/util/analytics'
 
 import * as styles from './style.css'
@@ -135,6 +139,8 @@ const ConsoleTableInner = ({
 	loadingAfter,
 	fetchMoreWhenScrolled,
 }: ConsoleTableInnerProps) => {
+	const { state } = useReplayerContext()
+
 	const bodyRef = useRef<HTMLDivElement>(null)
 	const [expanded, setExpanded] = useState<ExpandedState>({})
 
@@ -278,10 +284,15 @@ const ConsoleTableInner = ({
 	)
 
 	useEffect(() => {
-		if (autoScroll && lastActiveLogIndex >= 0 && !!logEdges.length) {
+		if (
+			autoScroll &&
+			state === ReplayerState.Playing &&
+			lastActiveLogIndex >= 0 &&
+			!!logEdges.length
+		) {
 			scrollFunction(lastActiveLogIndex)
 		}
-	}, [lastActiveLogIndex, logEdges, scrollFunction, autoScroll])
+	}, [lastActiveLogIndex, logEdges, scrollFunction, autoScroll, state])
 
 	return (
 		<Table height="full" noBorder>

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -260,6 +260,7 @@ export const Select = <T,>({
 						newOptions = [...newOptions, ...missingOptions]
 					}
 				} else if (
+					!!value &&
 					!newOptions.some((option) => optionsMatch(option, value))
 				) {
 					newOptions = [...newOptions, { name: value, value }]


### PR DESCRIPTION
## Summary
1. Don't autoscroll when player is paused
2. Don't add blank items to select list

![Screenshot 2024-09-27 at 12 27 32 PM](https://github.com/user-attachments/assets/e0dd8551-29a2-416a-83eb-f01eca3f90c6)

## How did you test this change?
1. View a session's logs with autscroll
- [ ] Autoscroll does not jump when player is paused
2. Create new user
- [ ] No blank options on selects on About me page

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
