### PR TITLE
Create new event keys

### DIFF
--- a/backend/clickhouse/migrations/000122_create_event_key_values_new.down.sql
+++ b/backend/clickhouse/migrations/000122_create_event_key_values_new.down.sql
@@ -1,0 +1,1 @@
+DROP Table IF EXISTS event_key_values_new

--- a/backend/clickhouse/migrations/000122_create_event_key_values_new.up.sql
+++ b/backend/clickhouse/migrations/000122_create_event_key_values_new.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS event_key_values_new (
+    `ProjectId` Int32,
+    `Event` LowCardinality(String),
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) ENGINE = SummingMergeTree
+ORDER BY (ProjectId, Event, Key, Day, Value);

--- a/backend/clickhouse/migrations/000123_create_event_keys_new.down.sql
+++ b/backend/clickhouse/migrations/000123_create_event_keys_new.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS event_keys_new;

--- a/backend/clickhouse/migrations/000123_create_event_keys_new.up.sql
+++ b/backend/clickhouse/migrations/000123_create_event_keys_new.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS event_keys_new (
+    `ProjectId` Int32,
+    `Event` LowCardinality(String),
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Count` UInt64,
+    `Type` String
+) ENGINE = SummingMergeTree
+ORDER BY (ProjectId, Event, Key, Day);

--- a/backend/clickhouse/migrations/000124_create_event_keys_new_mv.down.sql
+++ b/backend/clickhouse/migrations/000124_create_event_keys_new_mv.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS event_keys_mv;

--- a/backend/clickhouse/migrations/000124_create_event_keys_new_mv.up.sql
+++ b/backend/clickhouse/migrations/000124_create_event_keys_new_mv.up.sql
@@ -1,0 +1,24 @@
+CREATE MATERIALIZED VIEW IF NOT EXISTS event_keys_new_mv TO event_keys_new (
+    `ProjectId` Int32,
+    `Event` LowCardinality(String),
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Type` LowCardinality(String),
+    `Count` UInt64
+) AS
+SELECT ProjectId,
+    Event,
+    Key,
+    Day,
+    if(
+        isNull(toFloat64OrNull(Value)),
+        'String',
+        'Numeric'
+    ) AS Type,
+    sum(Count) AS Count
+FROM event_key_values_new
+GROUP BY ProjectId,
+    Event,
+    Key,
+    Day,
+    Type;

--- a/backend/clickhouse/migrations/000125_create_event_attributes_new_mv.down.sql
+++ b/backend/clickhouse/migrations/000125_create_event_attributes_new_mv.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS event_attributes_new_mv;

--- a/backend/clickhouse/migrations/000125_create_event_attributes_new_mv.up.sql
+++ b/backend/clickhouse/migrations/000125_create_event_attributes_new_mv.up.sql
@@ -1,0 +1,43 @@
+CREATE MATERIALIZED VIEW IF NOT EXISTS event_attributes_new_mv TO event_key_values_new (
+    `ProjectId` UInt32,
+    `Event` String,
+    `Key` String,
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) AS
+SELECT ProjectID AS ProjectId,
+    Event,
+    arrayJoin(Attributes).1 AS Key,
+    toStartOfDay(Timestamp) AS Day,
+    arrayJoin(Attributes).2 AS Value,
+    count() AS Count
+FROM session_events
+WHERE (
+        Key NOT IN (
+            'browser_name',
+            'browser_version',
+            'city',
+            'country',
+            'environment',
+            'event',
+            'first_session',
+            'identified',
+            'identifier',
+            'ip',
+            'os_name',
+            'os_version',
+            'secure_session_id',
+            'service_version',
+            'session_active_length',
+            'session_length',
+            'session_pages_visited',
+            'state'
+        )
+    )
+    AND (Value != '')
+GROUP BY ProjectId,
+    Event,
+    Key,
+    Day,
+    Value;

--- a/backend/clickhouse/migrations/000126_write_event_event_name_new.down.sql
+++ b/backend/clickhouse/migrations/000126_write_event_event_name_new.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS event_event_name_new_mv;

--- a/backend/clickhouse/migrations/000126_write_event_event_name_new.up.sql
+++ b/backend/clickhouse/migrations/000126_write_event_event_name_new.up.sql
@@ -1,0 +1,21 @@
+CREATE MATERIALIZED VIEW IF NOT EXISTS event_event_name_new_mv TO event_key_values_new (
+    `ProjectId` Int32,
+    `Event` String,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) AS
+SELECT ProjectID as ProjectId,
+    Event,
+    'event' AS Key,
+    toStartOfDay(Timestamp) AS Day,
+    Event AS Value,
+    count() AS Count
+FROM session_events
+WHERE (Event != '')
+GROUP BY ProjectId,
+    Event,
+    Key,
+    Day,
+    Value;

--- a/backend/clickhouse/migrations/000127_write_event_session_fields_new.down.sql
+++ b/backend/clickhouse/migrations/000127_write_event_session_fields_new.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS event_session_fields_new_mv;

--- a/backend/clickhouse/migrations/000127_write_event_session_fields_new.up.sql
+++ b/backend/clickhouse/migrations/000127_write_event_session_fields_new.up.sql
@@ -1,0 +1,35 @@
+CREATE MATERIALIZED VIEW IF NOT EXISTS event_session_fields_new_mv TO event_key_values_new (
+    `ProjectId` Int32,
+    `Event` String,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) AS
+SELECT ProjectID as ProjectId,
+    '' AS Event,
+    Name AS Key,
+    toStartOfDay(SessionCreatedAt) AS Day,
+    Value AS Value,
+    count() AS Count
+FROM fields
+WHERE (
+    Name in (
+        'browser_name',
+        'browser_version',
+        'city',
+        'country',
+        'environment',
+        'identifier',
+        'ip',
+        'os_name',
+        'os_version',
+        'secure_session_id',
+        'service_version'
+    )
+)
+GROUP BY ProjectId,
+    Event,
+    Key,
+    Day,
+    Value;


### PR DESCRIPTION
## Summary
We want to be able to fetch key and value recommendations based on the event name. Recreate the tables adding an `Event` column.

## How did you test this change?
See follow up PR: https://github.com/highlight/highlight/pull/9400

https://www.loom.com/share/17eb2f77a4ed4ab4aa24a9b090735b80?sid=66db46e6-550e-41d8-bb1a-5a777e95e370

## Are there any deployment considerations?
Delete old tables and views after deployment in follow up

## Does this work require review from our design team?
N/A
