### PR TITLE
Clean up Hubspot tracking and dup title tags

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -84,7 +84,6 @@
 		/>
 		<meta property="twitter:image" content="/hero.png" />
 
-		<title>highlight.io</title>
 		<!-- Google Tag Manager -->
 		<script type="module" src="./src/gtm.js" defer></script>
 		<!-- End Google Tag Manager -->
@@ -104,6 +103,7 @@
 		<script type="module" src="./src/canny.js" defer></script>
 		<script type="module" src="./src/index.tsx" defer></script>
 	</head>
+
 	<body class="highlight-light-theme">
 		<!-- Google Tag Manager (noscript) -->
 		<noscript

--- a/highlight.io/pages/_app.tsx
+++ b/highlight.io/pages/_app.tsx
@@ -37,10 +37,6 @@ function MyApp({ Component, pageProps }: AppProps) {
 	return (
 		<>
 			<Head>
-				<title>
-					highlight.io: The open source monitoring platform.
-				</title>
-
 				<link
 					rel="preconnect"
 					href="https://fonts.googleapis.com"

--- a/highlight.io/pages/_document.js
+++ b/highlight.io/pages/_document.js
@@ -75,13 +75,6 @@ class HighlightDocument extends Document {
     reb2b.SNIPPET_VERSION = "1.0.1";reb2b.load("Y4O7Z0HY8PNX");}();
 						`}
 					</Script>
-					<Script
-						type="text/javascript"
-						id="hs-script-loader"
-						async
-						defer
-						src="//js.hs-scripts.com/20473940.js"
-					></Script>
 				</Head>
 				<body style={{ overflowX: 'hidden' }}>
 					<Main />


### PR DESCRIPTION
## Summary

Cleans up a couple things on our main app and website templates:

* Removes a duplicate Hubspot tracking script from the marketing site
* Removes duplicate `<title>` tags on both the marketing site and app
* Formats the templates using Prettier

## How did you test this change?

Click tested the main app the marketing site in local previews. Ensured the Hubspot script was being loaded correctly.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A