### PR TITLE
Write events to clickhouse async

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -318,7 +318,7 @@ func (r *Resolver) CreateSessionEvents(ctx context.Context, sessionID int, event
 		})
 	}
 
-	err := r.Clickhouse.BatchWriteSessionEventRows(ctxW, sessionEvents)
+	err := r.Clickhouse.WriteSessionEventRows(ctxW, sessionEvents)
 	if err != nil {
 		return e.Wrap(err, "error writing session events to clickhouse")
 	}


### PR DESCRIPTION
## Summary
Issue in Clickhouse with too many parts from inserting session events. Update this to write async to avoid too many writes.

## How did you test this change?
1. Start a session
2. Look at the events on clickhouse
- [ ] Events processing correctly

## Are there any deployment considerations?
Keep an eye on parts

## Does this work require review from our design team?
N/A
