### PR TITLE
Fix trace redirection loop

### DIFF
--- a/frontend/src/pages/Traces/TracesPage.tsx
+++ b/frontend/src/pages/Traces/TracesPage.tsx
@@ -61,6 +61,10 @@ import analytics from '@/util/analytics'
 import { formatNumber } from '@/util/numbers'
 
 import * as styles from './TracesPage.css'
+import {
+	DEMO_PROJECT_ID,
+	DEMO_WORKSPACE_PROXY_APPLICATION_ID,
+} from '@/components/DemoWorkspaceButton/DemoWorkspaceButton'
 
 export type TracesOutletContext = Partial<Trace>[]
 
@@ -243,8 +247,13 @@ export const TracesPage: React.FC = () => {
 
 	useEffect(() => {
 		if (!resource) {
+			const redirectProjectId =
+				projectId === DEMO_PROJECT_ID
+					? DEMO_WORKSPACE_PROXY_APPLICATION_ID
+					: projectId
+
 			navigate({
-				pathname: `/${projectId}/traces`,
+				pathname: `/${redirectProjectId}/traces`,
 				search: location.search,
 			})
 		}


### PR DESCRIPTION
## Summary
The traces page on demo is looping in redirects causing lots of network requests to be sent and cancelled. Fix the use effect to no longer loop.

## How did you test this change?
1. Visit the demo traces page (`/demo/traces`)
- [ ] No redirection loops

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A