### PR TITLE
Fix width of graphing combobox dropdown

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6620,6 +6620,9 @@ body {
 ._7o1fd82 {
   line-height: 24px;
 }
+._7o1fd83 {
+  max-width: 280px;
+}
 ._11t98zr0 {
   border-bottom: var(--_1pyqka9k) solid 1px;
 }

--- a/frontend/src/__generated/ve/pages/Graphing/Combobox/styles.css.js
+++ b/frontend/src/__generated/ve/pages/Graphing/Combobox/styles.css.js
@@ -1,9 +1,11 @@
 // src/pages/Graphing/Combobox/styles.css.ts
 var combobox = "_7o1fd80";
+var comboboxPopover = "_7o1fd83";
 var comboboxText = "_7o1fd82";
 var comboboxWrapper = "_7o1fd81";
 export {
   combobox,
+  comboboxPopover,
   comboboxText,
   comboboxWrapper
 };

--- a/frontend/src/pages/Graphing/Combobox/index.tsx
+++ b/frontend/src/pages/Graphing/Combobox/index.tsx
@@ -105,6 +105,7 @@ export const Combobox: React.FC<Props> = ({
 			onChangeQuery={setQuery}
 			cssClass={style.combobox}
 			wrapperCssClass={style.comboboxWrapper}
+			popoverCssClass={style.comboboxPopover}
 			queryPlaceholder="Filter..."
 			disabled={disabled}
 		/>

--- a/frontend/src/pages/Graphing/Combobox/styles.css.ts
+++ b/frontend/src/pages/Graphing/Combobox/styles.css.ts
@@ -13,3 +13,7 @@ export const comboboxWrapper = style({
 export const comboboxText = style({
 	lineHeight: '24px',
 })
+
+export const comboboxPopover = style({
+	maxWidth: 280,
+})

--- a/frontend/src/pages/Graphing/EventSelection/ClickFilters.tsx
+++ b/frontend/src/pages/Graphing/EventSelection/ClickFilters.tsx
@@ -183,6 +183,7 @@ export const ClickFilters: React.FC<Props> = ({
 						onChangeQuery={setClickQuery}
 						cssClass={comboBoxStyle.combobox}
 						wrapperCssClass={comboBoxStyle.comboboxWrapper}
+						popoverCssClass={comboBoxStyle.comboboxPopover}
 						queryPlaceholder="Filter..."
 						creatableRender={(value) => (
 							<Text cssClass={comboBoxStyle.comboboxText}>

--- a/frontend/src/pages/Graphing/EventSelection/NavigateFilters.tsx
+++ b/frontend/src/pages/Graphing/EventSelection/NavigateFilters.tsx
@@ -190,6 +190,7 @@ export const NavigateFilters: React.FC<Props> = ({
 						onChangeQuery={setNavigateQuery}
 						cssClass={comboBoxStyle.combobox}
 						wrapperCssClass={comboBoxStyle.comboboxWrapper}
+						popoverCssClass={comboBoxStyle.comboboxPopover}
 						queryPlaceholder="Filter..."
 						creatableRender={(value) => (
 							<Text cssClass={comboBoxStyle.comboboxText}>

--- a/frontend/src/pages/Graphing/EventSelection/TrackFilters.tsx
+++ b/frontend/src/pages/Graphing/EventSelection/TrackFilters.tsx
@@ -88,6 +88,7 @@ export const TrackFilters: React.FC<Props> = ({
 					onChangeQuery={setEventNameQuery}
 					cssClass={comboBoxStyle.combobox}
 					wrapperCssClass={comboBoxStyle.comboboxWrapper}
+					popoverCssClass={comboBoxStyle.comboboxPopover}
 					queryPlaceholder="Filter..."
 					creatableRender={(value) => (
 						<Text cssClass={comboBoxStyle.comboboxText}>


### PR DESCRIPTION
## Summary
The graphing combobox width can extend too far. Fix this width to about the length of the right panel.

![image](https://github.com/user-attachments/assets/ee4383b1-3296-462e-95cf-b5795159a87c)

## How did you test this change?
1. View the metrics page (`/metrics`)
2. Start creating an "Event" metric
3. Click on "Click" event type
4. Expand the "Text" dropdown
- [ ] Dropdown does not expand across the page

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
