### PR TITLE
sample sessions by user when possible

### DIFF
--- a/backend/public-graph/graph/sampling.go
+++ b/backend/public-graph/graph/sampling.go
@@ -255,7 +255,11 @@ func (r *Resolver) IsSessionExcluded(ctx context.Context, s *model.Session, sess
 }
 
 func (r *Resolver) isSessionExcludedBySample(ctx context.Context, session *model.Session) bool {
-	return !r.isItemIngestedBySample(ctx, privateModel.ProductTypeSessions, session.ProjectID, session.SecureID)
+	samplingKey := session.Identifier
+	if samplingKey == "" {
+		samplingKey = session.SecureID
+	}
+	return !r.isItemIngestedBySample(ctx, privateModel.ProductTypeSessions, session.ProjectID, samplingKey)
 }
 
 func (r *Resolver) isSessionExcludedByRateLimit(ctx context.Context, session *model.Session) bool {


### PR DESCRIPTION
## Summary

Update session sampling logic to use the user identifier as the key when possible to be able to capture all sessions of a given user

## How did you test this change?

unit test

## Are there any deployment considerations?

no, single customer using session sampling

## Does this work require review from our design team?

no