### PR TITLE
fix search suggestions when no defaultValueOptions provided

### DIFF
--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -416,7 +416,7 @@ export const Search: React.FC<{
 	let visibleItems: SearchResult[] = showValues
 		? getVisibleValues(
 				activePart,
-				defaultValueOptions?.concat(values ?? []),
+				(defaultValueOptions ?? []).concat(values ?? []),
 			)
 		: getVisibleKeys(query, activePart, keys)
 


### PR DESCRIPTION
## Summary
- when `defaultValueOptions` was undefined, was skipping values entirely
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
