### PR TITLE
Fix option dropdown renderer

### DIFF
--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -43,10 +43,8 @@ import { DestinationInput } from '@/pages/Alerts/DestinationInput'
 import { Combobox } from '@/pages/Graphing/Combobox'
 import {
 	FUNCTION_TYPES,
-	PRODUCT_ICONS,
-	PRODUCT_ICONS_WITH_EVENTS,
-	PRODUCTS,
-	PRODUCTS_WITH_EVENTS,
+	PRODUCT_OPTIONS,
+	PRODUCT_OPTIONS_WITH_EVENTS,
 } from '@/pages/Graphing/constants'
 import { HeaderDivider } from '@/pages/Graphing/Dashboard'
 import { LabeledRow } from '@/pages/Graphing/LabeledRow'
@@ -95,17 +93,11 @@ export const AlertForm: React.FC = () => {
 	const [searchParams] = useSearchParams()
 
 	const eventSearchEnabled = useFeatureFlag(Feature.EventSearch)
-	const { products, productIcons } = useMemo(() => {
+	const productOptions = useMemo(() => {
 		if (!eventSearchEnabled) {
-			return {
-				products: PRODUCTS,
-				productIcons: PRODUCT_ICONS,
-			}
+			return PRODUCT_OPTIONS
 		}
-		return {
-			products: PRODUCTS_WITH_EVENTS,
-			productIcons: PRODUCT_ICONS_WITH_EVENTS,
-		}
+		return PRODUCT_OPTIONS_WITH_EVENTS
 	}, [eventSearchEnabled])
 
 	const isEdit = alert_id !== undefined
@@ -136,7 +128,7 @@ export const AlertForm: React.FC = () => {
 
 	const [alertName, setAlertName] = useState('')
 	const [productType, setProductType] = useState(
-		(searchParams.get('source') as ProductType) || products[0],
+		(searchParams.get('source') as ProductType) || productOptions[0].value,
 	)
 	const [functionType, setFunctionType] = useState(MetricAggregator.Count)
 	const [functionColumn, setFunctionColumn] = useState('')
@@ -452,11 +444,10 @@ export const AlertForm: React.FC = () => {
 										name="source"
 										tooltip="The resource being queried, one of the four highlight.io resources."
 									>
-										<OptionDropdown<ProductType>
-											options={products}
+										<OptionDropdown
+											options={productOptions}
 											selection={productType}
 											setSelection={handleProductChange}
-											icons={productIcons}
 										/>
 									</LabeledRow>
 									{ALERT_PRODUCT_INFO[productType] && (
@@ -527,7 +518,7 @@ export const AlertForm: React.FC = () => {
 												name="function"
 												tooltip="Determines how data points are aggregated. If the function requires a numeric field as input, one can be chosen."
 											>
-												<OptionDropdown<MetricAggregator>
+												<OptionDropdown
 													options={FUNCTION_TYPES}
 													selection={functionType}
 													setSelection={
@@ -582,7 +573,7 @@ export const AlertForm: React.FC = () => {
 												label="Alert conditions"
 												name="alertConditions"
 											>
-												<OptionDropdown<AlertCondition>
+												<OptionDropdown
 													options={
 														ALERT_CONDITION_OPTIONS
 													}
@@ -622,13 +613,10 @@ export const AlertForm: React.FC = () => {
 													label="Alert window"
 													name="thresholdWindow"
 												>
-													<OptionDropdown<string>
-														options={FREQUENCY_OPTIONS.map(
-															(f) => f.value,
-														)}
-														labels={FREQUENCY_OPTIONS.map(
-															(f) => f.name,
-														)}
+													<OptionDropdown
+														options={
+															FREQUENCY_OPTIONS
+														}
 														selection={String(
 															thresholdWindow,
 														)}
@@ -646,13 +634,8 @@ export const AlertForm: React.FC = () => {
 												label="Cooldown"
 												name="thresholdCooldown"
 											>
-												<OptionDropdown<string>
-													options={FREQUENCY_OPTIONS.map(
-														(f) => f.value,
-													)}
-													labels={FREQUENCY_OPTIONS.map(
-														(f) => f.name,
-													)}
+												<OptionDropdown
+													options={FREQUENCY_OPTIONS}
 													selection={String(
 														thresholdCooldown,
 													)}

--- a/frontend/src/pages/Graphing/EventSelection/ClickFilters.tsx
+++ b/frontend/src/pages/Graphing/EventSelection/ClickFilters.tsx
@@ -163,7 +163,7 @@ export const ClickFilters: React.FC<Props> = ({
 		<>
 			<Box display="flex" flexDirection="row" gap="4">
 				<LabeledRow label="Click type" name="clickType">
-					<OptionDropdown<ClickType>
+					<OptionDropdown
 						options={CLICK_TYPES}
 						selection={clickType}
 						setSelection={setClickType}

--- a/frontend/src/pages/Graphing/EventSelection/NavigateFilters.tsx
+++ b/frontend/src/pages/Graphing/EventSelection/NavigateFilters.tsx
@@ -170,7 +170,7 @@ export const NavigateFilters: React.FC<Props> = ({
 		<>
 			<Box display="flex" flexDirection="row" gap="4">
 				<LabeledRow label="Navigate type" name="navigateType">
-					<OptionDropdown<NavigateType>
+					<OptionDropdown
 						options={NAVIGATE_TYPES}
 						selection={navigateType}
 						setSelection={setNavigateType}

--- a/frontend/src/pages/Graphing/EventSelection/index.tsx
+++ b/frontend/src/pages/Graphing/EventSelection/index.tsx
@@ -134,7 +134,7 @@ export const EventSelection: React.FC<Props> = ({
 			backgroundColor="nested"
 		>
 			<LabeledRow label="Event type" name="eventType">
-				<OptionDropdown<EventType>
+				<OptionDropdown
 					options={EVENT_TYPES}
 					selection={eventType}
 					setSelection={setEventType}

--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -44,9 +44,7 @@ import Graph, {
 	getViewConfig,
 	TIMESTAMP_KEY,
 	View,
-	VIEW_ICONS,
-	VIEW_LABELS,
-	VIEWS,
+	VIEW_OPTIONS,
 } from '@/pages/Graphing/components/Graph'
 import {
 	LINE_DISPLAY,
@@ -68,10 +66,8 @@ import {
 	DEFAULT_BUCKET_COUNT,
 	DEFAULT_BUCKET_INTERVAL,
 	FUNCTION_TYPES,
-	PRODUCT_ICONS,
-	PRODUCT_ICONS_WITH_EVENTS,
-	PRODUCTS,
-	PRODUCTS_WITH_EVENTS,
+	PRODUCT_OPTIONS,
+	PRODUCT_OPTIONS_WITH_EVENTS,
 } from './constants'
 import * as style from './GraphingEditor.css'
 import { LabeledRow } from './LabeledRow'
@@ -165,17 +161,11 @@ export const GraphingEditor: React.FC = () => {
 	}>()
 
 	const eventSearchEnabled = useFeatureFlag(Feature.EventSearch)
-	const { products, productIcons } = useMemo(() => {
+	const productOptions = useMemo(() => {
 		if (!eventSearchEnabled) {
-			return {
-				products: PRODUCTS,
-				productIcons: PRODUCT_ICONS,
-			}
+			return PRODUCT_OPTIONS
 		}
-		return {
-			products: PRODUCTS_WITH_EVENTS,
-			productIcons: PRODUCT_ICONS_WITH_EVENTS,
-		}
+		return PRODUCT_OPTIONS_WITH_EVENTS
 	}, [eventSearchEnabled])
 
 	const isEdit = graph_id !== undefined
@@ -376,8 +366,8 @@ export const GraphingEditor: React.FC = () => {
 
 	const { projectId } = useProjectId()
 
-	const [productType, setProductType] = useState(products[0])
-	const [viewType, setViewType] = useState(VIEWS[0])
+	const [productType, setProductType] = useState(productOptions[0].value)
+	const [viewType, setViewType] = useState(VIEW_OPTIONS[0].value)
 	const [lineNullHandling, setLineNullHandling] = useState(
 		LINE_NULL_HANDLING[0],
 	)
@@ -640,10 +630,9 @@ export const GraphingEditor: React.FC = () => {
 										tooltip="The resource being queried, one of the four highlight.io resources."
 									>
 										<OptionDropdown<ProductType>
-											options={products}
+											options={productOptions}
 											selection={productType}
 											setSelection={setProductType}
-											icons={productIcons}
 										/>
 									</LabeledRow>
 								</SidebarSection>
@@ -697,7 +686,7 @@ export const GraphingEditor: React.FC = () => {
 										name="function"
 										tooltip="Determines how data points are aggregated. If the function requires a numeric field as input, one can be chosen."
 									>
-										<OptionDropdown<MetricAggregator>
+										<OptionDropdown
 											options={FUNCTION_TYPES}
 											selection={functionType}
 											setSelection={setFunctionType}
@@ -758,7 +747,7 @@ export const GraphingEditor: React.FC = () => {
 												name="limitBy"
 												tooltip="The function used to determine which groups are included."
 											>
-												<OptionDropdown<MetricAggregator>
+												<OptionDropdown
 													options={FUNCTION_TYPES}
 													selection={
 														limitFunctionType
@@ -794,12 +783,10 @@ export const GraphingEditor: React.FC = () => {
 										label="View type"
 										name="viewType"
 									>
-										<OptionDropdown<View>
-											options={VIEWS}
+										<OptionDropdown
+											options={VIEW_OPTIONS}
 											selection={viewType}
 											setSelection={setViewType}
-											icons={VIEW_ICONS}
-											labels={VIEW_LABELS}
 										/>
 									</LabeledRow>
 									{viewType === 'Line chart' && (

--- a/frontend/src/pages/Graphing/OptionDropdown/index.tsx
+++ b/frontend/src/pages/Graphing/OptionDropdown/index.tsx
@@ -5,36 +5,33 @@ import {
 	Stack,
 	Text,
 } from '@highlight-run/ui/components'
-import React from 'react'
+import React, { useMemo } from 'react'
+
+type Options<T> = T[] | SelectOption[]
 
 export const OptionDropdown = <T extends string>({
 	options,
 	selection,
 	setSelection,
-	icons,
-	labels,
 	disabled,
 }: {
-	options: T[]
+	options: Options<T>
 	selection: T
 	setSelection: (option: T) => void
-	icons?: JSX.Element[]
-	labels?: string[]
 	disabled?: boolean
 }) => {
-	const selectedIndex = options.indexOf(selection)
-	const selectedIcon = icons?.at(selectedIndex)
-	const selectedLabel = labels?.at(selectedIndex)
 	return (
 		<Box flex="stretch">
 			<Select<T>
 				value={selection}
-				renderValue={() => {
+				renderValue={(value) => {
 					return (
 						<Text color="secondaryContentOnEnabled">
 							<Stack direction="row" alignItems="center" gap="4">
-								{selectedIcon}
-								{selectedLabel ?? selection}
+								<SelectValue
+									options={options}
+									value={value as T}
+								/>
 							</Stack>
 						</Text>
 					)
@@ -42,18 +39,37 @@ export const OptionDropdown = <T extends string>({
 				options={options}
 				onValueChange={(v: SelectOption) => setSelection(v.value as T)}
 				disabled={disabled}
-			>
-				{options.map((option, i) => (
-					<Select.Option key={option} value={option}>
-						<Text color="secondaryContentOnEnabled">
-							<Stack direction="row" alignItems="center" gap="4">
-								{icons?.at(i)}
-								{labels?.at(i) ?? options?.at(i)}
-							</Stack>
-						</Text>
-					</Select.Option>
-				))}
-			</Select>
+			/>
 		</Box>
+	)
+}
+
+const SelectValue = <T extends string>({
+	options,
+	value,
+}: {
+	options: Options<T>
+	value: T
+}) => {
+	const selectedOption = useMemo(() => {
+		if (typeof options === 'string') {
+			return value
+		}
+
+		return (
+			(options as SelectOption[]).find((opt) => opt.value === value) ||
+			value
+		)
+	}, [options, value])
+
+	if (typeof selectedOption === 'string') {
+		return value
+	}
+
+	return (
+		<>
+			{selectedOption.icon}
+			{selectedOption.name || selectedOption.value}
+		</>
 	)
 }

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -49,13 +49,24 @@ import {
 import * as style from './Graph.css'
 
 export type View = 'Line chart' | 'Bar chart' | 'Table'
-export const VIEWS: View[] = ['Line chart', 'Bar chart', 'Table']
-export const VIEW_ICONS = [
-	<IconSolidChartSquareLine size={16} key="line chart" />,
-	<IconSolidChartSquareBar size={16} key="bar chart" />,
-	<IconSolidTable size={16} key="table" />,
+
+export const VIEW_OPTIONS = [
+	{
+		value: 'Line chart',
+		name: 'Line chart',
+		icon: <IconSolidChartSquareLine size={16} />,
+	},
+	{
+		value: 'Bar chart',
+		name: 'Bar chart / histogram',
+		icon: <IconSolidChartSquareBar size={16} />,
+	},
+	{
+		value: 'Table',
+		name: 'Table',
+		icon: <IconSolidTable size={16} />,
+	},
 ]
-export const VIEW_LABELS = ['Line chart', 'Bar chart / histogram', 'Table']
 
 export const TIMESTAMP_KEY = 'Timestamp'
 export const GROUP_KEY = 'Group'

--- a/frontend/src/pages/Graphing/constants.tsx
+++ b/frontend/src/pages/Graphing/constants.tsx
@@ -1,5 +1,4 @@
 import {
-	IconSolidChartBar,
 	IconSolidFire,
 	IconSolidLightningBolt,
 	IconSolidLogs,
@@ -12,29 +11,41 @@ import { MetricAggregator, ProductType } from '@/graph/generated/schemas'
 export const DEFAULT_BUCKET_COUNT = 50
 export const DEFAULT_BUCKET_INTERVAL = 300
 
-export const PRODUCTS: ProductType[] = [
-	ProductType.Logs,
-	ProductType.Traces,
-	ProductType.Sessions,
-	ProductType.Errors,
+export const PRODUCT_OPTIONS = [
+	{
+		name: ProductType.Logs,
+		value: ProductType.Logs,
+		icon: <IconSolidLogs key="logs" />,
+	},
+	{
+		name: ProductType.Traces,
+		value: ProductType.Traces,
+		icon: <IconSolidTraces key="traces" />,
+	},
+	{
+		name: ProductType.Sessions,
+		value: ProductType.Sessions,
+		icon: <IconSolidPlayCircle key="sessions" />,
+	},
+	{
+		name: ProductType.Errors,
+		value: ProductType.Errors,
+		icon: <IconSolidLightningBolt key="errors" />,
+	},
 	// TODO(vkorolik) metrics disabled in the frontend to avoid confusion
-	// ProductType.Metrics,
+	// {
+	// 	name: ProductType.Metrics,
+	// 	value: ProductType.Metrics,
+	// 	icon: <IconSolidChartBar key="metrics" />,
+	// }
 ]
 
-export const PRODUCTS_WITH_EVENTS: ProductType[] = PRODUCTS.concat([
-	ProductType.Events,
-])
-
-export const PRODUCT_ICONS = [
-	<IconSolidLogs key="logs" />,
-	<IconSolidTraces key="traces" />,
-	<IconSolidPlayCircle key="sessions" />,
-	<IconSolidLightningBolt key="errors" />,
-	<IconSolidChartBar key="metrics" />,
-]
-
-export const PRODUCT_ICONS_WITH_EVENTS = PRODUCT_ICONS.concat([
-	<IconSolidFire key="events" />,
+export const PRODUCT_OPTIONS_WITH_EVENTS = PRODUCT_OPTIONS.concat([
+	{
+		name: ProductType.Events,
+		value: ProductType.Events,
+		icon: <IconSolidFire key="events" />,
+	},
 ])
 
 export const NUMERIC_FUNCTION_TYPES: MetricAggregator[] = [

--- a/frontend/src/pages/IntegrationsPage/components/ClickUpIntegration/ClickUpListSelector.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/ClickUpIntegration/ClickUpListSelector.tsx
@@ -23,14 +23,14 @@ const ClickUpListSelector: React.FC<ContainerSelectionProps> = ({
 				f.lists.map((l) => ({
 					value: l.id,
 					id: l.id,
-					displayValue: `${f.name} > ${l.name}`,
+					name: `${f.name} > ${l.name}`,
 				})),
 			) || []
 		const folderlessLists =
 			data?.clickup_folderless_lists.map((l) => ({
 				value: l.id,
 				id: l.id,
-				displayValue: `${l.name}`,
+				name: `${l.name}`,
 			})) || []
 		return folderLists.concat(folderlessLists)
 	}, [data])
@@ -53,8 +53,7 @@ const ClickUpListSelector: React.FC<ContainerSelectionProps> = ({
 	return (
 		<Form.NamedSection label="List" name="clickupList">
 			<OptionDropdown
-				options={clickUpListOptions.map((o) => o.id)}
-				labels={clickUpListOptions.map((o) => o.displayValue)}
+				options={clickUpListOptions}
 				selection={selectedClickUpListId}
 				setSelection={setClickUpListId}
 				disabled={disabled || loading}

--- a/frontend/src/pages/IntegrationsPage/components/ClickUpIntegration/ClickUpListSelector.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/ClickUpIntegration/ClickUpListSelector.tsx
@@ -50,6 +50,8 @@ const ClickUpListSelector: React.FC<ContainerSelectionProps> = ({
 		}
 	}, [selectedClickUpListId, clickUpListOptions, setClickUpListId])
 
+	console.log('clickUpListOptions', clickUpListOptions)
+
 	return (
 		<Form.NamedSection label="List" name="clickupList">
 			<OptionDropdown

--- a/frontend/src/pages/IntegrationsPage/components/ClickUpIntegration/ClickUpListSelector.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/ClickUpIntegration/ClickUpListSelector.tsx
@@ -50,8 +50,6 @@ const ClickUpListSelector: React.FC<ContainerSelectionProps> = ({
 		}
 	}, [selectedClickUpListId, clickUpListOptions, setClickUpListId])
 
-	console.log('clickUpListOptions', clickUpListOptions)
-
 	return (
 		<Form.NamedSection label="List" name="clickupList">
 			<OptionDropdown

--- a/frontend/src/pages/IntegrationsPage/components/GitHubIntegration/GitHubRepoSelector.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/GitHubIntegration/GitHubRepoSelector.tsx
@@ -20,7 +20,7 @@ const GitHubRepoSelector: React.FC<ContainerSelectionProps> = ({
 			data?.github_repos?.map((repo) => ({
 				value: repo.name,
 				id: repo.name,
-				displayValue: repo.name,
+				name: repo.name,
 			})) || []
 		)
 	}, [data])
@@ -50,8 +50,7 @@ const GitHubRepoSelector: React.FC<ContainerSelectionProps> = ({
 	return (
 		<Form.NamedSection label="Repository" name="githubRepo">
 			<OptionDropdown
-				options={githubReposOptions.map((o) => o.id)}
-				labels={githubReposOptions.map((o) => o.displayValue)}
+				options={githubReposOptions}
 				selection={selectedGitHubRepoId}
 				setSelection={setGitHubRepoId}
 				disabled={disabled}

--- a/frontend/src/pages/IntegrationsPage/components/GitlabIntegration/GitlabProjectSelector.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/GitlabIntegration/GitlabProjectSelector.tsx
@@ -18,7 +18,7 @@ const GitlabProjectAndIssueTypeSelector: React.FC<ContainerSelectionProps> = ({
 			(data?.gitlab_projects || []).map((team: GitlabProject) => ({
 				value: team.id.toString(),
 				id: team.id.toString(),
-				displayValue: team.nameWithNameSpace,
+				name: team.nameWithNameSpace,
 			})) || []
 		)
 	}, [data?.gitlab_projects])
@@ -36,8 +36,7 @@ const GitlabProjectAndIssueTypeSelector: React.FC<ContainerSelectionProps> = ({
 		<>
 			<Form.NamedSection label="Project" name="gitlabProject">
 				<OptionDropdown
-					options={gitlabProjectOptions.map((o) => o.id)}
-					labels={gitlabProjectOptions.map((o) => o.displayValue)}
+					options={gitlabProjectOptions}
 					selection={selectedGitlabProjectId}
 					setSelection={setGitlabProjectId}
 					disabled={disabled}

--- a/frontend/src/pages/IntegrationsPage/components/HeightIntegration/HeightListSelector.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/HeightIntegration/HeightListSelector.tsx
@@ -23,7 +23,7 @@ const HeightListSelector: React.FC<ContainerSelectionProps> = ({
 				return {
 					value: list.id,
 					id: list.id,
-					displayValue: list.name,
+					name: list.name,
 				}
 			}) || []
 		)
@@ -47,8 +47,7 @@ const HeightListSelector: React.FC<ContainerSelectionProps> = ({
 	return (
 		<Form.NamedSection label="List" name="heightList">
 			<OptionDropdown
-				options={heightListOptions.map((o) => o.id)}
-				labels={heightListOptions.map((o) => o.displayValue)}
+				options={heightListOptions}
 				selection={selectedHeightListId}
 				setSelection={setHeightListId}
 				disabled={disabled || loading}

--- a/frontend/src/pages/IntegrationsPage/components/JiraIntegration/JiraProjectSelector.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/JiraIntegration/JiraProjectSelector.tsx
@@ -18,7 +18,7 @@ const JiraProjectAndIssueTypeSelector: React.FC<ContainerSelectionProps> = ({
 			(data?.jira_projects || []).map((team: any) => ({
 				value: team.id,
 				id: team.id,
-				displayValue: `${team.name} (${team.key})`,
+				name: `${team.name} (${team.key})`,
 			})) || []
 		)
 	}, [data?.jira_projects])
@@ -42,7 +42,7 @@ const JiraProjectAndIssueTypeSelector: React.FC<ContainerSelectionProps> = ({
 		(issueType: any) => ({
 			value: issueType.id,
 			id: issueType.id,
-			displayValue: `${issueType.name} - (${issueType.description})`,
+			name: `${issueType.name} - (${issueType.description})`,
 		}),
 	)
 
@@ -66,8 +66,7 @@ const JiraProjectAndIssueTypeSelector: React.FC<ContainerSelectionProps> = ({
 		<>
 			<Form.NamedSection label="Project" name="jiraProject">
 				<OptionDropdown
-					options={jiraProjectsOptions.map((o) => o.id)}
-					labels={jiraProjectsOptions.map((o) => o.displayValue)}
+					options={jiraProjectsOptions}
 					selection={selectedJiraProjectId}
 					setSelection={setJiraProjectId}
 					disabled={disabled}
@@ -75,8 +74,7 @@ const JiraProjectAndIssueTypeSelector: React.FC<ContainerSelectionProps> = ({
 			</Form.NamedSection>
 			<Form.NamedSection label="Issue Type" name="jiraIssue">
 				<OptionDropdown
-					options={jiraIssueTypeOptions.map((o) => o.id)}
-					labels={jiraIssueTypeOptions.map((o) => o.displayValue)}
+					options={jiraIssueTypeOptions}
 					selection={selectedJiraIssueTypeId}
 					setSelection={setJiraIssueTypeId}
 					disabled={disabled}

--- a/frontend/src/pages/IntegrationsPage/components/LinearIntegration/LinearTeamSelector.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/LinearIntegration/LinearTeamSelector.tsx
@@ -17,7 +17,7 @@ const LinearTeamSelector: React.FC<ContainerSelectionProps> = ({
 			teams?.map((team) => ({
 				value: team.team_id,
 				id: team.team_id,
-				displayValue: `${team.name} (${team.key})`,
+				name: `${team.name} (${team.key})`,
 			})) || []
 		)
 	}, [teams])
@@ -47,8 +47,7 @@ const LinearTeamSelector: React.FC<ContainerSelectionProps> = ({
 	return (
 		<Form.NamedSection label="Team" name="linearTeam">
 			<OptionDropdown
-				options={linearTeamsOptions.map((o) => o.id)}
-				labels={linearTeamsOptions.map((o) => o.displayValue)}
+				options={linearTeamsOptions}
 				selection={selectedLinearTeamId}
 				setSelection={setLinearTeamId}
 				disabled={disabled}


### PR DESCRIPTION
## Summary
Since passing in the `options` directly to the `<Select/>` in https://github.com/highlight/highlight/pull/9402, the Select is just rendering the selected value and not using the custom renderer. Update to use the renderer properly. 

https://www.loom.com/share/5dc6caa895fd45fdb5101b128a839b2e?sid=6e4c2729-8abb-4f7e-8231-850c0abb78fe

## How did you test this change?
1. Make a new alert on the alerts page (`/alerts`)
2. Select a source
- [ ] Icon and value are updated correctly
4. Select one of the frequency dropdowns (i.e. numbers with labels)
- [ ] Label and value are updated correctly

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
