### PR TITLE
Fix session related resource player error

### DIFF
--- a/frontend/src/components/RelatedResources/SessionPanel.tsx
+++ b/frontend/src/components/RelatedResources/SessionPanel.tsx
@@ -36,6 +36,26 @@ import { useResizePlayer } from '@/pages/Player/utils/utils'
 export const SessionPanel: React.FC<{ resource: RelatedSession }> = ({
 	resource,
 }) => {
+	const playerRef = useRef<HTMLDivElement>(null)
+	const playerContext = usePlayer(playerRef, true)
+	const { session } = playerContext
+	const resourcesContext = useResources(session)
+	const toolbarContext = useToolbarItems()
+
+	return (
+		<ReplayerContextProvider value={playerContext}>
+			<ResourcesContextProvider value={resourcesContext}>
+				<ToolbarItemsContextProvider value={toolbarContext}>
+					<SessionPanelBase resource={resource} />
+				</ToolbarItemsContextProvider>
+			</ResourcesContextProvider>
+		</ReplayerContextProvider>
+	)
+}
+
+const SessionPanelBase: React.FC<{ resource: RelatedSession }> = ({
+	resource,
+}) => {
 	const { projectId } = useNumericProjectId()
 	const playerRef = useRef<HTMLDivElement>(null)
 	const playerWrapperRef = useRef<HTMLDivElement>(null)
@@ -49,8 +69,6 @@ export const SessionPanel: React.FC<{ resource: RelatedSession }> = ({
 		sessionViewability,
 		setScale,
 	} = playerContext
-	const resourcesContext = useResources(session)
-	const toolbarContext = useToolbarItems()
 	const replayerWrapperBbox = replayer?.wrapper.getBoundingClientRect()
 	const { playerCenterPanelRef } = usePlayerUIContext()
 
@@ -75,106 +93,98 @@ export const SessionPanel: React.FC<{ resource: RelatedSession }> = ({
 	const showSession = sessionViewability === SessionViewability.VIEWABLE
 
 	return (
-		<ReplayerContextProvider value={playerContext}>
-			<ResourcesContextProvider value={resourcesContext}>
-				<ToolbarItemsContextProvider value={toolbarContext}>
-					<Panel.Header path={path}>
-						<Stack
-							justify="space-between"
-							align="center"
-							flexGrow={1}
-							direction="row"
-							overflow="hidden"
-							gap="4"
-						>
-							<Stack
-								align="center"
-								direction="row"
-								flexGrow={1}
-								overflow="hidden"
-							>
-								<SessionViewportMetadata />
-								<SessionCurrentUrl />
-							</Stack>
-
-							<SessionShareButtonV2 />
-							<Panel.HeaderDivider />
-						</Stack>
-					</Panel.Header>
-
-					<Box
-						display="flex"
-						flexDirection="column"
-						width="full"
-						height="full"
-						id="playerCenterPanel"
-						ref={playerCenterPanelRef}
+		<>
+			<Panel.Header path={path}>
+				<Stack
+					justify="space-between"
+					align="center"
+					flexGrow={1}
+					direction="row"
+					overflow="hidden"
+					gap="4"
+				>
+					<Stack
+						align="center"
+						direction="row"
+						flexGrow={1}
+						overflow="hidden"
 					>
-						{showSession ? (
-							<Box height="full" cssClass={styles.playerBody}>
-								<div className={styles.playerCenterColumn}>
-									{centerColumnResizeListener}
-									<Box
-										display="flex"
-										flexDirection="column"
-										flexGrow={1}
-									>
-										<div
-											className={clsx(
-												styles.rrwebPlayerWrapper,
-												{
-													[styles.blurBackground]:
-														isLoadingEvents &&
-														isPlayerReady,
-												},
-											)}
-											ref={playerWrapperRef}
+						<SessionViewportMetadata />
+						<SessionCurrentUrl />
+					</Stack>
+
+					<SessionShareButtonV2 />
+					<Panel.HeaderDivider />
+				</Stack>
+			</Panel.Header>
+
+			<Box
+				display="flex"
+				flexDirection="column"
+				width="full"
+				height="full"
+				id="playerCenterPanel"
+				ref={playerCenterPanelRef}
+			>
+				{showSession ? (
+					<Box height="full" cssClass={styles.playerBody}>
+						<div className={styles.playerCenterColumn}>
+							{centerColumnResizeListener}
+							<Box
+								display="flex"
+								flexDirection="column"
+								flexGrow={1}
+							>
+								<div
+									className={clsx(styles.rrwebPlayerWrapper, {
+										[styles.blurBackground]:
+											isLoadingEvents && isPlayerReady,
+									})}
+									ref={playerWrapperRef}
+								>
+									{resizeListener}
+									{replayerState ===
+										ReplayerState.SessionRecordingStopped && (
+										<Box
+											display="flex"
+											alignItems="center"
+											flexDirection="column"
+											justifyContent="center"
+											position="absolute"
+											style={{
+												height: replayerWrapperBbox?.height,
+												width: replayerWrapperBbox?.width,
+												zIndex: 2,
+											}}
 										>
-											{resizeListener}
-											{replayerState ===
-												ReplayerState.SessionRecordingStopped && (
-												<Box
-													display="flex"
-													alignItems="center"
-													flexDirection="column"
-													justifyContent="center"
-													position="absolute"
-													style={{
-														height: replayerWrapperBbox?.height,
-														width: replayerWrapperBbox?.width,
-														zIndex: 2,
-													}}
-												>
-													<ManualStopCard />
-												</Box>
-											)}
-											<div
-												style={{
-													visibility: isPlayerReady
-														? 'visible'
-														: 'hidden',
-												}}
-												className="highlight-block"
-												id="player"
-												ref={playerRef}
-											/>
-											{!isPlayerReady && <LoadingBox />}
-										</div>
-										<Toolbar width={controllerWidth} />
-									</Box>
-									<DevToolsWindowV2 width={controllerWidth} />
+											<ManualStopCard />
+										</Box>
+									)}
+									<div
+										style={{
+											visibility: isPlayerReady
+												? 'visible'
+												: 'hidden',
+										}}
+										className="highlight-block"
+										id="player"
+										ref={playerRef}
+									/>
+									{!isPlayerReady && <LoadingBox />}
 								</div>
-								<NetworkResourcePanel />
+								<Toolbar width={controllerWidth} />
 							</Box>
-						) : (
-							<SessionFiller
-								sessionViewability={sessionViewability}
-								session={session}
-							/>
-						)}
+							<DevToolsWindowV2 width={controllerWidth} />
+						</div>
+						<NetworkResourcePanel />
 					</Box>
-				</ToolbarItemsContextProvider>
-			</ResourcesContextProvider>
-		</ReplayerContextProvider>
+				) : (
+					<SessionFiller
+						sessionViewability={sessionViewability}
+						session={session}
+					/>
+				)}
+			</Box>
+		</>
 	)
 }

--- a/frontend/src/components/RelatedResources/SessionPanel.tsx
+++ b/frontend/src/components/RelatedResources/SessionPanel.tsx
@@ -47,18 +47,21 @@ export const SessionPanel: React.FC<{ resource: RelatedSession }> = ({
 		<ReplayerContextProvider value={playerContext}>
 			<ResourcesContextProvider value={resourcesContext}>
 				<ToolbarItemsContextProvider value={toolbarContext}>
-					<SessionPanelBase resource={resource} />
+					<SessionPanelBase
+						resource={resource}
+						playerRef={playerRef}
+					/>
 				</ToolbarItemsContextProvider>
 			</ResourcesContextProvider>
 		</ReplayerContextProvider>
 	)
 }
 
-const SessionPanelBase: React.FC<{ resource: RelatedSession }> = ({
-	resource,
-}) => {
+const SessionPanelBase: React.FC<{
+	resource: RelatedSession
+	playerRef: React.RefObject<HTMLDivElement>
+}> = ({ resource, playerRef }) => {
 	const { projectId } = useNumericProjectId()
-	const playerRef = useRef<HTMLDivElement>(null)
 	const playerWrapperRef = useRef<HTMLDivElement>(null)
 	const {
 		session,

--- a/frontend/src/components/RelatedResources/SessionPanel.tsx
+++ b/frontend/src/components/RelatedResources/SessionPanel.tsx
@@ -14,6 +14,7 @@ import { PlayerSearchParameters } from '@/pages/Player/PlayerHook/utils'
 import {
 	ReplayerContextProvider,
 	ReplayerState,
+	useReplayerContext,
 } from '@/pages/Player/ReplayerContext'
 import {
 	ResourcesContextProvider,
@@ -59,7 +60,6 @@ const SessionPanelBase: React.FC<{ resource: RelatedSession }> = ({
 	const { projectId } = useNumericProjectId()
 	const playerRef = useRef<HTMLDivElement>(null)
 	const playerWrapperRef = useRef<HTMLDivElement>(null)
-	const playerContext = usePlayer(playerRef, true)
 	const {
 		session,
 		state: replayerState,
@@ -68,7 +68,7 @@ const SessionPanelBase: React.FC<{ resource: RelatedSession }> = ({
 		replayer,
 		sessionViewability,
 		setScale,
-	} = playerContext
+	} = useReplayerContext()
 	const replayerWrapperBbox = replayer?.wrapper.getBoundingClientRect()
 	const { playerCenterPanelRef } = usePlayerUIContext()
 

--- a/sdk/base.Dockerfile
+++ b/sdk/base.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM python:bookworm
+FROM --platform=$BUILDPLATFORM python:3.12-bookworm
 
 WORKDIR /highlight/sdk
 COPY . .


### PR DESCRIPTION
## Summary
The SessionPanel is crashing - `useResizePlayer` calls `useReplayerContext` , so it must be called within the `ReplayerContextProvider`. Move the call into a Base component of the SessionPanel.

## How did you test this change?
1. View traces
2. Use the search `secure_session_id EXISTS`
3. Click on the session id to play
- [x] Able to play session in panel
- [x] No crash

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
