### PR TITLE
support firelens structured logging from kinesis firehose

### DIFF
--- a/backend/http/logging_test.go
+++ b/backend/http/logging_test.go
@@ -38,7 +38,8 @@ const KinesisFirehoseFirelensJson = `{
     "container_name": "example-json-logger",
     "ecs_cluster": "highlight-production-cluster",
     "ecs_task_arn": "arn:aws:ecs:us-east-2:173971919437:task/highlight-production-cluster/b202eacdb71a473e812e81eaf8f4f8c0",
-    "ecs_task_definition": "example-json-logger:3"
+    "ecs_task_definition": "example-json-logger:3",
+  	"highlight.trace_id": "f80fc1e87e7bce2bb992167f47f8ab00"
 }`
 
 const KinesisFirehoseFirelensFluentbitJson = `{
@@ -50,7 +51,8 @@ const KinesisFirehoseFirelensFluentbitJson = `{
     "container_name": "example-json-logger",
     "ecs_cluster": "highlight-production-cluster",
     "ecs_task_arn": "arn:aws:ecs:us-east-2:173971919437:task/highlight-production-cluster/20f475b66b2b45c8b4253d9fbf40ff1d",
-    "ecs_task_definition": "example-json-logger:4"
+    "ecs_task_definition": "example-json-logger:4",
+  	"trace_id": "f80fc1e87e7bce2bb992167f47f8ab00"
 }`
 
 const KinesisFirehoseFirelensPinoJson = `{
@@ -69,6 +71,7 @@ const KinesisFirehoseFirelensPinoJson = `{
     "version": "1.2.3",
     "env": "staging"
   },
+  "traceId": "67047adc000000007307322150893952",
   "trace_id": "f80fc1e87e7bce2bb992167f47f8ab00",
   "span_id": "9fdca739939f9145",
   "trace_flags": "01",
@@ -222,6 +225,8 @@ func TestHandleFirehoseFireLens(t *testing.T) {
 			spans := spanRecorder.Ended()
 			span := spans[len(spans)-1]
 			event := span.Events()[len(span.Events())-1]
+			assert.True(t, span.SpanContext().TraceID().IsValid())
+			assert.Equal(t, "f80fc1e87e7bce2bb992167f47f8ab00", span.SpanContext().TraceID().String())
 			assert.Equal(t, "highlight.log", span.Name())
 			assert.Equal(t, "log", event.Name)
 

--- a/sdk/highlight-go/highlight.go
+++ b/sdk/highlight-go/highlight.go
@@ -131,10 +131,6 @@ var (
 	otlp       *OTLP
 )
 
-const (
-	consumeErrorWorkerStopped = "highlight worker stopped"
-)
-
 // Logger is an interface that implements Log and Logf
 type Logger interface {
 	Error(v ...interface{})

--- a/sdk/highlight-go/highlight.go
+++ b/sdk/highlight-go/highlight.go
@@ -14,7 +14,6 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 )
@@ -265,12 +264,6 @@ func InterceptRequestWithContext(ctx context.Context, r *http.Request) context.C
 }
 
 func validateRequest(ctx context.Context) (sessionSecureID string, requestID string, err error) {
-	stateMutex.RLock()
-	defer stateMutex.RUnlock()
-	if state == stopped {
-		err = errors.New(consumeErrorWorkerStopped)
-		return
-	}
 	if v := ctx.Value(string(ContextKeys.SessionSecureID)); v != nil {
 		sessionSecureID = v.(string)
 	}

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -207,7 +207,7 @@ func StartTraceWithTracer(ctx context.Context, tracer trace.Tracer, name string,
 		if err != nil {
 			data, _ := base64.StdEncoding.DecodeString(requestID)
 			hex := fmt.Sprintf("%032x", data)
-			tid, err = trace.TraceIDFromHex(hex)
+			tid, _ = trace.TraceIDFromHex(hex)
 		}
 		spanCtx = spanCtx.WithTraceID(tid)
 	}

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -202,9 +202,13 @@ func StartTraceWithTracer(ctx context.Context, tracer trace.Tracer, name string,
 	sessionID, requestID, _ := validateRequest(ctx)
 	spanCtx := trace.SpanContextFromContext(ctx)
 	if requestID != "" {
-		data, _ := base64.StdEncoding.DecodeString(requestID)
-		hex := fmt.Sprintf("%032x", data)
-		tid, _ := trace.TraceIDFromHex(hex)
+		// try parse the requestID as hex; fall back to parsing as base64
+		tid, err := trace.TraceIDFromHex(requestID)
+		if err != nil {
+			data, _ := base64.StdEncoding.DecodeString(requestID)
+			hex := fmt.Sprintf("%032x", data)
+			tid, err = trace.TraceIDFromHex(hex)
+		}
 		spanCtx = spanCtx.WithTraceID(tid)
 	}
 	opts = append(opts, trace.WithTimestamp(t))


### PR DESCRIPTION
## Summary

Ensures the `/logs/firehose` endpoint supports firelens structured logs

## How did you test this change?

New unit tests

testing deployed in prod
![Screenshot from 2024-10-07 21-39-19](https://github.com/user-attachments/assets/e5e4774d-cf9f-44fe-a2d4-0ed3ceb81b02)


## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
