### PR TITLE
increase limit for all key value lookup to account for fields

### DIFF
--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -29,6 +29,7 @@ import (
 const SamplingRows = 20_000_000
 const KeysMaxRows = 1_000_000
 const KeyValuesMaxRows = 1_000_000
+const AllKeyValuesMaxRows = 100_000_000
 const MaxBuckets = 100
 
 type SampleableTableConfig struct {
@@ -541,7 +542,7 @@ func (client *Client) AllKeys(ctx context.Context, projectID int, startDate time
 
 func (client *Client) AllKeyValues(ctx context.Context, projectID int, keyName string, startDate time.Time, endDate time.Time, query *string, limit *int) ([]string, error) {
 	chCtx := clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
-		"max_rows_to_read": KeyValuesMaxRows,
+		"max_rows_to_read": AllKeyValuesMaxRows,
 	}))
 
 	limitCount := 500


### PR DESCRIPTION
## Summary
- session fields are stored differently and expected to have many more rows
- in our project, value suggestions are breaking for variables because of this
- increase the rows max in the `AllKeyValues` function to account for this
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will monitor in prod after deploying
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
