### PR TITLE
Update website banner to point to upcoming livestream

### DIFF
--- a/highlight.io/components/common/CallToAction/OSSCallToAction.tsx
+++ b/highlight.io/components/common/CallToAction/OSSCallToAction.tsx
@@ -16,23 +16,24 @@ export const OSSCallToAction = () => {
 				}}
 			>
 				<h3 className="text-center leading-normal">
-					Join our{' '}
+					Check out the{' '}
 					<span className={styles.highlightedText}>
-						Fullstack Monitoring for .NET Applications
+						Optimizing AI Applications with OpenTelemetry
 					</span>{' '}
 					livestream.
 				</h3>
 				<div className="text-center px-2 md:px-16 mt-6">
 					<Typography type="copy1" className="leading-relaxed">
-						Join us September 5th at 1pm PDT to learn how to
-						leverage OpenTelemetry to get fullstack visibility into
-						everything happening in your .NET applications.
+						Join us November 5th at 9am PT to learn about optimizing
+						AI applications. We&apos;ll cover best practices,
+						performance tips, and monitoring strategies to enhance
+						AI-powered software.
 					</Typography>
 				</div>
 				<div className="flex justify-center mt-8">
 					<div className="flex flex-col lg:flex-row justify-center gap-4 w-full px-5 md:w-auto">
 						<PrimaryButton
-							href="https://lu.ma/51zg6p43?utm_source=highlight-oss-cta"
+							href="https://www.linuxfoundation.org/webinars/optimizing-ai-applications-with-opentelemetry?hsLang=en&utm_source=highlight-oss-cta"
 							target="_blank"
 							rel="noreferrer"
 							className="md:max-w-[180px]"

--- a/highlight.io/components/common/Footer/Footer.tsx
+++ b/highlight.io/components/common/Footer/Footer.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import Link from 'next/link'
-import { FaGithub, FaLinkedinIn } from 'react-icons/fa'
+import { FaGithub, FaLinkedinIn, FaPodcast } from 'react-icons/fa'
 import { FaXTwitter } from 'react-icons/fa6'
 import { COMPETITORS } from '../../Competitors/competitors'
 import { PRODUCTS } from '../../Products/products'
@@ -54,6 +54,17 @@ export const Footer = ({ light }: { light?: boolean }) => {
 							href="https://github.com/highlight/highlight"
 						>
 							<FaGithub className="w-[24px] h-[24px]" />
+						</a>
+						<a
+							className={
+								light
+									? 'text-[#6F6E77] hover:text-black'
+									: 'text-white hover:text-color-primary-300'
+							}
+							href="https://podcasters.spotify.com/pod/show/highlightio"
+							target="_blank"
+						>
+							<FaPodcast className="w-[24px] h-[24px]" />
 						</a>
 					</div>
 				</div>

--- a/highlight.io/components/common/Navbar/Navbar.tsx
+++ b/highlight.io/components/common/Navbar/Navbar.tsx
@@ -40,15 +40,15 @@ const LaunchWeekBanner = () => {
 const LivestreamBanner = () => {
 	return (
 		<Link
-			href="https://lu.ma/51zg6p43?utm_source=highlight-banner"
+			href="https://www.linuxfoundation.org/webinars/optimizing-ai-applications-with-opentelemetry?hsLang=en&utm_source=highlight-banner"
 			target="_blank"
 			rel="noreferrer"
 			className="hidden md:flex text-center justify-center items-center w-full py-2.5 px-3 bg-color-primary-200 text-white hover:bg-opacity-90"
 		>
 			<Typography type="copy3">
-				Join our livestream: September 5th at 1pm PT on Fullstack
-				Monitoring for .NET Applications with OpenTelemetry. Register{' '}
-				<span className="font-semibold underline">here</span>.
+				Learn how to use OpenTelemetry for optimizing AI applications at
+				our livestream on November 5th at 9am PT -{' '}
+				<span className="font-semibold underline">Register here</span>
 			</Typography>
 		</Link>
 	)

--- a/highlight.io/components/common/Navbar/ResourceDropdown.tsx
+++ b/highlight.io/components/common/Navbar/ResourceDropdown.tsx
@@ -73,6 +73,12 @@ const ResourceDropdown = ({
 			link: '/ambassador-program',
 			sameTab: true,
 		},
+		{
+			title: 'Podcast',
+			icon: <Icons.HiMicrophone className={styles.copyOnLight} />,
+			link: 'https://podcasters.spotify.com/pod/show/highlightio',
+			sameTab: false,
+		},
 	]
 
 	return (


### PR DESCRIPTION
## Summary

Updates the stale banner content and OSS CTA to point people to the upcoming livestream on optimizing AI applications.

<img width="1271" alt="Screenshot 2024-10-10 at 4 12 21 PM" src="https://github.com/user-attachments/assets/0ca9534c-aa26-4657-b37d-e611a30f0bf6">

<img width="1061" alt="Screenshot 2024-10-10 at 4 12 11 PM" src="https://github.com/user-attachments/assets/ee876a7a-1bde-438a-ab7f-462bd577c773">

Also adds a link to the podcast in the main nav and footer.

<img width="503" alt="Screenshot 2024-10-10 at 4 12 25 PM" src="https://github.com/user-attachments/assets/3030e211-47fe-4817-a146-1f50c10bdf6f">

<img width="213" alt="Screenshot 2024-10-10 at 4 15 01 PM" src="https://github.com/user-attachments/assets/e43eea99-4800-4433-af37-9ad3199f6e97">

## How did you test this change?

Local website preview click test.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A