### PR TITLE
support showing active hours in session feed ui

### DIFF
--- a/backend/lambda-functions/deleteSessions/handlers/handlers.go
+++ b/backend/lambda-functions/deleteSessions/handlers/handlers.go
@@ -141,7 +141,7 @@ func (h *handlers) GetSessionIdsByQuery(ctx context.Context, event utils.QuerySe
 		batchId := uuid.New().String()
 		toDelete := []model.DeleteSessionsTask{}
 
-		ids, _, _, err := h.clickhouseClient.QuerySessionIds(ctx, nil, event.ProjectId, 10000, event.Params, "CreatedAt DESC, ID DESC", pointy.Int(page), time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+		ids, _, _, _, _, err := h.clickhouseClient.QuerySessionIds(ctx, nil, event.ProjectId, 10000, event.Params, "CreatedAt DESC, ID DESC", pointy.Int(page), time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
 		if err != nil {
 			return nil, err
 		}

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -692,8 +692,10 @@ type SessionsHistogram struct {
 }
 
 type SessionResults struct {
-	Sessions   []Session
-	TotalCount int64
+	Sessions          []Session
+	TotalCount        int64
+	TotalLength       int64
+	TotalActiveLength int64
 }
 
 type Session struct {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -1412,8 +1412,10 @@ type ComplexityRoot struct {
 	}
 
 	SessionResults struct {
-		Sessions   func(childComplexity int) int
-		TotalCount func(childComplexity int) int
+		Sessions          func(childComplexity int) int
+		TotalActiveLength func(childComplexity int) int
+		TotalCount        func(childComplexity int) int
+		TotalLength       func(childComplexity int) int
 	}
 
 	SessionsHistogram struct {
@@ -10216,12 +10218,26 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SessionResults.Sessions(childComplexity), true
 
+	case "SessionResults.totalActiveLength":
+		if e.complexity.SessionResults.TotalActiveLength == nil {
+			break
+		}
+
+		return e.complexity.SessionResults.TotalActiveLength(childComplexity), true
+
 	case "SessionResults.totalCount":
 		if e.complexity.SessionResults.TotalCount == nil {
 			break
 		}
 
 		return e.complexity.SessionResults.TotalCount(childComplexity), true
+
+	case "SessionResults.totalLength":
+		if e.complexity.SessionResults.TotalLength == nil {
+			break
+		}
+
+		return e.complexity.SessionResults.TotalLength(childComplexity), true
 
 	case "SessionsHistogram.bucket_times":
 		if e.complexity.SessionsHistogram.BucketTimes == nil {
@@ -13111,6 +13127,8 @@ type ErrorsHistogram {
 type SessionResults {
 	sessions: [Session!]!
 	totalCount: Int64!
+	totalLength: Int64!
+	totalActiveLength: Int64!
 }
 
 type ErrorResults {
@@ -57588,6 +57606,10 @@ func (ec *executionContext) fieldContext_Query_sessions_clickhouse(ctx context.C
 				return ec.fieldContext_SessionResults_sessions(ctx, field)
 			case "totalCount":
 				return ec.fieldContext_SessionResults_totalCount(ctx, field)
+			case "totalLength":
+				return ec.fieldContext_SessionResults_totalLength(ctx, field)
+			case "totalActiveLength":
+				return ec.fieldContext_SessionResults_totalActiveLength(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type SessionResults", field.Name)
 		},
@@ -57649,6 +57671,10 @@ func (ec *executionContext) fieldContext_Query_sessions(ctx context.Context, fie
 				return ec.fieldContext_SessionResults_sessions(ctx, field)
 			case "totalCount":
 				return ec.fieldContext_SessionResults_totalCount(ctx, field)
+			case "totalLength":
+				return ec.fieldContext_SessionResults_totalLength(ctx, field)
+			case "totalActiveLength":
+				return ec.fieldContext_SessionResults_totalActiveLength(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type SessionResults", field.Name)
 		},
@@ -73386,6 +73412,94 @@ func (ec *executionContext) _SessionResults_totalCount(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext_SessionResults_totalCount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SessionResults",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SessionResults_totalLength(ctx context.Context, field graphql.CollectedField, obj *model1.SessionResults) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SessionResults_totalLength(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TotalLength, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int64)
+	fc.Result = res
+	return ec.marshalNInt642int64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SessionResults_totalLength(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SessionResults",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SessionResults_totalActiveLength(ctx context.Context, field graphql.CollectedField, obj *model1.SessionResults) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SessionResults_totalActiveLength(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TotalActiveLength, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int64)
+	fc.Result = res
+	return ec.marshalNInt642int64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SessionResults_totalActiveLength(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "SessionResults",
 		Field:      field,
@@ -98063,6 +98177,16 @@ func (ec *executionContext) _SessionResults(ctx context.Context, sel ast.Selecti
 			}
 		case "totalCount":
 			out.Values[i] = ec._SessionResults_totalCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "totalLength":
+			out.Values[i] = ec._SessionResults_totalLength(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "totalActiveLength":
+			out.Values[i] = ec._SessionResults_totalActiveLength(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1458,6 +1458,8 @@ type ErrorsHistogram {
 type SessionResults {
 	sessions: [Session!]!
 	totalCount: Int64!
+	totalLength: Int64!
+	totalActiveLength: Int64!
 }
 
 type ErrorResults {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -6527,7 +6527,7 @@ func (r *queryResolver) Sessions(ctx context.Context, projectID int, count int, 
 		return nil, err
 	}
 
-	ids, total, ordered, err := r.ClickhouseClient.QuerySessionIds(ctx, admin, projectID, count, params, chSortStr, page, retentionDate)
+	ids, total, totalLength, totalActiveLength, ordered, err := r.ClickhouseClient.QuerySessionIds(ctx, admin, projectID, count, params, chSortStr, page, retentionDate)
 	if err != nil {
 		return nil, err
 	}
@@ -6555,8 +6555,10 @@ func (r *queryResolver) Sessions(ctx context.Context, projectID int, count int, 
 	}
 
 	return &model.SessionResults{
-		Sessions:   results,
-		TotalCount: total,
+		Sessions:          results,
+		TotalCount:        total,
+		TotalLength:       totalLength,
+		TotalActiveLength: totalActiveLength,
 	}, nil
 }
 

--- a/frontend/src/components/Search/SearchContext.tsx
+++ b/frontend/src/components/Search/SearchContext.tsx
@@ -37,6 +37,7 @@ interface SearchContext extends Partial<ReturnType<typeof useSearchTime>> {
 	setPage: (page: number) => void
 	results: any[]
 	totalCount: number
+	resultFormatted?: string
 	moreResults: number
 	resetMoreResults: () => void
 	histogramBucketSize?: DateHistogramBucketSize
@@ -64,6 +65,7 @@ interface Props extends Partial<ReturnType<typeof useSearchTime>> {
 	page?: SearchContext['page']
 	setPage?: SearchContext['setPage']
 	results?: SearchContext['results']
+	resultFormatted?: SearchContext['resultFormatted']
 	totalCount?: SearchContext['totalCount']
 	histogramBucketSize?: SearchContext['histogramBucketSize']
 	moreResults?: SearchContext['moreResults']
@@ -83,6 +85,7 @@ export const SearchContext: React.FC<Props> = ({
 	loading = false,
 	initialQuery,
 	results = [],
+	resultFormatted = '',
 	totalCount = 0,
 	moreResults = 0,
 	page = START_PAGE,
@@ -109,6 +112,7 @@ export const SearchContext: React.FC<Props> = ({
 		<SearchContextProvider
 			value={{
 				results,
+				resultFormatted,
 				totalCount,
 				moreResults,
 				histogramBucketSize,

--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -56,7 +56,6 @@ import {
 import { ProductType, SavedSegmentEntityType } from '@/graph/generated/schemas'
 import { useDebounce } from '@/hooks/useDebounce'
 import { useApplicationContext } from '@/routers/AppRouter/context/ApplicationContext'
-import { formatNumber } from '@/util/numbers'
 
 import { AiSearch } from './AiSearch'
 import * as styles from './SearchForm.css'
@@ -115,7 +114,7 @@ export type SearchFormProps = {
 	savedSegmentType?: SavedSegmentEntityType
 	textAreaRef?: React.RefObject<HTMLTextAreaElement>
 	isPanelView?: boolean
-	resultCount?: number
+	resultFormatted?: string
 	loading?: boolean
 	creatables?: { [key: string]: Creatable }
 	enableAIMode?: boolean
@@ -137,7 +136,7 @@ const SearchForm: React.FC<SearchFormProps> = ({
 	savedSegmentType,
 	textAreaRef,
 	isPanelView,
-	resultCount,
+	resultFormatted,
 	loading,
 	creatables,
 	enableAIMode,
@@ -263,14 +262,11 @@ const SearchForm: React.FC<SearchFormProps> = ({
 									<Box display="flex" alignItems="center">
 										{loading ? (
 											<LoadingBox />
-										) : (
-											resultCount != null && (
-												<Text color="weak">
-													{formatNumber(resultCount)}{' '}
-													results
-												</Text>
-											)
-										)}
+										) : resultFormatted ? (
+											<Text color="weak">
+												{resultFormatted}
+											</Text>
+										) : null}
 									</Box>
 									{SegmentMenu}
 								</Stack>

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -7530,6 +7530,8 @@ export const GetSessionsDocument = gql`
 				email
 			}
 			totalCount
+			totalLength
+			totalActiveLength
 		}
 	}
 `

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -2394,7 +2394,7 @@ export type GetSessionsQueryVariables = Types.Exact<{
 export type GetSessionsQuery = { __typename?: 'Query' } & {
 	sessions: { __typename?: 'SessionResults' } & Pick<
 		Types.SessionResults,
-		'totalCount'
+		'totalCount' | 'totalLength' | 'totalActiveLength'
 	> & {
 			sessions: Array<
 				{ __typename?: 'Session' } & Pick<

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -3579,7 +3579,9 @@ export type SessionQuery = {
 export type SessionResults = {
 	__typename?: 'SessionResults'
 	sessions: Array<Session>
+	totalActiveLength: Scalars['Int64']
 	totalCount: Scalars['Int64']
+	totalLength: Scalars['Int64']
 }
 
 export type SessionsHistogram = {

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -576,6 +576,8 @@ query GetSessions(
 			email
 		}
 		totalCount
+		totalLength
+		totalActiveLength
 	}
 }
 

--- a/frontend/src/hooks/useFeatureFlag/useFeatureFlag.ts
+++ b/frontend/src/hooks/useFeatureFlag/useFeatureFlag.ts
@@ -16,6 +16,7 @@ interface Config {
 export enum Feature {
 	EventSearch,
 	PlayerNoChunkRemoval,
+	SessionResultsVerbose,
 }
 
 // configures the criteria and percentage of population for which the feature is active.
@@ -28,6 +29,11 @@ export const FeatureConfig: { [key: number]: Config } = {
 	[Feature.PlayerNoChunkRemoval]: {
 		workspace: true,
 		percent: 0,
+	},
+	[Feature.SessionResultsVerbose]: {
+		workspace: true,
+		percent: 0,
+		workspaceOverride: new Set<string>(['1', '5422', '27699']),
 	},
 } as const
 

--- a/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
+++ b/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
@@ -32,6 +32,7 @@ export const SearchPanel = () => {
 	const { showBanner } = useGlobalContext()
 	const {
 		results: errorGroups,
+		resultFormatted,
 		totalCount,
 		moreResults: moreErrors,
 		resetMoreResults: resetMoreErrors,
@@ -108,7 +109,7 @@ export const SearchPanel = () => {
 				timeMode="fixed-range"
 				savedSegmentType={SavedSegmentEntityType.Error}
 				actions={actions}
-				resultCount={totalCount}
+				resultFormatted={resultFormatted}
 				loading={loading}
 				enableAIMode={
 					workspaceSettings?.workspaceSettings?.ai_query_builder

--- a/frontend/src/pages/FrontPlugin/components/HighlightSessions.tsx
+++ b/frontend/src/pages/FrontPlugin/components/HighlightSessions.tsx
@@ -25,7 +25,7 @@ export function HighlightSessions() {
 		loading,
 		setQuery,
 		query,
-		totalCount,
+		resultFormatted,
 		startDate,
 		endDate,
 		selectedPreset,
@@ -115,7 +115,7 @@ export function HighlightSessions() {
 					productType={ProductType.Sessions}
 					timeMode="fixed-range"
 					savedSegmentType={SavedSegmentEntityType.Session}
-					resultCount={totalCount}
+					resultFormatted={resultFormatted}
 					loading={loading}
 					hideCreateAlert
 					isPanelView

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -299,7 +299,12 @@ export const PlayerInitialState = {
 	sessionEndTime: 0,
 	sessionIntervals: [],
 	sessionMetadata: EMPTY_SESSION_METADATA,
-	sessionResults: { sessions: [], totalCount: -1 },
+	sessionResults: {
+		sessions: [],
+		totalCount: 0,
+		totalLength: 0,
+		totalActiveLength: 0,
+	},
 	sessionViewability: SessionViewability.VIEWABLE,
 	session_secure_id: '',
 	time: 0,

--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -67,6 +67,7 @@ import {
 } from './constants'
 import { SessionView } from './SessionView'
 import * as style from './styles.css'
+import { formatResult } from '@pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/helpers'
 
 const PAGE_PARAM = withDefault(NumberParam, START_PAGE)
 
@@ -319,6 +320,12 @@ export const PlayerPage = () => {
 						onSubmit={handleSubmit}
 						loading={getSessionsData.loading}
 						results={getSessionsData.sessions}
+						resultFormatted={formatResult(
+							getSessionsData.totalCount,
+							getSessionsData.totalLength,
+							getSessionsData.totalActiveLength,
+							sessionFeedConfiguration.resultFormat,
+						)}
 						totalCount={getSessionsData.totalCount}
 						moreResults={getSessionsData.moreSessions}
 						resetMoreResults={getSessionsData.resetMoreSessions}

--- a/frontend/src/pages/Player/SessionView.tsx
+++ b/frontend/src/pages/Player/SessionView.tsx
@@ -104,6 +104,9 @@ export const SessionView: React.FC<SessionViewProps> = ({
 	useEffect(() => {
 		setSessionResults({
 			totalCount,
+			// not available from search context; not be used by replayer
+			totalLength: 0,
+			totalActiveLength: 0,
 			sessions: results,
 		})
 	}, [setSessionResults, totalCount, results])

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/helpers.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/helpers.ts
@@ -5,6 +5,7 @@ import moment from 'moment'
 import {
 	SESSION_FEED_COUNT_FORMAT,
 	SESSION_FEED_DATETIME_FORMAT,
+	SESSION_FEED_RESULT_FORMAT,
 	SESSION_FEED_SORT_ORDER,
 } from '../context/SessionFeedConfigurationContext'
 
@@ -73,4 +74,21 @@ export const getSortOrderDisplayName = (sortOrder: SESSION_FEED_SORT_ORDER) => {
 		default:
 			return 'Descending (Newest first)'
 	}
+}
+
+export const formatResult = (
+	count: number,
+	totalTime: moment.Duration | undefined,
+	activeTime: moment.Duration | undefined,
+	format: SESSION_FEED_RESULT_FORMAT,
+) => {
+	const humanizeFormat = { m: 1440 }
+	if (format === 'Count/Length/ActiveLength' && totalTime && activeTime) {
+		return `${count.toLocaleString()} results, ${totalTime.humanize(humanizeFormat)} total, ${activeTime.humanize(humanizeFormat)} active`
+	} else if (format === 'Active Length' && activeTime) {
+		return activeTime.humanize(humanizeFormat)
+	} else if (format === 'Length' && totalTime) {
+		return totalTime.humanize(humanizeFormat)
+	}
+	return `${count.toLocaleString()} results`
 }

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/helpers.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/helpers.ts
@@ -86,7 +86,13 @@ export const formatResult = (
 	activeTime: moment.Duration | undefined,
 	format: SESSION_FEED_RESULT_FORMAT,
 ) => {
-	if (format === 'Count/Length/ActiveLength' && totalTime && activeTime) {
+	if (count === 0) {
+		return `${count.toLocaleString()} results`
+	} else if (
+		format === 'Count/Length/ActiveLength' &&
+		totalTime &&
+		activeTime
+	) {
 		return `${count.toLocaleString()} results, ${durationFormatter(totalTime)} total, ${durationFormatter(activeTime)} active`
 	} else if (format === 'Active Length' && activeTime) {
 		return durationFormatter(activeTime)

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/helpers.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/helpers.ts
@@ -76,19 +76,22 @@ export const getSortOrderDisplayName = (sortOrder: SESSION_FEED_SORT_ORDER) => {
 	}
 }
 
+const durationFormatter = (dur: moment.Duration) => {
+	return dur.humanize()
+}
+
 export const formatResult = (
 	count: number,
 	totalTime: moment.Duration | undefined,
 	activeTime: moment.Duration | undefined,
 	format: SESSION_FEED_RESULT_FORMAT,
 ) => {
-	const humanizeFormat = { m: 1440 }
 	if (format === 'Count/Length/ActiveLength' && totalTime && activeTime) {
-		return `${count.toLocaleString()} results, ${totalTime.humanize(humanizeFormat)} total, ${activeTime.humanize(humanizeFormat)} active`
+		return `${count.toLocaleString()} results, ${durationFormatter(totalTime)} total, ${durationFormatter(activeTime)} active`
 	} else if (format === 'Active Length' && activeTime) {
-		return activeTime.humanize(humanizeFormat)
+		return durationFormatter(activeTime)
 	} else if (format === 'Length' && totalTime) {
-		return totalTime.humanize(humanizeFormat)
+		return durationFormatter(totalTime)
 	}
 	return `${count.toLocaleString()} results`
 }

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/index.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/index.tsx
@@ -6,6 +6,7 @@ import {
 	IconSolidAdjustments,
 	IconSolidCheck,
 	IconSolidClipboardList,
+	IconSolidDocumentReport,
 	IconSolidFastForward,
 	IconSolidSortDescending,
 	IconSolidTrash,
@@ -23,13 +24,20 @@ import { useSearchContext } from '@/components/Search/SearchContext'
 import {
 	countFormats,
 	dateTimeFormats,
+	resultFormats,
 	sortOrders,
 } from '@/pages/Sessions/SessionsFeedV3/context/SessionFeedConfigurationContext'
 
 import DeleteSessionsModal from '../DeleteSessionsModal'
 import { useSessionFeedConfiguration } from '../hooks/useSessionFeedConfiguration'
-import { formatCount, formatDatetime, getSortOrderDisplayName } from './helpers'
+import {
+	formatCount,
+	formatDatetime,
+	formatResult,
+	getSortOrderDisplayName,
+} from './helpers'
 import * as styles from './styles.css'
+import moment from 'moment'
 
 const Section: React.FC<React.PropsWithChildren<{ clickable?: true }>> = ({
 	children,
@@ -109,7 +117,7 @@ export const SessionFeedConfigDropdown = function () {
 				emphasis="low"
 				iconRight={<IconSolidAdjustments size={14} />}
 			/>
-			<Menu.List style={{ minWidth: 264 }} cssClass={styles.menuContents}>
+			<Menu.List style={{ minWidth: 420 }} cssClass={styles.menuContents}>
 				<Section>
 					<Menu.Item
 						key="autoplay"
@@ -355,6 +363,94 @@ export const SessionFeedConfigDropdown = function () {
 													}
 													text={formatCount(
 														12321,
+														format,
+													).toString()}
+												/>
+											</SectionRow>
+										</Menu.Item>
+									))}
+								</Menu.List>
+							</Menu>
+						</SectionRow>
+					</Menu.Item>
+					<Menu.Item key="results" className={styles.menuItem}>
+						<SectionRow>
+							<IconGroup
+								icon={
+									<IconSolidDocumentReport
+										size={16}
+										color={
+											vars.theme.interactive.fill
+												.secondary.content.text
+										}
+									/>
+								}
+								text="Result format"
+							/>
+							<Menu>
+								<Menu.Button
+									kind="secondary"
+									size="small"
+									emphasis="low"
+									cssClass={styles.menuButton}
+									onClick={(e: any) => e.preventDefault()}
+								>
+									{formatResult(
+										12321,
+										moment.duration(3, 'hours'),
+										moment.duration(1, 'hours'),
+										sessionFeedConfiguration.resultFormat,
+									)}
+								</Menu.Button>
+
+								<Menu.List
+									style={{ minWidth: 350 }}
+									cssClass={styles.menuContents}
+								>
+									{resultFormats.map((format) => (
+										<Menu.Item
+											key={format}
+											onClick={(e) => {
+												e.preventDefault()
+												sessionFeedConfiguration.setResultFormat(
+													format,
+												)
+											}}
+										>
+											<SectionRow>
+												<IconGroup
+													icon={
+														format ===
+														sessionFeedConfiguration.resultFormat ? (
+															<IconSolidCheck
+																size={16}
+																color={
+																	vars.theme
+																		.interactive
+																		.fill
+																		.primary
+																		.enabled
+																}
+															/>
+														) : (
+															<Box
+																style={{
+																	width: 16,
+																	height: 16,
+																}}
+															/>
+														)
+													}
+													text={formatResult(
+														12321,
+														moment.duration(
+															3,
+															'hours',
+														),
+														moment.duration(
+															1,
+															'hours',
+														),
 														format,
 													).toString()}
 												/>

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
@@ -30,7 +30,7 @@ import { useGlobalContext } from '@routers/ProjectRouter/context/GlobalContext'
 import { useParams } from '@util/react-router/useParams'
 import { roundFeedDate } from '@util/time'
 import clsx from 'clsx'
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import { AdditionalFeedResults } from '@/components/FeedResults/FeedResults'
 import { useSearchContext } from '@/components/Search/SearchContext'
@@ -45,6 +45,8 @@ import { SessionFeedConfigurationContextProvider } from './context/SessionFeedCo
 import { useSessionFeedConfiguration } from './hooks/useSessionFeedConfiguration'
 import { SessionFeedConfigDropdown } from './SessionFeedConfigDropdown'
 import * as style from './SessionFeedV3.css'
+import { formatResult } from '@pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/helpers'
+import moment from 'moment/moment'
 
 export const SessionsHistogram: React.FC<{ readonly?: boolean }> = React.memo(
 	({ readonly }) => {
@@ -182,6 +184,27 @@ export const SessionFeedV3 = React.memo(() => {
 
 	const { presets, minDate } = useRetentionPresets(ProductType.Sessions)
 
+	const resultTotalTime = useMemo(
+		() =>
+			moment.duration(
+				results
+					.map((s: Maybe<Session>) => s?.length)
+					.reduce((a, b) => a + b, 0),
+				'ms',
+			),
+		[results],
+	)
+	const resultActiveTime = useMemo(
+		() =>
+			moment.duration(
+				results
+					.map((s: Maybe<Session>) => s?.active_length)
+					.reduce((a, b) => a + b, 0),
+				'ms',
+			),
+		[results],
+	)
+
 	return (
 		<SessionFeedConfigurationContextProvider
 			value={sessionFeedConfiguration}
@@ -208,7 +231,12 @@ export const SessionFeedV3 = React.memo(() => {
 					timeMode="fixed-range"
 					savedSegmentType={SavedSegmentEntityType.Session}
 					actions={actions}
-					resultCount={totalCount}
+					resultFormatted={formatResult(
+						totalCount,
+						resultTotalTime,
+						resultActiveTime,
+						sessionFeedConfiguration.resultFormat,
+					)}
 					loading={loading}
 					creatables={{
 						sample: {

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
@@ -30,7 +30,7 @@ import { useGlobalContext } from '@routers/ProjectRouter/context/GlobalContext'
 import { useParams } from '@util/react-router/useParams'
 import { roundFeedDate } from '@util/time'
 import clsx from 'clsx'
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import { AdditionalFeedResults } from '@/components/FeedResults/FeedResults'
 import { useSearchContext } from '@/components/Search/SearchContext'
@@ -45,8 +45,6 @@ import { SessionFeedConfigurationContextProvider } from './context/SessionFeedCo
 import { useSessionFeedConfiguration } from './hooks/useSessionFeedConfiguration'
 import { SessionFeedConfigDropdown } from './SessionFeedConfigDropdown'
 import * as style from './SessionFeedV3.css'
-import { formatResult } from '@pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/helpers'
-import moment from 'moment/moment'
 
 export const SessionsHistogram: React.FC<{ readonly?: boolean }> = React.memo(
 	({ readonly }) => {
@@ -144,6 +142,7 @@ export const SessionFeedV3 = React.memo(() => {
 		endDate,
 		selectedPreset,
 		results,
+		resultFormatted,
 		moreResults,
 		resetMoreResults,
 		page,
@@ -184,27 +183,6 @@ export const SessionFeedV3 = React.memo(() => {
 
 	const { presets, minDate } = useRetentionPresets(ProductType.Sessions)
 
-	const resultTotalTime = useMemo(
-		() =>
-			moment.duration(
-				results
-					.map((s: Maybe<Session>) => s?.length)
-					.reduce((a, b) => a + b, 0),
-				'ms',
-			),
-		[results],
-	)
-	const resultActiveTime = useMemo(
-		() =>
-			moment.duration(
-				results
-					.map((s: Maybe<Session>) => s?.active_length)
-					.reduce((a, b) => a + b, 0),
-				'ms',
-			),
-		[results],
-	)
-
 	return (
 		<SessionFeedConfigurationContextProvider
 			value={sessionFeedConfiguration}
@@ -231,12 +209,7 @@ export const SessionFeedV3 = React.memo(() => {
 					timeMode="fixed-range"
 					savedSegmentType={SavedSegmentEntityType.Session}
 					actions={actions}
-					resultFormatted={formatResult(
-						totalCount,
-						resultTotalTime,
-						resultActiveTime,
-						sessionFeedConfiguration.resultFormat,
-					)}
+					resultFormatted={resultFormatted}
 					loading={loading}
 					creatables={{
 						sample: {

--- a/frontend/src/pages/Sessions/SessionsFeedV3/context/SessionFeedConfigurationContext.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/context/SessionFeedConfigurationContext.ts
@@ -21,6 +21,15 @@ export const sortOrders = ['Descending', 'Ascending'] as const
 
 export type SESSION_FEED_SORT_ORDER = (typeof sortOrders)[number]
 
+export const resultFormats = [
+	'Count',
+	'Length',
+	'Active Length',
+	'Count/Length/ActiveLength',
+] as const
+
+export type SESSION_FEED_RESULT_FORMAT = (typeof resultFormats)[number]
+
 export interface SessionFeedConfigurationContext {
 	datetimeFormat: SESSION_FEED_DATETIME_FORMAT
 	setDatetimeFormat: (newDatetimeFormat: SESSION_FEED_DATETIME_FORMAT) => void

--- a/frontend/src/pages/Sessions/SessionsFeedV3/hooks/useSessionFeedConfiguration.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/hooks/useSessionFeedConfiguration.ts
@@ -7,6 +7,7 @@ import {
 	SESSION_FEED_SORT_ORDER,
 } from '@/pages/Sessions/SessionsFeedV3/context/SessionFeedConfigurationContext'
 import useFeatureFlag, { Feature } from '@hooks/useFeatureFlag/useFeatureFlag'
+import { useEffect } from 'react'
 
 const LOCAL_STORAGE_KEY_PREFIX = 'highlightSessionFeedConfiguration'
 
@@ -29,8 +30,14 @@ export const useSessionFeedConfiguration = () => {
 	const [resultFormat, setResultFormat] =
 		useLocalStorage<SESSION_FEED_RESULT_FORMAT>(
 			`${LOCAL_STORAGE_KEY_PREFIX}ResultFormat`,
-			sessionResultsVerbose ? 'Count/Length/ActiveLength' : 'Count',
+			'Count',
 		)
+
+	useEffect(() => {
+		if (sessionResultsVerbose) {
+			setResultFormat('Count/Length/ActiveLength')
+		}
+	}, [sessionResultsVerbose, setResultFormat])
 
 	return {
 		datetimeFormat,

--- a/frontend/src/pages/Sessions/SessionsFeedV3/hooks/useSessionFeedConfiguration.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/hooks/useSessionFeedConfiguration.ts
@@ -3,12 +3,15 @@ import useLocalStorage from '@rehooks/local-storage'
 import {
 	SESSION_FEED_COUNT_FORMAT,
 	SESSION_FEED_DATETIME_FORMAT,
+	SESSION_FEED_RESULT_FORMAT,
 	SESSION_FEED_SORT_ORDER,
 } from '@/pages/Sessions/SessionsFeedV3/context/SessionFeedConfigurationContext'
+import useFeatureFlag, { Feature } from '@hooks/useFeatureFlag/useFeatureFlag'
 
 const LOCAL_STORAGE_KEY_PREFIX = 'highlightSessionFeedConfiguration'
 
 export const useSessionFeedConfiguration = () => {
+	const sessionResultsVerbose = useFeatureFlag(Feature.SessionResultsVerbose)
 	const [datetimeFormat, setDatetimeFormat] =
 		useLocalStorage<SESSION_FEED_DATETIME_FORMAT>(
 			`${LOCAL_STORAGE_KEY_PREFIX}DatetimeFormatV2`,
@@ -23,6 +26,11 @@ export const useSessionFeedConfiguration = () => {
 		`${LOCAL_STORAGE_KEY_PREFIX}SortOrder`,
 		'Descending',
 	)
+	const [resultFormat, setResultFormat] =
+		useLocalStorage<SESSION_FEED_RESULT_FORMAT>(
+			`${LOCAL_STORAGE_KEY_PREFIX}ResultFormat`,
+			sessionResultsVerbose ? 'Count/Length/ActiveLength' : 'Count',
+		)
 
 	return {
 		datetimeFormat,
@@ -31,5 +39,7 @@ export const useSessionFeedConfiguration = () => {
 		setCountFormat,
 		sortOrder,
 		setSortOrder,
+		resultFormat,
+		setResultFormat,
 	}
 }

--- a/frontend/src/pages/Sessions/SessionsFeedV3/hooks/useSessionFeedConfiguration.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/hooks/useSessionFeedConfiguration.ts
@@ -32,12 +32,23 @@ export const useSessionFeedConfiguration = () => {
 			`${LOCAL_STORAGE_KEY_PREFIX}ResultFormat`,
 			'Count',
 		)
+	const [resultFormatConfigured, setResultFormatConfigured] =
+		useLocalStorage<boolean>(
+			`${LOCAL_STORAGE_KEY_PREFIX}ResultFormat-configured`,
+			false,
+		)
 
 	useEffect(() => {
-		if (sessionResultsVerbose) {
+		if (!resultFormatConfigured && sessionResultsVerbose) {
 			setResultFormat('Count/Length/ActiveLength')
+			setResultFormatConfigured(true)
 		}
-	}, [sessionResultsVerbose, setResultFormat])
+	}, [
+		resultFormatConfigured,
+		sessionResultsVerbose,
+		setResultFormat,
+		setResultFormatConfigured,
+	])
 
 	return {
 		datetimeFormat,

--- a/frontend/src/pages/Sessions/useGetSessions.ts
+++ b/frontend/src/pages/Sessions/useGetSessions.ts
@@ -2,7 +2,7 @@ import { PAGE_SIZE } from '@components/SearchPagination/SearchPagination'
 import { useGetSessionsLazyQuery, useGetSessionsQuery } from '@graph/hooks'
 import { usePollQuery } from '@util/search'
 import moment from 'moment'
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { TIME_FORMAT } from '@/components/Search/SearchForm/constants'
 import { GetHistogramBucketSize } from '@/components/SearchResultsHistogram/SearchResultsHistogram'
@@ -92,6 +92,15 @@ export const useGetSessions = ({
 		maxResults: PAGE_SIZE,
 	})
 
+	const totalLength = useMemo(
+		() => moment.duration(data?.sessions?.totalLength || 0, 'ms'),
+		[data?.sessions?.totalLength],
+	)
+	const totalActiveLength = useMemo(
+		() => moment.duration(data?.sessions?.totalActiveLength || 0, 'ms'),
+		[data?.sessions?.totalActiveLength],
+	)
+
 	return {
 		sessions: data?.sessions?.sessions || [],
 		sessionSes: data?.sessions?.sessions.map((eg) => eg.secure_id) || [],
@@ -101,6 +110,8 @@ export const useGetSessions = ({
 		error,
 		refetch,
 		totalCount: data?.sessions?.totalCount || 0,
+		totalLength: totalLength,
+		totalActiveLength: totalActiveLength,
 		histogramBucketSize: determineHistogramBucketSize(startDate, endDate),
 		pollingExpired,
 	}


### PR DESCRIPTION
## Summary

Add a session feed configuration option that allows rendering the session total time rather than count.
Automatically enabled by default for certain workspaces.

## How did you test this change?

reflame
![Screenshot from 2024-10-11 15-02-46](https://github.com/user-attachments/assets/4db4cc44-6c1b-4831-b5f3-f560956fc667)

![Screenshot from 2024-10-11 15-52-46](https://github.com/user-attachments/assets/ed4e692a-f1a0-4baf-9a08-73c098001721)

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
