### PR TITLE
Fix alert page crash

### DIFF
--- a/backend/jobs/metric-alerts/metric-alerts.go
+++ b/backend/jobs/metric-alerts/metric-alerts.go
@@ -103,6 +103,8 @@ func processMetricAlert(ctx context.Context, DB *gorm.DB, MailClient *sendgrid.C
 		config = clickhouse.MetricsSampleableTableConfig
 	case modelInputs.ProductTypeTraces:
 		config = clickhouse.TracesSampleableTableConfig
+	case modelInputs.ProductTypeEvents:
+		config = clickhouse.EventsSampleableTableConfig
 	default:
 		return errors.Errorf("Unknown product type: %s", alert.ProductType)
 	}

--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -50,6 +50,8 @@ import { HeaderDivider } from '@/pages/Graphing/Dashboard'
 import { LabeledRow } from '@/pages/Graphing/LabeledRow'
 import { OptionDropdown } from '@/pages/Graphing/OptionDropdown'
 import { EventSelection } from '@/pages/Graphing/EventSelection'
+import { GraphContextProvider } from '@/pages/Graphing/context/GraphContext'
+import { useGraphData } from '@pages/Graphing/hooks/useGraphData'
 
 import { AlertGraph } from '../AlertGraph'
 import * as style from './styles.css'
@@ -87,6 +89,7 @@ const ALERT_PRODUCT_INFO = {
 
 export const AlertForm: React.FC = () => {
 	const { projectId } = useProjectId()
+	const graphContext = useGraphData()
 	const { alert_id } = useParams<{
 		alert_id: string
 	}>()
@@ -310,7 +313,7 @@ export const AlertForm: React.FC = () => {
 		createAlertContext.loading || updateAlertContext.loading || !alertName
 
 	return (
-		<>
+		<GraphContextProvider value={graphContext}>
 			<Helmet>
 				<title>{isEdit ? 'Edit' : 'Create'} Alert</title>
 			</Helmet>
@@ -661,6 +664,6 @@ export const AlertForm: React.FC = () => {
 					</Box>
 				</Box>
 			</Box>
-		</>
+		</GraphContextProvider>
 	)
 }


### PR DESCRIPTION
## Summary
Alert page crashing due to trying to call useContext from outside wrapper -> wrap the form in the GraphContextProvider

## How did you test this change?
- [ ] Able to create a new alert
- [ ] Able to view/edit a current alert

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
