### PR TITLE
Fix alert bucketing

### DIFF
--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -30,7 +30,7 @@ const SamplingRows = 20_000_000
 const KeysMaxRows = 1_000_000
 const KeyValuesMaxRows = 1_000_000
 const AllKeyValuesMaxRows = 100_000_000
-const MaxBuckets = 100
+const MaxBuckets = 240
 
 type SampleableTableConfig struct {
 	tableConfig         model.TableConfig


### PR DESCRIPTION
## Summary
Up the max buckets to 240 - alerts look at [4 hour windows](https://github.com/highlight/highlight/blob/main/backend/jobs/metric-alerts/metric-alerts.go#L76-L78) with [1 minute buckets](https://github.com/highlight/highlight/blob/main/backend/jobs/metric-alerts/metric-alerts.go#L76-L78), so they need 240 buckets to correctly calculate the `bucket_index` and metric_history `timestamp`.

```
// uses bucket max of 100
bucketIndex = toUInt64(intDiv((timetamp - min) * bucketCount(max of 100) / (max - min)))
// uses the original bucket count of 240
Timestamp = fromUnixTimestamp(toInt64(bucket_index*(max-min)/bucketCount + min))

After cancelation
Timestamp = timetamp *  bucketCount(max of 100) / bucketCount
```

<img width="614" alt="Screenshot 2024-10-16 at 12 36 32 PM" src="https://github.com/user-attachments/assets/54967dbd-9c76-405e-ae45-9d58e878bc4c">

## How did you test this change?
1. Create an log alert
2. Let it run
- [ ] Dates are correct

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A