### PR TITLE
fix writing session click events as fields

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2384,7 +2384,10 @@ func (r *Resolver) AddSessionEvents(ctx context.Context, sessionID int, events *
 
 				attributes := make(map[string]string)
 				for k, v := range propertiesObject {
-					attributes[k] = fmt.Sprintf("%v", v)
+					attributes[k] = fmt.Sprintf("%.*v", SESSION_FIELD_MAX_LENGTH, v)
+					if len(attributes[k]) > 0 {
+						fields[k] = attributes[k]
+					}
 				}
 
 				sessionEvents = append(sessionEvents,

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -225,8 +225,13 @@ func init() {
 	}
 }
 
+type AppendProperty struct {
+	Key   string
+	Value string
+}
+
 // Change to AppendProperties(sessionId,properties,type)
-func (r *Resolver) AppendProperties(ctx context.Context, sessionID int, properties map[string]string, propType Property) error {
+func (r *Resolver) AppendProperties(ctx context.Context, sessionID int, properties []AppendProperty, propType Property) error {
 	outerSpan, ctx := util.StartSpanFromContext(ctx, "public-graph.AppendProperties",
 		util.ResourceName("go.sessions.AppendProperties"), util.Tag("sessionID", sessionID))
 	defer outerSpan.Finish()
@@ -244,16 +249,16 @@ func (r *Resolver) AppendProperties(ctx context.Context, sessionID int, properti
 		util.ResourceName("processProperties"), util.Tag("num_properties", len(properties)))
 	var modelFields []*model.Field
 	projectID := session.ProjectID
-	for k, fv := range properties {
-		if len(fv) > SESSION_FIELD_MAX_LENGTH {
-			log.WithContext(ctx).Warnf("property %s from session %d exceeds max expected field length, skipping", k, sessionID)
-		} else if fv == "" {
+	for _, fv := range properties {
+		if len(fv.Value) > SESSION_FIELD_MAX_LENGTH {
+			log.WithContext(ctx).Warnf("property %s from session %d exceeds max expected field length, skipping", fv.Key, sessionID)
+		} else if fv.Value == "" {
 			// Skip when the field value is blank
-		} else if NumberRegex.MatchString(k) {
+		} else if NumberRegex.MatchString(fv.Key) {
 			// Skip when the field name is a number
 			// (this can be sent by clients if a string is passed as an `addProperties` payload)
 		} else {
-			modelFields = append(modelFields, &model.Field{ProjectID: projectID, Name: k, Value: fv, Type: string(propType)})
+			modelFields = append(modelFields, &model.Field{ProjectID: projectID, Name: fv.Key, Value: fv.Value, Type: string(propType)})
 		}
 	}
 
@@ -1078,7 +1083,9 @@ func (r *Resolver) IndexSessionClickhouse(ctx context.Context, session *model.Se
 	if session.AppVersion != nil {
 		sessionProperties["service_version"] = *session.AppVersion
 	}
-	if err := r.AppendProperties(ctx, session.ID, sessionProperties, PropertyType.SESSION); err != nil {
+	if err := r.AppendProperties(ctx, session.ID, lo.MapToSlice(sessionProperties, func(key string, value string) AppendProperty {
+		return AppendProperty{key, value}
+	}), PropertyType.SESSION); err != nil {
 		log.WithContext(ctx).Error(e.Wrap(err, "error adding set of properties to db"))
 	}
 	return r.DataSyncQueue.Submit(ctx, strconv.Itoa(session.ID), &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: session.ID}})
@@ -1562,7 +1569,9 @@ func (r *Resolver) IdentifySessionImpl(ctx context.Context, sessionSecureID stri
 	if err := session.SetUserProperties(allUserProperties); err != nil {
 		return e.Wrapf(err, "[IdentifySession] [project_id: %d] error appending user properties to session object {id: %d}", session.ProjectID, sessionID)
 	}
-	if err := r.AppendProperties(spanCtx, sessionID, newUserProperties, PropertyType.USER); err != nil {
+	if err := r.AppendProperties(spanCtx, sessionID, lo.MapToSlice(newUserProperties, func(key string, value string) AppendProperty {
+		return AppendProperty{key, value}
+	}), PropertyType.USER); err != nil {
 		log.WithContext(ctx).Error(e.Wrapf(err, "[IdentifySession] error adding set of identify properties to db: session: %d", sessionID))
 	}
 	setUserPropsSpan.Finish()
@@ -1682,7 +1691,9 @@ func (r *Resolver) AddSessionPropertiesImpl(ctx context.Context, sessionSecureID
 	for k, v := range obj {
 		fields[k] = fmt.Sprintf("%v", v)
 	}
-	err = r.AppendProperties(ctx, sessionObj.ID, fields, PropertyType.SESSION)
+	err = r.AppendProperties(ctx, sessionObj.ID, lo.MapToSlice(fields, func(key string, value string) AppendProperty {
+		return AppendProperty{key, value}
+	}), PropertyType.SESSION)
 	if err != nil {
 		return e.Wrap(err, "error adding set of properties to db")
 	}
@@ -2326,7 +2337,9 @@ func (r *Resolver) AddTrackPropertiesImpl(ctx context.Context, sessionSecureID s
 			return e.New("therewasonceahumblebumblebeeflyingthroughtheforestwhensuddenlyadropofwaterfullyencasedhimittookhimasecondtofigureoutthathesinaraindropsuddenlytheraindrophitthegroundasifhewasdivingintoapoolandheflewawaywithnofurtherissues")
 		}
 	}
-	err = r.AppendProperties(ctx, sessionObj.ID, fields, PropertyType.TRACK)
+	err = r.AppendProperties(ctx, sessionObj.ID, lo.MapToSlice(fields, func(key string, value string) AppendProperty {
+		return AppendProperty{key, value}
+	}), PropertyType.TRACK)
 	if err != nil {
 		return e.Wrap(err, "error adding set of properties to db")
 	}
@@ -2338,7 +2351,7 @@ func (r *Resolver) AddSessionEvents(ctx context.Context, sessionID int, events *
 		util.ResourceName("go.sessions.AddSessionEvents"))
 	defer outerSpan.Finish()
 
-	fields := map[string]string{}
+	var fields []AppendProperty
 	sessionEvents := []*clickhouse.SessionEventRow{}
 
 	for _, event := range events.Events {
@@ -2386,7 +2399,7 @@ func (r *Resolver) AddSessionEvents(ctx context.Context, sessionID int, events *
 				for k, v := range propertiesObject {
 					attributes[k] = fmt.Sprintf("%.*v", SESSION_FIELD_MAX_LENGTH, v)
 					if len(attributes[k]) > 0 {
-						fields[k] = attributes[k]
+						fields = append(fields, AppendProperty{k, attributes[k]})
 					}
 				}
 
@@ -2456,13 +2469,7 @@ func (r *Resolver) AddSessionEvents(ctx context.Context, sessionID int, events *
 				for k, v := range propertiesObject {
 					formattedVal := fmt.Sprintf("%.*v", SESSION_FIELD_MAX_LENGTH, v)
 					if len(formattedVal) > 0 {
-						fields[k] = formattedVal
-					}
-					// the value below is used for testing using /buttons
-					testTrackingMessage := "therewasonceahumblebumblebeeflyingthroughtheforestwhensuddenlyadropofwaterfullyencasedhimittookhimasecondtofigureoutthathesinaraindropsuddenlytheraindrophitthegroundasifhewasdivingintoapoolandheflewawaywithnofurtherissues"
-					if fields[k] == testTrackingMessage {
-						log.WithContext(ctx).WithField("session_id", sessionID).Error(testTrackingMessage)
-						continue
+						fields = append(fields, AppendProperty{k, formattedVal})
 					}
 				}
 			}
@@ -3503,7 +3510,7 @@ func (r *Resolver) submitFrontendConsoleMessages(ctx context.Context, sessionObj
 	return nil
 }
 
-func (r *Resolver) SendSessionTrackPropertiesAlert(ctx context.Context, workspace *model.Workspace, project *model.Project, session *model.Session, properties map[string]string) error {
+func (r *Resolver) SendSessionTrackPropertiesAlert(ctx context.Context, workspace *model.Workspace, project *model.Project, session *model.Session, properties []AppendProperty) error {
 	alertWorkerSpan, ctx := util.StartSpanFromContext(ctx, "public-graph.AppendProperties",
 		util.ResourceName("go.sessions.AppendProperties.alertWorker"), util.Tag("sessionID", session.ID))
 	defer alertWorkerSpan.Finish()
@@ -3567,17 +3574,17 @@ func (r *Resolver) SendSessionTrackPropertiesAlert(ctx context.Context, workspac
 
 		// relatedFields is the list of fields not inside of matchedFields.
 		var relatedFields []*model.Field
-		for k, fv := range properties {
+		for _, fv := range properties {
 			isAMatchedField := false
 
 			for _, matchedField := range matchedFields {
-				if matchedField.Name == k && matchedField.Value == fv {
+				if matchedField.Name == fv.Key && matchedField.Value == fv.Value {
 					isAMatchedField = true
 				}
 			}
 
 			if !isAMatchedField {
-				relatedFields = append(relatedFields, &model.Field{ProjectID: session.ProjectID, Name: k, Value: fv, Type: string(PropertyType.TRACK)})
+				relatedFields = append(relatedFields, &model.Field{ProjectID: session.ProjectID, Name: fv.Key, Value: fv.Value, Type: string(PropertyType.TRACK)})
 			}
 		}
 

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -814,9 +814,9 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 	if len(visitFields) >= 1 {
 		landingPage := visitFields[0]
 		exitPage := visitFields[len(visitFields)-1]
-		sessionProperties := map[string]string{
-			"landing_page": landingPage.Value,
-			"exit_page":    exitPage.Value,
+		sessionProperties := []pubgraph.AppendProperty{
+			{"landing_page", landingPage.Value},
+			{"exit_page", exitPage.Value},
 		}
 
 		if err := w.PublicResolver.AppendProperties(ctx, s.ID, sessionProperties, pubgraph.PropertyType.SESSION); err != nil {

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -815,8 +815,8 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 		landingPage := visitFields[0]
 		exitPage := visitFields[len(visitFields)-1]
 		sessionProperties := []pubgraph.AppendProperty{
-			{"landing_page", landingPage.Value},
-			{"exit_page", exitPage.Value},
+			{Key: "landing_page", Value: landingPage.Value},
+			{Key: "exit_page", Value: exitPage.Value},
 		}
 
 		if err := w.PublicResolver.AppendProperties(ctx, s.ID, sessionProperties, pubgraph.PropertyType.SESSION); err != nil {


### PR DESCRIPTION
## Summary

* Ensure that click events are written as session fields

## How did you test this change?

session showing up with `clickTextContent` filter
![Screenshot from 2024-10-16 15-22-31](https://github.com/user-attachments/assets/f4800428-14f9-477d-81b0-1f9609cb686c)

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no