### PR TITLE
Fix alert UX bugs

### DIFF
--- a/frontend/src/pages/Alerts/AlertEnableSwitch/AlertEnableSwitch.tsx
+++ b/frontend/src/pages/Alerts/AlertEnableSwitch/AlertEnableSwitch.tsx
@@ -26,7 +26,9 @@ export const AlertEnableSwitch: React.FC<
 	const [updateLogAlertIsDisabled] = useUpdateLogAlertIsDisabledMutation()
 	const [updateAlertDisabled] = useUpdateAlertDisabledMutation()
 
-	const onChange = async () => {
+	const onChange = async (_: boolean, e: React.MouseEvent) => {
+		e.preventDefault()
+
 		setLoading(true)
 		const isDisabled = !disabled
 

--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -23,6 +23,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom'
 import { SearchContext } from '@/components/Search/SearchContext'
 import { Search } from '@/components/Search/SearchForm/SearchForm'
 import {
+	GetAlertDocument,
 	useCreateAlertMutation,
 	useDeleteAlertMutation,
 	useGetAlertQuery,
@@ -115,14 +116,16 @@ export const AlertForm: React.FC = () => {
 		})
 
 	const [createAlert, createAlertContext] = useCreateAlertMutation({
-		refetchQueries: [
-			namedOperations.Query.GetAlert,
-			namedOperations.Query.GetAlertsPagePayload,
-		],
+		refetchQueries: [namedOperations.Query.GetAlertsPagePayload],
 	})
 	const [updateAlert, updateAlertContext] = useUpdateAlertMutation({
 		refetchQueries: [
-			namedOperations.Query.GetAlert,
+			{
+				query: GetAlertDocument,
+				variables: {
+					id: alert_id!,
+				},
+			},
 			namedOperations.Query.GetAlertsPagePayload,
 		],
 	})
@@ -196,8 +199,9 @@ export const AlertForm: React.FC = () => {
 		setFunctionColumn('')
 	}
 
-	const redirectToAlert = () => {
-		navigate(`/${projectId}/alerts/${alert_id}`)
+	const redirectToAlert = (id?: string) => {
+		const redirectId = id || alert_id
+		navigate(`/${projectId}/alerts/${redirectId}`)
 	}
 
 	const redirectToAlerts = () => {
@@ -241,9 +245,10 @@ export const AlertForm: React.FC = () => {
 					...formVariables,
 				},
 			})
-				.then(() => {
+				.then((response) => {
 					toast.success(`${alertName} created`).then(() => {
-						redirectToAlert()
+						console.log('reponse', response)
+						redirectToAlert(response?.data?.createAlert?.id)
 					})
 				})
 				.catch(() => {
@@ -396,7 +401,11 @@ export const AlertForm: React.FC = () => {
 							<Button
 								emphasis="low"
 								kind="secondary"
-								onClick={redirectToAlert}
+								onClick={() =>
+									alert_id
+										? redirectToAlert()
+										: redirectToAlerts()
+								}
 								trackingId="AlertCancel"
 							>
 								Cancel

--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -247,7 +247,6 @@ export const AlertForm: React.FC = () => {
 			})
 				.then((response) => {
 					toast.success(`${alertName} created`).then(() => {
-						console.log('reponse', response)
 						redirectToAlert(response?.data?.createAlert?.id)
 					})
 				})

--- a/frontend/src/pages/Alerts/AlertPage/index.tsx
+++ b/frontend/src/pages/Alerts/AlertPage/index.tsx
@@ -18,8 +18,8 @@ import { Helmet } from 'react-helmet'
 
 import { Button } from '@components/Button'
 import { toast } from '@/components/Toaster'
-import { namedOperations } from '@/graph/generated/operations'
 import {
+	GetAlertDocument,
 	useGetAlertQuery,
 	useGetAlertingAlertStateChangesLazyQuery,
 	useGetLastAlertStateChangesLazyQuery,
@@ -130,7 +130,14 @@ export const AlertPage: React.FC = () => {
 
 		setUpdateLoading(true)
 		await updateAlertDisabled({
-			refetchQueries: [namedOperations.Query.GetAlert],
+			refetchQueries: [
+				{
+					query: GetAlertDocument,
+					variables: {
+						id: alert_id!,
+					},
+				},
+			],
 			variables: {
 				alert_id: alert_id!,
 				project_id: projectId,

--- a/frontend/src/pages/Alerts/Alerts.tsx
+++ b/frontend/src/pages/Alerts/Alerts.tsx
@@ -479,7 +479,6 @@ const AlertRow = ({
 	const alertLink = getAlertLink(record)
 
 	const naviageToEditAlert = (e: React.MouseEvent<HTMLButtonElement>) => {
-		e.stopPropagation()
 		e.preventDefault()
 
 		const editAlertLink = getEditAlertLink(record)


### PR DESCRIPTION
## Summary
Fixes the following bugs on the alert page
- creating a new alert redirects to the alert correctly after creation
- Pressing cancel on the new alert form redirects back to the alerts page
- Pausing/enabling an alert on the alerts page does not redirect
- Only refetch the updated alert when updating an alert (previously refetched all cached alerts - event deleted ones)
- Don't refetch any alerts when creating a new alert

## How did you test this change?
1. Create a new alert but cancel
- [ ] Redirected to alerts page
2. Create a new alert and save
- [ ] Redirected to newly created alert page
3. Modify alert and save
- [ ] Redirected to page
- [ ] Alert page updated appropriately
4. Delete an alert
- [ ] Redirected to alerts page
5. Click into another alert
6. Enable/Pause the alert
- [ ] Alert page updated appropriately
- [ ] No errors trying to fetch deleted alert
7. Enable an alert from the alerts page
- [ ] Alerts page updated appropriately
- [ ] No redirections

https://www.loom.com/share/294789372200465f814849f8b810dc64?sid=f3294439-6395-4b79-bc80-0a2f97c69e52

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
