### PR TITLE
Fix session and error alert links

### DIFF
--- a/frontend/src/components/CreateAlertButton/CreateAlertButton.tsx
+++ b/frontend/src/components/CreateAlertButton/CreateAlertButton.tsx
@@ -3,14 +3,11 @@ import { Box, IconSolidBell } from '@highlight-run/ui/components'
 import { useProjectId } from '@hooks/useProjectId'
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
+import { ProductType } from '@/graph/generated/schemas'
 
 import * as styles from './style.css'
 
-export const CreateAlertButton = function ({
-	type,
-}: {
-	type: 'session' | 'errors'
-}) {
+export const CreateAlertButton = function ({ type }: { type: ProductType }) {
 	const { projectId } = useProjectId()
 	const navigate = useNavigate()
 	return (
@@ -21,7 +18,10 @@ export const CreateAlertButton = function ({
 			trackingId={`${type}-player-bar-alerts`}
 			iconLeft={<IconSolidBell />}
 			onClick={() => {
-				navigate(`/${projectId}/alerts/${type}/new`)
+				navigate({
+					pathname: `/${projectId}/alerts/new`,
+					search: `source=${type}`,
+				})
 			}}
 		>
 			Turn on alerts

--- a/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
@@ -373,7 +373,16 @@ function TopBar({
 		},
 		skip: !projectId,
 	})
-	const showCreateAlertButton = alertsData?.error_alerts?.length === 0
+
+	const showCreateAlertButton = useMemo(() => {
+		if (!!alertsData?.error_alerts?.length) {
+			return false
+		}
+
+		return !alertsData?.alerts?.some(
+			(alert) => alert?.product_type === ProductType.Errors,
+		)
+	}, [alertsData])
 
 	const {
 		showLeftPanel,
@@ -427,7 +436,7 @@ function TopBar({
 					<Box display="flex" gap="8" alignItems="center">
 						<ErrorShareButton errorGroup={errorGroup} />
 						{showCreateAlertButton ? (
-							<CreateAlertButton type="errors" />
+							<CreateAlertButton type={ProductType.Errors} />
 						) : null}
 						<Divider />
 						<ErrorStateSelect

--- a/frontend/src/pages/Player/SessionLevelBar/SessionLevelBarV2.tsx
+++ b/frontend/src/pages/Player/SessionLevelBar/SessionLevelBarV2.tsx
@@ -31,12 +31,13 @@ import usePlayerConfiguration from '@pages/Player/PlayerHook/utils/usePlayerConf
 import { useReplayerContext } from '@pages/Player/ReplayerContext'
 import analytics from '@util/analytics'
 import { delay } from 'lodash'
-import React, { useRef, useState } from 'react'
+import React, { useMemo, useRef, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { useNavigate } from 'react-router-dom'
 
 import { PlayerModeSwitch } from '@/pages/Player/SessionLevelBar/PlayerModeSwitch/PlayerModeSwitch'
 import { useSessionParams } from '@/pages/Sessions/utils'
+import { ProductType } from '@/graph/generated/schemas'
 
 import SessionShareButtonV2 from '../SessionShareButton/SessionShareButtonV2'
 import * as styles from './SessionLevelBarV2.css'
@@ -68,7 +69,16 @@ export const SessionLevelBarV2: React.FC<
 		},
 		skip: !projectId,
 	})
-	const showCreateAlertButton = alertsData?.new_session_alerts?.length === 0
+
+	const showCreateAlertButton = useMemo(() => {
+		if (!!alertsData?.new_session_alerts?.length) {
+			return false
+		}
+
+		return !alertsData?.alerts?.some(
+			(alert) => alert?.product_type === ProductType.Sessions,
+		)
+	}, [alertsData])
 
 	const isDefaultView = DEFAULT_RIGHT_PANEL_VIEWS.includes(rightPanelView)
 
@@ -168,7 +178,9 @@ export const SessionLevelBarV2: React.FC<
 						<>
 							<SessionShareButtonV2 />
 							{showCreateAlertButton ? (
-								<CreateAlertButton type="session" />
+								<CreateAlertButton
+									type={ProductType.Sessions}
+								/>
 							) : null}
 							<Divider />
 							<PlayerModeSwitch />


### PR DESCRIPTION
## Summary
The session and errors page have alert links to pages that do not exist. Update to link to the correct page and update the logic to check if a new alert exists.

## How did you test this change?
1. With no session alerts, view a session
- [ ] "Turn on alerts" button is displayed
2. Click on the "Turn on alerts" button
- [ ] Links to the new alert form
- [ ]  Sessions source prefilled
3. Create an alert
4. View the session again
- [ ] "Turn on alerts" button is NOT displayed
5. Repeat for errors

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
