### PR TITLE
Fix incorrect API reference in Node docs

### DIFF
--- a/highlight.io/components/QuickstartContent/traces/node-js/manual.tsx
+++ b/highlight.io/components/QuickstartContent/traces/node-js/manual.tsx
@@ -19,7 +19,7 @@ export const JSManualTracesContent: QuickStartContent = {
 		{
 			title: 'Wrap your code using the Node.js SDK.',
 			content:
-				'By wrapping your code with `startSpan` and `endSpan`, the `@highlight-run/node` SDK will record a span. You can create more child spans or add custom attributes to each span.',
+				'By calling `H.startActiveSpan()` and `span.end()`, the `@highlight-run/node` SDK will record a span. You can create more child spans or add custom attributes to each span.',
 			code: [
 				{
 					text: `
@@ -57,7 +57,7 @@ app.get('/', async (req, res) => {
 	await H.runWithHeaders(req.headers, () => {
 		const span = H.startActiveSpan("custom-span", {})
 		const err = new Error('this is a test error')
-		
+
 		console.info('Sending error to highlight')
 		H.consumeError(err)
 


### PR DESCRIPTION
## Summary

Fixes some misleading information about methods that did not exist on our Node SDK (`startSpan` and `endSpan`).

## How did you test this change?

Checked docs in PR preview.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A