### PR TITLE
update session results format

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -688,8 +688,8 @@ type SessionsHistogram struct {
 	BucketTimes           []time.Time `json:"bucket_times"`
 	SessionsWithoutErrors []int64     `json:"sessions_without_errors"`
 	SessionsWithErrors    []int64     `json:"sessions_with_errors"`
-	InactiveLengths       []int64     `json:"total_sessions"`
-	ActiveLengths         []int64     `json:"total_sessions"`
+	InactiveLengths       []int64     `json:"inactive_lengths"`
+	ActiveLengths         []int64     `json:"active_lengths"`
 	TotalSessions         []int64     `json:"total_sessions"`
 }
 

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -688,6 +688,8 @@ type SessionsHistogram struct {
 	BucketTimes           []time.Time `json:"bucket_times"`
 	SessionsWithoutErrors []int64     `json:"sessions_without_errors"`
 	SessionsWithErrors    []int64     `json:"sessions_with_errors"`
+	InactiveLengths       []int64     `json:"total_sessions"`
+	ActiveLengths         []int64     `json:"total_sessions"`
 	TotalSessions         []int64     `json:"total_sessions"`
 }
 

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -1429,7 +1429,9 @@ type ComplexityRoot struct {
 	}
 
 	SessionsHistogram struct {
+		ActiveLengths         func(childComplexity int) int
 		BucketTimes           func(childComplexity int) int
+		InactiveLengths       func(childComplexity int) int
 		SessionsWithErrors    func(childComplexity int) int
 		SessionsWithoutErrors func(childComplexity int) int
 		TotalSessions         func(childComplexity int) int
@@ -10310,12 +10312,26 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SessionResults.TotalLength(childComplexity), true
 
+	case "SessionsHistogram.active_lengths":
+		if e.complexity.SessionsHistogram.ActiveLengths == nil {
+			break
+		}
+
+		return e.complexity.SessionsHistogram.ActiveLengths(childComplexity), true
+
 	case "SessionsHistogram.bucket_times":
 		if e.complexity.SessionsHistogram.BucketTimes == nil {
 			break
 		}
 
 		return e.complexity.SessionsHistogram.BucketTimes(childComplexity), true
+
+	case "SessionsHistogram.inactive_lengths":
+		if e.complexity.SessionsHistogram.InactiveLengths == nil {
+			break
+		}
+
+		return e.complexity.SessionsHistogram.InactiveLengths(childComplexity), true
 
 	case "SessionsHistogram.sessions_with_errors":
 		if e.complexity.SessionsHistogram.SessionsWithErrors == nil {
@@ -13198,6 +13214,8 @@ type SessionsHistogram {
 	sessions_without_errors: [Int64!]!
 	sessions_with_errors: [Int64!]!
 	total_sessions: [Int64!]!
+	inactive_lengths: [Int64!]!
+	active_lengths: [Int64!]!
 }
 
 type ErrorsHistogram {
@@ -58231,6 +58249,10 @@ func (ec *executionContext) fieldContext_Query_sessions_histogram_clickhouse(ctx
 				return ec.fieldContext_SessionsHistogram_sessions_with_errors(ctx, field)
 			case "total_sessions":
 				return ec.fieldContext_SessionsHistogram_total_sessions(ctx, field)
+			case "inactive_lengths":
+				return ec.fieldContext_SessionsHistogram_inactive_lengths(ctx, field)
+			case "active_lengths":
+				return ec.fieldContext_SessionsHistogram_active_lengths(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type SessionsHistogram", field.Name)
 		},
@@ -58296,6 +58318,10 @@ func (ec *executionContext) fieldContext_Query_sessions_histogram(ctx context.Co
 				return ec.fieldContext_SessionsHistogram_sessions_with_errors(ctx, field)
 			case "total_sessions":
 				return ec.fieldContext_SessionsHistogram_total_sessions(ctx, field)
+			case "inactive_lengths":
+				return ec.fieldContext_SessionsHistogram_inactive_lengths(ctx, field)
+			case "active_lengths":
+				return ec.fieldContext_SessionsHistogram_active_lengths(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type SessionsHistogram", field.Name)
 		},
@@ -74299,6 +74325,94 @@ func (ec *executionContext) _SessionsHistogram_total_sessions(ctx context.Contex
 }
 
 func (ec *executionContext) fieldContext_SessionsHistogram_total_sessions(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SessionsHistogram",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SessionsHistogram_inactive_lengths(ctx context.Context, field graphql.CollectedField, obj *model1.SessionsHistogram) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SessionsHistogram_inactive_lengths(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.InactiveLengths, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]int64)
+	fc.Result = res
+	return ec.marshalNInt642ᚕint64ᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SessionsHistogram_inactive_lengths(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SessionsHistogram",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SessionsHistogram_active_lengths(ctx context.Context, field graphql.CollectedField, obj *model1.SessionsHistogram) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SessionsHistogram_active_lengths(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ActiveLengths, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]int64)
+	fc.Result = res
+	return ec.marshalNInt642ᚕint64ᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SessionsHistogram_active_lengths(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "SessionsHistogram",
 		Field:      field,
@@ -99006,6 +99120,16 @@ func (ec *executionContext) _SessionsHistogram(ctx context.Context, sel ast.Sele
 			}
 		case "total_sessions":
 			out.Values[i] = ec._SessionsHistogram_total_sessions(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "inactive_lengths":
+			out.Values[i] = ec._SessionsHistogram_inactive_lengths(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "active_lengths":
+			out.Values[i] = ec._SessionsHistogram_active_lengths(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1457,6 +1457,8 @@ type SessionsHistogram {
 	sessions_without_errors: [Int64!]!
 	sessions_with_errors: [Int64!]!
 	total_sessions: [Int64!]!
+	inactive_lengths: [Int64!]!
+	active_lengths: [Int64!]!
 }
 
 type ErrorsHistogram {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -6632,7 +6632,7 @@ func (r *queryResolver) SessionsHistogram(ctx context.Context, projectID int, pa
 		return nil, err
 	}
 
-	bucketTimes, totals, withErrors, withoutErrors, err := r.ClickhouseClient.QuerySessionHistogram(ctx, admin, projectID, params, retentionDate, histogramOptions)
+	bucketTimes, totals, withErrors, withoutErrors, inactiveLengths, activeLengths, err := r.ClickhouseClient.QuerySessionHistogram(ctx, admin, projectID, params, retentionDate, histogramOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -6646,6 +6646,8 @@ func (r *queryResolver) SessionsHistogram(ctx context.Context, projectID int, pa
 		BucketTimes:           MergeHistogramBucketTimes(bucketTimes, histogramOptions.BucketSize.Multiple),
 		SessionsWithoutErrors: MergeHistogramBucketCounts(withoutErrors, histogramOptions.BucketSize.Multiple),
 		SessionsWithErrors:    MergeHistogramBucketCounts(withErrors, histogramOptions.BucketSize.Multiple),
+		InactiveLengths:       MergeHistogramBucketCounts(inactiveLengths, histogramOptions.BucketSize.Multiple),
+		ActiveLengths:         MergeHistogramBucketCounts(activeLengths, histogramOptions.BucketSize.Multiple),
 		TotalSessions:         MergeHistogramBucketCounts(totals, histogramOptions.BucketSize.Multiple),
 	}, nil
 }

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -7723,6 +7723,8 @@ export const GetSessionsHistogramDocument = gql`
 			sessions_without_errors
 			sessions_with_errors
 			total_sessions
+			inactive_lengths
+			active_lengths
 		}
 	}
 `

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -2527,6 +2527,8 @@ export type GetSessionsHistogramQuery = { __typename?: 'Query' } & {
 		| 'sessions_without_errors'
 		| 'sessions_with_errors'
 		| 'total_sessions'
+		| 'inactive_lengths'
+		| 'active_lengths'
 	>
 }
 

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -3624,7 +3624,9 @@ export type SessionResults = {
 
 export type SessionsHistogram = {
 	__typename?: 'SessionsHistogram'
+	active_lengths: Array<Scalars['Int64']>
 	bucket_times: Array<Scalars['Timestamp']>
+	inactive_lengths: Array<Scalars['Int64']>
 	sessions_with_errors: Array<Scalars['Int64']>
 	sessions_without_errors: Array<Scalars['Int64']>
 	total_sessions: Array<Scalars['Int64']>

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -655,6 +655,8 @@ query GetSessionsHistogram(
 		sessions_without_errors
 		sessions_with_errors
 		total_sessions
+		inactive_lengths
+		active_lengths
 	}
 }
 

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/helpers.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/helpers.ts
@@ -77,7 +77,7 @@ export const getSortOrderDisplayName = (sortOrder: SESSION_FEED_SORT_ORDER) => {
 }
 
 const durationFormatter = (dur: moment.Duration) => {
-	return (dur.milliseconds() / 1000 / 60 / 60).toFixed(1).toLocaleString()
+	return dur.as('hours').toFixed(1).toLocaleString()
 }
 
 export const formatResult = (

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/helpers.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/helpers.ts
@@ -77,7 +77,7 @@ export const getSortOrderDisplayName = (sortOrder: SESSION_FEED_SORT_ORDER) => {
 }
 
 const durationFormatter = (dur: moment.Duration) => {
-	return dur.humanize()
+	return (dur.milliseconds() / 1000 / 60 / 60).toFixed(1).toLocaleString()
 }
 
 export const formatResult = (
@@ -93,11 +93,11 @@ export const formatResult = (
 		totalTime &&
 		activeTime
 	) {
-		return `${count.toLocaleString()} results, ${durationFormatter(totalTime)} total, ${durationFormatter(activeTime)} active`
+		return `${count.toLocaleString()} results, ${durationFormatter(totalTime)} total hours, ${durationFormatter(activeTime)} active hours`
 	} else if (format === 'Active Length' && activeTime) {
-		return durationFormatter(activeTime)
+		return `${durationFormatter(activeTime)} active hours`
 	} else if (format === 'Length' && totalTime) {
-		return durationFormatter(totalTime)
+		return `${durationFormatter(totalTime)} total hours`
 	}
 	return `${count.toLocaleString()} results`
 }

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/index.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/index.tsx
@@ -511,7 +511,7 @@ export const SessionFeedConfigDropdown = function () {
 												<IconGroup
 													icon={
 														format ===
-														sessionFeedConfiguration.setSessionHistogramFormat ? (
+														sessionFeedConfiguration.sessionHistogramFormat ? (
 															<IconSolidCheck
 																size={16}
 																color={

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/index.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/index.tsx
@@ -7,6 +7,7 @@ import {
 	IconSolidCheck,
 	IconSolidClipboardList,
 	IconSolidDocumentReport,
+	IconSolidDocumentText,
 	IconSolidFastForward,
 	IconSolidSortDescending,
 	IconSolidTrash,
@@ -25,6 +26,7 @@ import {
 	countFormats,
 	dateTimeFormats,
 	resultFormats,
+	sessionHistogramFormats,
 	sortOrders,
 } from '@/pages/Sessions/SessionsFeedV3/context/SessionFeedConfigurationContext'
 
@@ -377,7 +379,7 @@ export const SessionFeedConfigDropdown = function () {
 						<SectionRow>
 							<IconGroup
 								icon={
-									<IconSolidDocumentReport
+									<IconSolidDocumentText
 										size={16}
 										color={
 											vars.theme.interactive.fill
@@ -453,6 +455,83 @@ export const SessionFeedConfigDropdown = function () {
 														),
 														format,
 													).toString()}
+												/>
+											</SectionRow>
+										</Menu.Item>
+									))}
+								</Menu.List>
+							</Menu>
+						</SectionRow>
+					</Menu.Item>
+					<Menu.Item
+						key="sessionHistogram"
+						className={styles.menuItem}
+					>
+						<SectionRow>
+							<IconGroup
+								icon={
+									<IconSolidDocumentReport
+										size={16}
+										color={
+											vars.theme.interactive.fill
+												.secondary.content.text
+										}
+									/>
+								}
+								text="Session Histogram format"
+							/>
+							<Menu>
+								<Menu.Button
+									kind="secondary"
+									size="small"
+									emphasis="low"
+									cssClass={styles.menuButton}
+									onClick={(e: any) => e.preventDefault()}
+								>
+									{
+										sessionFeedConfiguration.sessionHistogramFormat
+									}
+								</Menu.Button>
+
+								<Menu.List
+									style={{ minWidth: 350 }}
+									cssClass={styles.menuContents}
+								>
+									{sessionHistogramFormats.map((format) => (
+										<Menu.Item
+											key={format}
+											onClick={(e) => {
+												e.preventDefault()
+												sessionFeedConfiguration.setSessionHistogramFormat(
+													format,
+												)
+											}}
+										>
+											<SectionRow>
+												<IconGroup
+													icon={
+														format ===
+														sessionFeedConfiguration.setSessionHistogramFormat ? (
+															<IconSolidCheck
+																size={16}
+																color={
+																	vars.theme
+																		.interactive
+																		.fill
+																		.primary
+																		.enabled
+																}
+															/>
+														) : (
+															<Box
+																style={{
+																	width: 16,
+																	height: 16,
+																}}
+															/>
+														)
+													}
+													text={format}
 												/>
 											</SectionRow>
 										</Menu.Item>

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
@@ -114,14 +114,14 @@ export const SessionsHistogram: React.FC<{ readonly?: boolean }> = React.memo(
 								color: 'n11',
 								counts: data?.sessions_histogram.inactive_lengths
 									.map(msToHours)
-									.map((h) => h.toFixed(1)),
+									.map((h) => Number(h.toFixed(1))),
 							},
 							{
 								label: 'active hours',
 								color: 'p11',
 								counts: data?.sessions_histogram.active_lengths
 									.map(msToHours)
-									.map((h) => h.toFixed(1)),
+									.map((h) => Number(h.toFixed(1))),
 							},
 						]
 					: [

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
@@ -112,16 +112,16 @@ export const SessionsHistogram: React.FC<{ readonly?: boolean }> = React.memo(
 							{
 								label: 'inactive hours',
 								color: 'n11',
-								counts: data?.sessions_histogram.inactive_lengths
-									.map(msToHours)
-									.map((h) => Number(h.toFixed(1))),
+								counts: data?.sessions_histogram.inactive_lengths.map(
+									msToHours,
+								),
 							},
 							{
 								label: 'active hours',
 								color: 'p11',
-								counts: data?.sessions_histogram.active_lengths
-									.map(msToHours)
-									.map((h) => Number(h.toFixed(1))),
+								counts: data?.sessions_histogram.active_lengths.map(
+									msToHours,
+								),
 							},
 						]
 					: [

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
@@ -28,7 +28,7 @@ import { SessionFeedCard } from '@pages/Sessions/SessionsFeedV3/SessionFeedCard/
 import { SessionReport } from '@pages/Sessions/SessionsFeedV3/SessionReport'
 import { useGlobalContext } from '@routers/ProjectRouter/context/GlobalContext'
 import { useParams } from '@util/react-router/useParams'
-import { roundFeedDate } from '@util/time'
+import { roundFeedDate, msToHours } from '@util/time'
 import clsx from 'clsx'
 import React from 'react'
 
@@ -59,6 +59,7 @@ export const SessionsHistogram: React.FC<{ readonly?: boolean }> = React.memo(
 			endDate,
 			updateSearchTime,
 		} = useSearchContext()
+		const sessionFeedConfiguration = useSessionFeedConfiguration()
 
 		const { loading, data } = useGetSessionsHistogramQuery({
 			variables: {
@@ -104,18 +105,39 @@ export const SessionsHistogram: React.FC<{ readonly?: boolean }> = React.memo(
 			histogram.bucketTimes = data?.sessions_histogram.bucket_times.map(
 				(startTime) => new Date(startTime).valueOf(),
 			)
-			histogram.seriesList = [
-				{
-					label: 'sessions',
-					color: 'n11',
-					counts: data?.sessions_histogram.sessions_without_errors,
-				},
-				{
-					label: 'w/errors',
-					color: 'p11',
-					counts: data?.sessions_histogram.sessions_with_errors,
-				},
-			]
+			histogram.seriesList =
+				sessionFeedConfiguration.sessionHistogramFormat ===
+				'Active/Inactive Time'
+					? [
+							{
+								label: 'inactive hours',
+								color: 'n11',
+								counts: data?.sessions_histogram.inactive_lengths
+									.map(msToHours)
+									.map((h) => h.toFixed(1)),
+							},
+							{
+								label: 'active hours',
+								color: 'p11',
+								counts: data?.sessions_histogram.active_lengths
+									.map(msToHours)
+									.map((h) => h.toFixed(1)),
+							},
+						]
+					: [
+							{
+								label: 'sessions',
+								color: 'n11',
+								counts: data?.sessions_histogram
+									.sessions_without_errors,
+							},
+							{
+								label: 'w/errors',
+								color: 'p11',
+								counts: data?.sessions_histogram
+									.sessions_with_errors,
+							},
+						]
 		}
 
 		return (

--- a/frontend/src/pages/Sessions/SessionsFeedV3/context/SessionFeedConfigurationContext.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/context/SessionFeedConfigurationContext.ts
@@ -21,6 +21,13 @@ export const sortOrders = ['Descending', 'Ascending'] as const
 
 export type SESSION_FEED_SORT_ORDER = (typeof sortOrders)[number]
 
+export const sessionHistogramFormats = [
+	'With/Without Errors',
+	'Active/Inactive Time',
+] as const
+
+export type SESSION_HISTOGRAM_FORMAT = (typeof sessionHistogramFormats)[number]
+
 export const resultFormats = [
 	'Count',
 	'Length',

--- a/frontend/src/pages/Sessions/SessionsFeedV3/hooks/useSessionFeedConfiguration.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/hooks/useSessionFeedConfiguration.ts
@@ -47,7 +47,7 @@ export const useSessionFeedConfiguration = () => {
 	useEffect(() => {
 		if (!resultFormatConfigured && sessionResultsVerbose) {
 			setResultFormat('Count/Length/ActiveLength')
-			setSessionHistogramFormat('Active Time')
+			setSessionHistogramFormat('Active/Inactive Time')
 			setResultFormatConfigured(true)
 		}
 	}, [

--- a/frontend/src/pages/Sessions/SessionsFeedV3/hooks/useSessionFeedConfiguration.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/hooks/useSessionFeedConfiguration.ts
@@ -5,6 +5,7 @@ import {
 	SESSION_FEED_DATETIME_FORMAT,
 	SESSION_FEED_RESULT_FORMAT,
 	SESSION_FEED_SORT_ORDER,
+	SESSION_HISTOGRAM_FORMAT,
 } from '@/pages/Sessions/SessionsFeedV3/context/SessionFeedConfigurationContext'
 import useFeatureFlag, { Feature } from '@hooks/useFeatureFlag/useFeatureFlag'
 import { useEffect } from 'react'
@@ -27,6 +28,11 @@ export const useSessionFeedConfiguration = () => {
 		`${LOCAL_STORAGE_KEY_PREFIX}SortOrder`,
 		'Descending',
 	)
+	const [sessionHistogramFormat, setSessionHistogramFormat] =
+		useLocalStorage<SESSION_HISTOGRAM_FORMAT>(
+			`${LOCAL_STORAGE_KEY_PREFIX}HistogramFormat`,
+			'With/Without Errors',
+		)
 	const [resultFormat, setResultFormat] =
 		useLocalStorage<SESSION_FEED_RESULT_FORMAT>(
 			`${LOCAL_STORAGE_KEY_PREFIX}ResultFormat`,
@@ -34,13 +40,14 @@ export const useSessionFeedConfiguration = () => {
 		)
 	const [resultFormatConfigured, setResultFormatConfigured] =
 		useLocalStorage<boolean>(
-			`${LOCAL_STORAGE_KEY_PREFIX}ResultFormat-configured`,
+			`${LOCAL_STORAGE_KEY_PREFIX}ResultFormat-configured-v2`,
 			false,
 		)
 
 	useEffect(() => {
 		if (!resultFormatConfigured && sessionResultsVerbose) {
 			setResultFormat('Count/Length/ActiveLength')
+			setSessionHistogramFormat('Active Time')
 			setResultFormatConfigured(true)
 		}
 	}, [
@@ -57,6 +64,8 @@ export const useSessionFeedConfiguration = () => {
 		setCountFormat,
 		sortOrder,
 		setSortOrder,
+		sessionHistogramFormat,
+		setSessionHistogramFormat,
 		resultFormat,
 		setResultFormat,
 	}

--- a/frontend/src/pages/Sessions/SessionsFeedV3/hooks/useSessionFeedConfiguration.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/hooks/useSessionFeedConfiguration.ts
@@ -54,6 +54,7 @@ export const useSessionFeedConfiguration = () => {
 		resultFormatConfigured,
 		sessionResultsVerbose,
 		setResultFormat,
+		setSessionHistogramFormat,
 		setResultFormatConfigured,
 	])
 

--- a/frontend/src/util/time.ts
+++ b/frontend/src/util/time.ts
@@ -42,6 +42,10 @@ export function formatTimeAsHMS(millis: number) {
 		: `${parts.h}:${minutesStr}:${secondsStr}`
 }
 
+export function msToHours(ms: number) {
+	return ms / 1000 / 60 / 60
+}
+
 interface TimeAsAplhanumOptions {
 	showDetails?: boolean
 	zeroUnit?: string

--- a/frontend/src/util/time.ts
+++ b/frontend/src/util/time.ts
@@ -43,7 +43,8 @@ export function formatTimeAsHMS(millis: number) {
 }
 
 export function msToHours(ms: number) {
-	return ms / 1000 / 60 / 60
+	const h = ms / 1000 / 60 / 60
+	return h < 10 / 60 ? Math.round(h * 1_000) / 1_000 : h
 }
 
 interface TimeAsAplhanumOptions {


### PR DESCRIPTION
## Summary

* Visualize active/inactive session time in hours
* Support new session histogram format of session active vs inactive time

Closes SUP-128

## How did you test this change?

![image](https://github.com/user-attachments/assets/0e2a492d-4240-4c91-996b-59ee2d75770f)

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no