### PR TITLE
Only admin admins to invite

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -920,6 +920,10 @@ func (r *mutationResolver) SendAdminWorkspaceInvite(ctx context.Context, workspa
 		return nil, err
 	}
 
+	if role != model.AdminRole.ADMIN && role != model.AdminRole.MEMBER {
+		return nil, e.Errorf("invalid role %s", role)
+	}
+
 	err = r.validateAdminRole(ctx, workspaceID)
 	if err != nil {
 		return nil, err

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -920,16 +920,9 @@ func (r *mutationResolver) SendAdminWorkspaceInvite(ctx context.Context, workspa
 		return nil, err
 	}
 
-	if role != model.AdminRole.ADMIN && role != model.AdminRole.MEMBER {
-		return nil, e.Errorf("invalid role %s", role)
-	}
-
-	// If the new invite is for an admin role, the inviter must be an admin
-	if role == model.AdminRole.ADMIN {
-		err := r.validateAdminRole(ctx, workspaceID)
-		if err != nil {
-			return nil, err
-		}
+	err = r.validateAdminRole(ctx, workspaceID)
+	if err != nil {
+		return nil, err
 	}
 
 	// Check if an invite to the email address already exists

--- a/frontend/src/components/Billing/EnterpriseFeatureButton.tsx
+++ b/frontend/src/components/Billing/EnterpriseFeatureButton.tsx
@@ -36,6 +36,7 @@ interface Props {
 	className?: string
 	variant?: 'basic'
 	shown?: true
+	disabled?: boolean
 }
 
 export default function EnterpriseFeatureButton({
@@ -48,6 +49,7 @@ export default function EnterpriseFeatureButton({
 	onShowModal,
 	onClose,
 	shown,
+	disabled,
 }: PropsWithChildren<Props>) {
 	const { currentWorkspace } = useApplicationContext()
 	const { data, loading } = useGetWorkspaceSettingsQuery({
@@ -70,7 +72,7 @@ export default function EnterpriseFeatureButton({
 	>(shown ? 'features' : undefined)
 
 	const checkFeature = useCallback(async () => {
-		if (loading || !data?.workspaceSettings) return
+		if (loading || !data?.workspaceSettings || disabled) return
 		if (!data.workspaceSettings[setting]) {
 			analytics.track(`enterprise-request-${name}`)
 			if (onShowModal) {
@@ -80,7 +82,15 @@ export default function EnterpriseFeatureButton({
 			return
 		}
 		await fn()
-	}, [loading, data?.workspaceSettings, setting, fn, name, onShowModal])
+	}, [
+		loading,
+		data?.workspaceSettings,
+		disabled,
+		setting,
+		fn,
+		name,
+		onShowModal,
+	])
 
 	let action: JSX.Element
 	if (variant === 'basic') {

--- a/frontend/src/pages/Auth/InviteTeam.tsx
+++ b/frontend/src/pages/Auth/InviteTeam.tsx
@@ -95,14 +95,13 @@ export const InviteTeamForm: React.FC = () => {
 	const adminRole = adminRoleData?.admin_role?.role ?? AdminRole.Member
 	const adminProjects = adminRoleData?.admin_role?.projectIds ?? []
 
-	const enableAutoJoinInput =
-		new_workspace && !isCommonEmailDomain && adminRole === AdminRole.Admin
+	const enableAutoJoinInput = new_workspace && !isCommonEmailDomain
 
 	useEffect(() => {
-		if (adminProjects.length > 0) {
+		if (adminProjects.length > 0 || adminRole !== AdminRole.Admin) {
 			navigate(redirectRoute)
 		}
-	}, [adminProjects.length, navigate, redirectRoute])
+	}, [adminProjects.length, adminRole, navigate, redirectRoute])
 
 	const formStore = Form.useStore({
 		defaultValues: {

--- a/frontend/src/pages/WorkspaceTeam/WorkspaceTeam.tsx
+++ b/frontend/src/pages/WorkspaceTeam/WorkspaceTeam.tsx
@@ -7,7 +7,9 @@ import {
 	IconSolidUserAdd,
 	Stack,
 	Tabs,
+	Tooltip,
 } from '@highlight-run/ui/components'
+import { useAuthContext } from '@/authentication/AuthContext'
 import AllMembers from '@pages/WorkspaceTeam/components/AllMembers'
 import { AutoJoinForm } from '@pages/WorkspaceTeam/components/AutoJoinForm'
 import InviteMemberModal from '@pages/WorkspaceTeam/components/InviteMemberModal'
@@ -125,6 +127,10 @@ const TabContentContainer = ({
 	title: string
 	toggleInviteModal: React.Dispatch<React.SetStateAction<boolean>>
 }) => {
+	const { workspaceRole } = useAuthContext()
+
+	const isAdminUser = workspaceRole === AdminRole.Admin
+
 	return (
 		<Box mt="8">
 			<Stack
@@ -134,20 +140,29 @@ const TabContentContainer = ({
 				direction="row"
 			>
 				<h4 className={styles.tabTitle}>{title}</h4>
-				<EnterpriseFeatureButton
-					setting="enable_business_seats"
-					name="More than 15 team members"
-					fn={() => toggleInviteModal((shown) => !shown)}
-					variant="basic"
+				<Tooltip
+					disabled={isAdminUser}
+					trigger={
+						<EnterpriseFeatureButton
+							setting="enable_business_seats"
+							name="More than 15 team members"
+							fn={() => toggleInviteModal((shown) => !shown)}
+							disabled={!isAdminUser}
+							variant="basic"
+						>
+							<Button
+								trackingId="WorkspaceTeamInviteMember"
+								iconLeft={<IconSolidUserAdd />}
+								onClick={() => null}
+								disabled={!isAdminUser}
+							>
+								Invite users
+							</Button>
+						</EnterpriseFeatureButton>
+					}
 				>
-					<Button
-						trackingId="WorkspaceTeamInviteMember"
-						iconLeft={<IconSolidUserAdd />}
-						onClick={() => console.log('invite users button')}
-					>
-						Invite users
-					</Button>
-				</EnterpriseFeatureButton>
+					Please contact an admin to invite users
+				</Tooltip>
 			</Stack>
 			{children}
 		</Box>

--- a/frontend/src/pages/WorkspaceTeam/components/InviteMemberModal.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/InviteMemberModal.tsx
@@ -14,7 +14,6 @@ import moment from 'moment'
 import { useEffect, useRef, useState } from 'react'
 import { StringParam, useQueryParam } from 'use-query-params'
 
-import { useAuthContext } from '@/authentication/AuthContext'
 import {
 	DISABLED_REASON_IS_ADMIN,
 	PopoverCell,
@@ -89,11 +88,6 @@ function InviteMemberModal({
 
 	const { allProjects } = useApplicationContext()
 
-	const { workspaceRole } = useAuthContext()
-
-	const roleOptions =
-		workspaceRole === AdminRole.Admin ? RoleOptions : [RoleOptions[0]]
-
 	const disabledReason =
 		newAdminRole === AdminRole.Admin ? DISABLED_REASON_IS_ADMIN : undefined
 
@@ -120,7 +114,7 @@ function InviteMemberModal({
 						<Box borderRadius="4" p="4" cssClass={styles.popover}>
 							<PopoverCell
 								label="roles"
-								options={roleOptions}
+								options={RoleOptions}
 								initialSelection={newAdminRole}
 								onChange={(role) => {
 									setNewAdminRole(role)


### PR DESCRIPTION
## Summary
Update the application to not allow member users to send invites to Highlight:
- Disable button to invite for non-admin
- Redirect from invite_team page for non-admin
- Secure backend for no non-admin invites

![Screenshot 2024-10-24 at 5 19 42 PM](https://github.com/user-attachments/assets/634ae9dd-836e-4f9e-8923-7f58de17fd9a)

## How did you test this change?
1. As a admin invite a member
- [ ] Able to invite member
2. Sign up as the member
- [ ] Member able to sign up
- [ ] Invite page is skipped
3. Try to invite another member on the team settings
- [ ] Invite button is disabled

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
