### PR TITLE
Move session event processing to kafka queue

### DIFF
--- a/backend/clickhouse/events.go
+++ b/backend/clickhouse/events.go
@@ -2,17 +2,16 @@ package clickhouse
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/google/uuid"
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/highlight-run/highlight/backend/parser"
 	"github.com/huandu/go-sqlbuilder"
 	"github.com/openlyinc/pointy"
+	e "github.com/pkg/errors"
 	"github.com/samber/lo"
 
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
@@ -87,42 +86,31 @@ type SessionEventRow struct {
 	Attributes       map[string]string
 }
 
-func (client *Client) WriteSessionEventRows(ctx context.Context, eventRows []*SessionEventRow) error {
+func (client *Client) BatchWriteSessionEventRows(ctx context.Context, eventRows []*SessionEventRow) error {
 	if len(eventRows) == 0 {
 		return nil
 	}
 
-	chEvents := []interface{}{}
-
-	for _, event := range eventRows {
-		if event == nil {
-			return errors.New("nil event")
+	rows := lo.Map(eventRows, func(l *SessionEventRow, _ int) interface{} {
+		if len(l.UUID) == 0 {
+			l.UUID = uuid.New().String()
 		}
+		return l
+	})
 
-		newEvent := *event
-		if len(newEvent.UUID) == 0 {
-			newEvent.UUID = uuid.New().String()
-		}
-
-		chEvents = append(chEvents, newEvent)
+	batch, err := client.conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s", SessionEventsTable))
+	if err != nil {
+		return e.Wrap(err, "failed to create session events batch")
 	}
 
-	if len(chEvents) > 0 {
-		chCtx := clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
-			"async_insert":          1,
-			"wait_for_async_insert": 1,
-		}))
-
-		eventsSql, eventsArgs := sqlbuilder.
-			NewStruct(new(SessionEventRow)).
-			InsertInto(SessionEventsTable, chEvents...).
-			BuildWithFlavor(sqlbuilder.ClickHouse)
-		eventsSql, eventsArgs = replaceTimestampInserts(eventsSql, eventsArgs, map[int]bool{3: true, 4: true}, MicroSeconds)
-
-		return client.conn.Exec(chCtx, eventsSql, eventsArgs...)
+	for _, sessionEventRow := range rows {
+		err = batch.AppendStruct(sessionEventRow)
+		if err != nil {
+			return err
+		}
 	}
 
-	return nil
+	return batch.Send()
 }
 
 func (client *Client) ReadEventsMetrics(ctx context.Context, projectID int, params modelInputs.QueryInput, column string, metricTypes []modelInputs.MetricAggregator, groupBy []string, nBuckets *int, bucketBy string, bucketWindow *int, limit *int, limitAggregator *modelInputs.MetricAggregator, limitColumn *string) (*modelInputs.MetricsBuckets, error) {

--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -5,9 +5,10 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/highlight-run/highlight/backend/env"
 	"strings"
 	"time"
+
+	"github.com/highlight-run/highlight/backend/env"
 
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
@@ -478,6 +479,8 @@ func (p *Queue) deserializeMessage(compressed []byte) (RetryableMessage, error) 
 		msg = &LogRowMessage{}
 	} else if msgType.Type == PushTracesFlattened {
 		msg = &TraceRowMessage{}
+	} else if msgType.Type == PushSessionEvents {
+		msg = &SessionEventRowMessage{}
 	} else {
 		msg = &Message{}
 	}

--- a/backend/kafka-queue/types.go
+++ b/backend/kafka-queue/types.go
@@ -36,6 +36,7 @@ const (
 	PushCompressedPayload                  PayloadType = iota
 	PushLogsFlattened                      PayloadType = iota
 	PushTracesFlattened                    PayloadType = iota
+	PushSessionEvents                      PayloadType = iota
 	HealthCheck                            PayloadType = math.MaxInt
 )
 
@@ -260,6 +261,41 @@ func (m *TraceRowMessage) GetKafkaMessage() *kafka.Message {
 	return m.KafkaMessage
 }
 func (m *TraceRowMessage) SetKafkaMessage(value *kafka.Message) {
+	m.KafkaMessage = value
+}
+
+type SessionEventRowMessage struct {
+	Type         PayloadType
+	Failures     int
+	MaxRetries   int
+	KafkaMessage *kafka.Message `json:",omitempty"`
+	*clickhouse.SessionEventRow
+}
+
+func (m *SessionEventRowMessage) GetType() PayloadType {
+	return PushSessionEvents
+}
+
+func (m *SessionEventRowMessage) GetFailures() int {
+	return m.Failures
+}
+
+func (m *SessionEventRowMessage) SetFailures(value int) {
+	m.Failures = value
+}
+
+func (m *SessionEventRowMessage) GetMaxRetries() int {
+	return m.MaxRetries
+}
+
+func (m *SessionEventRowMessage) SetMaxRetries(value int) {
+	m.MaxRetries = value
+}
+
+func (m *SessionEventRowMessage) GetKafkaMessage() *kafka.Message {
+	return m.KafkaMessage
+}
+func (m *SessionEventRowMessage) SetKafkaMessage(value *kafka.Message) {
 	m.KafkaMessage = value
 }
 

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -327,7 +327,7 @@ func (r *Resolver) SubmitSessionEvents(ctx context.Context, sessionID int, event
 
 	err := r.DataSyncQueue.Submit(ctx, "", messages...)
 	if err != nil {
-		return e.Wrap(err, "failed to submit otel project traces to public worker queue")
+		return e.Wrap(err, "failed to submit session events to public worker queue")
 	}
 
 	return nil

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/highlight-run/highlight/backend/env"
 	"github.com/highlight-run/highlight/backend/geolocation"
+	kafkaqueue "github.com/highlight-run/highlight/backend/kafka-queue"
 	"github.com/oschwald/geoip2-golang"
 
 	"go.opentelemetry.io/otel/codes"
@@ -295,11 +296,11 @@ func (r *Resolver) AppendProperties(ctx context.Context, sessionID int, properti
 	return nil
 }
 
-func (r *Resolver) CreateSessionEvents(ctx context.Context, sessionID int, events []*clickhouse.SessionEventRow) error {
-	outerSpan, ctxT := util.StartSpanFromContext(ctx, "public-graph.CreateSessionEvents", util.Tag("sessionID", sessionID))
+func (r *Resolver) SubmitSessionEvents(ctx context.Context, sessionID int, events []*clickhouse.SessionEventRow) error {
+	outerSpan, ctxT := util.StartSpanFromContext(ctx, "public-graph.SubmitSessionEvents", util.Tag("sessionID", sessionID))
 	defer outerSpan.Finish()
 
-	loadSessionSpan, ctxS := util.StartSpanFromContext(ctxT, "public-graph.CreateSessionEvents.loadSessions", util.Tag("sessionID", sessionID))
+	loadSessionSpan, ctxS := util.StartSpanFromContext(ctxT, "public-graph.SubmitSessionEvents.loadSessions", util.Tag("sessionID", sessionID))
 	session := &model.Session{}
 	res := r.DB.WithContext(ctxS).Where(&model.Session{Model: model.Model{ID: sessionID}}).Take(&session)
 	if err := res.Error; err != nil {
@@ -307,25 +308,26 @@ func (r *Resolver) CreateSessionEvents(ctx context.Context, sessionID int, event
 	}
 	loadSessionSpan.Finish()
 
-	clickhouseSpan, ctxW := util.StartSpanFromContext(ctxT, "public-graph.CreateSessionEvents.flush.sessionEvents")
-	clickhouseSpan.SetAttribute("NumSessionEventRows", len(events))
-	defer clickhouseSpan.Finish()
-
-	sessionEvents := []*clickhouse.SessionEventRow{}
+	var messages []kafkaqueue.RetryableMessage
 	for _, event := range events {
-		sessionEvents = append(sessionEvents, &clickhouse.SessionEventRow{
+		sessionEvent := &clickhouse.SessionEventRow{
 			ProjectID:        uint32(session.ProjectID),
 			SessionID:        uint64(session.ID),
 			SessionCreatedAt: session.CreatedAt.UnixMicro(),
 			Timestamp:        event.Timestamp,
 			Event:            event.Event,
 			Attributes:       event.Attributes,
+		}
+
+		messages = append(messages, &kafkaqueue.SessionEventRowMessage{
+			Type:            kafkaqueue.PushSessionEvents,
+			SessionEventRow: sessionEvent,
 		})
 	}
 
-	err := r.Clickhouse.WriteSessionEventRows(ctxW, sessionEvents)
+	err := r.DataSyncQueue.Submit(ctx, "", messages...)
 	if err != nil {
-		return e.Wrap(err, "error writing session events to clickhouse")
+		return e.Wrap(err, "failed to submit otel project traces to public worker queue")
 	}
 
 	return nil
@@ -2483,7 +2485,7 @@ func (r *Resolver) AddSessionEvents(ctx context.Context, sessionID int, events *
 	}
 
 	if len(sessionEvents) > 0 {
-		if err := r.CreateSessionEvents(ctx, sessionID, sessionEvents); err != nil {
+		if err := r.SubmitSessionEvents(ctx, sessionID, sessionEvents); err != nil {
 			log.WithContext(ctx).WithField("session_id", sessionID).Error(e.Wrapf(err, "error creating session events for session %d", sessionID))
 		}
 	}

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -474,7 +474,7 @@ func (k *KafkaBatchWorker) flushSessionEvents(ctx context.Context, sessionEventR
 	span, ctxT := util.StartSpanFromContext(ctx, fmt.Sprintf("worker.kafka.%s.flush.clickhouse", k.Name), util.WithHighlightTracingDisabled(true))
 	span.SetAttribute("NumTraceRows", len(sessionEventRows))
 	span.SetAttribute("PayloadSizeBytes", binary.Size(sessionEventRows))
-	err := k.Worker.PublicResolver.Clickhouse.WriteSessionEventRows(ctxT, sessionEventRows)
+	err := k.Worker.PublicResolver.Clickhouse.BatchWriteSessionEventRows(ctxT, sessionEventRows)
 	defer span.Finish(err)
 	if err != nil {
 		log.WithContext(ctxT).WithError(err).Error("failed to batch write session events to clickhouse")

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -153,6 +153,7 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) error {
 	var syncErrorObjectIds []int
 	var logRows []*clickhouse.LogRow
 	var traceRows []*clickhouse.ClickhouseTraceRow
+	var sessionEventRows []*clickhouse.SessionEventRow
 
 	var lastMsg kafkaqueue.RetryableMessage
 	var oldestMsg = time.Now()
@@ -163,7 +164,7 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) error {
 		}
 
 		publicWorkerMessage, ok := lastMsg.(*kafka_queue.Message)
-		if !ok && lastMsg.GetType() != kafkaqueue.PushLogsFlattened && lastMsg.GetType() != kafkaqueue.PushTracesFlattened {
+		if !ok && lastMsg.GetType() != kafkaqueue.PushLogsFlattened && lastMsg.GetType() != kafkaqueue.PushTracesFlattened && lastMsg.GetType() != kafkaqueue.PushSessionEvents {
 			log.WithContext(ctx).Errorf("type assertion failed for *kafka_queue.Message")
 			continue
 		}
@@ -203,6 +204,15 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) error {
 			if traceRow != nil {
 				traceRows = append(traceRows, clickhouse.ConvertTraceRow(traceRow))
 			}
+		case kafkaqueue.PushSessionEvents:
+			sessionEventRow, ok := lastMsg.(*kafka_queue.SessionEventRowMessage)
+			if !ok {
+				log.WithContext(ctx).Errorf("type assertion failed for *kafka_queue.SessionEventRowMessage")
+				continue
+			}
+			if sessionEventRow != nil {
+				sessionEventRows = append(sessionEventRows, sessionEventRow.SessionEventRow)
+			}
 		default:
 			log.WithContext(ctx).Errorf("unknown message type received by batch worker %+v", lastMsg.GetType())
 		}
@@ -211,11 +221,12 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) error {
 	k.log(
 		ctx,
 		log.Fields{
-			"session_ids":       syncSessionIds,
-			"error_group_ids":   syncErrorGroupIds,
-			"error_object_ids":  syncErrorObjectIds,
-			"log_rows_length":   len(logRows),
-			"trace_rows_length": len(traceRows),
+			"session_ids":           syncSessionIds,
+			"error_group_ids":       syncErrorGroupIds,
+			"error_object_ids":      syncErrorObjectIds,
+			"log_rows_length":       len(logRows),
+			"trace_rows_length":     len(traceRows),
+			"session_events_length": len(sessionEventRows),
 		},
 		"KafkaBatchWorker organized messages",
 	)
@@ -240,6 +251,12 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) error {
 	}
 	if len(traceRows) > 0 {
 		if err := k.flushTraces(wCtx, traceRows); err != nil {
+			workSpan.Finish(err)
+			return err
+		}
+	}
+	if len(sessionEventRows) > 0 {
+		if err := k.flushSessionEvents(wCtx, sessionEventRows); err != nil {
 			workSpan.Finish(err)
 			return err
 		}
@@ -450,6 +467,21 @@ func (k *KafkaBatchWorker) flushTraces(ctx context.Context, traceRows []*clickho
 			return err
 		}
 	}
+	return nil
+}
+
+func (k *KafkaBatchWorker) flushSessionEvents(ctx context.Context, sessionEventRows []*clickhouse.SessionEventRow) error {
+	span, ctxT := util.StartSpanFromContext(ctx, fmt.Sprintf("worker.kafka.%s.flush.clickhouse", k.Name), util.WithHighlightTracingDisabled(true))
+	span.SetAttribute("NumTraceRows", len(sessionEventRows))
+	span.SetAttribute("PayloadSizeBytes", binary.Size(sessionEventRows))
+	err := k.Worker.PublicResolver.Clickhouse.WriteSessionEventRows(ctxT, sessionEventRows)
+	defer span.Finish(err)
+	if err != nil {
+		log.WithContext(ctxT).WithError(err).Error("failed to batch write session events to clickhouse")
+		span.Finish(err)
+		return err
+	}
+
 	return nil
 }
 

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -840,7 +840,7 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 			},
 		}
 
-		if err := w.PublicResolver.CreateSessionEvents(ctx, s.ID, sessionEvents); err != nil {
+		if err := w.PublicResolver.SubmitSessionEvents(ctx, s.ID, sessionEvents); err != nil {
 			log.WithContext(ctx).Error(e.Wrapf(err, "error creating session events for session %d", s.ID))
 		}
 	}


### PR DESCRIPTION
## Summary
Move the session event processing to the DataSyncQueue so it does not block push payload

## How did you test this change?
1. Run the app and click around
- [ ] Confirm events are still being processed and inserted into ClickHouse

## Are there any deployment considerations?
1. How will this additional load add to the DataSync Queue?
2. How will it scale with Production data?

## Does this work require review from our design team?
N/A
