### PR TITLE
fix session video export with replaced assets

### DIFF
--- a/render/src/index.ts
+++ b/render/src/index.ts
@@ -90,8 +90,8 @@ if (process.env.DEV?.length) {
 		handler({
 			queryStringParameters: {
 				format: 'video/mp4',
-				project: '1',
-				session: '617599894',
+				project: '5403',
+				session: '965816134',
 			},
 		} as unknown as APIGatewayEvent),
 	])

--- a/render/src/index.ts
+++ b/render/src/index.ts
@@ -90,8 +90,8 @@ if (process.env.DEV?.length) {
 		handler({
 			queryStringParameters: {
 				format: 'video/mp4',
-				project: '5403',
-				session: '965816134',
+				project: '1',
+				session: '617599894',
 			},
 		} as unknown as APIGatewayEvent),
 	])

--- a/render/src/render.ts
+++ b/render/src/render.ts
@@ -64,7 +64,6 @@ async function setupOAuthProjectToken(
 			secure: true,
 			sameSite: 'None',
 		} as CookieParam
-		console.log('setting project-token cookie', cookieParam)
 		await page.setCookie(cookieParam)
 	}
 }

--- a/render/src/serial.ts
+++ b/render/src/serial.ts
@@ -42,7 +42,7 @@ export async function serialRender(
 	if (chunkEvents.length === 1) {
 		return {
 			dir,
-			files: await render(chunkEvents[0], 0, intervals, 0, 1, {
+			files: await render(project, chunkEvents[0], 0, intervals, 0, 1, {
 				fps,
 				ts,
 				tsEnd,
@@ -54,7 +54,7 @@ export async function serialRender(
 		const files: string[] = []
 		for (const [idx, events] of chunkEvents.entries()) {
 			files.push(
-				...(await render(events, idx, intervals, 0, 1, {
+				...(await render(project, events, idx, intervals, 0, 1, {
 					fps,
 					video: true,
 				})),


### PR DESCRIPTION
## Summary

Sets up oauth API access in the render lambda to get a project token and configure the puppeteer instance
with the project token cookie for loading replaced assets . This allows loading custom media and CSS that is
replaced with a pri.highlight.io/assets/... URL.

* Improves rendering speed of lambda by speeding up playback

Closes SUP-146

## How did you test this change?

https://highlight-session-render.s3.us-east-2.amazonaws.com/5403/W3Hfwlqq0DxPuL395GjZssKqF72h.mp4

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
