### PR TITLE
persist table sort order by id

### DIFF
--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -169,6 +169,10 @@ export interface SeriesInfo {
 	strokeColors?: string[] | Map<string, string>
 }
 
+export interface VizId {
+	visualizationId: string | undefined
+}
+
 export interface AxisConfig {
 	showXAxis?: boolean
 	showYAxis?: boolean
@@ -1314,6 +1318,7 @@ const Graph = ({
 						viewConfig={viewConfig}
 						series={series}
 						disabled={disabled}
+						visualizationId={id}
 					/>
 				)
 				break

--- a/frontend/src/pages/Graphing/components/Table.tsx
+++ b/frontend/src/pages/Graphing/components/Table.tsx
@@ -8,16 +8,17 @@ import {
 } from '@highlight-run/ui/components'
 import clsx from 'clsx'
 import _ from 'lodash'
-import { useState } from 'react'
 
 import {
 	getTickFormatter,
 	GROUP_KEY,
 	InnerChartProps,
 	SeriesInfo,
+	VizId,
 } from '@/pages/Graphing/components/Graph'
 
 import * as style from './Table.css'
+import useLocalStorage from '@rehooks/local-storage'
 
 export type TableNullHandling = 'Hide row' | 'Blank' | 'Zero'
 export const TABLE_NULL_HANDLING: TableNullHandling[] = [
@@ -47,7 +48,8 @@ export const MetricTable = ({
 	series,
 	viewConfig,
 	disabled,
-}: InnerChartProps<TableConfig> & SeriesInfo) => {
+	visualizationId,
+}: InnerChartProps<TableConfig> & SeriesInfo & VizId) => {
 	const xAxisTickFormatter = getTickFormatter(xAxisMetric)
 	const valueFormatter = getTickFormatter(yAxisMetric)
 
@@ -56,8 +58,14 @@ export const MetricTable = ({
 
 	const showMetricFn = series.join('') === ''
 
-	const [sortColumn, setSortColumn] = useState(-1)
-	const [sortAsc, setSortAsc] = useState(true)
+	const [sortAsc, setSortAsc] = useLocalStorage<boolean>(
+		`sort-asc-${visualizationId}`,
+		true,
+	)
+	const [sortColumn, setSortColumn] = useLocalStorage<number>(
+		`sort-col-${visualizationId}`,
+		-1,
+	)
 
 	const onSort = (colIdx: number) => () => {
 		if (sortColumn === colIdx) {


### PR DESCRIPTION
## Summary
- use local storage variables to store the sort column and asc/desc by visualization id
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
