### PR TITLE
Respect `tracingOrigins` network instrumentation context propagation

### DIFF
--- a/.changeset/four-lizards-mix.md
+++ b/.changeset/four-lizards-mix.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+respect traceOrigins setting for context propagation

--- a/.changeset/four-lizards-mix.md
+++ b/.changeset/four-lizards-mix.md
@@ -1,5 +1,0 @@
----
-'highlight.run': patch
----
-
-respect traceOrigins setting for context propagation

--- a/sdk/client/src/otel/index.test.ts
+++ b/sdk/client/src/otel/index.test.ts
@@ -1,0 +1,25 @@
+import { getCorsUrlsPattern } from './index'
+
+describe('getCorsUrlsPattern', () => {
+	it('handles `tracingOrigins: false` correctly', () => {
+		expect(getCorsUrlsPattern(false)).toEqual(/^$/)
+	})
+
+	it('handles `tracingOrigins: true` correctly', () => {
+		expect(getCorsUrlsPattern(true)).toEqual([
+			/localhost/,
+			/^\//,
+			/localhost:3000/,
+		])
+	})
+
+	it('handles `tracingOrigins: [string, string]` correctly', () => {
+		expect(
+			getCorsUrlsPattern([
+				'example.com',
+				'localhost:3000',
+				'pub.highlight.io',
+			]),
+		).toEqual([/example.com/, /localhost:3000/, /pub.highlight.io/])
+	})
+})

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -1,5 +1,11 @@
 # highlight.run
 
+## 9.5.2
+
+### Patch Changes
+
+-   df0b226: respect traceOrigins setting for context propagation
+
 ## 9.5.1
 
 ### Patch Changes

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "9.5.1",
+	"version": "9.5.2",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "9.5.1"
+export default "9.5.2"

--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @highlight-run/next
 
+## 7.6.2
+
+### Patch Changes
+
+-   Updated dependencies [df0b226]
+    -   highlight.run@9.5.2
+    -   @highlight-run/node@3.9.4
+    -   @highlight-run/react@7.0.2
+
 ## 7.6.1
 
 ### Patch Changes

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "7.6.1",
+	"version": "7.6.2",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-react/CHANGELOG.md
+++ b/sdk/highlight-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @highlight-run/react
 
+## 7.0.2
+
+### Patch Changes
+
+-   Updated dependencies [df0b226]
+    -   highlight.run@9.5.2
+
 ## 7.0.1
 
 ### Patch Changes

--- a/sdk/highlight-react/package.json
+++ b/sdk/highlight-react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/react",
-	"version": "7.0.1",
+	"version": "7.0.2",
 	"description": "The official Highlight SDK for React",
 	"license": "Apache-2.0",
 	"peerDependencies": {

--- a/sdk/highlight-remix/CHANGELOG.md
+++ b/sdk/highlight-remix/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @highlight-run/remix
 
+## 2.0.65
+
+### Patch Changes
+
+-   Updated dependencies [df0b226]
+    -   highlight.run@9.5.2
+    -   @highlight-run/node@3.9.4
+    -   @highlight-run/react@7.0.2
+
 ## 2.0.64
 
 ### Patch Changes

--- a/sdk/highlight-remix/package.json
+++ b/sdk/highlight-remix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/remix",
-	"version": "2.0.64",
+	"version": "2.0.65",
 	"description": "Client for interfacing with Highlight in Remix",
 	"packageManager": "yarn@4.0.2",
 	"author": "",


### PR DESCRIPTION
## Summary

Ensures that the `traceparent` header is only assigned on requests to URLs that match the `tracingOrigins` setting on the client config. Previously, we were adding the `traceparent` header to all requests.

## How did you test this change?

Added some unit tests for the logic behind the new config setting and tested locally by inspecting network traffic with different settings - see results below.

**`['pri.highlight.io', 'localhost:8082/private']` (default - header included)**
<img width="1273" alt="Screenshot 2024-10-28 at 4 11 41 PM" src="https://github.com/user-attachments/assets/5e3d4b30-b5bb-4f55-a94e-15c0d804232e">

**`['pri.highlight.io']` (header not included)**
<img width="1273" alt="Screenshot 2024-10-28 at 4 11 15 PM" src="https://github.com/user-attachments/assets/bf79c0b5-f2f1-4d07-bd8e-b3a5469d0fb1">

**`true` (header included)**
<img width="1274" alt="Screenshot 2024-10-28 at 4 12 02 PM" src="https://github.com/user-attachments/assets/6cbfb623-ef59-4469-bb30-a83a317f22f5">

## Are there any deployment considerations?

Need to notify some customers about this change since they have been waiting on the fix.

## Does this work require review from our design team?

N/A