### PR TITLE
Fix span sorting in trace waterfall view

### DIFF
--- a/frontend/src/pages/Traces/TraceProvider.tsx
+++ b/frontend/src/pages/Traces/TraceProvider.tsx
@@ -10,7 +10,7 @@ import {
 	getTraceTimes,
 	organizeSpansForFlameGraph,
 	organizeSpansWithChildren,
-	traceSortFn,
+	traceSortByStartTimeFn,
 } from '@/pages/Traces/utils'
 
 type TraceContext = {
@@ -131,7 +131,7 @@ export const TraceProvider: React.FC<React.PropsWithChildren<Props>> = ({
 			return []
 		}
 
-		const spans = [...data.trace.trace].sort(traceSortFn)
+		const spans = [...data.trace.trace].sort(traceSortByStartTimeFn)
 		return organizeSpansWithChildren(spans)
 	}, [data?.trace?.trace])
 

--- a/frontend/src/pages/Traces/utils.ts
+++ b/frontend/src/pages/Traces/utils.ts
@@ -277,3 +277,13 @@ export const traceSortFn = (
 
 	return startA - startB
 }
+
+export const traceSortByStartTimeFn = (
+	a: Partial<FlameGraphSpan>,
+	b: Partial<FlameGraphSpan>,
+) => {
+	const startA = new Date(a.timestamp ?? 0).getTime()
+	const startB = new Date(b.timestamp ?? 0).getTime()
+
+	return startA - startB
+}


### PR DESCRIPTION
## Summary

Fixes an issue where spans were being rendered in the wrong order on the waterfall view of the flame graph. This change ensures that spans are always rendered in order of when they started, which makes more sense in this context than the other sorting method we use, which optimizes for placement on a flame graph.

## How did you test this change?

Click tested by viewing a trace in the waterfall UI before and after making this change.

**Before**
<img width="907" alt="Screenshot 2024-10-28 at 4 28 07 PM" src="https://github.com/user-attachments/assets/8bbd1140-e227-40c4-b222-7292d10566ee">

**After**
<img width="518" alt="Screenshot 2024-10-28 at 4 27 46 PM" src="https://github.com/user-attachments/assets/e3080d1e-c112-4f8c-a199-62db9009ac10">

## Are there any deployment considerations?

I will notify customers who reported this issue in Discord that it is fixed.

## Does this work require review from our design team?

N/A