### PR TITLE
Check buckets

### DIFF
--- a/backend/jobs/metric-alerts/metric-alerts.go
+++ b/backend/jobs/metric-alerts/metric-alerts.go
@@ -195,7 +195,7 @@ func processMetricAlert(ctx context.Context, DB *gorm.DB, MailClient *sendgrid.C
 		groupByKey = groupBy[0]
 	}
 
-	bucketsInner := buckets.Buckets
+	var bucketsInner []*modelInputs.MetricBucket
 
 	stateChanges := []modelInputs.AlertStateChange{}
 	if saveMetricState {
@@ -235,6 +235,8 @@ func processMetricAlert(ctx context.Context, DB *gorm.DB, MailClient *sendgrid.C
 			}
 			bucketsInner = newBuckets
 		}
+	} else if buckets != nil {
+		bucketsInner = buckets.Buckets
 	}
 
 	if len(bucketsInner) == 0 {


### PR DESCRIPTION
## Summary
Metric monitors are not sending alerts due to nil pointer - reference the pointer more safely

<img width="750" alt="Screenshot 2024-10-29 at 5 01 39 PM" src="https://github.com/user-attachments/assets/161d4ecc-26dc-44db-984e-1ad306183549">

## How did you test this change?
1. Create a log, trace, error, and session alert
- [ ] Log alert correctly sends
- [ ] Trace alert correctly sends
- [ ] Session alert correctly sends
- [ ] Error alert correctly sends

## Are there any deployment considerations?
Monitor for any downstream errors

## Does this work require review from our design team?
N/A