### PR TITLE
document opentelemetry project id attributes

### DIFF
--- a/docs-content/general/4_company/open-source/contributing/adding-an-sdk.md
+++ b/docs-content/general/4_company/open-source/contributing/adding-an-sdk.md
@@ -19,6 +19,72 @@ In our SDKs, we instantiate the following constructs to exports data over OTLP H
 
 The SDK provides common methods for recording exceptions or logging, but this may depend on the language. For example, in Go, a logger hook API is provided to be configured by the application, but in Python, we automatically ingest a hook into the built in `logging` package.
 
+## Configuring OpenTelemetry attributes
+
+Highlight follows OpenTelemetry [semantic conventions](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/) to record data in highlight with metadata you expect. However, there are a few key attributes that highlight treats distinctly.
+
+### Setting the Highlight Project ID
+
+To have your OpenTelemetry data land in your highlight project, you must provide the highlight project identifier with the data.
+This can be done via an exporter HTTP header, resource attributes, or data attributes (on the individual span / log / metric records). 
+
+- x-highlight-project - use this HTTP header for OpenTelemetry exporter configuration
+- highlight.project_id - use this Attribute key for Resource or Record attributes
+
+### Example Node.js OpenTelemetry configuration
+
+```typescript
+import { NodeSDK } from '@opentelemetry/sdk-node'
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { Resource } from '@opentelemetry/resources'
+import type { Attributes } from '@opentelemetry/api'
+
+const attributes: Attributes = {
+	// Provide the highlight project ID as a resource attribute or via the exporter headers
+    // 'highlight.project_id': '<YOUR_PROJECT_ID>',
+    'service.name': 'my-service'
+}
+const sdk = new NodeSDK({
+	resource: new Resource(attributes),
+	traceExporter: new OTLPTraceExporter({
+		// NB: this is the url for trace exports. if you are using a language which supports
+		// the opentelemetry logs format, use 'https://otel.highlight.io:4318/v1/logs'
+		url: 'https://otel.highlight.io:4318/v1/traces',
+		// In some OpenTelemetry implementations, it's easier to provide 
+		// the project ID as a header rather than a resource attribute.
+		headers: { 'x-highlight-project': '<YOUR_PROJECT_ID>' }
+	})
+});
+const tracer = trace.getTracer('my-tracer');
+sdk.start();
+
+
+const log = (level: string, message: string) => {
+    const span = tracer.startSpan('main')
+    span.setAttributes({
+        ['highlight.session_id']: 'abc123',
+        ['highlight.trace_id']: 'def456',
+        customer: 'vadim',
+        customer_id: 1234
+    })
+
+    span.addEvent('log', {
+        ['log.severity']: level,
+        ['log.message']: message
+    }, new Date())
+
+    span.addEvent('metric', {
+        ['metric.name']: 'my-web-vital',
+        ['metric.value']: 12.34
+    }, new Date())
+    span.end()
+};
+
+log('info', 'hello, world!')
+```
+
+See the OpenTelemetry [getting started guide](/docs/getting-started/native-opentelemetry/tracing) as well for more details.
+
 ## Recording an Error
 
 Data we send over the OpenTelemetry specification is as a [Trace](https://opentelemetry.io/docs/reference/specification/trace/) with attributes set per the [semantic conventions](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/).

--- a/docs-content/general/4_company/open-source/contributing/adding-an-sdk.md
+++ b/docs-content/general/4_company/open-source/contributing/adding-an-sdk.md
@@ -21,11 +21,11 @@ The SDK provides common methods for recording exceptions or logging, but this ma
 
 ## Configuring OpenTelemetry attributes
 
-Highlight follows OpenTelemetry [semantic conventions](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/) to record data in highlight with metadata you expect. However, there are a few key attributes that highlight treats distinctly.
+Highlight follows OpenTelemetry [semantic conventions](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/) to record data in Highlight with metadata you expect. However, there are a few key attributes that highlight treats distinctly.
 
 ### Setting the Highlight Project ID
 
-To have your OpenTelemetry data land in your highlight project, you must provide the highlight project identifier with the data.
+To have your OpenTelemetry data land in your Highlight project, you must provide the Highlight project identifier with the data.
 This can be done via an exporter HTTP header, resource attributes, or data attributes (on the individual span / log / metric records). 
 
 - x-highlight-project - use this HTTP header for OpenTelemetry exporter configuration

--- a/docs-content/general/4_company/open-source/contributing/adding-an-sdk.md
+++ b/docs-content/general/4_company/open-source/contributing/adding-an-sdk.md
@@ -83,7 +83,7 @@ const log = (level: string, message: string) => {
 log('info', 'hello, world!')
 ```
 
-See the OpenTelemetry [getting started guide](/docs/getting-started/native-opentelemetry/tracing) as well for more details.
+See the OpenTelemetry [getting started guide](/getting-started/native-opentelemetry/tracing) as well for more details.
 
 ## Recording an Error
 

--- a/docs-content/general/4_company/open-source/contributing/adding-an-sdk.md
+++ b/docs-content/general/4_company/open-source/contributing/adding-an-sdk.md
@@ -83,7 +83,7 @@ const log = (level: string, message: string) => {
 log('info', 'hello, world!')
 ```
 
-See the OpenTelemetry [getting started guide](/getting-started/native-opentelemetry/tracing) as well for more details.
+See the OpenTelemetry [getting started guide](../../../../getting-started/7_native-opentelemetry/4_tracing.md) as well for more details.
 
 ## Recording an Error
 

--- a/highlight.io/components/QuickstartContent/backend/otlp.tsx
+++ b/highlight.io/components/QuickstartContent/backend/otlp.tsx
@@ -17,12 +17,18 @@ import { Resource } from '@opentelemetry/resources'
 import type { Attributes } from '@opentelemetry/api'
 
 const attributes: Attributes = {
+	// Provide the highlight project ID as a resource attribute or via the exporter headers
     'highlight.project_id': '<YOUR_PROJECT_ID>'
 }
 const sdk = new NodeSDK({
 	resource: new Resource(attributes),
 	traceExporter: new OTLPTraceExporter({
+		// NB: this is the url for trace exports. if you are using a language which supports
+		// the opentelemetry logs format, use 'https://otel.highlight.io:4318/v1/logs'
 		url: 'https://otel.highlight.io:4318/v1/traces'
+		// In some OpenTelemetry implementations, it's easier to provide 
+		// the project ID as a header rather than a resource attribute.
+		// headers: { 'x-highlight-project': '<YOUR_PROJECT_ID>' }
 	})
 });
 const tracer = trace.getTracer('my-service');

--- a/highlight.io/components/QuickstartContent/logging/otlp.tsx
+++ b/highlight.io/components/QuickstartContent/logging/otlp.tsx
@@ -17,6 +17,7 @@ import { Resource } from '@opentelemetry/resources'
 import type { Attributes } from '@opentelemetry/api'
 
 const attributes: Attributes = {
+	// Provide the highlight project ID as a resource attribute or via the exporter headers
     'highlight.project_id': '<YOUR_PROJECT_ID>'
 }
 const sdk = new NodeSDK({
@@ -25,6 +26,9 @@ const sdk = new NodeSDK({
 		// NB: this is the url for trace exports. if you are using a language which supports
 		// the opentelemetry logs format, use 'https://otel.highlight.io:4318/v1/logs'
 		url: 'https://otel.highlight.io:4318/v1/traces'
+		// In some OpenTelemetry implementations, it's easier to provide 
+		// the project ID as a header rather than a resource attribute.
+		// headers: { 'x-highlight-project': '<YOUR_PROJECT_ID>' }
 	})
 });
 const tracer = trace.getTracer('my-service');

--- a/highlight.io/components/QuickstartContent/traces/otlp.tsx
+++ b/highlight.io/components/QuickstartContent/traces/otlp.tsx
@@ -17,12 +17,18 @@ import { Resource } from '@opentelemetry/resources'
 import type { Attributes } from '@opentelemetry/api'
 
 const attributes: Attributes = {
+    // Provide the highlight project ID as a resource attribute or via the exporter headers
     'highlight.project_id': '<YOUR_PROJECT_ID>'
 }
 const sdk = new NodeSDK({
 	resource: new Resource(attributes),
 	traceExporter: new OTLPTraceExporter({
+		// NB: this is the url for trace exports. if you are using a language which supports
+		// the opentelemetry logs format, use 'https://otel.highlight.io:4318/v1/logs'
 		url: 'https://otel.highlight.io:4318/v1/traces'
+		// In some OpenTelemetry implementations, it's easier to provide 
+		// the project ID as a header rather than a resource attribute.
+		// headers: { 'x-highlight-project': '<YOUR_PROJECT_ID>' }
 	})
 });
 sdk.start();`,


### PR DESCRIPTION
## Summary

Add highlight project ID to the OpenTelemetry docs to make it more clear how
to configure project ID propagation in various OTeL SDKs.

## How did you test this change?

[Vercel preview
](https://highlight-landing-git-vadim-otlp-project-docs-highlight-run.vercel.app/)
## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
