### PR TITLE
remove mouseMoveState for perf

### DIFF
--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -227,8 +227,6 @@ export const useGraphCallbacks = (
 	const chartRef = useRef<HTMLDivElement>(null)
 	const tooltipRef = useRef<HTMLDivElement>(null)
 
-	const [mouseMoveState, setMouseMoveState] =
-		useState<CategoricalChartState>()
 	const [frozenTooltip, setFrozenTooltip] = useState<CategoricalChartState>()
 
 	const allowDrag = setTimeRange !== undefined
@@ -266,8 +264,6 @@ export const useGraphCallbacks = (
 
 	const onMouseMove = allowDrag
 		? (e: CategoricalChartState) => {
-				setMouseMoveState(e)
-
 				if (refAreaStart !== undefined && e.activeLabel !== undefined) {
 					setRefAreaEnd(Number(e.activeLabel))
 					setFrozenTooltip(undefined)
@@ -338,12 +334,7 @@ export const useGraphCallbacks = (
 		/>
 	)
 
-	const tooltipCanFreeze =
-		loadExemplars &&
-		!frozenTooltip &&
-		mouseMoveState?.activePayload?.find(
-			(p) => ![undefined, null].includes(p.value),
-		)
+	const tooltipCanFreeze = loadExemplars && !frozenTooltip
 
 	return {
 		referenceArea,


### PR DESCRIPTION
## Summary
- this state was being tracked to determine whether or not to show a pointer for drilldown - this will cause a pointer to always be shown but will speed up perf for complex graphs significantly due to not having to rerender on mouse move
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally w/ complex group by
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
