### PR TITLE
support winston json formatted log messages

### DIFF
--- a/e2e/nextjs/pages/api/hello.ts
+++ b/e2e/nextjs/pages/api/hello.ts
@@ -6,6 +6,8 @@ function handler(req: NextApiRequest, res: NextApiResponse) {
 	const user = {
 		name: 'vadim',
 	} as any
+	logger.info({ key: 'my json message', foo: 'bar', user })
+
 	for (let i = 0; i < 100; i++) {
 		user[i.toString()] = Math.random()
 	}

--- a/e2e/nextjs/pages/api/winston.config.ts
+++ b/e2e/nextjs/pages/api/winston.config.ts
@@ -38,5 +38,13 @@ export const logger = winston.createLogger({
 		winston.format.timestamp(),
 		winston.format.prettyPrint(),
 	),
-	transports: [new winston.transports.Console(), highlightTransport],
+	transports: [
+		new winston.transports.Console({
+			level: 'debug',
+			handleExceptions: true,
+			// @ts-ignore
+			json: true,
+		}),
+		highlightTransport,
+	],
 })

--- a/highlight.io/next.config.js
+++ b/highlight.io/next.config.js
@@ -3,13 +3,16 @@ const getStaticPages = require('./scripts/get-static-pages')
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-	webpack: (config) => {
+	webpack: (config, { isServer }) => {
 		config.resolve.fallback = {
 			...config.resolve.fallback, // if you miss it, all the other options in fallback, specified
 			// by next.js will be dropped. Doesn't make much sense, but how it is
 			fs: false, // the solution
 		}
-
+		// configure server-side sourcemaps
+		if (isServer) {
+			config.devtool = 'source-map'
+		}
 		return config
 	},
 	compress: true,


### PR DESCRIPTION
## Summary

Supports ingesting structured json messages that have a message that is json.
This now unwraps the inner json to be top level attributes, in addition to serializing the top json payload as the message.

## How did you test this change?

![Screenshot from 2024-10-31 14-00-00](https://github.com/user-attachments/assets/d506710e-1bcf-44c4-bcfa-ba8321cbc25a)

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no