### PR TITLE
make checks backwards compatible with null threshold/condition

### DIFF
--- a/backend/alerts/predictions/predictions.go
+++ b/backend/alerts/predictions/predictions.go
@@ -30,10 +30,10 @@ type PredictionInput struct {
 }
 
 type PredictionResult struct {
-	DS        map[uint64]uint64  `json:"ds"`
-	YHat      map[uint64]float64 `json:"yhat"`
-	YHatLower map[uint64]float64 `json:"yhat_lower"`
-	YHatUpper map[uint64]float64 `json:"yhat_upper"`
+	DS        map[int]uint64  `json:"ds"`
+	YHat      map[int]float64 `json:"yhat"`
+	YHatLower map[int]float64 `json:"yhat_lower"`
+	YHatUpper map[int]float64 `json:"yhat_upper"`
 }
 
 func AddPredictions(ctx context.Context, metricBuckets []*modelInputs.MetricBucket, settings modelInputs.PredictionSettings) error {
@@ -92,12 +92,12 @@ func AddPredictions(ctx context.Context, metricBuckets []*modelInputs.MetricBuck
 			return err
 		}
 
-		for _, b := range buckets {
+		for idx, b := range buckets {
 			if settings.ThresholdCondition != modelInputs.ThresholdConditionBelow {
-				b.YhatUpper = pointy.Float64(result.YHatUpper[b.BucketID])
+				b.YhatUpper = pointy.Float64(result.YHatUpper[idx])
 			}
 			if settings.ThresholdCondition != modelInputs.ThresholdConditionAbove {
-				b.YhatLower = pointy.Float64(result.YHatLower[b.BucketID])
+				b.YhatLower = pointy.Float64(result.YHatLower[idx])
 			}
 		}
 	}

--- a/backend/clickhouse/metric_history.go
+++ b/backend/clickhouse/metric_history.go
@@ -64,7 +64,7 @@ func (client *Client) AggregateMetricStates(ctx context.Context, metricId string
 	groupCols := []string{"1"}
 
 	if windowSeconds != nil {
-		selectCols = append(selectCols, fmt.Sprintf("date_diff('second', %s, Timestamp) / %d as BucketId", startDate.Format("2006-01-02 15:04:05"), windowSeconds))
+		selectCols = append(selectCols, fmt.Sprintf("toUInt64(date_diff('second', %s, Timestamp) / %d) as BucketId", sb.Var(startDate), *windowSeconds))
 		groupCols = append(groupCols, "2")
 	}
 
@@ -110,10 +110,11 @@ func (client *Client) AggregateMetricStates(ctx context.Context, metricId string
 		if err := rows.ScanStruct(&result); err != nil {
 			return nil, err
 		}
+		val := result.Value
 		results = append(results, &modelInputs.MetricBucket{
 			BucketID:    result.BucketId,
 			Group:       []string{result.GroupByKey},
-			MetricValue: &result.Value,
+			MetricValue: &val,
 			YhatLower:   nil,
 			YhatUpper:   nil,
 		})

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -53,6 +53,7 @@ type ReadMetricsInput struct {
 	LimitColumn        *string
 	SavedMetricState   *SavedMetricState
 	PredictionSettings *modelInputs.PredictionSettings
+	NoBucketMax        bool
 }
 
 func readObjects[TObj interface{}](ctx context.Context, client *Client, config model.TableConfig, samplingConfig model.TableConfig, projectID int, params modelInputs.QueryInput, pagination Pagination, scanObject func(driver.Rows) (*Edge[TObj], error)) (*Connection[TObj], error) {
@@ -986,7 +987,7 @@ func (client *Client) ReadMetrics(ctx context.Context, input ReadMetricsInput) (
 		} else if input.BucketCount != nil {
 			nBuckets = *input.BucketCount
 		}
-		if nBuckets > MaxBuckets {
+		if nBuckets > MaxBuckets && !input.NoBucketMax {
 			nBuckets = MaxBuckets
 		}
 		if nBuckets < 1 {
@@ -994,7 +995,7 @@ func (client *Client) ReadMetrics(ctx context.Context, input ReadMetricsInput) (
 		}
 	} else {
 		nBuckets = int(int64(input.Params.DateRange.EndDate.Sub(input.Params.DateRange.StartDate).Seconds()) / int64(*input.BucketWindow))
-		if nBuckets > MaxBuckets {
+		if nBuckets > MaxBuckets && !input.NoBucketMax {
 			nBuckets = MaxBuckets
 			input.Params.DateRange.StartDate = input.Params.DateRange.EndDate.Add(-1 * time.Duration(MaxBuckets**input.BucketWindow) * time.Second)
 		}

--- a/backend/jobs/metric-alerts/metric-alerts.go
+++ b/backend/jobs/metric-alerts/metric-alerts.go
@@ -257,19 +257,19 @@ func processMetricAlert(ctx context.Context, DB *gorm.DB, MailClient *sendgrid.C
 		}
 
 		alertCondition := false
-		if alert.ThresholdType == modelInputs.ThresholdTypeConstant {
-			if alert.ThresholdCondition == modelInputs.ThresholdConditionAbove {
-				alertCondition = *bucket.MetricValue >= thresholdValue
-			} else if alert.ThresholdCondition == modelInputs.ThresholdConditionBelow {
-				alertCondition = *bucket.MetricValue <= thresholdValue
-			}
-		} else if alert.ThresholdType == modelInputs.ThresholdTypeAnomaly {
+		if alert.ThresholdType == modelInputs.ThresholdTypeAnomaly {
 			if alert.ThresholdCondition == modelInputs.ThresholdConditionAbove && bucket.YhatUpper != nil {
 				alertCondition = *bucket.MetricValue >= *bucket.YhatUpper
 			} else if alert.ThresholdCondition == modelInputs.ThresholdConditionBelow && bucket.YhatLower != nil {
 				alertCondition = *bucket.MetricValue <= *bucket.YhatLower
 			} else if alert.ThresholdCondition == modelInputs.ThresholdConditionOutside && bucket.YhatUpper != nil && bucket.YhatLower != nil {
 				alertCondition = *bucket.MetricValue >= *bucket.YhatUpper || *bucket.MetricValue <= *bucket.YhatLower
+			}
+		} else {
+			if alert.ThresholdCondition == modelInputs.ThresholdConditionBelow {
+				alertCondition = *bucket.MetricValue <= thresholdValue
+			} else {
+				alertCondition = *bucket.MetricValue >= thresholdValue
 			}
 		}
 

--- a/backend/jobs/metric-alerts/metric-alerts.go
+++ b/backend/jobs/metric-alerts/metric-alerts.go
@@ -186,6 +186,7 @@ func processMetricAlert(ctx context.Context, DB *gorm.DB, MailClient *sendgrid.C
 		Limit:            pointy.Int(20),
 		LimitAggregator:  &aggregatorCount,
 		SavedMetricState: savedState,
+		NoBucketMax:      true,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
- don't want to have to migrate old alerts to ensure alerts keep working for on-prem customers
- logic assumes alerts default to constant / above threshold
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ensuring evaluation running locally for null entries
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
