### PR TITLE
Customize related resource table

### DIFF
--- a/frontend/src/components/CustomColumnPopover/index.tsx
+++ b/frontend/src/components/CustomColumnPopover/index.tsx
@@ -75,6 +75,7 @@ type Props<T> = {
 	selectedColumns: SerializedColumn[]
 	standardColumns: Record<string, SerializedColumn>
 	setSelectedColumns: (columns: SerializedColumn[]) => void
+	preventKeySearch?: boolean
 }
 
 export const CustomColumnPopover = <T,>({
@@ -83,6 +84,7 @@ export const CustomColumnPopover = <T,>({
 	selectedColumns,
 	standardColumns,
 	setSelectedColumns,
+	preventKeySearch,
 }: Props<T>) => {
 	const { project_id } = useParams()
 	const [query, setQuery] = useState<string>('')
@@ -97,7 +99,7 @@ export const CustomColumnPopover = <T,>({
 	const [getKeys, { data, loading }] = useGetKeysLazyQuery()
 
 	useEffect(() => {
-		if (debouncedQuery) {
+		if (!preventKeySearch && debouncedQuery) {
 			getKeys({
 				variables: {
 					product_type: productType,
@@ -110,7 +112,15 @@ export const CustomColumnPopover = <T,>({
 				},
 			})
 		}
-	}, [debouncedQuery, startDate, endDate, productType, project_id, getKeys])
+	}, [
+		debouncedQuery,
+		startDate,
+		endDate,
+		productType,
+		project_id,
+		getKeys,
+		preventKeySearch,
+	])
 
 	const defaultColumnOptions = useMemo(() => {
 		const seletedColumnHash = selectedColumns.reduce(

--- a/frontend/src/components/RelatedResources/LogsPanel.tsx
+++ b/frontend/src/components/RelatedResources/LogsPanel.tsx
@@ -2,6 +2,7 @@ import { Box, Callout, Text } from '@highlight-run/ui/components'
 import { stringify } from 'query-string'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { DateTimeParam, encodeQueryParams, StringParam } from 'use-query-params'
+import useLocalStorage from '@rehooks/local-storage'
 
 import { LinkButton } from '@/components/LinkButton'
 import {
@@ -16,6 +17,8 @@ import { ProductType } from '@/graph/generated/schemas'
 import { useNumericProjectId } from '@/hooks/useProjectId'
 import { LogsTable } from '@/pages/LogsPage/LogsTable/LogsTable'
 import { useGetLogs } from '@/pages/LogsPage/useGetLogs'
+import { SerializedColumn } from '@/components/CustomColumnPopover'
+import { DEFAULT_LOG_COLUMNS } from '@/pages/LogsPage/LogsTable/CustomColumns/columns'
 
 export const LogsPanel: React.FC<{ resource: RelatedLogs }> = ({
 	resource,
@@ -25,6 +28,10 @@ export const LogsPanel: React.FC<{ resource: RelatedLogs }> = ({
 	const { queryParts } = parseSearch(query)
 	const handleSubmit = (query: string) => set({ ...resource, query })
 	const { projectId } = useNumericProjectId()
+
+	const [selectedColumns, setSelectedColumns] = useLocalStorage<
+		SerializedColumn[]
+	>(`highlight-logs-related-table-columns`, DEFAULT_LOG_COLUMNS)
 
 	/* eslint-disable react-hooks/exhaustive-deps */
 	const startDate = useMemo(() => new Date(resource.startDate), [])
@@ -128,6 +135,8 @@ export const LogsPanel: React.FC<{ resource: RelatedLogs }> = ({
 								loadingAfter={loadingAfter}
 								selectedCursor={undefined}
 								fetchMoreWhenScrolled={fetchMoreWhenScrolled}
+								selectedColumns={selectedColumns}
+								setSelectedColumns={setSelectedColumns}
 								bodyHeight="calc(100% - 64px)"
 							/>
 						)}

--- a/frontend/src/components/RelatedResources/RelatedResourceList.tsx
+++ b/frontend/src/components/RelatedResources/RelatedResourceList.tsx
@@ -12,13 +12,10 @@ import { SearchForm } from '@/components/Search/SearchForm/SearchForm'
 import { parseSearch } from '@/components/Search/utils'
 import { ProductType } from '@/graph/generated/schemas'
 import { useNumericProjectId } from '@/hooks/useProjectId'
-import { DEFAULT_ERROR_OBJECT_COLUMNS } from '@/pages/ErrorsV2/CustomColumns/columns'
 import { ErrorObjectColumnRenderers } from '@/pages/ErrorsV2/CustomColumns/renderers'
-import { DEFAULT_SESSION_COLUMNS } from '@/pages/Sessions/CustomColumns/columns'
 import { SessionColumnRenderers } from '@/pages/Sessions/CustomColumns/renderers'
 import { useGetErrorObjectsPaginated } from '@/pages/Sessions/useGetErrorObjectsPaginated'
 import { useGetSessionsPaginated } from '@/pages/Sessions/useGetSessionsPaginated'
-import { DEFAULT_TRACE_COLUMNS } from '@/pages/Traces/CustomColumns/columns'
 import { TraceColumnRenderers } from '@/pages/Traces/CustomColumns/renderers'
 import { useGetTraces } from '@/pages/Traces/useGetTraces'
 import { useGetEventsPaginated } from '@/pages/Sessions/useGetEventsPaginated'
@@ -169,7 +166,6 @@ export const RelatedResourceList: React.FC<{
 					fetchMoreWhenScrolled={fetchMoreWhenScrolled}
 					bodyHeight="calc(100% - 64px)"
 					resources={errorObjects}
-					selectedColumns={DEFAULT_ERROR_OBJECT_COLUMNS}
 					columnRenderers={ErrorObjectColumnRenderers}
 				/>
 			)
@@ -179,7 +175,6 @@ export const RelatedResourceList: React.FC<{
 			innerTable = (
 				<ResourceTable
 					resourceType={resource.type}
-					selectedColumns={DEFAULT_SESSION_COLUMNS}
 					query={query}
 					queryParts={queryParts}
 					loading={sessionsLoading}
@@ -197,7 +192,6 @@ export const RelatedResourceList: React.FC<{
 			innerTable = (
 				<ResourceTable
 					resourceType={resource.type}
-					selectedColumns={DEFAULT_TRACE_COLUMNS}
 					columnRenderers={TraceColumnRenderers}
 					query={query}
 					queryParts={queryParts}
@@ -216,7 +210,6 @@ export const RelatedResourceList: React.FC<{
 				<ResourceTable
 					// show sessions for events
 					resourceType="sessions"
-					selectedColumns={DEFAULT_SESSION_COLUMNS}
 					query={query}
 					queryParts={queryParts}
 					loading={eventsLoading}

--- a/frontend/src/components/RelatedResources/RelatedResourceList.tsx
+++ b/frontend/src/components/RelatedResources/RelatedResourceList.tsx
@@ -10,7 +10,7 @@ import { ResourceTable } from '@/components/RelatedResources/ResourceTable'
 import { SearchContext } from '@/components/Search/SearchContext'
 import { SearchForm } from '@/components/Search/SearchForm/SearchForm'
 import { parseSearch } from '@/components/Search/utils'
-import { ProductType } from '@/graph/generated/schemas'
+import { ProductType, SortDirection } from '@/graph/generated/schemas'
 import { useNumericProjectId } from '@/hooks/useProjectId'
 import { ErrorObjectColumnRenderers } from '@/pages/ErrorsV2/CustomColumns/renderers'
 import { SessionColumnRenderers } from '@/pages/Sessions/CustomColumns/renderers'
@@ -37,6 +37,32 @@ export const RelatedResourceList: React.FC<{
 	const startDate = useMemo(() => new Date(resource.startDate), [])
 	const endDate = useMemo(() => new Date(resource.endDate), [])
 	/* eslint-enable react-hooks/exhaustive-deps */
+
+	const [sortDirection, setSortDirection] = useState<SortDirection>()
+	const [sortColumn, setSortColumn] = useState<string>()
+
+	const handleSort = useCallback(
+		(column: string, direction?: SortDirection | null) => {
+			if (
+				column === sortColumn &&
+				(direction === null || sortDirection === SortDirection.Asc)
+			) {
+				setSortColumn(undefined)
+				setSortDirection(undefined)
+			} else {
+				const nextDirection =
+					direction ??
+					(column === sortColumn &&
+					sortDirection === SortDirection.Desc
+						? SortDirection.Asc
+						: SortDirection.Desc)
+
+				setSortColumn(column)
+				setSortDirection(nextDirection)
+			}
+		},
+		[setSortColumn, setSortDirection, sortColumn, sortDirection],
+	)
 
 	const path = useMemo(() => {
 		const encodedQuery = encodeQueryParams(
@@ -78,6 +104,8 @@ export const RelatedResourceList: React.FC<{
 		startDate,
 		endDate,
 		skipPolling: true,
+		sortColumn,
+		sortDirection,
 		skip: resource.type !== 'traces',
 	})
 
@@ -201,6 +229,9 @@ export const RelatedResourceList: React.FC<{
 					fetchMoreWhenScrolled={fetchMoreWhenScrolled}
 					bodyHeight="calc(100% - 64px)"
 					resources={traceEdges}
+					handleSort={handleSort}
+					sortDirection={sortDirection}
+					sortColumn={sortColumn}
 				/>
 			)
 			break

--- a/frontend/src/components/RelatedResources/ResourceTable.tsx
+++ b/frontend/src/components/RelatedResources/ResourceTable.tsx
@@ -46,7 +46,11 @@ import {
 	DEFAULT_TRACE_COLUMNS,
 	HIGHLIGHT_STANDARD_COLUMNS as TRACE_STANDARD_COLUMNS,
 } from '@/pages/Traces/CustomColumns/columns'
-import { ProductType, TraceEdge } from '@/graph/generated/schemas'
+import {
+	ProductType,
+	SortDirection,
+	TraceEdge,
+} from '@/graph/generated/schemas'
 
 import * as styles from './ResourceTable.css'
 
@@ -119,6 +123,9 @@ type TableInnerProps<T> = {
 	fetchMoreWhenScrolled: (target: HTMLDivElement) => void
 	bodyHeight: string
 	columnRenderers: ColumnRenderMap
+	sortDirection?: SortDirection
+	sortColumn?: string
+	handleSort?: (column: string, direction?: SortDirection | null) => void
 }
 
 const LOADING_AFTER_HEIGHT = 28
@@ -156,6 +163,9 @@ const TableInner = <T,>({
 	bodyHeight,
 	fetchMoreWhenScrolled,
 	columnRenderers,
+	sortDirection,
+	sortColumn,
+	handleSort,
 }: TableInnerProps<T>) => {
 	const bodyRef = useRef<HTMLDivElement>(null)
 
@@ -185,6 +195,9 @@ const TableInner = <T,>({
 				id: column.id,
 				component: column.label,
 				showActions: true,
+				onSort: (direction?: SortDirection | null) => {
+					handleSort?.(column.id, direction)
+				},
 			})
 
 			const accessorFn =
@@ -303,6 +316,8 @@ const TableInner = <T,>({
 							standardColumns={resourceAttributes.standardColumns}
 							trackingIdPrefix={`${resourceType}-related-table-column`}
 							setSelectedColumns={setSelectedColumns}
+							sortColumn={sortColumn}
+							sortDirection={sortDirection}
 						/>
 					))}
 				</Table.Row>

--- a/frontend/src/components/RelatedResources/ResourceTable.tsx
+++ b/frontend/src/components/RelatedResources/ResourceTable.tsx
@@ -1,4 +1,16 @@
 import { ApolloError } from '@apollo/client'
+import useLocalStorage from '@rehooks/local-storage'
+import React, { Key, useEffect, useMemo, useRef } from 'react'
+import {
+	ColumnDef,
+	createColumnHelper,
+	flexRender,
+	getCoreRowModel,
+	Row,
+	useReactTable,
+} from '@tanstack/react-table'
+import { useVirtualizer } from '@tanstack/react-virtual'
+
 import { Link } from '@components/Link'
 import LoadingBox from '@components/LoadingBox'
 import {
@@ -10,39 +22,40 @@ import {
 	Table,
 	Text,
 } from '@highlight-run/ui/components'
-import { HIGHLIGHT_STANDARD_COLUMNS } from '@pages/LogsPage/LogsTable/CustomColumns/columns'
 import { FullScreenContainer } from '@pages/LogsPage/LogsTable/FullScreenContainer'
-import {
-	ColumnDef,
-	createColumnHelper,
-	flexRender,
-	getCoreRowModel,
-	Row,
-	useReactTable,
-} from '@tanstack/react-table'
-import { useVirtualizer } from '@tanstack/react-virtual'
-import React, { Key, useEffect, useMemo, useRef } from 'react'
-
 import {
 	ColumnHeader,
 	CustomColumnHeader,
 } from '@/components/CustomColumnHeader'
-import { CustomColumn } from '@/components/CustomColumnPopover'
+import {
+	CustomColumnPopover,
+	SerializedColumn,
+} from '@/components/CustomColumnPopover'
 import { NoResourcesFound } from '@/components/RelatedResources/NoResourcesFound'
 import { SearchExpression } from '@/components/Search/Parser/listener'
 import { ColumnRenderMap } from '@/pages/LogsPage/LogsTable/CustomColumns/renderers'
+import {
+	DEFAULT_ERROR_OBJECT_COLUMNS,
+	ERROR_OBJECT_STANDARD_COLUMNS,
+} from '@/pages/ErrorsV2/CustomColumns/columns'
+import {
+	DEFAULT_SESSION_COLUMNS,
+	SESSION_STANDARD_COLUMNS,
+} from '@/pages/Sessions/CustomColumns/columns'
+import {
+	DEFAULT_TRACE_COLUMNS,
+	HIGHLIGHT_STANDARD_COLUMNS as TRACE_STANDARD_COLUMNS,
+} from '@/pages/Traces/CustomColumns/columns'
+import { ProductType, TraceEdge } from '@/graph/generated/schemas'
 
 import * as styles from './ResourceTable.css'
 
-type Props<T, TCol extends string> = {
+type Props<T> = {
 	loading: boolean
 	error: ApolloError | undefined
-	resourceType: 'traces' | 'sessions' | 'errors'
-} & TableInnerProps<T, TCol>
+} & TableInnerProps<T>
 
-export const ResourceTable = <T, TCol extends string>(
-	props: Props<T, TCol>,
-) => {
+export const ResourceTable = <T,>(props: Props<T>) => {
 	if (props.loading) {
 		return (
 			<FullScreenContainer>
@@ -97,30 +110,65 @@ export const ResourceTable = <T, TCol extends string>(
 	return <TableInner {...props} />
 }
 
-type TableInnerProps<T, TCol extends string> = {
+type TableInnerProps<T> = {
+	resourceType: 'traces' | 'sessions' | 'errors'
 	loadingAfter: boolean
 	resources: T[]
 	query: string
 	queryParts: SearchExpression[]
 	fetchMoreWhenScrolled: (target: HTMLDivElement) => void
 	bodyHeight: string
-	selectedColumns: CustomColumn<T, TCol>[]
 	columnRenderers: ColumnRenderMap
 }
 
 const LOADING_AFTER_HEIGHT = 28
 
-const TableInner = <T, TCol extends string>({
+const RESOURCE_TYPE_SETTINGS = {
+	traces: {
+		productType: ProductType.Traces,
+		defaultColumns: DEFAULT_TRACE_COLUMNS,
+		standardColumns: TRACE_STANDARD_COLUMNS,
+		accessor: (row: TraceEdge) => row.node.traceAttributes,
+		preventKeySearch: false,
+	},
+	sessions: {
+		productType: ProductType.Sessions,
+		defaultColumns: DEFAULT_SESSION_COLUMNS,
+		standardColumns: SESSION_STANDARD_COLUMNS,
+		accessor: () => null,
+		preventKeySearch: true,
+	},
+	errors: {
+		productType: ProductType.Errors,
+		defaultColumns: DEFAULT_ERROR_OBJECT_COLUMNS,
+		standardColumns: ERROR_OBJECT_STANDARD_COLUMNS,
+		accessor: () => null,
+		preventKeySearch: true,
+	},
+}
+
+const TableInner = <T,>({
+	resourceType,
 	resources,
 	loadingAfter,
 	query,
 	queryParts,
 	bodyHeight,
 	fetchMoreWhenScrolled,
-	selectedColumns,
 	columnRenderers,
-}: TableInnerProps<T, TCol>) => {
+}: TableInnerProps<T>) => {
 	const bodyRef = useRef<HTMLDivElement>(null)
+
+	const resourceAttributes = useMemo(() => {
+		return RESOURCE_TYPE_SETTINGS[resourceType]
+	}, [resourceType])
+
+	const [selectedColumns, setSelectedColumns] = useLocalStorage<
+		SerializedColumn[]
+	>(
+		`highlight-${resourceType}-related-table-columns`,
+		resourceAttributes.defaultColumns,
+	)
 
 	const columnHelper = createColumnHelper<T>()
 
@@ -136,13 +184,22 @@ const TableInner = <T, TCol extends string>({
 			columnHeaders.push({
 				id: column.id,
 				component: column.label,
+				showActions: true,
 			})
 
-			const accessor = columnHelper.accessor(column.accessor, {
+			const accessorFn =
+				column.id in resourceAttributes.standardColumns
+					? resourceAttributes.standardColumns[column.id].accessor
+					: resourceAttributes.accessor
+
+			const columnType =
+				column.id in resourceAttributes.standardColumns
+					? resourceAttributes.standardColumns[column.id].type
+					: 'string'
+
+			const accessor = columnHelper.accessor(accessorFn as any, {
 				cell: ({ row, getValue }) => {
-					const ColumnRenderer =
-						columnRenderers[column.type as string] ??
-						columnRenderers['string']
+					const ColumnRenderer = columnRenderers[columnType]
 
 					return (
 						<ColumnRenderer
@@ -158,6 +215,22 @@ const TableInner = <T, TCol extends string>({
 			})
 
 			columns.push(accessor)
+		})
+
+		gridColumns.push('25px')
+		columnHeaders.push({
+			id: 'edit-column-button',
+			noPadding: true,
+			component: (
+				<CustomColumnPopover
+					selectedColumns={selectedColumns}
+					setSelectedColumns={setSelectedColumns}
+					productType={resourceAttributes.productType}
+					standardColumns={resourceAttributes.standardColumns}
+					attributeAccessor={resourceAttributes.accessor}
+					preventKeySearch={resourceAttributes.preventKeySearch}
+				/>
+			),
 		})
 
 		return {
@@ -227,9 +300,9 @@ const TableInner = <T, TCol extends string>({
 							key={header.id}
 							header={header}
 							selectedColumns={selectedColumns}
-							standardColumns={HIGHLIGHT_STANDARD_COLUMNS}
-							trackingIdPrefix="LogsTableColumn"
-							setSelectedColumns={() => {}}
+							standardColumns={resourceAttributes.standardColumns}
+							trackingIdPrefix={`${resourceType}-related-table-column`}
+							setSelectedColumns={setSelectedColumns}
 						/>
 					))}
 				</Table.Row>

--- a/frontend/src/pages/ErrorsV2/CustomColumns/columns.ts
+++ b/frontend/src/pages/ErrorsV2/CustomColumns/columns.ts
@@ -29,6 +29,42 @@ const SESSION_COLUMN: ErrorObjectCustomColumn = {
 	accessor: (row: ErrorObjectNode) => row.session?.secureID,
 }
 
+const SERVICE_NAME_COLUMN: ErrorObjectCustomColumn = {
+	id: 'service_name',
+	label: 'Service',
+	type: 'string',
+	size: '1fr',
+	accessor: (row: ErrorObjectNode) => row.serviceName,
+}
+
+const SERVICE_VERSION_COLUMN: ErrorObjectCustomColumn = {
+	id: 'service_version',
+	label: 'Version',
+	type: 'string',
+	size: '1fr',
+	accessor: (row: ErrorObjectNode) => row.serviceVersion,
+}
+
+const ERROR_GROUP_SECURE_ID_COLUMN: ErrorObjectCustomColumn = {
+	id: 'error_group_secure_id',
+	label: 'Group Secure ID',
+	type: 'string',
+	size: '1fr',
+	accessor: (row: ErrorObjectNode) => row.errorGroupSecureID,
+}
+
+export const ERROR_OBJECT_STANDARD_COLUMNS: Record<
+	string,
+	ErrorObjectCustomColumn
+> = {
+	timestamp: TIMESTAMP_COLUMN,
+	event: EVENT_COLUMN,
+	session: SESSION_COLUMN,
+	service_name: SERVICE_NAME_COLUMN,
+	service_version: SERVICE_VERSION_COLUMN,
+	error_group_secure_id: ERROR_GROUP_SECURE_ID_COLUMN,
+}
+
 export const DEFAULT_ERROR_OBJECT_COLUMNS = [
 	EVENT_COLUMN,
 	SESSION_COLUMN,

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -695,11 +695,6 @@ export const useGraphData = (
 					metrics.metrics.buckets.find((b) => b.group.length) !==
 					undefined
 
-				console.log(
-					'hasGroups',
-					metrics.metrics.buckets.find((b) => b.group.length),
-				)
-
 				for (const b of metrics.metrics.buckets) {
 					const seriesKey = hasGroups
 						? b.group.join(', ') || NO_GROUP_PLACEHOLDER

--- a/frontend/src/pages/Sessions/CustomColumns/columns.ts
+++ b/frontend/src/pages/Sessions/CustomColumns/columns.ts
@@ -41,6 +41,122 @@ const ACTIVE_LENGTH_COLUMN: SessionCustomColumn = {
 	accessor: (row: Session) => row.active_length,
 }
 
+const LENGTH_COLUMN: SessionCustomColumn = {
+	id: 'length',
+	label: 'Length',
+	type: 'duration',
+	size: '1fr',
+	accessor: (row: Session) => row.length,
+}
+
+const BROWSER_NAME_COLUMN: SessionCustomColumn = {
+	id: 'browser_name',
+	label: 'Browser',
+	type: 'string',
+	size: '1fr',
+	accessor: (row: Session) => row.browser_name,
+}
+
+const BROWSER_VERSION_COLUMN: SessionCustomColumn = {
+	id: 'browser_version',
+	label: 'Browser Version',
+	type: 'string',
+	size: '1fr',
+	accessor: (row: Session) => row.browser_version,
+}
+
+const CITY_COLUMN: SessionCustomColumn = {
+	id: 'city',
+	label: 'City',
+	type: 'string',
+	size: '1fr',
+	accessor: (row: Session) => row.city,
+}
+
+const FIRST_TIME_COLUMN: SessionCustomColumn = {
+	id: 'first_time',
+	label: 'First Session',
+	type: 'string',
+	size: '1fr',
+	accessor: (row: Session) => String(row.first_time),
+}
+
+const HAS_RAGE_CLICKS_COLUMN: SessionCustomColumn = {
+	id: 'has_rage_clicks',
+	label: 'Has Rage Clicks',
+	type: 'string',
+	size: '1fr',
+	accessor: (row: Session) => String(row.has_rage_clicks),
+}
+
+const HAS_ERRORS_COLUMN: SessionCustomColumn = {
+	id: 'has_errors',
+	label: 'Has Errors',
+	type: 'string',
+	size: '1fr',
+	accessor: (row: Session) => String(row.has_errors),
+}
+
+const IDENTIFIER_COLUMN: SessionCustomColumn = {
+	id: 'identifier',
+	label: 'Identifier',
+	type: 'string',
+	size: '1fr',
+	accessor: (row: Session) => row.identifier,
+}
+
+const OS_NAME_COLUMN: SessionCustomColumn = {
+	id: 'os_name',
+	label: 'OS',
+	type: 'string',
+	size: '1fr',
+	accessor: (row: Session) => row.os_name,
+}
+
+const OS_VERSION_COLUMN: SessionCustomColumn = {
+	id: 'os_version',
+	label: 'OS Version',
+	type: 'string',
+	size: '1fr',
+	accessor: (row: Session) => row.os_version,
+}
+
+const STATE_COLUMN: SessionCustomColumn = {
+	id: 'state',
+	label: 'State',
+	type: 'string',
+	size: '1fr',
+	accessor: (row: Session) => row.state,
+}
+
+const VIEWED_COLUMN: SessionCustomColumn = {
+	id: 'viewed',
+	label: 'Viewed',
+	type: 'string',
+	size: '1fr',
+	accessor: (row: Session) => String(row.viewed),
+}
+
+export const SESSION_STANDARD_COLUMNS: Record<string, SessionCustomColumn> = {
+	secure_id: SECURE_ID_COLUMN,
+	email: EMAIL_COLUMN,
+	identifier: IDENTIFIER_COLUMN,
+	city: CITY_COLUMN,
+	state: STATE_COLUMN,
+	country: COUNTRY_COLUMN,
+	created_at: CREATED_AT_COLUMN,
+	active_length: ACTIVE_LENGTH_COLUMN,
+	length: LENGTH_COLUMN,
+	first_time: FIRST_TIME_COLUMN,
+	has_errors: HAS_ERRORS_COLUMN,
+	has_rage_clicks: HAS_RAGE_CLICKS_COLUMN,
+	browser_name: BROWSER_NAME_COLUMN,
+	browser_version: BROWSER_VERSION_COLUMN,
+	os_name: OS_NAME_COLUMN,
+	os_version: OS_VERSION_COLUMN,
+	viewed: VIEWED_COLUMN,
+}
+
 export const DEFAULT_SESSION_COLUMNS = [
 	SECURE_ID_COLUMN,
 	EMAIL_COLUMN,


### PR DESCRIPTION
## Summary
Allow users to customize their related resource tables and sort if the table supports it (i.e. only traces)

https://www.loom.com/share/d9478badded3411686478b160ccd4b2f?sid=bd2d47b9-a03a-4297-b311-39e0b17d6310

## How did you test this change?
1. Create a graph or alert of traces
2. Drill down to a timestamp
- [ ] Able to sort column
- [ ] Able to add/drop columns
- [ ] Able to resize columns
3. Close the related resources and reopen
- [ ] Custom columns persist
4. View trace table
- [ ] No changes to trace table
5. Repeat for sessions, errors, logs, and events
- [ ] Session and event tables persist across each other
- [ ] Not able to sort any of the above tables

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
