### PR TITLE
fix: update `pages` to `app` for app router

### DIFF
--- a/docs-content/getting-started/fullstack-frameworks/next-js/3_app-router.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/3_app-router.md
@@ -165,7 +165,7 @@ export default withHighlightConfig(nextConfig)
  Otherwise, the next server will not enable the `instrumentationHook` in your production deploy.
 ```
 
-2. Call `registerHighlight` in `instrumentation.ts` or `src/instrumentation.ts` if you're using a `/src` folder. Make sure that `instrumentation.ts` is a sibling of your `pages` folder. 
+2. Call `registerHighlight` in `instrumentation.ts` or `src/instrumentation.ts` if you're using a `/src` folder. Make sure that `instrumentation.ts` is a sibling of your `app` folder.
 ```jsx
 // instrumentation.ts or src/instrumentation.ts
 import { CONSTANTS } from './constants'


### PR DESCRIPTION
app folder is used when using the app router instead of having a pages folder.
