### PR TITLE
allow timestamp to be graphed as y axis, add default option to date picker

### DIFF
--- a/backend/clickhouse/events.go
+++ b/backend/clickhouse/events.go
@@ -42,6 +42,7 @@ var eventKeysToColumns = map[string]string{
 	string(modelInputs.ReservedEventKeyOsVersion):           "OSVersion",
 	string(modelInputs.ReservedEventKeySecureSessionID):     "SecureSessionId",
 	string(modelInputs.ReservedEventKeyState):               "State",
+	string(modelInputs.ReservedEventKeyTimestamp):           "Timestamp",
 }
 
 var defaultEventKeys = []*modelInputs.QueryKey{
@@ -51,6 +52,7 @@ var defaultEventKeys = []*modelInputs.QueryKey{
 	{Name: string(modelInputs.ReservedEventKeySessionActiveLength), Type: modelInputs.KeyTypeNumeric},
 	{Name: string(modelInputs.ReservedEventKeySessionLength), Type: modelInputs.KeyTypeNumeric},
 	{Name: string(modelInputs.ReservedEventKeySessionPagesVisited), Type: modelInputs.KeyTypeNumeric},
+	{Name: string(modelInputs.ReservedEventKeyTimestamp), Type: modelInputs.KeyTypeNumeric},
 }
 
 var eventBooleanKeys = map[string]bool{

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -46,6 +46,7 @@ var defaultLogKeys = []*modelInputs.QueryKey{
 	{Name: string(modelInputs.ReservedLogKeySpanID), Type: modelInputs.KeyTypeString},
 	{Name: string(modelInputs.ReservedLogKeyTraceID), Type: modelInputs.KeyTypeString},
 	{Name: string(modelInputs.ReservedLogKeyMessage), Type: modelInputs.KeyTypeString},
+	{Name: string(modelInputs.ReservedLogKeyTimestamp), Type: modelInputs.KeyTypeNumeric},
 }
 
 var reservedLogKeys = lo.Map(modelInputs.AllReservedLogKey, func(key modelInputs.ReservedLogKey, _ int) string {

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -1140,6 +1140,10 @@ func TestLogsKeys(t *testing.T) {
 			Name: "message",
 			Type: "String",
 		},
+		{
+			Name: "timestamp",
+			Type: "Numeric",
+		},
 	}
 	assert.Equal(t, expected, keys)
 }

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -125,6 +125,7 @@ var defaultSessionsKeys = []*modelInputs.QueryKey{
 	{Name: string(modelInputs.ReservedSessionKeySecureID), Type: modelInputs.KeyTypeString},
 	{Name: string(modelInputs.ReservedSessionKeyViewedByAnyone), Type: modelInputs.KeyTypeBoolean},
 	{Name: string(modelInputs.ReservedSessionKeyViewedByMe), Type: modelInputs.KeyTypeBoolean},
+	{Name: string(modelInputs.ReservedSessionKeyTimestamp), Type: modelInputs.KeyTypeNumeric},
 }
 
 var booleanKeys = map[string]bool{
@@ -521,6 +522,7 @@ var SessionsJoinedTableConfig = model.TableConfig{
 		string(modelInputs.ReservedSessionKeyPagesVisited):       "PagesVisited",
 		string(modelInputs.ReservedSessionKeySecureID):           "SecureID",
 		string(modelInputs.ReservedSessionKeyState):              "State",
+		string(modelInputs.ReservedSessionKeyTimestamp):          "Timestamp",
 		string(modelInputs.ReservedSessionKeyViewedByAnyone):     "Viewed",
 		string(modelInputs.ReservedSessionKeyWithinBillingQuota): "WithinBillingQuota",
 

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -79,6 +79,7 @@ var defaultTraceKeys = []*modelInputs.QueryKey{
 	{Name: string(modelInputs.ReservedTraceKeySecureSessionID), Type: modelInputs.KeyTypeString},
 	{Name: string(modelInputs.ReservedTraceKeyMetricName), Type: modelInputs.KeyTypeString},
 	{Name: string(modelInputs.ReservedTraceKeyMetricValue), Type: modelInputs.KeyTypeNumeric},
+	{Name: string(modelInputs.ReservedTraceKeyTimestamp), Type: modelInputs.KeyTypeNumeric},
 }
 
 var reservedTraceKeys = lo.Map(modelInputs.AllReservedTraceKey, func(key modelInputs.ReservedTraceKey, _ int) string {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -12840,6 +12840,7 @@ enum ReservedSessionKey {
 	secure_id
 	service_version
 	state
+	timestamp
 	viewed_by_anyone
 	viewed_by_me
 	within_billing_quota
@@ -12869,6 +12870,7 @@ enum ReservedEventKey {
 	session_length
 	session_pages_visited
 	state
+	timestamp
 }
 
 enum LogSource {

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -2259,6 +2259,7 @@ const (
 	ReservedEventKeySessionLength       ReservedEventKey = "session_length"
 	ReservedEventKeySessionPagesVisited ReservedEventKey = "session_pages_visited"
 	ReservedEventKeyState               ReservedEventKey = "state"
+	ReservedEventKeyTimestamp           ReservedEventKey = "timestamp"
 )
 
 var AllReservedEventKey = []ReservedEventKey{
@@ -2280,11 +2281,12 @@ var AllReservedEventKey = []ReservedEventKey{
 	ReservedEventKeySessionLength,
 	ReservedEventKeySessionPagesVisited,
 	ReservedEventKeyState,
+	ReservedEventKeyTimestamp,
 }
 
 func (e ReservedEventKey) IsValid() bool {
 	switch e {
-	case ReservedEventKeyBrowserName, ReservedEventKeyBrowserVersion, ReservedEventKeyCity, ReservedEventKeyCountry, ReservedEventKeyEnvironment, ReservedEventKeyEvent, ReservedEventKeyFirstSession, ReservedEventKeyIdentified, ReservedEventKeyIdentifier, ReservedEventKeyIP, ReservedEventKeyOsName, ReservedEventKeyOsVersion, ReservedEventKeySecureSessionID, ReservedEventKeyServiceVersion, ReservedEventKeySessionActiveLength, ReservedEventKeySessionLength, ReservedEventKeySessionPagesVisited, ReservedEventKeyState:
+	case ReservedEventKeyBrowserName, ReservedEventKeyBrowserVersion, ReservedEventKeyCity, ReservedEventKeyCountry, ReservedEventKeyEnvironment, ReservedEventKeyEvent, ReservedEventKeyFirstSession, ReservedEventKeyIdentified, ReservedEventKeyIdentifier, ReservedEventKeyIP, ReservedEventKeyOsName, ReservedEventKeyOsVersion, ReservedEventKeySecureSessionID, ReservedEventKeyServiceVersion, ReservedEventKeySessionActiveLength, ReservedEventKeySessionLength, ReservedEventKeySessionPagesVisited, ReservedEventKeyState, ReservedEventKeyTimestamp:
 		return true
 	}
 	return false
@@ -2396,6 +2398,7 @@ const (
 	ReservedSessionKeySecureID           ReservedSessionKey = "secure_id"
 	ReservedSessionKeyServiceVersion     ReservedSessionKey = "service_version"
 	ReservedSessionKeyState              ReservedSessionKey = "state"
+	ReservedSessionKeyTimestamp          ReservedSessionKey = "timestamp"
 	ReservedSessionKeyViewedByAnyone     ReservedSessionKey = "viewed_by_anyone"
 	ReservedSessionKeyViewedByMe         ReservedSessionKey = "viewed_by_me"
 	ReservedSessionKeyWithinBillingQuota ReservedSessionKey = "within_billing_quota"
@@ -2429,6 +2432,7 @@ var AllReservedSessionKey = []ReservedSessionKey{
 	ReservedSessionKeySecureID,
 	ReservedSessionKeyServiceVersion,
 	ReservedSessionKeyState,
+	ReservedSessionKeyTimestamp,
 	ReservedSessionKeyViewedByAnyone,
 	ReservedSessionKeyViewedByMe,
 	ReservedSessionKeyWithinBillingQuota,
@@ -2439,7 +2443,7 @@ var AllReservedSessionKey = []ReservedSessionKey{
 
 func (e ReservedSessionKey) IsValid() bool {
 	switch e {
-	case ReservedSessionKeyActiveLength, ReservedSessionKeyBrowserName, ReservedSessionKeyBrowserVersion, ReservedSessionKeyCity, ReservedSessionKeyCompleted, ReservedSessionKeyCountry, ReservedSessionKeyEnvironment, ReservedSessionKeyExcluded, ReservedSessionKeyFirstTime, ReservedSessionKeyHasComments, ReservedSessionKeyHasErrors, ReservedSessionKeyHasRageClicks, ReservedSessionKeyIdentified, ReservedSessionKeyIdentifier, ReservedSessionKeyIP, ReservedSessionKeyLength, ReservedSessionKeyNormalness, ReservedSessionKeyOsName, ReservedSessionKeyOsVersion, ReservedSessionKeyPagesVisited, ReservedSessionKeySample, ReservedSessionKeySecureID, ReservedSessionKeyServiceVersion, ReservedSessionKeyState, ReservedSessionKeyViewedByAnyone, ReservedSessionKeyViewedByMe, ReservedSessionKeyWithinBillingQuota, ReservedSessionKeyLocState, ReservedSessionKeyProcessed, ReservedSessionKeyViewed:
+	case ReservedSessionKeyActiveLength, ReservedSessionKeyBrowserName, ReservedSessionKeyBrowserVersion, ReservedSessionKeyCity, ReservedSessionKeyCompleted, ReservedSessionKeyCountry, ReservedSessionKeyEnvironment, ReservedSessionKeyExcluded, ReservedSessionKeyFirstTime, ReservedSessionKeyHasComments, ReservedSessionKeyHasErrors, ReservedSessionKeyHasRageClicks, ReservedSessionKeyIdentified, ReservedSessionKeyIdentifier, ReservedSessionKeyIP, ReservedSessionKeyLength, ReservedSessionKeyNormalness, ReservedSessionKeyOsName, ReservedSessionKeyOsVersion, ReservedSessionKeyPagesVisited, ReservedSessionKeySample, ReservedSessionKeySecureID, ReservedSessionKeyServiceVersion, ReservedSessionKeyState, ReservedSessionKeyTimestamp, ReservedSessionKeyViewedByAnyone, ReservedSessionKeyViewedByMe, ReservedSessionKeyWithinBillingQuota, ReservedSessionKeyLocState, ReservedSessionKeyProcessed, ReservedSessionKeyViewed:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1066,6 +1066,7 @@ enum ReservedSessionKey {
 	secure_id
 	service_version
 	state
+	timestamp
 	viewed_by_anyone
 	viewed_by_me
 	within_billing_quota
@@ -1095,6 +1096,7 @@ enum ReservedEventKey {
 	session_length
 	session_pages_visited
 	state
+	timestamp
 }
 
 enum LogSource {

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -3204,6 +3204,7 @@ export enum ReservedEventKey {
 	SessionLength = 'session_length',
 	SessionPagesVisited = 'session_pages_visited',
 	State = 'state',
+	Timestamp = 'timestamp',
 }
 
 export enum ReservedLogKey {
@@ -3247,6 +3248,7 @@ export enum ReservedSessionKey {
 	SecureId = 'secure_id',
 	ServiceVersion = 'service_version',
 	State = 'state',
+	Timestamp = 'timestamp',
 	Viewed = 'viewed',
 	ViewedByAnyone = 'viewed_by_anyone',
 	ViewedByMe = 'viewed_by_me',

--- a/frontend/src/pages/Graphing/Dashboard.tsx
+++ b/frontend/src/pages/Graphing/Dashboard.tsx
@@ -24,6 +24,7 @@ import {
 	IconSolidCog,
 	IconSolidPlus,
 	parsePreset,
+	presetValue,
 	Stack,
 	Tag,
 	Text,
@@ -140,12 +141,17 @@ export const Dashboard = () => {
 		variables: { id: dashboard_id! },
 	})
 
+	const [defaultTimePreset, setDefaultTimePreset] = useState(
+		DEFAULT_TIME_PRESETS[2],
+	)
 	useEffect(() => {
 		if (data) {
 			setGraphs(data.visualization.graphs)
 			const preset = data.visualization.timePreset
 			if (preset) {
-				updateSearchTime(new Date(), new Date(), parsePreset(preset))
+				const parsed = parsePreset(preset)
+				updateSearchTime(new Date(), new Date(), parsed)
+				setDefaultTimePreset(parsed)
 			}
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -248,6 +254,47 @@ export const Dashboard = () => {
 									onDatesChange={updateSearchTime}
 									presets={presets}
 									minDate={minDate}
+									defaultPreset={defaultTimePreset}
+									setDefaultPreset={(preset) => {
+										const timePreset = presetValue(preset)
+										upsertViz({
+											variables: {
+												visualization: {
+													projectId,
+													id: dashboard_id,
+													timePreset,
+												},
+											},
+											optimisticResponse: {
+												upsertVisualization:
+													dashboard_id!,
+											},
+											update(cache) {
+												const vizId = cache.identify({
+													id: dashboard_id,
+													__typename: 'Visualization',
+												})
+												cache.modify({
+													id: vizId,
+													fields: {
+														timePreset() {
+															return timePreset
+														},
+													},
+												})
+											},
+										})
+											.then(() => {
+												toast.success(
+													'Dashboard updated',
+												)
+											})
+											.catch(() =>
+												toast.error(
+													'Failed to update dashboard',
+												),
+											)
+									}}
 								/>
 								<HeaderDivider />
 								<Button

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -397,7 +397,7 @@ const durationUnitMap: [number, string][] = [
 const DEFAULT_TIME_METRIC = 'ns'
 
 export const getTickFormatter = (metric: string, data?: any[] | undefined) => {
-	if (metric === 'Timestamp') {
+	if (metric === 'Timestamp' || metric === 'timestamp') {
 		if (data === undefined) {
 			return (value: any) =>
 				moment(value * 1000).format('MMM D, h:mm:ss A')
@@ -1325,42 +1325,41 @@ const Graph = ({
 					{title || 'Untitled metric view'}
 				</Text>
 			</Box>
-			{
-				<Box
-					style={{ height: height ?? '100%' }}
-					key={series.join(';')} // Hacky but recharts' ResponsiveContainer has issues when this height changes so just rerender the whole thing
-					cssClass={clsx({
-						[style.disabled]: disabled,
-					})}
-					position="relative"
-				>
-					{loading && (
-						<Stack
-							position="absolute"
-							width="full"
-							height="full"
-							alignItems="center"
-							justifyContent="center"
-							cssClass={style.loadingOverlay}
-						>
-							<Badge
-								size="medium"
-								shape="basic"
-								variant="gray"
-								label="Loading"
-								iconStart={
-									<IconSolidLoading
-										className={loadingIcon}
-										color={vars.theme.static.content.weak}
-									/>
-								}
-							/>
-						</Stack>
-					)}
-					{innerChart}
-				</Box>
-			}
+			<Box
+				style={{ height: height ?? '100%' }}
+				key={series.join(';')} // Hacky but recharts' ResponsiveContainer has issues when this height changes so just rerender the whole thing
+				cssClass={clsx({
+					[style.disabled]: disabled,
+				})}
+				position="relative"
+			>
+				{loading && (
+					<Stack
+						position="absolute"
+						width="full"
+						height="full"
+						alignItems="center"
+						justifyContent="center"
+						cssClass={style.loadingOverlay}
+					>
+						<Badge
+							size="medium"
+							shape="basic"
+							variant="gray"
+							label="Loading"
+							iconStart={
+								<IconSolidLoading
+									className={loadingIcon}
+									color={vars.theme.static.content.weak}
+								/>
+							}
+						/>
+					</Stack>
+				)}
+				{innerChart}
+			</Box>
 			{loading &&
+				(data ?? []).length === 0 &&
 				groupByKeys !== undefined &&
 				groupByKeys.length > 0 &&
 				viewConfig.showLegend && (

--- a/packages/ui/src/components/DatePicker/DateRangePicker.stories.tsx
+++ b/packages/ui/src/components/DatePicker/DateRangePicker.stories.tsx
@@ -1,0 +1,38 @@
+import { Meta } from '@storybook/react'
+
+import { Box } from '../Box/Box'
+
+import { DateRangePicker, DEFAULT_TIME_PRESETS } from './DateRangePicker'
+import { useState } from 'react'
+
+export default {
+	title: 'Components/DateRangePicker',
+	component: DateRangePicker,
+	decorators: [
+		(Story) => (
+			<Box style={{ width: 300 }}>
+				<Story />
+			</Box>
+		),
+	],
+} as Meta<typeof DateRangePicker>
+
+export const Basic = () => {
+	const [defaultPreset, setDefaultPreset] = useState(DEFAULT_TIME_PRESETS[2])
+	return (
+		<DateRangePicker
+			selectedValue={{
+				startDate: new Date(),
+				endDate: new Date(),
+				selectedPreset: DEFAULT_TIME_PRESETS[2],
+			}}
+			onDatesChange={() => {
+				return null
+			}}
+			presets={DEFAULT_TIME_PRESETS}
+			minDate={new Date()}
+			defaultPreset={defaultPreset}
+			setDefaultPreset={setDefaultPreset}
+		/>
+	)
+}

--- a/packages/ui/src/components/DatePicker/DateRangePicker/index.tsx
+++ b/packages/ui/src/components/DatePicker/DateRangePicker/index.tsx
@@ -27,7 +27,7 @@ import {
 	isPresetSelected,
 	setTimeOnDate,
 } from './helpers'
-import { Badge } from '@/components/Badge/Badge'
+import { Badge } from '../../Badge/Badge'
 
 export type DateRangePreset = {
 	unit: moment.DurationInputArg2

--- a/packages/ui/src/components/DatePicker/DateRangePicker/index.tsx
+++ b/packages/ui/src/components/DatePicker/DateRangePicker/index.tsx
@@ -9,6 +9,7 @@ import {
 	IconSolidCheck,
 	IconSolidCheveronDown,
 	IconSolidCheveronRight,
+	IconSolidClock,
 } from '../../icons'
 import { Menu, MenuButtonProps } from '../../Menu/Menu'
 import { Stack } from '../../Stack/Stack'
@@ -26,6 +27,7 @@ import {
 	isPresetSelected,
 	setTimeOnDate,
 } from './helpers'
+import { Badge } from '@/components/Badge/Badge'
 
 export type DateRangePreset = {
 	unit: moment.DurationInputArg2
@@ -109,6 +111,8 @@ type Props = {
 	minDate: Date
 	maxDate?: Date
 	noCustom?: boolean
+	defaultPreset?: DateRangePreset
+	setDefaultPreset?: (preset: DateRangePreset) => void
 } & Omit<MenuButtonProps, 'ref' | 'store'>
 
 export const DateRangePicker: React.FC<Props> = (props) => {
@@ -140,6 +144,8 @@ const DateRangePickerImpl = ({
 	onDatesChange,
 	presets,
 	noCustom,
+	defaultPreset,
+	setDefaultPreset,
 	minDate,
 	maxDate = moment().toDate(),
 	open,
@@ -368,7 +374,7 @@ const DateRangePickerImpl = ({
 				{buttonLabel}
 			</Menu.Button>
 			<Menu.List>
-				{menuState === MenuState.Default ? (
+				{menuState === MenuState.Default && (
 					<>
 						{presetOptions.map((preset) => {
 							return (
@@ -431,8 +437,71 @@ const DateRangePickerImpl = ({
 								</Stack>
 							</Menu.Item>
 						)}
+						{defaultPreset && setDefaultPreset && (
+							<>
+								<Menu.Divider />
+								<Menu>
+									<Menu.Button render={<Menu.Item />}>
+										<Stack
+											width={'full'}
+											display={'flex'}
+											direction={'row'}
+											alignItems={'center'}
+											justifyContent={'space-between'}
+										>
+											<Stack
+												direction="row"
+												align="center"
+												gap="4"
+											>
+												<IconSolidClock size={16} />
+												<Text userSelect="none">
+													Default
+												</Text>
+												<Badge
+													label={`${defaultPreset.quantity} ${defaultPreset.unit}`}
+												/>
+											</Stack>
+											<IconSolidCheveronRight size={16} />
+										</Stack>
+									</Menu.Button>
+									<Menu.List>
+										{presetOptions.map((preset) => {
+											return (
+												<Menu.Item
+													key={preset.label}
+													onClick={(e) => {
+														e.preventDefault()
+														e.stopPropagation()
+														setDefaultPreset(preset)
+													}}
+												>
+													<Stack
+														py="2"
+														direction="row"
+														align="center"
+														gap="4"
+													>
+														<CheckboxIconIfSelected
+															isSelected={isPresetSelected(
+																preset,
+																defaultPreset,
+															)}
+														/>
+														<Text userSelect="none">
+															{`${preset.quantity} ${preset.unit}`}
+														</Text>
+													</Stack>
+												</Menu.Item>
+											)
+										})}
+									</Menu.List>
+								</Menu>
+							</>
+						)}
 					</>
-				) : (
+				)}
+				{menuState === MenuState.Custom && (
 					<Form>
 						<Box
 							borderBottom={'divider'}


### PR DESCRIPTION
## Summary
- allow timestamp to be used as y axis field (formatted as a date)
- add default selection to date picker as a submenu
- fix loading state padding bug
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
