### PR TITLE
support custom email inputs for alert destinations

### DIFF
--- a/frontend/src/pages/Alerts/DestinationInput/index.tsx
+++ b/frontend/src/pages/Alerts/DestinationInput/index.tsx
@@ -347,7 +347,7 @@ export const DestinationInput: React.FC<Props> = ({
 						onChange={setSelectedEmails}
 						notFoundContent={<p>No email suggestions</p>}
 						className={styles.selectContainer}
-						mode="multiple"
+						mode="tags"
 						labelInValue
 						value={selectedEmails}
 					/>

--- a/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
+++ b/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
@@ -710,7 +710,7 @@ const LogAlertForm = () => {
 							}
 							notFoundContent={<p>No email suggestions</p>}
 							className={styles.selectContainer}
-							mode="multiple"
+							mode="tags"
 							value={formStore.getValue(formStore.names.emails)}
 						/>
 					</Form.NamedSection>

--- a/frontend/src/pages/Alerts/components/AlertNotifyForm/AlertNotifyForm.tsx
+++ b/frontend/src/pages/Alerts/components/AlertNotifyForm/AlertNotifyForm.tsx
@@ -182,7 +182,7 @@ const AlertNotifyForm = () => {
 					}
 					notFoundContent={<p>No email suggestions</p>}
 					className={styles.selectContainer}
-					mode="multiple"
+					mode="tags"
 					value={formStore.getValue(formStore.names.emails)}
 				/>
 			</Form.NamedSection>


### PR DESCRIPTION
## Summary

* Support custom inputs for email box of alert destinations

## How did you test this change?

![Screenshot from 2024-11-04 18-13-56](https://github.com/user-attachments/assets/61b74c62-fdd1-4846-9e55-38c851381fa9)


## Are there any deployment considerations?

no

## Does this work require review from our design team?

no