### PR TITLE
fix dashboard re-rendering due to context loop

### DIFF
--- a/frontend/src/pages/Graphing/Dashboard.tsx
+++ b/frontend/src/pages/Graphing/Dashboard.tsx
@@ -30,7 +30,7 @@ import {
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
 import clsx from 'clsx'
-import { useEffect, useId, useState } from 'react'
+import { useCallback, useEffect, useId, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { Link, useNavigate } from 'react-router-dom'
 
@@ -41,7 +41,7 @@ import {
 	useUpsertVisualizationMutation,
 } from '@/graph/generated/hooks'
 import { GetVisualizationQuery } from '@/graph/generated/operations'
-import { GraphInput } from '@/graph/generated/schemas'
+import { GraphInput, Graph as TGraph } from '@/graph/generated/schemas'
 import { useProjectId } from '@/hooks/useProjectId'
 import { useSearchTime } from '@/hooks/useSearchTime'
 import { DashboardCard } from '@/pages/Graphing/components/DashboardCard'
@@ -172,6 +172,18 @@ export const Dashboard = () => {
 	const graphContext = useGraphData()
 
 	const noGraphs = graphs?.length === 0
+
+	const onDownload = useCallback(
+		(g: TGraph) =>
+			exportGraph(
+				g.id,
+				g.title,
+				g.functionType,
+				g.metric,
+				graphContext.graphData.current[g.id],
+			),
+		[graphContext.graphData],
+	)
 
 	return (
 		<>
@@ -543,16 +555,7 @@ export const Dashboard = () => {
 																		}
 															}
 															onDownload={() =>
-																exportGraph(
-																	g.id,
-																	g.title,
-																	g.functionType,
-																	g.metric,
-																	graphContext
-																		.graphData[
-																		g.id
-																	],
-																)
+																onDownload(g)
 															}
 														>
 															<Graph

--- a/frontend/src/pages/Graphing/Dashboard.tsx
+++ b/frontend/src/pages/Graphing/Dashboard.tsx
@@ -180,7 +180,9 @@ export const Dashboard = () => {
 				g.title,
 				g.functionType,
 				g.metric,
-				graphContext.graphData.current[g.id],
+				graphContext.graphData.current
+					? graphContext.graphData.current[g.id]
+					: [],
 			),
 		[graphContext.graphData],
 	)

--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -1069,7 +1069,8 @@ export const GraphingEditor: React.FC = () => {
 											/>
 										</LabeledRow>
 										{settings.groupByEnabled &&
-										viewType !== 'Table' ? (
+										viewType !== 'Table' &&
+										viewType !== 'Funnel chart' ? (
 											<Box
 												display="flex"
 												flexDirection="row"

--- a/frontend/src/pages/Graphing/context/GraphContext.ts
+++ b/frontend/src/pages/Graphing/context/GraphContext.ts
@@ -1,10 +1,10 @@
 import { createContext } from '@util/context/context'
-import React from 'react'
+import React, { RefObject } from 'react'
 
 export type GraphData = { [graphID: string]: any[] }
 
 export interface GraphContext {
-	graphData: GraphData
+	graphData: React.RefObject<GraphData>
 	setGraphData: React.Dispatch<React.SetStateAction<GraphData>>
 }
 

--- a/frontend/src/pages/Graphing/context/GraphContext.ts
+++ b/frontend/src/pages/Graphing/context/GraphContext.ts
@@ -1,5 +1,5 @@
 import { createContext } from '@util/context/context'
-import React, { RefObject } from 'react'
+import React from 'react'
 
 export type GraphData = { [graphID: string]: any[] }
 

--- a/frontend/src/pages/Graphing/hooks/useGraphData.tsx
+++ b/frontend/src/pages/Graphing/hooks/useGraphData.tsx
@@ -5,7 +5,7 @@ export function useGraphData(): GraphContext {
 	const graphData = useRef<GraphData>({})
 
 	return {
-		graphData: graphData.current,
+		graphData,
 		setGraphData: (
 			graph?: GraphData | ((graph?: GraphData) => GraphData),
 		) => {

--- a/frontend/src/pages/Graphing/hooks/useGraphData.tsx
+++ b/frontend/src/pages/Graphing/hooks/useGraphData.tsx
@@ -7,7 +7,7 @@ export function useGraphData(): GraphContext {
 	return {
 		graphData,
 		setGraphData: (
-			graph?: GraphData | ((graph?: GraphData) => GraphData),
+			graph?: GraphData | ((graph: GraphData) => GraphData),
 		) => {
 			if (typeof graph === 'function') {
 				graphData.current = graph(graphData.current)

--- a/frontend/src/pages/Graphing/hooks/useGraphData.tsx
+++ b/frontend/src/pages/Graphing/hooks/useGraphData.tsx
@@ -11,7 +11,7 @@ export function useGraphData(): GraphContext {
 		) => {
 			if (typeof graph === 'function') {
 				graphData.current = graph(graphData.current)
-			} else {
+			} else if (graph) {
 				graphData.current = graph
 			}
 		},

--- a/frontend/src/pages/Graphing/hooks/useGraphData.tsx
+++ b/frontend/src/pages/Graphing/hooks/useGraphData.tsx
@@ -1,11 +1,19 @@
-import { useState } from 'react'
+import { useRef } from 'react'
 import { GraphContext, GraphData } from '@pages/Graphing/context/GraphContext'
 
 export function useGraphData(): GraphContext {
-	const [graphData, setGraphData] = useState<GraphData>({})
+	const graphData = useRef<GraphData>({})
 
 	return {
-		graphData,
-		setGraphData,
+		graphData: graphData.current,
+		setGraphData: (
+			graph?: GraphData | ((graph?: GraphData) => GraphData),
+		) => {
+			if (typeof graph === 'function') {
+				graphData.current = graph(graphData.current)
+			} else {
+				graphData.current = graph
+			}
+		},
 	}
 }


### PR DESCRIPTION
## Summary

* Uses a `ref` for the graph data since the data is used for data export 
* Updates the editor for funnel charts to avoid showing limit

## How did you test this change?

[reflame](https://preview.highlight.io/1/metrics/20560?relative_time=last_7_days&%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201JBYE2RM1B9F5XD7N6M8FW76X%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22vadim%2Fdashboard-rerendering%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D)

![Screenshot from 2024-11-05 09-17-06](https://github.com/user-attachments/assets/488c9a18-c1c1-40a0-9b90-8379fda29537)


## Are there any deployment considerations?

no

## Does this work require review from our design team?

no