### PR TITLE
create and exchange new logs table, save timestamp with full precision

### DIFF
--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -40,9 +40,7 @@ func NewLogRow(timestamp time.Time, projectID uint32, opts ...LogRowOption) *Log
 	}
 
 	logRow := &LogRow{
-		// ensure timestamp is written at second precision,
-		// since clickhouse schema will truncate to second precision anyways.
-		Timestamp:      timestamp.Truncate(time.Second),
+		Timestamp:      timestamp,
 		ProjectId:      projectID,
 		UUID:           uuid.New().String(),
 		SeverityText:   makeLogLevel("INFO").String(),

--- a/backend/clickhouse/migrations/000130_logs_new_ts.down.sql
+++ b/backend/clickhouse/migrations/000130_logs_new_ts.down.sql
@@ -1,0 +1,4 @@
+EXCHANGE TABLES logs
+AND logs_new_ts;
+DROP TABLE IF EXISTS logs_new_ts;
+DROP VIEW IF EXISTS logs_new_ts_mv;

--- a/backend/clickhouse/migrations/000130_logs_new_ts.down.sql
+++ b/backend/clickhouse/migrations/000130_logs_new_ts.down.sql
@@ -1,4 +1,3 @@
 EXCHANGE TABLES logs
 AND logs_new_ts;
 DROP TABLE IF EXISTS logs_new_ts;
-DROP VIEW IF EXISTS logs_new_ts_mv;

--- a/backend/clickhouse/migrations/000130_logs_new_ts.up.sql
+++ b/backend/clickhouse/migrations/000130_logs_new_ts.up.sql
@@ -23,8 +23,5 @@ CREATE TABLE IF NOT EXISTS logs_new_ts (
 ORDER BY (ProjectId, Timestamp, UUID) TTL toDateTime(Timestamp) + toIntervalDay(30) SETTINGS ttl_only_drop_parts = 1,
     index_granularity = 8192,
     allow_experimental_block_number_column = 1;
-CREATE MATERIALIZED VIEW IF NOT EXISTS logs_new_ts_mv TO logs_new_ts AS
-SELECT *
-FROM logs;
 EXCHANGE TABLES logs
 AND logs_new_ts;

--- a/backend/clickhouse/migrations/000130_logs_new_ts.up.sql
+++ b/backend/clickhouse/migrations/000130_logs_new_ts.up.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS logs_new_ts (
+    `Timestamp` DateTime64(9),
+    `UUID` UUID,
+    `TraceId` String,
+    `SpanId` String,
+    `TraceFlags` UInt32,
+    `SeverityText` LowCardinality(String),
+    `SeverityNumber` Int32,
+    `ServiceName` LowCardinality(String),
+    `Body` String,
+    `LogAttributes` Map(LowCardinality(String), String),
+    `ProjectId` UInt32,
+    `SecureSessionId` String,
+    `Source` String,
+    `ServiceVersion` String,
+    `Environment` String,
+    INDEX idx_trace_id TraceId TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_secure_session_id SecureSessionId TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_log_attr_key mapKeys(LogAttributes) TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_log_attr_value mapValues(LogAttributes) TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_body Body TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1
+) ENGINE = ReplacingMergeTree PARTITION BY toDate(Timestamp)
+ORDER BY (ProjectId, Timestamp, UUID) TTL toDateTime(Timestamp) + toIntervalDay(30) SETTINGS ttl_only_drop_parts = 1,
+    index_granularity = 8192,
+    allow_experimental_block_number_column = 1;
+CREATE MATERIALIZED VIEW IF NOT EXISTS logs_new_ts_mv TO logs_new_ts AS
+SELECT *
+FROM logs;
+EXCHANGE TABLES logs
+AND logs_new_ts;


### PR DESCRIPTION
## Summary
- creates new logs table with DateTime(9) precision timestamps
- exchanges old and new logs tables
- write new log rows without truncating timestamps
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- verified new logs are written and returned by the `GetLogs` endpoint with full precision
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- new logs table has already been created in prod and backfilled with data. this will exchange it with the existing logs table.
- will follow up by deleting the existing logs table once everything looks good
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
