### PR TITLE
report better middleware spans from @highlight-run/node

### DIFF
--- a/.changeset/odd-fireants-melt.md
+++ b/.changeset/odd-fireants-melt.md
@@ -1,0 +1,7 @@
+---
+'@highlight-run/node': minor
+'@highlight-run/apollo': patch
+'@highlight-run/next': patch
+---
+
+support span naming in runwithheaders and set a default span name for route middlewares

--- a/docs-content/getting-started/fullstack-frameworks/next-js/2_page-router.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/2_page-router.md
@@ -150,7 +150,7 @@ function ThrowerOfErrors({
 We use `experimental.instrumentationHook` to capture [Next.js's automatic instrumentation](https://nextjs.org/docs/app/building-your-application/optimizing/open-telemetry). This method captures detailed API route tracing as well as server-side errors.
 
 1. Enable `experimental.instrumentationHook` in `next.config.js`.
-2. Ignore warnings from `@highlight-run/node` due to a [known OpenTelemetry issue](https://github.com/open-telemetry/opentelemetry-js/issues/4173#issuecomment-1822938936)
+2. Setup the `withHighlightConfig` wrapper for auto-upload of your [sourcemaps](../../../general/6_product-features/2_error-monitoring/sourcemaps.md).
 
 ```javascript
 // next.config.mjs
@@ -160,16 +160,15 @@ const nextConfig = {
 	experimental: {
 		instrumentationHook: true,
 	},
-	webpack(config, options) {
-		if (options.isServer) {
-			config.ignoreWarnings = [{ module: /highlight-(run\/)?node/ }]
-		}
-		return config
-	},
 	// ...additional config
 }
 
 export default withHighlightConfig(nextConfig)
+```
+
+```hint
+ If you are using a Docker image to deploy your Next.js app, make sure that the `next.config.js` file is copied into the final Docker image.
+ Otherwise, the next server will not enable the `instrumentationHook` in your production deploy.
 ```
 
 2. Call `registerHighlight` in `instrumentation.ts` or `src/instrumentation.ts` if you're using a `/src` folder. Make sure that `instrumentation.ts` is a sibling of your `pages` folder. 

--- a/docs-content/getting-started/fullstack-frameworks/next-js/3_app-router.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/3_app-router.md
@@ -144,7 +144,7 @@ function ThrowerOfErrors({
 We use `experimental.instrumentationHook` to capture [Next.js's automatic instrumentation](https://nextjs.org/docs/app/building-your-application/optimizing/open-telemetry). This method captures detailed API route tracing as well as server-side errors.
 
 1. Enable `experimental.instrumentationHook` in `next.config.js`.
-2. Ignore warnings from `@highlight-run/node` due to a [known OpenTelemetry issue](https://github.com/open-telemetry/opentelemetry-js/issues/4173#issuecomment-1822938936)
+2. Setup the `withHighlightConfig` wrapper for auto-upload of your [sourcemaps](../../../general/6_product-features/2_error-monitoring/sourcemaps.md). 
 
 ```javascript
 // next.config.mjs
@@ -154,17 +154,15 @@ const nextConfig = {
 	experimental: {
 		instrumentationHook: true,
 	},
-	webpack(config, options) {
-		if (options.isServer) {
-			config.ignoreWarnings = [{ module: /highlight-(run\/)?node/ }]
-		}
-
-		return config
-	},
 	// ...additional config
 }
 
 export default withHighlightConfig(nextConfig)
+```
+
+```hint
+ If you are using a Docker image to deploy your Next.js app, make sure that the `next.config.js` file is copied into the final Docker image.
+ Otherwise, the next server will not enable the `instrumentationHook` in your production deploy.
 ```
 
 2. Call `registerHighlight` in `instrumentation.ts` or `src/instrumentation.ts` if you're using a `/src` folder. Make sure that `instrumentation.ts` is a sibling of your `pages` folder. 

--- a/docs-content/getting-started/fullstack-frameworks/next-js/7_advanced-config.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/7_advanced-config.md
@@ -59,7 +59,7 @@ export default withPageRouterHighlight(async function handler(
 	res: NextApiResponse,
 ) {
 	return new Promise<void>(async (resolve) => {
-		const span = await H.startActiveSpan('page-router-span', {})
+		const { span } = H.startWithHeaders('page-router-span', {})
 
 		console.info('Here: /pages/api/page-router-trace.ts ⌚⌚⌚')
 
@@ -80,7 +80,7 @@ export const GET = withAppRouterHighlight(async function GET(
 	request: NextRequest,
 ) {
 	return new Promise(async (resolve) => {
-		const span = await H.startActiveSpan('app-router-span', {})
+        const { span } = H.startWithHeaders('app-router-span', {})
 
 		console.info('Here: /pages/api/app-router-trace/route.ts ⏰⏰⏰')
 

--- a/docs-content/sdk/nodejs.md
+++ b/docs-content/sdk/nodejs.md
@@ -217,7 +217,7 @@ import { H } from "@highlight-run/node";
 
 const onError = async (request: http.IncomingMessage, error: Error): void => {
     const callbackResult = await H.runWithHeaders&lt;ReturnType&gt;(req.headers, async () => {
-        const span = await H.startActiveSpan("custom-span-name", {});
+        const { span } = H.startWithHeaders('custom-span-name', {})
         // do work
         span.end();
       });
@@ -228,12 +228,16 @@ const onError = async (request: http.IncomingMessage, error: Error): void => {
 
 <section className="section">
   <div className="left">
-    <h3>H.startActiveSpan</h3>
-    <p>H.startActiveSpan() returns a Promise, which resolves to a span that carries all of the current Open Telemetry context as its parent span.</p>
+    <h3>H.startWithHeaders</h3>
+    <p>H.startWithHeaders() returns a Span and a Span Context to propagate the current trace to child spans.</p>
     <h6>Method Parameters</h6>
     <aside className="parameter">
       <h5>name<code>string</code> <code>required</code></h5>
       <p>Custom span name</p>
+    </aside>
+    <aside className="parameter">
+      <h5>headers<code>http.Headers</code> <code>required</code></h5>
+      <p>A headers object corresponding to the incoming http request headers. Can be an empty object: <code>{}</code></p>
     </aside>
     <aside className="parameter">
       <h5>options <code>optional</code></h5>
@@ -271,7 +275,11 @@ const onError = async (request: http.IncomingMessage, error: Error): void => {
     <h6>Method Return</h6>
     <aside className="parameter">
       <h5>span</h5>
-      <p>Returns a Promise that resolves to a custom span</p>
+      <p>Returns the started span</p>
+    </aside>
+    <aside className="parameter">
+      <h5>ctx</h5>
+      <p>Returns the context of the current span for trace propagation</p>
     </aside>
   </div>
   <div className="right">
@@ -279,7 +287,7 @@ const onError = async (request: http.IncomingMessage, error: Error): void => {
 import * as http from "http";
 import { H } from "@highlight-run/node";
 
-const span = await H.startActiveSpan("custom-span-name", {});
+const { span } = H.startWithHeaders("custom-span-name", {});
         // do work
         span.end();
 });
@@ -308,7 +316,7 @@ const span = await H.startActiveSpan("custom-span-name", {});
 import * as http from "http";
 import { H } from "@highlight-run/node";
 
-const span = await H.startActiveSpan('my-custom-span-name');
+const { span } = await H.startWithHeaders('my-custom-span-name', {});
 
 // do work
 

--- a/e2e/express-ts/package.json
+++ b/e2e/express-ts/package.json
@@ -18,14 +18,18 @@
 		"@highlight-run/apollo": "workspace:*",
 		"@highlight-run/node": "workspace:*",
 		"@highlight-run/pino": "workspace:*",
+		"@opentelemetry/api": "^1.9.0",
 		"dotenv": "^16.3.1",
 		"express": "^4.19.2",
 		"graphql": "^16.8.1",
 		"pino": "^8.19.0",
-		"pino-pretty": "^10.2.3",
-		"ts-node": "^10.9.1"
+		"pino-pretty": "^10.2.3"
 	},
 	"devDependencies": {
+		"ts-node": "^10.9.2",
 		"typescript": "^5.3.2"
+	},
+	"installConfig": {
+		"hoistingLimits": "workspaces"
 	}
 }

--- a/e2e/express-ts/src/express.ts
+++ b/e2e/express-ts/src/express.ts
@@ -11,7 +11,7 @@ const port = 3003
 // This should be before any controllers (route definitions)
 app.use(Handlers.middleware(config))
 app.get('/', async (req, res) => {
-	await H.runWithHeaders(req.headers, async () => {
+	await H.runWithHeaders('custom /', req.headers, async () => {
 		const err = new Error('this is a test error', {
 			cause: { route: '/', foo: ['bar'] },
 		})
@@ -36,7 +36,7 @@ app.get('/', async (req, res) => {
 })
 
 app.get('/good', async (req, res) => {
-	await H.runWithHeaders(req.headers, () => {
+	await H.runWithHeaders('custom /good', req.headers, () => {
 		console.warn('doing some heavy work!')
 		let result = 0
 		for (let i = 0; i < 1000; i++) {
@@ -47,6 +47,10 @@ app.get('/good', async (req, res) => {
 
 		res.send('yay!')
 	})
+})
+
+app.get('/bad', async (req, res) => {
+	throw new Error('oh no, an error!')
 })
 
 // This should be before any other error middleware and after all controllers (route definitions)

--- a/e2e/express-ts/src/express.ts
+++ b/e2e/express-ts/src/express.ts
@@ -1,7 +1,10 @@
 import { H, Handlers } from '@highlight-run/node'
-import { context } from '@opentelemetry/api'
+import { context, type Span, trace } from '@opentelemetry/api'
 import express from 'express'
 import { config } from './instrumentation'
+import { appendFile, unlinkSync } from 'node:fs'
+
+const tracer = trace.getTracer('my-tracer', '0.1.0')
 
 H.init(config)
 
@@ -51,6 +54,83 @@ app.get('/good', async (req, res) => {
 
 app.get('/bad', async (req, res) => {
 	throw new Error('oh no, an error!')
+})
+
+const roll = () => {
+	return tracer.startActiveSpan(`doWork`, async (span: Span) => {
+		console.log('doing work')
+		let result: number = 0
+		for (let i = 0; i < 100; i++) {
+			await new Promise((r) =>
+				appendFile('test.txt', result.toString(), r),
+			)
+			result += i
+		}
+		unlinkSync('test.txt')
+		span.end()
+		return result
+	})
+}
+
+app.get('/test', async (req, res) => {
+	const value = tracer.startActiveSpan('rollTheDice', (span: Span) => {
+		const result = roll()
+		// Be sure to end the span!
+		span.end()
+		return result
+	})
+
+	res.send(`value: ${value}`)
+})
+
+const startSpan = (name: string) => {
+	return new Promise<Span>((resolve) =>
+		tracer.startActiveSpan(name, {}, resolve),
+	)
+}
+
+const roll2 = async () => {
+	const span = await startSpan(`doWork2`)
+	console.log('doing work 2')
+	let result: number = 0
+	for (let i = 0; i < 100; i++) {
+		await new Promise((r) => appendFile('test.txt', result.toString(), r))
+		result += i
+	}
+	unlinkSync('test.txt')
+	span.end()
+	return result
+}
+
+app.get('/test2', async (req, res) => {
+	const span = await startSpan(`rollTheDice2`)
+	console.log('roll 2')
+	const value = await roll2()
+	span.end()
+
+	res.send(`value: ${value}`)
+})
+
+const roll3 = async () => {
+	const spanP = startSpan(`doWork3`)
+	console.log('doing work 3')
+	let result: number = 0
+	for (let i = 0; i < 100; i++) {
+		await new Promise((r) => appendFile('test.txt', result.toString(), r))
+		result += i
+	}
+	unlinkSync('test.txt')
+	;(await spanP).end()
+	return result
+}
+
+app.get('/test3', async (req, res) => {
+	const spanP = startSpan(`rollTheDice3`)
+	console.log('roll 3')
+	const value = await roll3()
+	;(await spanP).end()
+
+	res.send(`value: ${value}`)
 })
 
 // This should be before any other error middleware and after all controllers (route definitions)

--- a/e2e/express-ts/src/pino.ts
+++ b/e2e/express-ts/src/pino.ts
@@ -27,11 +27,15 @@ export function startPino() {
 		},
 	})
 
-	H.runWithHeaders({ 'x-highlight-request': '987654/321654' }, () => {
-		logger.info('hello world')
+	H.runWithHeaders(
+		'custom-span',
+		{ 'x-highlight-request': '987654/321654' },
+		() => {
+			logger.info('hello world')
 
-		const child = logger.child({ a: 'property' })
+			const child = logger.child({ a: 'property' })
 
-		child.info('hello child!')
-	})
+			child.info('hello child!')
+		},
+	)
 }

--- a/e2e/express/src/index.mjs
+++ b/e2e/express/src/index.mjs
@@ -1,4 +1,5 @@
 import { H, Handlers } from '@highlight-run/node'
+import { appendFileSync, unlinkSync } from 'node:fs'
 import express from 'express'
 
 /** @type {import('@highlight-run/node').NodeOptions} */
@@ -38,8 +39,14 @@ app.get('/good', (req, res) => {
 		const value = Math.random() * 1000
 		result += value
 		console.warn('some work happening', { result, value })
+		appendFileSync('test.txt', result.toString())
 	}
+	unlinkSync('test.txt')
 	res.send('yay!')
+})
+
+app.get('/bad', (req, res) => {
+	throw new Error('this is an error')
 })
 
 // This should be before any other error middleware and after all controllers (route definitions)

--- a/e2e/nestjs/src/app.service.ts
+++ b/e2e/nestjs/src/app.service.ts
@@ -35,7 +35,7 @@ export class AppService {
     span.end();
 
     for (let i = 0; i < 10; i++) {
-      const { span } = H.startWithHeaders(`another request ${i}`, {
+      const { span: s } = H.startWithHeaders(`another request ${i}`, {
         attributes: { i },
       });
       console.log('hello, world!');

--- a/e2e/nestjs/src/app.service.ts
+++ b/e2e/nestjs/src/app.service.ts
@@ -15,7 +15,7 @@ export class AppService {
     error?: true;
     empty?: true;
   }): Promise<string[]> {
-    const span = await H.startActiveSpan('making request now', {});
+    const { span } = H.startWithHeaders('making request now', {});
     await firstValueFrom(
       this.httpService.post<any[]>(
         'https://pub.highlight.io/v1/logs/json',
@@ -35,7 +35,7 @@ export class AppService {
     span.end();
 
     for (let i = 0; i < 10; i++) {
-      const s = await H.startActiveSpan(`another request ${i}`, {
+      const { span } = H.startWithHeaders(`another request ${i}`, {
         attributes: { i },
       });
       console.log('hello, world!');

--- a/e2e/nestjs/src/app.service.ts
+++ b/e2e/nestjs/src/app.service.ts
@@ -35,9 +35,13 @@ export class AppService {
     span.end();
 
     for (let i = 0; i < 10; i++) {
-      const { span: s } = H.startWithHeaders(`another request ${i}`, {
-        attributes: { i },
-      });
+      const { span: s } = H.startWithHeaders(
+        `another request ${i}`,
+        {},
+        {
+          attributes: { i },
+        },
+      );
       console.log('hello, world!');
       this.logger.log('hello, world!');
       this.logger.warn('whoa there! ', Math.random());

--- a/e2e/nextjs/pages/api/page-router-trace.ts
+++ b/e2e/nextjs/pages/api/page-router-trace.ts
@@ -9,7 +9,7 @@ export default withPageRouterHighlight(async function handler(
 	res: NextApiResponse,
 ) {
 	return new Promise<void>(async (resolve) => {
-		const span = await H.startActiveSpan('page-router-span', {})
+		const { span } = H.startWithHeaders('page-router-span', {})
 
 		console.info('Here: /pages/api/page-router-trace.ts ⌚⌚⌚')
 

--- a/e2e/nextjs/src/app/_utils/app-router-highlight.config.ts
+++ b/e2e/nextjs/src/app/_utils/app-router-highlight.config.ts
@@ -39,14 +39,14 @@ function withPropagation(highlightHandler: HighlightHandler) {
 
 			propagation.inject(newContext, output)
 
-			const span = await H.startActiveSpan('propagation-test', {})
+			const result = H.runWithHeaders(
+				'app-router',
+				request.headers,
+				async () => await originalHandler(request, ctx),
+			)
 
 			request.headers.set('traceparent', output.traceparent ?? '')
 			request.headers.set('tracestate', output.tracestate ?? '')
-
-			const result = await originalHandler(request, ctx)
-
-			span.end()
 
 			return result
 		})

--- a/e2e/nextjs/src/app/api/app-router-trace/route.ts
+++ b/e2e/nextjs/src/app/api/app-router-trace/route.ts
@@ -8,7 +8,7 @@ export const GET = withAppRouterHighlight(async function GET(
 	request: NextRequest,
 ) {
 	return new Promise(async (resolve) => {
-		const span = await H.startActiveSpan('app-router-span', {})
+		const { span } = H.startWithHeaders('app-router-span', {})
 
 		logger.info({}, `app router trace get`)
 

--- a/highlight.io/components/QuickstartContent/traces/node-js/manual.tsx
+++ b/highlight.io/components/QuickstartContent/traces/node-js/manual.tsx
@@ -19,20 +19,24 @@ export const JSManualTracesContent: QuickStartContent = {
 		{
 			title: 'Wrap your code using the Node.js SDK.',
 			content:
-				'By calling `H.startActiveSpan()` and `span.end()`, the `@highlight-run/node` SDK will record a span. You can create more child spans or add custom attributes to each span.',
+				'By calling `H.startWithHeaders()` and `span.end()`, the `@highlight-run/node` SDK will record a span. You can create more child spans or add custom attributes to each span.',
 			code: [
 				{
 					text: `
 const functionToTrace = async (input int) => {
-	const span = await H.startActiveSpan("functionToTrace", {custom_property: input})
+	const { span, ctx } = H.startWithHeaders("functionToTrace", {}, {custom_property: input})
 	// ...
-	anotherFunction()
+	// use the current span context with the function call to ensure child spans are tied to the current span
+	// import api from '@opentelemetry/api'
+	api.context.with(ctx, () => {
+        anotherFunction()
+    })
 	// ...
 	span.end()
 }
 
 const anotherFunction = () => {
-	const span = H.startActiveSpan("anotherFunction", {})
+	const { span } = H.startWithHeaders("anotherFunction", {})
 
 	// ...
 	span.end()
@@ -55,7 +59,7 @@ module.exports = function() {
 					text: `
 app.get('/', async (req, res) => {
 	await H.runWithHeaders(req.headers, () => {
-		const span = H.startActiveSpan("custom-span", {})
+		const { span } = H.startWithHeaders("custom-span", {})
 		const err = new Error('this is a test error')
 
 		console.info('Sending error to highlight')

--- a/highlight.io/components/QuickstartContent/traces/node-js/nextjs.tsx
+++ b/highlight.io/components/QuickstartContent/traces/node-js/nextjs.tsx
@@ -26,7 +26,7 @@ export default withPageRouterHighlight(async function handler(
 	res: NextApiResponse,
 ) {
 	return new Promise<void>(async (resolve) => {
-		const span = await H.startActiveSpan('page-router-span', {})
+		const { span } = H.startWithHeaders('page-router-span', {})
 
 		console.info('Here: /pages/api/page-router-trace.ts ⌚⌚⌚')
 
@@ -54,7 +54,7 @@ export const GET = withAppRouterHighlight(async function GET(
 	request: NextRequest,
 ) {
 	return new Promise(async (resolve) => {
-		const span = await H.startActiveSpan('app-router-span', {})
+		const { span } = H.startWithHeaders('app-router-span', {})
 
 		console.info('Here: /pages/api/app-router-trace/route.ts ⏰⏰⏰')
 

--- a/sdk/highlight-apollo/src/apollo.ts
+++ b/sdk/highlight-apollo/src/apollo.ts
@@ -23,12 +23,16 @@ export const ApolloServerHighlightPlugin = function <T extends BaseContext>(
 
 			const { secureSessionId, requestId } = H.parseHeaders(headers)
 
-			H.runWithHeaders(headers, () => {
-				H._debug('processError', 'extracted from headers', {
-					secureSessionId,
-					requestId,
-				})
-			})
+			H.runWithHeaders(
+				`${req.request.http?.method?.toUpperCase()} - ${req.request.http?.search}`,
+				headers,
+				() => {
+					H._debug('processError', 'extracted from headers', {
+						secureSessionId,
+						requestId,
+					})
+				},
+			)
 
 			return {
 				async didEncounterErrors(

--- a/sdk/highlight-apollo/src/apolloV3.ts
+++ b/sdk/highlight-apollo/src/apolloV3.ts
@@ -25,12 +25,16 @@ export const ApolloServerV3HighlightPlugin = function <T extends BaseContext>(
 
 			const { secureSessionId, requestId } = H.parseHeaders(headers)
 
-			H.runWithHeaders(headers, () => {
-				H._debug('processError', 'extracted from headers', {
-					secureSessionId,
-					requestId,
-				})
-			})
+			H.runWithHeaders(
+				`${req.request.http?.method?.toUpperCase()} - ${req.request.http?.url}`,
+				headers,
+				() => {
+					H._debug('processError', 'extracted from headers', {
+						secureSessionId,
+						requestId,
+					})
+				},
+			)
 
 			return {
 				async didEncounterErrors(

--- a/sdk/highlight-next/src/util/highlight-edge.ts
+++ b/sdk/highlight-next/src/util/highlight-edge.ts
@@ -128,8 +128,10 @@ export const H: HighlightInterface = {
 		return { secureSessionId: undefined, requestId: undefined }
 	},
 	async runWithHeaders<T>(
+		name: string,
 		headers: Headers | IncomingHttpHeaders,
 		cb: () => T,
+		options?: any,
 	) {
 		headers && setHeaders(headers)
 

--- a/sdk/highlight-next/src/util/types.ts
+++ b/sdk/highlight-next/src/util/types.ts
@@ -5,7 +5,7 @@ import type {
 	NodeOptions,
 } from '@highlight-run/node'
 import type { WorkersSDK } from '@highlight-run/opentelemetry-sdk-workers'
-import type { Attributes } from '@opentelemetry/api'
+import type { Attributes, SpanOptions } from '@opentelemetry/api'
 import type { ResourceAttributes } from '@opentelemetry/resources/build/src/types'
 import type { IncomingHttpHeaders } from 'http'
 
@@ -34,7 +34,12 @@ export interface HighlightInterface {
 	isInitialized: () => boolean
 	metrics: (metrics: Metric[]) => void
 	parseHeaders: (headers: any) => HighlightContext
-	runWithHeaders: <T>(headers: any, cb: () => T) => Promise<T>
+	runWithHeaders: <T>(
+		name: string,
+		headers: any,
+		cb: () => T,
+		options?: SpanOptions,
+	) => Promise<T>
 	consumeError: (
 		error: Error,
 		secureSessionId?: string,

--- a/sdk/highlight-next/src/util/with-highlight-edge.ts
+++ b/sdk/highlight-next/src/util/with-highlight-edge.ts
@@ -28,6 +28,7 @@ export function Highlight(env: HighlightEnv) {
 
 			try {
 				const response = await H.runWithHeaders(
+					`${request.method?.toUpperCase()} - ${request.url}`,
 					request.headers as any,
 					async () => {
 						return await handler(request, event)

--- a/sdk/highlight-next/src/util/with-highlight-nodejs-app-router.ts
+++ b/sdk/highlight-next/src/util/with-highlight-nodejs-app-router.ts
@@ -18,6 +18,7 @@ export function Highlight(options: NodeOptions) {
 
 			try {
 				return await H.runWithHeaders<Promise<Response>>(
+					`${request.method?.toUpperCase()} - ${request.url}`,
 					request.headers as any,
 					async () => originalHandler(request, context),
 				)

--- a/sdk/highlight-next/src/util/with-highlight-nodejs-page-router.ts
+++ b/sdk/highlight-next/src/util/with-highlight-nodejs-page-router.ts
@@ -3,7 +3,11 @@ import { H } from './highlight-node'
 
 import { IncomingHttpHeaders } from 'http'
 
-export declare type HasHeaders = { headers: IncomingHttpHeaders }
+export declare type HasHeaders = {
+	headers: IncomingHttpHeaders
+	method?: string
+	url?: string
+}
 export declare type HasStatus = {
 	readonly statusCode: number
 	readonly statusMessage: string
@@ -28,9 +32,13 @@ export const Highlight =
 			const start = new Date()
 
 			try {
-				return await H.runWithHeaders(req.headers, async () => {
-					return await originalHandler(req, res)
-				})
+				return await H.runWithHeaders(
+					`${req.method?.toUpperCase()} - ${req.url}`,
+					req.headers,
+					async () => {
+						return await originalHandler(req, res)
+					},
+				)
 			} catch (e) {
 				res.status(500).send('Internal Server Error')
 				throw e

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -451,14 +451,13 @@ export class Highlight {
 	}
 
 	async runWithHeaders<T>(
+		name: string,
 		headers: Headers | IncomingHttpHeaders,
 		cb: (span: OtelSpan) => T | Promise<T>,
+		options?: SpanOptions,
 	) {
 		const { secureSessionId, requestId } = this.parseHeaders(headers)
-		const { span, ctx } = await this.startWithHeaders(
-			'highlight-ctx',
-			headers,
-		)
+		const { span, ctx } = this.startWithHeaders(name, headers, options)
 		try {
 			return await api.context.with(ctx, async () => {
 				return cb(span)

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -497,12 +497,6 @@ export class Highlight {
 
 		return { span, ctx: contextWithSpanSet }
 	}
-
-	startActiveSpan(name: string, options?: SpanOptions) {
-		return new Promise<OtelSpan>((resolve) =>
-			this.tracer.startActiveSpan(name, options || {}, resolve),
-		)
-	}
 }
 function parseHeaders(
 	headers: Headers | IncomingHttpHeaders,

--- a/sdk/highlight-node/src/sdk.ts
+++ b/sdk/highlight-node/src/sdk.ts
@@ -23,8 +23,10 @@ export interface HighlightInterface {
 
 	// Use runWithHeaders to execute a method with a highlight context
 	runWithHeaders: <T>(
+		name: string,
 		headers: Headers | IncomingHttpHeaders,
 		cb: (span: OtelSpan) => T | Promise<T>,
+		options?: SpanOptions,
 	) => Promise<T>
 	startWithHeaders: (
 		name: string,
@@ -167,8 +169,8 @@ export const H: HighlightInterface = {
 		return highlight_obj.parseHeaders(headers)
 	},
 
-	runWithHeaders: (headers, cb) => {
-		return highlight_obj.runWithHeaders(headers, cb)
+	runWithHeaders: (name, headers, cb, options) => {
+		return highlight_obj.runWithHeaders(name, headers, cb, options)
 	},
 	startWithHeaders: (spanName, headers, options) => {
 		return highlight_obj.startWithHeaders(spanName, headers, options)

--- a/sdk/highlight-node/src/sdk.ts
+++ b/sdk/highlight-node/src/sdk.ts
@@ -31,7 +31,7 @@ export interface HighlightInterface {
 	startWithHeaders: (
 		name: string,
 		headers: Headers | IncomingHttpHeaders,
-		options: SpanOptions,
+		options?: SpanOptions,
 	) => { span: OtelSpan; ctx: Context }
 
 	consumeError: (
@@ -63,7 +63,6 @@ export interface HighlightInterface {
 		metadata?: Attributes,
 	) => Promise<void>
 	setAttributes: (attributes: ResourceAttributes) => void
-	startActiveSpan: (name: string, options: SpanOptions) => Promise<OtelSpan>
 	_debug: (...data: any[]) => void
 }
 
@@ -186,9 +185,6 @@ export const H: HighlightInterface = {
 	},
 	setAttributes: (attributes: ResourceAttributes) => {
 		return highlight_obj.setAttributes(attributes)
-	},
-	startActiveSpan: (name: string, options: SpanOptions) => {
-		return highlight_obj.startActiveSpan(name, options)
 	},
 
 	_debug: (...data: any[]) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -30598,12 +30598,13 @@ __metadata:
     "@highlight-run/apollo": "workspace:*"
     "@highlight-run/node": "workspace:*"
     "@highlight-run/pino": "workspace:*"
+    "@opentelemetry/api": "npm:^1.9.0"
     dotenv: "npm:^16.3.1"
     express: "npm:^4.19.2"
     graphql: "npm:^16.8.1"
     pino: "npm:^8.19.0"
     pino-pretty: "npm:^10.2.3"
-    ts-node: "npm:^10.9.1"
+    ts-node: "npm:^10.9.2"
     typescript: "npm:^5.3.2"
   languageName: unknown
   linkType: soft
@@ -56600,7 +56601,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-node@npm:^10.9.1, ts-node@npm:~10.9.0":
+"ts-node@npm:^10.9.1, ts-node@npm:^10.9.2, ts-node@npm:~10.9.0":
   version: 10.9.2
   resolution: "ts-node@npm:10.9.2"
   dependencies:


### PR DESCRIPTION
## Summary

* Names the `Handlers.middleware` `@highlight-run/node` spans based on the request method / route
* Fixes `Handlers.middleware` in `@highlight-run/node` not propagating span context correctly to child middleware invocation
* Updates apollo and next sdks accordingly

## How did you test this change?

e2e/express app [traces](https://app.highlight.io/1/traces?query=service_name%3De2e-express&related_resource=eyJ0eXBlIjoidHJhY2UiLCJpZCI6IjZhNmQ4YTAxZDM4ZTJmMzdjNDYyODhmYmNhNGM2M2JiIiwidGltZXN0YW1wIjoiMjAyNC0xMS0wNlQwNDo1NTo1My4yNjlaIiwic3BhbklEIjoiNzg4YjI3ZDcxYTYxMTJlMSJ9)

![Screenshot from 2024-11-05 22-56-39](https://github.com/user-attachments/assets/0ceee097-f9b3-4231-a9ba-20f2d46b8b92)

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
