### PR TITLE
Limit trace title to 2 lines

### DIFF
--- a/frontend/src/pages/Traces/TraceHeader.tsx
+++ b/frontend/src/pages/Traces/TraceHeader.tsx
@@ -18,7 +18,7 @@ export const TraceHeader = () => {
 
 	return (
 		<Stack direction="column" gap="12" pb="12">
-			<Heading level="h4" lines="2">
+			<Heading level="h4" lines="2" title={traceName}>
 				{traceName}
 			</Heading>
 			<Stack gap="4" direction="row" alignItems="center">

--- a/frontend/src/pages/Traces/TraceHeader.tsx
+++ b/frontend/src/pages/Traces/TraceHeader.tsx
@@ -18,7 +18,9 @@ export const TraceHeader = () => {
 
 	return (
 		<Stack direction="column" gap="12" pb="12">
-			<Heading level="h4">{traceName}</Heading>
+			<Heading level="h4" lines="2">
+				{traceName}
+			</Heading>
 			<Stack gap="4" direction="row" alignItems="center">
 				<Badge
 					size="medium"

--- a/packages/ui/src/components/Heading/Heading.tsx
+++ b/packages/ui/src/components/Heading/Heading.tsx
@@ -16,6 +16,7 @@ type Props = React.PropsWithChildren &
 		as?: Levels
 		level?: Levels
 		lines?: TruncateProps['lines']
+		title?: string
 	}
 
 export const Heading: React.FC<Props> = ({
@@ -24,6 +25,7 @@ export const Heading: React.FC<Props> = ({
 	children,
 	level = 'h2',
 	lines,
+	title,
 	...props
 }) => {
 	const content = lines ? (
@@ -36,6 +38,7 @@ export const Heading: React.FC<Props> = ({
 		<Box
 			as={as || level}
 			cssClass={styles.variants({ align, level })}
+			title={title}
 			{...props}
 		>
 			{content}


### PR DESCRIPTION
## Summary

Ensures trace titles are truncated if they are longer than 2 lines.

**Before**
<img width="1087" alt="Screenshot 2024-11-06 at 9 00 41 AM" src="https://github.com/user-attachments/assets/a89c2c30-7089-4c3c-b876-d0653b2130be">

**After**
<img width="1013" alt="Screenshot 2024-11-06 at 9 00 07 AM" src="https://github.com/user-attachments/assets/a7d7b8d6-66d6-4bb7-a93a-77c76a435af0">

## How did you test this change?

Click tested in the PR preview (see screenshots ☝️).

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A