### PR TITLE
support multiple heroku tokens for the same highlight project

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1295,9 +1295,9 @@ type IntegrationWorkspaceMapping struct {
 
 type IntegrationProjectMapping struct {
 	// idx_integration_project_mapping_integration_type_external_id is used to find a project for a given integration by its external id
-	IntegrationType modelInputs.IntegrationType `gorm:"uniqueIndex:idx_integration_project_mapping_project_id_integration_type;index:idx_integration_project_mapping_integration_type_external_id"`
-	ProjectID       int                         `gorm:"uniqueIndex:idx_integration_project_mapping_project_id_integration_type"`
-	ExternalID      string                      `gorm:"index:idx_integration_project_mapping_integration_type_external_id"`
+	IntegrationType modelInputs.IntegrationType `gorm:"index:idx_integration_project_mapping_integration_type_external_id"`
+	ProjectID       int
+	ExternalID      string `gorm:"index:idx_integration_project_mapping_integration_type_external_id"`
 }
 
 type OAuthClientStore struct {

--- a/frontend/src/pages/IntegrationsPage/components/HerokuIntegration/HerokuIntegration.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/HerokuIntegration/HerokuIntegration.tsx
@@ -11,6 +11,7 @@ import React from 'react'
 
 import styles from './HerokuIntegration.module.css'
 import { useHerokuIntegration } from './utils'
+import Select from '@components/Select/Select'
 
 const HerokuIntegration: React.FC<
 	React.PropsWithChildren<IntegrationConfigProps>
@@ -18,12 +19,12 @@ const HerokuIntegration: React.FC<
 	const { project_id } = useParams<{ project_id: string }>()
 	const { addHerokuToProject, removeHerokuIntegrationFromProject } =
 		useHerokuIntegration()
-	const formStore = Form.useStore({
+	const formStore = Form.useStore<{ tokens: string[] }>({
 		defaultValues: {
-			token: '',
+			tokens: [],
 		},
 	})
-	const token = formStore.useValue(formStore.names.token)
+	const tokens = formStore.useValue(formStore.names.tokens) as string[]
 
 	if (action === IntegrationAction.Disconnect) {
 		return (
@@ -79,12 +80,21 @@ const HerokuIntegration: React.FC<
 				</a>
 			</p>
 			<Form store={formStore} resetOnSubmit={false}>
-				<Form.Input
-					name={formStore.names.token}
-					label="Log Drain Token"
-					type="text"
-					autoFocus
-				/>
+				<Form.NamedSection
+					name={formStore.names.tokens}
+					label="Log Drain Token(s)"
+				>
+					<Select
+						aria-label="Log Drain Token(s)"
+						placeholder="d.9173ea1f-6f14-4976-9cf0-deadbeef1234"
+						onChange={(values: any): any =>
+							formStore.setValue(formStore.names.tokens, values)
+						}
+						className={styles.selectContainer}
+						mode="tags"
+						value={formStore.getValue(formStore.names.tokens)}
+					/>
+				</Form.NamedSection>
 			</Form>
 			<footer>
 				<Button
@@ -101,10 +111,10 @@ const HerokuIntegration: React.FC<
 					trackingId="IntegrationConfigurationSave-Heroku"
 					className={styles.modalBtn}
 					type="primary"
-					disabled={token.length < 38}
+					disabled={!tokens.filter((t) => t.length >= 38).length}
 					onClick={async () => {
 						setModalOpen(false)
-						await addHerokuToProject(token, project_id)
+						await addHerokuToProject(tokens, project_id)
 					}}
 				>
 					<AppsIcon className={styles.modalBtnIcon} /> Connect

--- a/frontend/src/pages/IntegrationsPage/components/HerokuIntegration/utils.ts
+++ b/frontend/src/pages/IntegrationsPage/components/HerokuIntegration/utils.ts
@@ -68,9 +68,13 @@ export const useHerokuIntegration = () => {
 	}, [HerokuIntegResponse, setIsHerokuConnectedToProject])
 
 	const addHerokuToProject = useCallback(
-		async (token: string, projectId?: string) => {
+		async (tokens: string[], projectId?: string) => {
 			setLoading(true)
-			await addHerokuIntegrationToProject(token, projectId)
+			await Promise.all(
+				tokens.map((token) =>
+					addHerokuIntegrationToProject(token, projectId),
+				),
+			)
 			setIsHerokuConnectedToProject(true)
 			toast.success('Highlight is now synced with Heroku!', {
 				duration: 5000,


### PR DESCRIPTION
## Summary

* Allows multiple heroku log drain tokens to be associated with the same highlight project

## How did you test this change?

https://www.loom.com/share/bf68f9c79ddd41a79386df0568ba74f0

## Are there any deployment considerations?

remove`idx_integration_project_mapping_project_id_integration_type` in production`

## Does this work require review from our design team?

no
