### PR TITLE
gate teams and jira as enterprise features

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -482,6 +482,9 @@ type AllWorkspaceSettings struct {
 	EnableDataDeletion    bool `gorm:"default:true"`
 	EnableNetworkTraces   bool `gorm:"default:true"`
 	EnableUnlistedSharing bool `gorm:"default:true"`
+
+	EnableJiraIntegration  bool `gorm:"default:false"`
+	EnableTeamsIntegration bool `gorm:"default:false"`
 }
 
 type HasSecret interface {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -209,9 +209,11 @@ type ComplexityRoot struct {
 		EnableGrafanaDashboard   func(childComplexity int) int
 		EnableIngestFiltering    func(childComplexity int) int
 		EnableIngestSampling     func(childComplexity int) int
+		EnableJiraIntegration    func(childComplexity int) int
 		EnableNetworkTraces      func(childComplexity int) int
 		EnableProjectLevelAccess func(childComplexity int) int
 		EnableSessionExport      func(childComplexity int) int
+		EnableTeamsIntegration   func(childComplexity int) int
 		EnableUnlistedSharing    func(childComplexity int) int
 		WorkspaceID              func(childComplexity int) int
 	}
@@ -2857,6 +2859,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.AllWorkspaceSettings.EnableIngestSampling(childComplexity), true
 
+	case "AllWorkspaceSettings.enable_jira_integration":
+		if e.complexity.AllWorkspaceSettings.EnableJiraIntegration == nil {
+			break
+		}
+
+		return e.complexity.AllWorkspaceSettings.EnableJiraIntegration(childComplexity), true
+
 	case "AllWorkspaceSettings.enable_network_traces":
 		if e.complexity.AllWorkspaceSettings.EnableNetworkTraces == nil {
 			break
@@ -2877,6 +2886,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.AllWorkspaceSettings.EnableSessionExport(childComplexity), true
+
+	case "AllWorkspaceSettings.enable_teams_integration":
+		if e.complexity.AllWorkspaceSettings.EnableTeamsIntegration == nil {
+			break
+		}
+
+		return e.complexity.AllWorkspaceSettings.EnableTeamsIntegration(childComplexity), true
 
 	case "AllWorkspaceSettings.enable_unlisted_sharing":
 		if e.complexity.AllWorkspaceSettings.EnableUnlistedSharing == nil {
@@ -12295,6 +12311,8 @@ type AllWorkspaceSettings {
 	enable_project_level_access: Boolean!
 	enable_session_export: Boolean!
 	enable_unlisted_sharing: Boolean!
+	enable_jira_integration: Boolean!
+	enable_teams_integration: Boolean!
 }
 
 type Account {
@@ -28104,6 +28122,94 @@ func (ec *executionContext) _AllWorkspaceSettings_enable_unlisted_sharing(ctx co
 }
 
 func (ec *executionContext) fieldContext_AllWorkspaceSettings_enable_unlisted_sharing(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AllWorkspaceSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AllWorkspaceSettings_enable_jira_integration(ctx context.Context, field graphql.CollectedField, obj *model1.AllWorkspaceSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AllWorkspaceSettings_enable_jira_integration(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.EnableJiraIntegration, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AllWorkspaceSettings_enable_jira_integration(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AllWorkspaceSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AllWorkspaceSettings_enable_teams_integration(ctx context.Context, field graphql.CollectedField, obj *model1.AllWorkspaceSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AllWorkspaceSettings_enable_teams_integration(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.EnableTeamsIntegration, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AllWorkspaceSettings_enable_teams_integration(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "AllWorkspaceSettings",
 		Field:      field,
@@ -46885,6 +46991,10 @@ func (ec *executionContext) fieldContext_Mutation_editWorkspaceSettings(ctx cont
 				return ec.fieldContext_AllWorkspaceSettings_enable_session_export(ctx, field)
 			case "enable_unlisted_sharing":
 				return ec.fieldContext_AllWorkspaceSettings_enable_unlisted_sharing(ctx, field)
+			case "enable_jira_integration":
+				return ec.fieldContext_AllWorkspaceSettings_enable_jira_integration(ctx, field)
+			case "enable_teams_integration":
+				return ec.fieldContext_AllWorkspaceSettings_enable_teams_integration(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type AllWorkspaceSettings", field.Name)
 		},
@@ -61983,6 +62093,10 @@ func (ec *executionContext) fieldContext_Query_workspaceSettings(ctx context.Con
 				return ec.fieldContext_AllWorkspaceSettings_enable_session_export(ctx, field)
 			case "enable_unlisted_sharing":
 				return ec.fieldContext_AllWorkspaceSettings_enable_unlisted_sharing(ctx, field)
+			case "enable_jira_integration":
+				return ec.fieldContext_AllWorkspaceSettings_enable_jira_integration(ctx, field)
+			case "enable_teams_integration":
+				return ec.fieldContext_AllWorkspaceSettings_enable_teams_integration(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type AllWorkspaceSettings", field.Name)
 		},
@@ -86993,6 +87107,16 @@ func (ec *executionContext) _AllWorkspaceSettings(ctx context.Context, sel ast.S
 			}
 		case "enable_unlisted_sharing":
 			out.Values[i] = ec._AllWorkspaceSettings_enable_unlisted_sharing(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "enable_jira_integration":
+			out.Values[i] = ec._AllWorkspaceSettings_enable_jira_integration(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "enable_teams_integration":
+			out.Values[i] = ec._AllWorkspaceSettings_enable_teams_integration(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -570,6 +570,8 @@ type AllWorkspaceSettings {
 	enable_project_level_access: Boolean!
 	enable_session_export: Boolean!
 	enable_unlisted_sharing: Boolean!
+	enable_jira_integration: Boolean!
+	enable_teams_integration: Boolean!
 }
 
 type Account {

--- a/frontend/src/components/Billing/EnterpriseFeatureButton.tsx
+++ b/frontend/src/components/Billing/EnterpriseFeatureButton.tsx
@@ -23,6 +23,10 @@ const FEATURE_DESCRIPTIONS = {
 	'Ingestion Sampling': 'control data ingestion rates and sample data.',
 	'Custom Data Retention':
 		'control data retention beyond the standard retention.',
+	'Jira Integration':
+		'create Jira issues from your highlight.io errors and sessions.',
+	'Teams Integration':
+		'receive highlight.io alerts via Microsoft Teams messages.',
 } as const
 
 type Feature = keyof typeof FEATURE_DESCRIPTIONS

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -14070,10 +14070,12 @@ export const GetWorkspaceSettingsDocument = gql`
 			enable_grafana_dashboard
 			enable_ingest_filtering
 			enable_ingest_sampling
+			enable_jira_integration
 			enable_network_traces
 			enable_project_level_access
 			enable_project_level_access
 			enable_session_export
+			enable_teams_integration
 			enable_unlisted_sharing
 		}
 	}

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4806,9 +4806,11 @@ export type GetWorkspaceSettingsQuery = { __typename?: 'Query' } & {
 			| 'enable_grafana_dashboard'
 			| 'enable_ingest_filtering'
 			| 'enable_ingest_sampling'
+			| 'enable_jira_integration'
 			| 'enable_network_traces'
 			| 'enable_project_level_access'
 			| 'enable_session_export'
+			| 'enable_teams_integration'
 			| 'enable_unlisted_sharing'
 		>
 	>

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -231,9 +231,11 @@ export type AllWorkspaceSettings = {
 	enable_grafana_dashboard: Scalars['Boolean']
 	enable_ingest_filtering: Scalars['Boolean']
 	enable_ingest_sampling: Scalars['Boolean']
+	enable_jira_integration: Scalars['Boolean']
 	enable_network_traces: Scalars['Boolean']
 	enable_project_level_access: Scalars['Boolean']
 	enable_session_export: Scalars['Boolean']
+	enable_teams_integration: Scalars['Boolean']
 	enable_unlisted_sharing: Scalars['Boolean']
 	workspace_id: Scalars['ID']
 }

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2279,10 +2279,12 @@ query GetWorkspaceSettings($workspace_id: ID!) {
 		enable_grafana_dashboard
 		enable_ingest_filtering
 		enable_ingest_sampling
+		enable_jira_integration
 		enable_network_traces
 		enable_project_level_access
 		enable_project_level_access
 		enable_session_export
+		enable_teams_integration
 		enable_unlisted_sharing
 	}
 }

--- a/frontend/src/pages/IntegrationsPage/components/Integration.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from 'react'
 import { IntegrationModal } from '@/pages/IntegrationsPage/components/IntegrationModal/IntegrationModal'
 
 import styles from './Integration.module.css'
+import EnterpriseFeatureButton from '@/components/Billing/EnterpriseFeatureButton'
 
 export enum IntegrationAction {
 	Setup,
@@ -66,6 +67,12 @@ const Integration = ({
 		)
 	}
 
+	const isGated = name === 'Jira' || name === 'Microsoft Teams'
+	const enterpriseSetting =
+		name === 'Jira' ? 'enable_jira_integration' : 'enable_teams_integration'
+	const enterpriseName =
+		name === 'Jira' ? 'Jira Integration' : 'Teams Integration'
+
 	return (
 		<>
 			<Card className={styles.integration} interactable>
@@ -78,28 +85,64 @@ const Integration = ({
 						})}
 					/>
 					<div className="flex flex-col gap-2">
-						<Switch
-							trackingId={`IntegrationConnect-${name}`}
-							label={
-								!showConfiguration && integrationEnabled
-									? 'Connected'
-									: 'Connect'
-							}
-							loading={
-								(showConfiguration && integrationEnabled) ||
-								(showDeleteConfirmation && !integrationEnabled)
-							}
-							size="default"
-							checked={integrationEnabled}
-							onChange={(newValue) => {
-								if (newValue) {
-									setShowConfiguration(true)
-								} else {
-									setShowDeleteConfirmation(true)
+						{isGated ? (
+							<EnterpriseFeatureButton
+								setting={enterpriseSetting}
+								name={enterpriseName}
+								fn={async () => {
+									const newValue = !integrationEnabled
+									if (newValue) {
+										setShowConfiguration(true)
+									} else {
+										setShowDeleteConfirmation(true)
+									}
+									setIntegrationEnabled(newValue)
+								}}
+								variant="basic"
+							>
+								<Switch
+									trackingId={`IntegrationConnect-${name}`}
+									label={
+										!showConfiguration && integrationEnabled
+											? 'Connected'
+											: 'Connect'
+									}
+									loading={
+										(showConfiguration &&
+											integrationEnabled) ||
+										(showDeleteConfirmation &&
+											!integrationEnabled)
+									}
+									size="default"
+									checked={integrationEnabled}
+								/>
+							</EnterpriseFeatureButton>
+						) : (
+							<Switch
+								trackingId={`IntegrationConnect-${name}`}
+								label={
+									!showConfiguration && integrationEnabled
+										? 'Connected'
+										: 'Connect'
 								}
-								setIntegrationEnabled(newValue)
-							}}
-						/>
+								loading={
+									(showConfiguration && integrationEnabled) ||
+									(showDeleteConfirmation &&
+										!integrationEnabled)
+								}
+								onChange={() => {
+									const newValue = !integrationEnabled
+									if (newValue) {
+										setShowConfiguration(true)
+									} else {
+										setShowDeleteConfirmation(true)
+									}
+									setIntegrationEnabled(newValue)
+								}}
+								size="default"
+								checked={integrationEnabled}
+							/>
+						)}
 						{hasSettings && (
 							<div className="flex h-[18px] w-full justify-end">
 								<Button


### PR DESCRIPTION
## Summary
- on the integrations page, put the Jira and Teams toggles behind the enterprise feature gate
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally with and without settings enabled
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- after deploying, will run this script to enable the enterprise settings for anyone already using jira / teams
```
update all_workspace_settings 
set enable_teams_integration = true 
where workspace_id in (
	select id from workspaces where microsoft_teams_tenant_id is not null
)

update all_workspace_settings 
set enable_jira_integration = true 
where workspace_id in (
	select workspace_id from integration_workspace_mappings where integration_type = 'Jira'
)
```
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
