### PR TITLE
fix @highlight-run/node & next propagation of w3c context

### DIFF
--- a/.changeset/metal-foxes-teach.md
+++ b/.changeset/metal-foxes-teach.md
@@ -1,5 +1,0 @@
----
-'@highlight-run/node': patch
----
-
-ensure W3CTraceContext is propagated to distributed services

--- a/.changeset/metal-foxes-teach.md
+++ b/.changeset/metal-foxes-teach.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/node': patch
+---
+
+ensure W3CTraceContext is propagated to distributed services

--- a/e2e/nextjs/pages/api/page-router-trace.ts
+++ b/e2e/nextjs/pages/api/page-router-trace.ts
@@ -15,7 +15,11 @@ export default withPageRouterHighlight(async function handler(
 		const headers = {}
 		await fetch('http://localhost:3010/x-highlight-request', {
 			method: 'GET',
-			headers, // Forward headers, x-highlight-request is critical
+			// forward headers
+			headers: Object.entries(req.headers).reduce(
+				(acc, [key, value]) => ({ ...acc, [key]: value }),
+				{},
+			),
 		}).catch(() =>
 			console.info('Inactive go service at http://localhost:3010'),
 		)

--- a/e2e/nextjs/pages/api/page-router-trace.ts
+++ b/e2e/nextjs/pages/api/page-router-trace.ts
@@ -3,6 +3,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import { withPageRouterHighlight } from '@/app/_utils/page-router-highlight.config'
 import { H } from '@highlight-run/next/server'
+import { context, propagation } from '@opentelemetry/api'
 
 export default withPageRouterHighlight(async function handler(
 	req: NextApiRequest,
@@ -11,7 +12,32 @@ export default withPageRouterHighlight(async function handler(
 	return new Promise<void>(async (resolve) => {
 		const { span } = H.startWithHeaders('page-router-span', {})
 
-		console.info('Here: /pages/api/page-router-trace.ts ⌚⌚⌚')
+		const headers = { ...request.headers }
+		await fetch('http://localhost:3010/x-highlight-request', {
+			method: 'GET',
+			headers, // Forward headers, x-highlight-request is critical
+		}).catch(() =>
+			console.info('Inactive go service at http://localhost:3010'),
+		)
+
+		await fetch('http://localhost:3010/traceparent', {
+			method: 'GET',
+			headers,
+		}).catch(() =>
+			console.info('Inactive go service at http://localhost:3010'),
+		)
+
+		propagation.inject(context.active(), headers)
+		await fetch('http://localhost:3010/traceparent', {
+			method: 'GET',
+			headers,
+		}).catch(() =>
+			console.info('Inactive go service at http://localhost:3010'),
+		)
+
+		console.info('Here: /pages/api/page-router-trace.ts ⌚⌚⌚', {
+			headers,
+		})
 
 		res.send(`Trace sent! Check out this random number: ${Math.random()}`)
 		span.end()

--- a/e2e/nextjs/pages/api/page-router-trace.ts
+++ b/e2e/nextjs/pages/api/page-router-trace.ts
@@ -12,7 +12,7 @@ export default withPageRouterHighlight(async function handler(
 	return new Promise<void>(async (resolve) => {
 		const { span } = H.startWithHeaders('page-router-span', {})
 
-		const headers = { ...request.headers }
+		const headers = {}
 		await fetch('http://localhost:3010/x-highlight-request', {
 			method: 'GET',
 			headers, // Forward headers, x-highlight-request is critical

--- a/e2e/nextjs/src/app/_utils/app-router-highlight.config.ts
+++ b/e2e/nextjs/src/app/_utils/app-router-highlight.config.ts
@@ -1,13 +1,7 @@
 // utils/app-router-highlight.config.ts:
 
-import { context, propagation, SpanContext, trace } from '@opentelemetry/api'
-
 import { highlightConfig } from '@/instrumentation'
-import { AppRouterHighlight, H, HighlightEnv } from '@highlight-run/next/server'
-import { TraceState } from '@opentelemetry/core'
-
-type HighlightHandler = ReturnType<typeof AppRouterHighlight>
-type HandlerFunction = Parameters<HighlightHandler>[0]
+import { AppRouterHighlight, HighlightEnv } from '@highlight-run/next/server'
 
 const env: HighlightEnv = {
 	...highlightConfig,
@@ -15,39 +9,4 @@ const env: HighlightEnv = {
 	environment: 'e2e-test',
 }
 
-export const withAppRouterHighlight = withPropagation(AppRouterHighlight(env))
-
-function withPropagation(highlightHandler: HighlightHandler) {
-	return (originalHandler: HandlerFunction) =>
-		highlightHandler(async (request, ctx) => {
-			const output: { traceparent?: string; tracestate?: string } = {}
-			const activeSpan = trace.getActiveSpan()
-
-			if (!activeSpan) {
-				return originalHandler(request, ctx)
-			}
-
-			const spanContext: SpanContext = {
-				...activeSpan.spanContext(),
-				traceState: new TraceState('a=b,c=d'),
-			}
-
-			const newContext = trace.setSpanContext(
-				context.active(),
-				spanContext,
-			)
-
-			propagation.inject(newContext, output)
-
-			const result = H.runWithHeaders(
-				'app-router',
-				request.headers,
-				async () => await originalHandler(request, ctx),
-			)
-
-			request.headers.set('traceparent', output.traceparent ?? '')
-			request.headers.set('tracestate', output.tracestate ?? '')
-
-			return result
-		})
-}
+export const withAppRouterHighlight = AppRouterHighlight(env)

--- a/e2e/nextjs/src/app/api/app-router-trace/route.ts
+++ b/e2e/nextjs/src/app/api/app-router-trace/route.ts
@@ -13,7 +13,7 @@ export const GET = withAppRouterHighlight(async function GET(
 
 		logger.info({}, `app router trace get`)
 
-		const headers = { ...request.headers }
+		const headers = {}
 		await fetch('http://localhost:3010/x-highlight-request', {
 			method: 'GET',
 			headers, // Forward headers, x-highlight-request is critical

--- a/e2e/nextjs/src/app/api/app-router-trace/route.ts
+++ b/e2e/nextjs/src/app/api/app-router-trace/route.ts
@@ -16,7 +16,7 @@ export const GET = withAppRouterHighlight(async function GET(
 		const headers = {}
 		await fetch('http://localhost:3010/x-highlight-request', {
 			method: 'GET',
-			headers, // Forward headers, x-highlight-request is critical
+			headers: request.headers, // Forward headers, x-highlight-request is critical
 		}).catch(() =>
 			console.info('Inactive go service at http://localhost:3010'),
 		)

--- a/e2e/nextjs/src/app/api/app-router-trace/route.ts
+++ b/e2e/nextjs/src/app/api/app-router-trace/route.ts
@@ -3,6 +3,7 @@ import { withAppRouterHighlight } from '@/app/_utils/app-router-highlight.config
 import logger from '@/highlight.logger'
 import { H } from '@highlight-run/next/server'
 import { NextRequest } from 'next/server'
+import { propagation, context } from '@opentelemetry/api'
 
 export const GET = withAppRouterHighlight(async function GET(
 	request: NextRequest,
@@ -12,21 +13,32 @@ export const GET = withAppRouterHighlight(async function GET(
 
 		logger.info({}, `app router trace get`)
 
+		const headers = { ...request.headers }
 		await fetch('http://localhost:3010/x-highlight-request', {
 			method: 'GET',
-			headers: request.headers, // Forward headers, x-highlight-request is critical
+			headers, // Forward headers, x-highlight-request is critical
 		}).catch(() =>
 			console.info('Inactive go service at http://localhost:3010'),
 		)
 
 		await fetch('http://localhost:3010/traceparent', {
 			method: 'GET',
-			headers: request.headers,
+			headers,
 		}).catch(() =>
 			console.info('Inactive go service at http://localhost:3010'),
 		)
 
-		console.info('Here: /pages/api/app-router-trace/route.ts ⏰⏰⏰')
+		propagation.inject(context.active(), headers)
+		await fetch('http://localhost:3010/traceparent', {
+			method: 'GET',
+			headers,
+		}).catch(() =>
+			console.info('Inactive go service at http://localhost:3010'),
+		)
+
+		console.info('Here: /pages/api/app-router-trace/route.ts ⏰⏰⏰', {
+			headers,
+		})
 
 		span.end()
 

--- a/e2e/nextjs/src/app/layout.tsx
+++ b/e2e/nextjs/src/app/layout.tsx
@@ -37,6 +37,8 @@ export default function RootLayout({
 					canvasClearWebGLBuffer: false,
 				}}
 				backendUrl={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_BACKEND_URL}
+				otlpEndpoint={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_OTLP_ENDPOINT}
+				enableOtelTracing
 			/>
 
 			<html lang="en" data-layout>

--- a/sdk/highlight-apollo/CHANGELOG.md
+++ b/sdk/highlight-apollo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @highlight-run/apollo
 
+## 3.4.24
+
+### Patch Changes
+
+-   Updated dependencies [f06a274]
+    -   @highlight-run/node@3.10.1
+
 ## 3.4.23
 
 ### Patch Changes

--- a/sdk/highlight-apollo/package.json
+++ b/sdk/highlight-apollo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/apollo",
-	"version": "3.4.23",
+	"version": "3.4.24",
 	"license": "Apache-2.0",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-nest/CHANGELOG.md
+++ b/sdk/highlight-nest/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @highlight-run/nest
 
+## 3.6.9
+
+### Patch Changes
+
+-   Updated dependencies [f06a274]
+    -   @highlight-run/node@3.10.1
+
 ## 3.6.8
 
 ### Patch Changes

--- a/sdk/highlight-nest/package.json
+++ b/sdk/highlight-nest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/nest",
-	"version": "3.6.8",
+	"version": "3.6.9",
 	"description": "Client for interfacing with Highlight in nestjs",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @highlight-run/next
 
+## 7.6.7
+
+### Patch Changes
+
+-   Updated dependencies [f06a274]
+    -   @highlight-run/node@3.10.1
+
 ## 7.6.6
 
 ### Patch Changes

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "7.6.6",
+	"version": "7.6.7",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-node/CHANGELOG.md
+++ b/sdk/highlight-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @highlight-run/node
 
+## 3.10.1
+
+### Patch Changes
+
+-   f06a274: ensure W3CTraceContext is propagated to distributed services
+
 ## 3.10.0
 
 ### Minor Changes

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/node",
-	"version": "3.10.0",
+	"version": "3.10.1",
 	"license": "Apache-2.0",
 	"scripts": {
 		"typegen": "tsc -d --emitDeclarationOnly",

--- a/sdk/highlight-remix/CHANGELOG.md
+++ b/sdk/highlight-remix/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @highlight-run/remix
 
+## 2.0.70
+
+### Patch Changes
+
+-   Updated dependencies [f06a274]
+    -   @highlight-run/node@3.10.1
+
 ## 2.0.69
 
 ### Patch Changes

--- a/sdk/highlight-remix/package.json
+++ b/sdk/highlight-remix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/remix",
-	"version": "2.0.69",
+	"version": "2.0.70",
 	"description": "Client for interfacing with Highlight in Remix",
 	"packageManager": "yarn@4.0.2",
 	"author": "",


### PR DESCRIPTION
## Summary

* Correctly configures trace context propagators in the @highlight-run/node sdk
* Defines an example of outgoing `fetch` context propagation via `@opentelemetry/api`
* Documents trace context propagation

## How did you test this change?

![Screenshot from 2024-11-07 18-47-45](https://github.com/user-attachments/assets/428f1a05-7463-431e-9e3c-72e599247928)
![Screenshot from 2024-11-07 18-47-13](https://github.com/user-attachments/assets/5175dd96-88a7-4f8a-a61b-52950a83343d)
![Screenshot from 2024-11-07 18-51-06](https://github.com/user-attachments/assets/d665e33c-40bd-48d7-9974-eacd84f4c2dc)

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no