### PR TITLE
skip second filter for no limit queries

### DIFF
--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -458,8 +458,8 @@ export const GraphingEditor: React.FC = () => {
 			setMetric('secure_session_id')
 			setGroupByEnabled(true)
 			setGroupByKeys(['secure_session_id'])
-			setLimit(Number.MAX_VALUE)
-		} else if (viewType === 'Table') {
+			setLimit(NO_LIMIT)
+		} else if (vt === 'Table') {
 			setLimit(NO_LIMIT)
 		}
 		setViewTypeImpl(vt)
@@ -581,20 +581,6 @@ export const GraphingEditor: React.FC = () => {
 			endDate,
 		}
 	}, [endDate, productType, startDate])
-
-	useEffect(() => {
-		if (viewType === 'Funnel chart') {
-			setBucketBySetting('None')
-			setFunctionType(MetricAggregator.CountDistinct)
-			// once events have other session attributes, we can support per-user aggregation
-			setMetric('secure_session_id')
-			setGroupByEnabled(true)
-			setGroupByKeys(['secure_session_id'])
-			setLimit(NO_LIMIT)
-		} else if (viewType === 'Table') {
-			setLimit(NO_LIMIT)
-		}
-	}, [viewType])
 
 	const { values } = useGraphingVariables(dashboard_id!)
 


### PR DESCRIPTION
## Summary
- skip the inner where clause (e.g. `g0 in (select * from traces where ... limit 10)`) for no-limit queries
- apply group not empty filter (e.g. `g0 != ''`) to top level where
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested limit / no limit queries locally
- debugged to look at generated sql queries
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, is backwards compatible
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
