### PR TITLE
add ability to disable CORS for self-hosted private graph

### DIFF
--- a/backend/env/environment.go
+++ b/backend/env/environment.go
@@ -48,6 +48,7 @@ type Configuration struct {
 	ConsumerFraction            string `mapstructure:"CONSUMER_SPAN_SAMPLING_FRACTION"`
 	DeleteSessionsArn           string `mapstructure:"DELETE_SESSIONS_ARN"`
 	DemoProjectID               string `mapstructure:"DEMO_PROJECT_ID"`
+	DisableCors                 string `mapstructure:"DISABLE_CORS"`
 	DiscordBotId                string `mapstructure:"DISCORD_BOT_ID"`
 	DiscordBotSecret            string `mapstructure:"DISCORD_BOT_SECRET"`
 	DiscordClientId             string `mapstructure:"DISCORD_CLIENT_ID"`

--- a/docker/.env
+++ b/docker/.env
@@ -55,6 +55,7 @@ WORKER_MAX_MEMORY_THRESHOLD
 
 # Note: turning on SSL requires updating otel-collector.yaml / otel-collector.hobby.yaml to use https
 SSL=false
+DISABLE_CORS=false
 REACT_APP_AUTH_MODE=password
 ADMIN_PASSWORD=password
 LICENSE_KEY


### PR DESCRIPTION
## Summary

Self hosted highlight instances may use a reverse proxy or other mechanism
for forwarding requests to the private graph that can handle the CORS policy and
may also interfere with the `Origin` header. Adds an `DISABLE_CORS` setting
from the environment that can be used to turn off private graph CORS.

## How did you test this change?

CI

## Are there any deployment considerations?

release new docker image

## Does this work require review from our design team?

no
