### PR TITLE
Allow user to disable highlight log traces

### DIFF
--- a/docs-content/sdk/python.md
+++ b/docs-content/sdk/python.md
@@ -54,6 +54,10 @@ slug: python
       <p>If enabled, Highlight will record log output from the logging module.</p>
     </aside>
     <aside className="parameter">
+      <h5>enable_log_traces<code>boolean</code> <code>optional</code></h5>
+      <p>If enabled, Highlight will record a trace for every log message.</p>
+    </aside>
+    <aside className="parameter">
       <h5>service_name<code>string</code> <code>optional</code></h5>
       <p>The name of your app.</p>
     </aside>

--- a/e2e/python/poetry.lock
+++ b/e2e/python/poetry.lock
@@ -909,7 +909,7 @@ files = [
 
 [[package]]
 name = "highlight-io"
-version = "0.8.10"
+version = "0.9.0"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 optional = false
 python-versions = ">=3.9,<4"

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -165,7 +165,9 @@ class H(object):
         )
         self._log_handler = LogHandler(self, level=log_level)
         if instrument_logging:
-            self._instrument_logging(log_level=log_level, enable_log_traces=enable_log_traces)
+            self._instrument_logging(
+                log_level=log_level, enable_log_traces=enable_log_traces
+            )
 
         class HighlightSpanProcessor(SpanProcessor):
             def on_start(

--- a/sdk/highlight-py/tests/test_sdk.py
+++ b/sdk/highlight-py/tests/test_sdk.py
@@ -82,11 +82,19 @@ def test_log_no_trace(mock_trace):
     logger.info(f"hey there!")
     h.flush()
 
+    assert mock_trace.call_args_list[0].args[1:] != ("highlight.log",)
+
+def test_log_with_trace(mock_trace):
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    h = highlight_io.H("1", instrument_logging=True, enable_log_traces=True)
+    logger.info(f"hey there!")
+    h.flush()
+
     assert mock_trace.call_args_list[0].args[1:] == ("highlight.log",)
 
-
 def test_test_decorator(mock_trace):
-    h = highlight_io.H("1", instrument_logging=True)
+    h = highlight_io.H("1", instrument_logging=True, enable_log_traces=True)
 
     @highlight_io.trace
     def my_func():

--- a/sdk/highlight-py/tests/test_sdk.py
+++ b/sdk/highlight-py/tests/test_sdk.py
@@ -84,6 +84,7 @@ def test_log_no_trace(mock_trace):
 
     assert mock_trace.call_args_list[0].args[1:] != ("highlight.log",)
 
+
 def test_log_with_trace(mock_trace):
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
@@ -92,6 +93,7 @@ def test_log_with_trace(mock_trace):
     h.flush()
 
     assert mock_trace.call_args_list[0].args[1:] == ("highlight.log",)
+
 
 def test_test_decorator(mock_trace):
     h = highlight_io.H("1", instrument_logging=True, enable_log_traces=True)


### PR DESCRIPTION
## Summary
For every log in the Python SDK, we emit a `highlight.log` trace. This can become noisy, so allow users to disable/enable this feature in the SDK.

### New SDK option
- enable_log_traces: `False` by default

## How did you test this change?
1. Start the Django app
2. Send a request to the Django app
- [ ] A `highlight.log` trace is not recorded for each log event 
3. Add `enable_log_traces=True` to the Highlight configuration
- [ ] A `highlight.log` trace is recorded for each log event 
-
## Are there any deployment considerations?
Minor package bump for change in behavior

## Does this work require review from our design team?
N/A
