### PR TITLE
update time clamping to +/- 30 days

### DIFF
--- a/backend/otel/extract_test.go
+++ b/backend/otel/extract_test.go
@@ -377,7 +377,7 @@ func TestExtractFields_HandleInvalidTimestamp(t *testing.T) {
 	curTime := time.Now().Truncate(time.Second).UTC()
 	resource := newResource(t, map[string]any{})
 	event := newEvent(map[string]string{})
-	event.SetTimestamp(pcommon.Timestamp(curTime.Add(3 * time.Hour).UnixNano()))
+	event.SetTimestamp(pcommon.Timestamp(curTime.Add(31 * 24 * time.Hour).UnixNano()))
 	fields, err := extractFields(ctx, extractFieldsParams{resource: &resource, event: &event, curTime: curTime})
 	assert.NoError(t, err)
 	assert.Equal(t, curTime, fields.timestamp)

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2040,8 +2040,8 @@ func ClampTime(input time.Time, curTime time.Time) time.Time {
 		return input
 	}
 
-	minTime := curTime.Add(-2 * time.Hour)
-	maxTime := curTime.Add(2 * time.Hour)
+	minTime := curTime.Add(-30 * 24 * time.Hour)
+	maxTime := curTime.Add(30 * 24 * time.Hour)
 	if input.Before(minTime) || input.After(maxTime) {
 		return curTime
 	}


### PR DESCRIPTION
## Summary
- now that we don't use the clickhouse setting to force merge parts after 1 hour, it shouldn't be as big of a performance issue to have data for old / future parts ingested
- changes the time clamping setting to +/- 30 days
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ensured logs/traces still ingested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will monitor perf and part count and revert if there's significant degradation
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
