### PR TITLE
Feature flag highlight.log traces

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -482,6 +482,8 @@ type AllWorkspaceSettings struct {
 
 	EnableJiraIntegration  bool `gorm:"default:false"`
 	EnableTeamsIntegration bool `gorm:"default:false"`
+
+	EnableLogTraceIngestion bool `gorm:"default:false"`
 }
 
 type HasSecret interface {

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -308,8 +308,11 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 						log.WithContext(ctx).WithError(err).Error("failed to get workspace settings")
 						continue
 					}
-
-					if settings == nil || !settings.EnableLogTraceIngestion {
+					if settings == nil {
+						log.WithContext(ctx).Error("no workspace settings found")
+						continue
+					}
+					if !settings.EnableLogTraceIngestion {
 						continue
 					}
 				}


### PR DESCRIPTION
## Summary
The `highlight.log` traces in the tracing project can be noisy and not very helpful for many users, but some users request them. Feature flag the ingestion of these traces to allow users to hide/show the `highlight.log` traces.

## How did you test this change?
1. Start the Django app
2. Send a curl request to the app
- [ ] No log traces recorded
2. Update the `AllWorkspaceSetting.EnableLogTraceIngestion` to `true` in Postgres
3. Restart the app and backend
4.  Send a curl request to the app
- [ ] Log traces recorded

![Screenshot 2024-11-19 at 10 26 28 AM](https://github.com/user-attachments/assets/f9dddd4a-5380-471c-918f-6d0332dc56b6)


## Are there any deployment considerations?
Fix boolean for appropriate organizations

## Does this work require review from our design team?
N/A
