### PR TITLE
remove IsIngestedBy spans for now

### DIFF
--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -15,7 +15,6 @@ import (
 	"github.com/highlight-run/highlight/backend/model"
 	privateModel "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/util"
-	"github.com/highlight/highlight/sdk/highlight-go"
 	hmetric "github.com/highlight/highlight/sdk/highlight-go/metric"
 	e "github.com/pkg/errors"
 	"github.com/samber/lo"
@@ -532,25 +531,16 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int, 
 				session.Fields = lo.Map(sessionToFields[session.ID], func(sf *sessionField, _ int) *model.Field {
 					return fieldsById[sf.FieldID]
 				})
-				span := util.StartSpan(
-					"IsIngestedBy", util.ResourceName("sampling"),
-					util.Tag(highlight.ProjectIDAttribute, session.ProjectID),
-					util.Tag(highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
-					util.Tag("product", privateModel.ProductTypeSessions),
-				)
 				// fields are populated, so calculate whether session is excluded
 				if k.Worker.PublicResolver.IsSessionExcludedByFilter(ctx, session) {
 					reason := privateModel.SessionExcludedReasonExclusionFilter
 					session.Excluded = true
 					session.ExcludedReason = &reason
-					span.SetAttribute("reason", session.ExcludedReason)
 					if err := k.Worker.PublicResolver.DB.WithContext(ctx).Model(&model.Session{Model: model.Model{ID: session.ID}}).
 						Select("Excluded", "ExcludedReason").Updates(&session).Error; err != nil {
 						return err
 					}
 				}
-				span.SetAttribute("ingested", !session.Excluded)
-				span.Finish()
 			}
 
 			allSessionObjs = append(allSessionObjs, sessionObjs...)


### PR DESCRIPTION
## Summary
- lots of `IsIngestedBy` spans are getting created while ingesting a large number of historical logs, disable these for now
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- run unit tests in `sampling_test.go` to make sure nothing is affected
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
