### PR TITLE
dynamic sampling

### DIFF
--- a/backend/clickhouse/errors.go
+++ b/backend/clickhouse/errors.go
@@ -665,9 +665,6 @@ var BackendErrorObjectInputConfig = model.TableConfig{
 
 var ErrorsSampleableTableConfig = SampleableTableConfig{
 	tableConfig: ErrorsJoinedTableConfig,
-	useSampling: func(time.Duration) bool {
-		return false
-	},
 }
 
 func ErrorMatchesQuery(errorObject *model2.BackendErrorObjectInput, filters listener.Filters) bool {

--- a/backend/clickhouse/events.go
+++ b/backend/clickhouse/events.go
@@ -74,9 +74,6 @@ var eventsTableConfig = model.TableConfig{
 
 var EventsSampleableTableConfig = SampleableTableConfig{
 	tableConfig: eventsTableConfig,
-	useSampling: func(d time.Duration) bool {
-		return false
-	},
 }
 
 type SessionEventRow struct {

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -78,7 +78,7 @@ var LogsTableConfig = model.TableConfig{
 }
 
 var logsSamplingTableConfig = model.TableConfig{
-	TableName:        fmt.Sprintf("%s SAMPLE %d", LogsSamplingTable, SamplingRows),
+	TableName:        LogsSamplingTable,
 	KeysToColumns:    logKeysToColumns,
 	ReservedKeys:     reservedLogKeys,
 	BodyColumn:       "Body",
@@ -88,9 +88,7 @@ var logsSamplingTableConfig = model.TableConfig{
 var LogsSampleableTableConfig = SampleableTableConfig{
 	tableConfig:         LogsTableConfig,
 	samplingTableConfig: logsSamplingTableConfig,
-	useSampling: func(d time.Duration) bool {
-		return d >= 24*time.Hour
-	},
+	sampleSizeRows:      20_000_000,
 }
 
 func (client *Client) BatchWriteLogRows(ctx context.Context, logRows []*LogRow) error {

--- a/backend/clickhouse/metrics.go
+++ b/backend/clickhouse/metrics.go
@@ -2,7 +2,6 @@ package clickhouse
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/aws/smithy-go/ptr"
@@ -31,15 +30,13 @@ var metricsSamplingTableConfig = model.TableConfig{
 	KeysToColumns:    metricsTableConfig.KeysToColumns,
 	ReservedKeys:     metricsTableConfig.ReservedKeys,
 	SelectColumns:    metricsTableConfig.SelectColumns,
-	TableName:        fmt.Sprintf("%s SAMPLE %d", TracesSamplingTable, SamplingRows),
+	TableName:        TracesSamplingTable,
 }
 
 var MetricsSampleableTableConfig = SampleableTableConfig{
 	tableConfig:         metricsTableConfig,
 	samplingTableConfig: metricsSamplingTableConfig,
-	useSampling: func(d time.Duration) bool {
-		return d >= time.Hour
-	},
+	sampleSizeRows:      20_000_000,
 }
 
 func (client *Client) ReadEventMetrics(ctx context.Context, projectID int, params modelInputs.QueryInput, column string, metricTypes []modelInputs.MetricAggregator, groupBy []string, nBuckets *int, bucketBy string, bucketWindow *int, limit *int, limitAggregator *modelInputs.MetricAggregator, limitColumn *string) (*modelInputs.MetricsBuckets, error) {

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -1044,7 +1044,7 @@ func (client *Client) ReadMetrics(ctx context.Context, input ReadMetricsInput) (
 		}
 
 		if samplingStats[originalTable].Rows > input.SampleableConfig.sampleSizeRows {
-			sampleRatio = float64(samplingStats[samplingTable].Rows) / float64(input.SampleableConfig.sampleSizeRows)
+			sampleRatio = float64(input.SampleableConfig.sampleSizeRows) / float64(samplingStats[samplingTable].Rows)
 		}
 	}
 

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -36,7 +36,7 @@ const NoLimit = 1_000_000_000_000
 type SampleableTableConfig struct {
 	tableConfig         model.TableConfig
 	samplingTableConfig model.TableConfig
-	useSampling         func(time.Duration) bool
+	sampleSizeRows      uint64
 }
 
 type ReadMetricsInput struct {
@@ -965,7 +965,89 @@ func (client *Client) saveMetricHistory(ctx context.Context, sb *sqlbuilder.Sele
 	return err
 }
 
+type SamplingStats struct {
+	Database string `ch:"database"`
+	Table    string `ch:"table"`
+	Parts    uint64 `ch:"parts"`
+	Rows     uint64 `ch:"rows"`
+	Marks    uint64 `ch:"marks"`
+}
+
+func (client *Client) getSamplingStats(ctx context.Context, tables []string, projectIds []int, dateRange modelInputs.DateRangeRequiredInput) (map[string]SamplingStats, error) {
+	tables = lo.Uniq(tables)
+	projectIds = lo.Uniq(projectIds)
+
+	builders := []sqlbuilder.Builder{}
+	for _, table := range tables {
+		sb := sqlbuilder.NewSelectBuilder()
+		sb.Select("1")
+		sb.From(table)
+		sb.Where(sb.In("ProjectId", projectIds))
+		sb.Where(sb.GreaterEqualThan("Timestamp", dateRange.StartDate))
+		sb.Where(sb.LessEqualThan("Timestamp", dateRange.EndDate))
+		builders = append(builders, sb)
+	}
+
+	sb := sqlbuilder.UnionAll(builders...)
+	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+	sql = "EXPLAIN ESTIMATE " + sql
+
+	span, ctx := util.StartSpanFromContext(ctx, "getSamplingStats.query")
+	span.SetAttribute("sql", sql)
+	span.SetAttribute("args", args)
+	rows, err := client.conn.Query(
+		ctx,
+		sql,
+		args...,
+	)
+	span.Finish(err)
+	if err != nil {
+		return nil, err
+	}
+
+	results := []SamplingStats{}
+	for rows.Next() {
+		var result SamplingStats
+		if err := rows.ScanStruct(&result); err != nil {
+			return nil, err
+		}
+		results = append(results, result)
+	}
+
+	statsByTable := lo.KeyBy(results, func(s SamplingStats) string {
+		return s.Table
+	})
+
+	return statsByTable, nil
+}
+
 func (client *Client) ReadMetrics(ctx context.Context, input ReadMetricsInput) (*modelInputs.MetricsBuckets, error) {
+
+	if input.Params.DateRange == nil {
+		input.Params.DateRange = &modelInputs.DateRangeRequiredInput{
+			StartDate: time.Now().Add(-time.Hour * 24 * 30),
+			EndDate:   time.Now(),
+		}
+	}
+
+	sampleRatio := 0.0
+	if input.SampleableConfig.sampleSizeRows != 0 {
+		originalTable := input.SampleableConfig.tableConfig.TableName
+		samplingTable := input.SampleableConfig.samplingTableConfig.TableName
+
+		samplingStats, err := client.getSamplingStats(ctx,
+			[]string{originalTable, samplingTable},
+			input.ProjectIDs,
+			*input.Params.DateRange)
+		if err != nil {
+			return nil, err
+		}
+
+		if samplingStats[originalTable].Rows > input.SampleableConfig.sampleSizeRows {
+			sampleRatio = float64(samplingStats[samplingTable].Rows) / float64(input.SampleableConfig.sampleSizeRows)
+		}
+	}
+
 	span, ctx := util.StartSpanFromContext(ctx, "clickhouse.readMetrics")
 	span.SetAttribute("project_ids", input.ProjectIDs)
 	span.SetAttribute("table", input.SampleableConfig.tableConfig.TableName)
@@ -1004,15 +1086,16 @@ func (client *Client) ReadMetrics(ctx context.Context, input ReadMetricsInput) (
 
 	startTimestamp := input.Params.DateRange.StartDate.Unix()
 	endTimestamp := input.Params.DateRange.EndDate.Unix()
-	useSampling := input.SampleableConfig.useSampling(input.Params.DateRange.EndDate.Sub(input.Params.DateRange.StartDate)) && input.SavedMetricState == nil
 
 	keysToColumns := input.SampleableConfig.tableConfig.KeysToColumns
 
 	var fromSb *sqlbuilder.SelectBuilder
 	var err error
 	var config model.TableConfig
+	useSampling := sampleRatio != 0
 	if useSampling {
 		config = input.SampleableConfig.samplingTableConfig
+		config.TableName = fmt.Sprintf("%s SAMPLE %f", config.TableName, sampleRatio)
 	} else {
 		config = input.SampleableConfig.tableConfig
 	}
@@ -1334,6 +1417,7 @@ func (client *Client) ReadMetrics(ctx context.Context, input ReadMetricsInput) (
 
 	return metrics, err
 }
+
 func formatColumn(input string, column string) string {
 	base := input
 	if base == "" {

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -544,9 +544,6 @@ var SessionsJoinedTableConfig = model.TableConfig{
 
 var SessionsSampleableTableConfig = SampleableTableConfig{
 	tableConfig: SessionsJoinedTableConfig,
-	useSampling: func(time.Duration) bool {
-		return false
-	},
 }
 
 func (client *Client) ReadSessionsMetrics(ctx context.Context, projectID int, params modelInputs.QueryInput, column string, metricTypes []modelInputs.MetricAggregator, groupBy []string, nBuckets *int, bucketBy string, bucketWindow *int, limit *int, limitAggregator *modelInputs.MetricAggregator, limitColumn *string) (*modelInputs.MetricsBuckets, error) {

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -106,7 +106,7 @@ var TracesTableConfig = model.TableConfig{
 }
 
 var tracesSamplingTableConfig = model.TableConfig{
-	TableName:        fmt.Sprintf("%s SAMPLE %d", TracesSamplingTable, SamplingRows),
+	TableName:        TracesSamplingTable,
 	BodyColumn:       "SpanName",
 	KeysToColumns:    traceKeysToColumns,
 	ReservedKeys:     reservedTraceKeys,
@@ -118,9 +118,7 @@ var tracesSamplingTableConfig = model.TableConfig{
 var TracesSampleableTableConfig = SampleableTableConfig{
 	tableConfig:         TracesTableConfig,
 	samplingTableConfig: tracesSamplingTableConfig,
-	useSampling: func(d time.Duration) bool {
-		return d >= time.Hour
-	},
+	sampleSizeRows:      20_000_000,
 }
 
 type ClickhouseTraceRow struct {


### PR DESCRIPTION
## Summary
- `SAMPLE N` queries are not working in current version
- also hard to predict if sampling is needed without checking source tables
- make `EXPLAIN ESTIMATE` query to any relevant tables to get a row estimate, then calculate the sampling ratio manually if the estimate is greater than the sampling threshold
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested metrics locally w/ all product types
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
