### PR TITLE
Fix data export table

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -9238,10 +9238,11 @@ func (r *queryResolver) SessionExports(ctx context.Context, projectID int) ([]*m
 	var sessionExports []*modelInputs.SessionExportWithSession
 	if err := r.DB.
 		WithContext(ctx).
-		Table("session_exports").
-		Joins("INNER JOIN sessions s ON s.id = session_exports.session_id").
+		Select("se.*, s.secure_id, s.identifier, s.active_length").
+		Table("session_exports se").
+		Joins("INNER JOIN sessions s ON s.id = se.session_id").
 		Where(`s.project_id = ?`, projectID).
-		Order("session_exports.id DESC").
+		Order("se.created_at DESC").
 		Scan(&sessionExports).Error; err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
The request time in the "Session Export Requests" table shows the time of the session, when it should be showing the time of the request. Update the request to use the session export `created_at` date and order by this date.

![Screenshot 2024-11-20 at 10 22 45 AM](https://github.com/user-attachments/assets/ea906c55-0ec6-409f-aebf-246adf6389b8)

## How did you test this change?
1. Make sure the `enable_session_export` is set to true for the workspace settings
2. View and download a session
3. View the Project settings
4. Navigate to the session replay section and view the "Session Export Requests" table
- [ ] Table showing data
- [ ] Request time reflects the request of the download
- [ ] Ordered by the time of the download

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
