### PR TITLE
optimize group w/ limit queries

### DIFF
--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -791,6 +790,32 @@ func matchesQuery[TObj interface{}](row *TObj, config model.TableConfig, filters
 	return true
 }
 
+func getLimitFnStr(aggregator modelInputs.MetricAggregator, column string) string {
+	switch aggregator {
+	case modelInputs.MetricAggregatorCount:
+		return "count()"
+	case modelInputs.MetricAggregatorCountDistinctKey, modelInputs.MetricAggregatorCountDistinct:
+		return fmt.Sprintf("count(distinct %s)", column)
+	case modelInputs.MetricAggregatorMin:
+		return fmt.Sprintf("min(%s)", column)
+	case modelInputs.MetricAggregatorAvg:
+		return fmt.Sprintf("avg(%s)", column)
+	case modelInputs.MetricAggregatorP50:
+		return fmt.Sprintf("quantile(.5)(%s)", column)
+	case modelInputs.MetricAggregatorP90:
+		return fmt.Sprintf("quantile(.9)(%s)", column)
+	case modelInputs.MetricAggregatorP95:
+		return fmt.Sprintf("quantile(.95)(%s)", column)
+	case modelInputs.MetricAggregatorP99:
+		return fmt.Sprintf("quantile(.99)(%s)", column)
+	case modelInputs.MetricAggregatorMax:
+		return fmt.Sprintf("max(%s)", column)
+	case modelInputs.MetricAggregatorSum:
+		return fmt.Sprintf("sum(%s)", column)
+	}
+	return ""
+}
+
 func getFnStr(aggregator modelInputs.MetricAggregator, column string, useSampling bool, useState bool) string {
 	switch aggregator {
 	case modelInputs.MetricAggregatorCount:
@@ -1197,6 +1222,7 @@ func (client *Client) ReadMetrics(ctx context.Context, input ReadMetricsInput) (
 
 	selectCols = append(selectCols, fromSb.As(metricExpr, "metric_value"))
 
+	groupAliases := []string{}
 	for idx, group := range input.GroupBy {
 		groupCol := ""
 		if col, found := keysToColumns[group]; found {
@@ -1205,10 +1231,12 @@ func (client *Client) ReadMetrics(ctx context.Context, input ReadMetricsInput) (
 			groupCol = getAttributeFilterCol(input.SampleableConfig, fromSb.Var(group), "toString")
 			attributeFields = append(attributeFields, group)
 		}
-		selectCols = append(selectCols, fromSb.As(groupCol, fmt.Sprintf("g%d", idx)))
-	}
 
-	fromSb.Select(selectCols...)
+		groupAlias := fmt.Sprintf("g%d", idx)
+		groupAliases = append(groupAliases, groupAlias)
+
+		selectCols = append(selectCols, fromSb.As(groupCol, groupAlias))
+	}
 
 	limitCount := 10
 	if input.Limit != nil {
@@ -1217,26 +1245,8 @@ func (client *Client) ReadMetrics(ctx context.Context, input ReadMetricsInput) (
 	if limitCount < 1 {
 		limitCount = 1
 	}
-
-	if input.LimitAggregator != nil && len(input.GroupBy) > 0 {
-		innerSb := sqlbuilder.NewSelectBuilder()
-		colStrs := []string{}
-		groupByIndexes := []string{}
-
-		for idx, group := range input.GroupBy {
-			var colStr string
-			if col, found := keysToColumns[group]; found {
-				colStr = col
-			} else {
-				colStr = getAttributeFilterCol(input.SampleableConfig, innerSb.Var(group), "toString")
-			}
-			groupByIndex := fmt.Sprintf("g%d", idx)
-			colStrs = append(colStrs, innerSb.As(colStr, groupByIndex))
-			groupByIndexes = append(groupByIndexes, groupByIndex)
-			innerSb.Where(innerSb.NotEqual(groupByIndex, ""))
-		}
-
-		limitFn := ""
+	useLimit := input.LimitAggregator != nil && len(input.GroupBy) > 0 && limitCount != NoLimit
+	if useLimit {
 		col := ""
 		if input.LimitColumn != nil {
 			col = *input.LimitColumn
@@ -1245,50 +1255,26 @@ func (client *Client) ReadMetrics(ctx context.Context, input ReadMetricsInput) (
 			col = topCol
 		} else {
 			attributeFields = append(attributeFields, col)
-			col = getAttributeFilterCol(input.SampleableConfig, innerSb.Var(col), "toFloat64OrNull")
-		}
-		limitFn = getFnStr(*input.LimitAggregator, col, false, false)
-
-		innerSb.
-			From(config.TableName).
-			Select(strings.Join(colStrs, ", "))
-
-		addAttributes(config, attributeFields, input.ProjectIDs, input.Params, innerSb)
-
-		innerSb.Where(innerSb.In("ProjectId", input.ProjectIDs)).
-			Where(innerSb.GreaterEqualThan("Timestamp", startTimestamp)).
-			Where(innerSb.LessEqualThan("Timestamp", endTimestamp))
-
-		applyBlockFilter(innerSb, input)
-
-		parser.AssignSearchFilters(innerSb, input.Params.Query, config)
-
-		innerSb.GroupBy(groupByIndexes...).
-			OrderBy(limitFn).
-			Desc().
-			Limit(limitCount)
-
-		fromColStrs := []string{}
-		for idx := range input.GroupBy {
-			groupByIndex := fmt.Sprintf("g%d", idx)
-			fromColStrs = append(fromColStrs, groupByIndex)
-			fromSb.Where(fromSb.NotEqual(groupByIndex, ""))
+			col = getAttributeFilterCol(input.SampleableConfig, fromSb.Var(col), "toFloat64OrNull")
 		}
 
-		if limitCount != NoLimit {
-			fromSb.Where(fromSb.In("("+strings.Join(fromColStrs, ", ")+")", innerSb))
-		}
+		limitExpr := fmt.Sprintf("%s OVER (PARTITION BY %s) as limit_metric",
+			getLimitFnStr(*input.LimitAggregator, col),
+			strings.Join(groupAliases, ", "))
+
+		selectCols = append(selectCols, limitExpr)
 	}
 
-	base := 5 + len(input.MetricTypes)
-	if input.SavedMetricState != nil {
-		base += 1
-	}
+	fromSb.Select(selectCols...)
 
-	groupByCols := []string{"1"}
-	for i := base; i < base+len(input.GroupBy); i++ {
-		groupByCols = append(groupByCols, strconv.Itoa(i))
+	groupByCols := []string{"bucket_index"}
+	orderByCols := []string{"bucket_index"}
+	if useLimit {
+		groupByCols = append(groupByCols, "limit_metric")
+		orderByCols = append(orderByCols, "limit_metric DESC")
 	}
+	groupByCols = append(groupByCols, groupAliases...)
+	orderByCols = append(orderByCols, groupAliases...)
 
 	addAttributes(config, attributeFields, input.ProjectIDs, input.Params, fromSb)
 
@@ -1301,15 +1287,33 @@ func (client *Client) ReadMetrics(ctx context.Context, input ReadMetricsInput) (
 	for idx, metricType := range input.MetricTypes {
 		outerSelect = append(outerSelect, fmt.Sprintf("%s as metric_value%d", getFnStr(metricType, "metric_value", true, input.SavedMetricState != nil), idx))
 	}
-	for idx := range input.GroupBy {
-		outerSelect = append(outerSelect, fmt.Sprintf("g%d", idx))
+	outerSelect = append(outerSelect, groupAliases...)
+	if useLimit {
+		outerSelect = append(outerSelect, fmt.Sprintf("dense_rank() OVER (ORDER BY limit_metric DESC, %s) as limit_rank", strings.Join(groupAliases, ", ")))
 	}
 	fromSb.Select(outerSelect...)
 	fromSb.From(fromSb.BuilderAs(innerSb, "inner"))
 
 	fromSb.GroupBy(groupByCols...)
-	fromSb.OrderBy(groupByCols...)
+	fromSb.OrderBy(orderByCols...)
 	fromSb.Limit(10000)
+
+	if useLimit {
+		outerSelect := []string{"bucket_index", "sample_factor", "min", "max"}
+		if input.SavedMetricState != nil {
+			outerSelect = append(outerSelect, "max_block_number")
+		}
+		for idx := range input.MetricTypes {
+			outerSelect = append(outerSelect, fmt.Sprintf("metric_value%d", idx))
+		}
+		outerSelect = append(outerSelect, groupAliases...)
+
+		innerSb := fromSb
+		fromSb = sqlbuilder.NewSelectBuilder()
+		fromSb.Select(outerSelect...)
+		fromSb.From(fromSb.BuilderAs(innerSb, "outer"))
+		fromSb.Where(fromSb.LessEqualThan("limit_rank", limitCount))
+	}
 
 	if input.SavedMetricState != nil {
 		if err := client.saveMetricHistory(ctx, fromSb, input); err != nil {


### PR DESCRIPTION
## Summary
- eliminates subquery in group by w/ limit queries to scan over the dataset once instead of twice, speeding up these queries by ~2x
- example query:
```
SELECT bucket_index, sample_factor, min, max, correlation_id, metric_value0, g0, limit_rank 
FROM (
  SELECT bucket_index, any(_sample_factor) as sample_factor, any(min) as min, any(max) as max, toInt64(0) as correlation_id, round(count() * any(_sample_factor)) as metric_value0, g0, dense_rank() over (order by limit_metric desc, g0) as limit_rank
  FROM (
    SELECT toUInt64(intDiv((toFloat64(Timestamp) - 1729464000.0) * 30, (1732059600.0 - 1729464000.0))) AS bucket_index, 1729464000.0 AS min, 1732059600.0 AS max, _sample_factor, 1.0 AS metric_value, toString(SpanName) AS g0, quantile(.5)(Duration) OVER (PARTITION BY g0) as limit_metric
    FROM traces_sampling_new 
    SAMPLE 0.00308575 
    WHERE ProjectId IN (1) 
    AND Timestamp <= now() 
    AND Timestamp >= now() - interval 7 DAY
    AND NOT (TraceAttributes['http.method'] = '') 
    AND NOT (TraceAttributes['http.url'] = '') 
    AND NOT (toString(SpanName) = 'highlight-metric') 
    AND NOT (toString(HighlightType) = 'highlight.internal') 
    AND g0 <> ''
  )
  GROUP BY bucket_index, limit_metric, g0
  ORDER BY bucket_index, limit_metric DESC, g0
  LIMIT 10000
)
WHERE limit_rank <= 6
```
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally with no, single, and multi-grouping
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
