### PR TITLE
add special case for project id where clause

### DIFF
--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -190,7 +190,12 @@ func makeSelectBuilder(
 
 	sb.Select(selectCols...)
 	sb.From(config.TableName)
-	sb.Where(sb.In("ProjectId", projectIDs))
+
+	if len(projectIDs) == 1 {
+		sb.Where(sb.Equal("ProjectId", projectIDs[0]))
+	} else {
+		sb.Where(sb.In("ProjectId", projectIDs))
+	}
 
 	if pagination.After != nil && len(*pagination.After) > 1 {
 		timestamp, uuid, err := decodeCursor(*pagination.After)


### PR DESCRIPTION
## Summary
- Vadim discovered this query was faster using `ProjectId=1` instead:
```
select distinct Timestamp, UUID
from logs
where ProjectId in (1)
and Timestamp < now()
and Timestamp > now() - interval '30 days'
order by Timestamp DESC, UUID DESC
limit 51
```
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally, ensured query was generated with equals
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, can revert if issues
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
