### PR TITLE
disable fs and http instrumentation by default

### DIFF
--- a/.changeset/long-plums-wait.md
+++ b/.changeset/long-plums-wait.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/node': minor
+---
+
+disable noisy fs and http instrumentation by default

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -56,7 +56,16 @@ type TraceMapValue = {
 
 const instrumentations = getNodeAutoInstrumentations({
 	'@opentelemetry/instrumentation-http': {
-		enabled: false,
+		enabled:
+			(process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS || '')
+				.split(',')
+				.indexOf('http') !== -1,
+	},
+	'@opentelemetry/instrumentation-fs': {
+		enabled:
+			(process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS || '')
+				.split(',')
+				.indexOf('fs') !== -1,
 	},
 	'@opentelemetry/instrumentation-pino': {
 		logHook: (span, record, level) => {


### PR DESCRIPTION
## Summary

Updates the `@highlight-run/node` sdk to avoid setting up noisy instrumentations (`fs` and `http`) by default.

## How did you test this change?

CI

no fs spans recorded
<img width="1358" alt="Screenshot 2024-11-26 at 17 07 13" src="https://github.com/user-attachments/assets/b90882af-558b-4f7e-8b14-75122b20e71c">

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no