### PR TITLE
tune opentelemetry traces export from highlight.run

### DIFF
--- a/.changeset/thirty-flies-swim.md
+++ b/.changeset/thirty-flies-swim.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+tune opentelemetry traces export from highlight.run

--- a/sdk/client/src/otel/exporter.ts
+++ b/sdk/client/src/otel/exporter.ts
@@ -1,11 +1,7 @@
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-web'
 import { OTLPExporterError } from '@opentelemetry/otlp-exporter-base'
-import {
-	BACKOFF_DELAY_MS,
-	BASE_DELAY_MS,
-	MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS,
-} from '../utils/graph'
+import { MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS } from '../utils/graph'
 
 type ExporterConfig = ConstructorParameters<typeof OTLPTraceExporter>[0]
 type SendOnErrorCallback = Parameters<OTLPTraceExporter['send']>[2]
@@ -35,7 +31,7 @@ export class OTLPTraceExporterBrowserWithXhrRetry extends OTLPTraceExporter {
 		onError: SendOnErrorCallback,
 	): void {
 		let retries = 0
-		const retry = async (error: OTLPExporterError) => {
+		const retry = (error: OTLPExporterError) => {
 			retries++
 			if (retries > MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS) {
 				console.error(
@@ -44,12 +40,6 @@ export class OTLPTraceExporterBrowserWithXhrRetry extends OTLPTraceExporter {
 				)
 				onError(error)
 			} else {
-				await new Promise((resolve) =>
-					setTimeout(
-						resolve,
-						BASE_DELAY_MS + BACKOFF_DELAY_MS * Math.pow(2, retries),
-					),
-				)
 				this.xhrTraceExporter.send(items, onSuccess, retry)
 			}
 		}

--- a/sdk/client/src/otel/index.ts
+++ b/sdk/client/src/otel/index.ts
@@ -90,14 +90,21 @@ export const setupBrowserTracing = (config: BrowserTracingConfig) => {
 
 	const exporter = new OTLPTraceExporterBrowserWithXhrRetry({
 		url: config.otlpEndpoint + '/v1/traces',
-		concurrencyLimit: 10,
+		concurrencyLimit: 100,
+		timeoutMillis: 30_000,
 		// Using any because we were getting an error importing CompressionAlgorithm
 		// from @opentelemetry/otlp-exporter-base.
 		compression: 'gzip' as any,
+		keepAlive: true,
+		httpAgentOptions: {
+			timeout: 30_000,
+			keepAlive: true,
+		},
 	})
 
 	const spanProcessor = new CustomBatchSpanProcessor(exporter, {
-		maxExportBatchSize: 15,
+		maxExportBatchSize: 100,
+		maxQueueSize: 1_000,
 	})
 	provider.addSpanProcessor(spanProcessor)
 


### PR DESCRIPTION
## Summary

Adjust OTeL WebJS traces export to support multiple export retries for transient network failures.

## How did you test this change?

simulating export failure

<img width="672" alt="Screenshot 2024-11-27 at 14 08 09" src="https://github.com/user-attachments/assets/d13be3a9-5b32-486d-8b95-f930290a2062">
<img width="838" alt="Screenshot 2024-11-27 at 14 08 16" src="https://github.com/user-attachments/assets/e9f892d0-5ef9-4dfa-b7e7-e7409e058111">


## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
