### PR TITLE
Ensure that OIDC Verifier claim expiration resets to the Sign In page

### DIFF
--- a/backend/private-graph/graph/middleware.go
+++ b/backend/private-graph/graph/middleware.go
@@ -112,7 +112,7 @@ func PrivateMiddleware(next http.Handler) http.Handler {
 		}
 
 		if token != "" {
-			ctx, err = AuthClient.updateContextWithAuthenticatedUser(ctx, token)
+			ctx, err = AuthClient.updateContextWithAuthenticatedUser(ctx, w, r, token)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
@@ -156,7 +156,7 @@ func WebsocketInitializationFunction() transport.WebsocketInitFunc {
 		if initPayload["token"] != nil {
 			token = fmt.Sprintf("%v", initPayload["token"])
 		}
-		ctx, err := AuthClient.updateContextWithAuthenticatedUser(socketContext, token)
+		ctx, err := AuthClient.updateContextWithAuthenticatedUser(socketContext, nil, nil, token)
 		if err != nil {
 			log.WithContext(ctx).Errorf("Unable to authenticate/initialize websocket: %s", err.Error())
 		}

--- a/highlight.io/pages/otel-course-signup.tsx
+++ b/highlight.io/pages/otel-course-signup.tsx
@@ -33,6 +33,9 @@ export default function OTelCourseSignup() {
 					inlineMessage:
 						"You're signed up! You will be redirected shortly.",
 					onFormSubmit: () => {
+						if (window.dataLayer) {
+							window.dataLayer.push({ event: 'course_submit' })
+						}
 						localStorage.setItem(LOCAL_STORAGE_KEY, 'true')
 						router.push(COURSE_URL + '?signedup=true')
 					},


### PR DESCRIPTION
## Summary

* Ensure that OIDC Verifier claim expiration resets to the Sign In page by logging user out
* Add data layer event to course submit.

## How did you test this change?

vercel preview, CI

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
