### PR TITLE
support inlining remote video elements using the canvas manager

### DIFF
--- a/.changeset/large-houses-own.md
+++ b/.changeset/large-houses-own.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': minor
+---
+
+support inlining any video tags by snapshotting as a canvas via inlineVideos setting

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -131,6 +131,7 @@ export type HighlightClassOptions = {
 	enablePromisePatch?: boolean
 	samplingStrategy?: SamplingStrategy
 	inlineImages?: boolean
+	inlineVideos?: boolean
 	inlineStylesheet?: boolean
 	recordCrossOriginIframe?: boolean
 	firstloadVersion?: string
@@ -172,6 +173,7 @@ export class Highlight {
 	enablePerformanceRecording!: boolean
 	samplingStrategy!: SamplingStrategy
 	inlineImages!: boolean
+	inlineVideos!: boolean
 	inlineStylesheet!: boolean
 	debugOptions!: DebugOptions
 	listeners!: listenerHandler[]
@@ -364,7 +366,8 @@ export class Highlight {
 			options.enablePerformanceRecording ?? true
 		// default to inlining stylesheets/images locally to help with recording accuracy
 		this.inlineImages = options.inlineImages ?? this._isOnLocalHost
-		this.inlineStylesheet = options.inlineStylesheet ?? true
+		this.inlineVideos = options.inlineVideos ?? this._isOnLocalHost
+		this.inlineStylesheet = options.inlineStylesheet ?? this._isOnLocalHost
 		this.samplingStrategy = {
 			canvasFactor: 0.5,
 			canvasMaxSnapshotDimension: 360,
@@ -756,6 +759,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 					return !this.options.recordCrossOriginIframe
 				},
 				inlineImages: this.inlineImages,
+				inlineVideos: this.inlineVideos,
 				collectFonts: this.inlineImages,
 				inlineStylesheet: this.inlineStylesheet,
 				plugins: [getRecordSequentialIdPlugin()],

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -195,15 +195,29 @@ export declare type HighlightOptions = {
 	 * Specifies whether to inline images into the recording.
 	 * This means that images that are local to the client (eg. client-generated blob: urls)
 	 * will be serialized into the recording and will be valid on replay.
+	 * This will also use canvas snapshotting to inline <video> elements
+	 * that use `src="blob:..."` data or webcam feeds (blank src) as <canvas> elements
 	 * Only enable this if you are running into issues with client-local images.
+	 * Will negatively affect performance.
 	 * @default false
 	 */
 	inlineImages?: boolean
+	/**
+	 * Specifies whether to inline <video> elements into the recording.
+	 * This means that video that are not accessible at a later time
+	 * (eg., a signed URL that is short lived)
+	 * will be serialized into the recording and will be valid on replay.
+	 * Only enable this if you are running into issues with the normal serialization.
+	 * Will negatively affect performance.
+	 * @default false
+	 */
+	inlineVideos?: boolean
 	/**
 	 * Specifies whether to inline stylesheets into the recording.
 	 * This means that stylesheets that are local to the client (eg. client-generated blob: urls)
 	 * will be serialized into the recording and will be valid on replay.
 	 * Only enable this if you are running into issues with client-local stylesheets.
+	 * May negatively affect performance.
 	 * @default true
 	 */
 	inlineStylesheet?: boolean


### PR DESCRIPTION
## Summary

Introduces new `inlineVideos` client setting that enables recording any `<video>` elements
as a canvas. This allows capturing `<video>` elements that may reference a `src="https://short-lives-url"`
that would not be accessible after the session is over, and ones that cannot be replaced server-side
because the highlight backend would not be authorized.

## How did you test this change?

local SDK build [capturing session](https://app.highlight.io/5403/sessions/h26yBQ4XdD7Oxs9JmXEzVpFwG28A)


<img width="151" alt="Screenshot 2025-02-20 at 18 05 51" src="https://github.com/user-attachments/assets/869077df-a807-4e83-a714-e122e70f55b0" />

original element is `<video crossorigin="anonymous" src="https://s3-signed-url...">`

<img width="844" alt="Screenshot 2025-02-20 at 18 06 17" src="https://github.com/user-attachments/assets/d44a10b8-5744-4707-8485-247d4ac4f378" />


## Are there any deployment considerations?

changeset 

## Does this work require review from our design team?

no