### PR TITLE
Write normal states for sessions and errors

### DIFF
--- a/backend/jobs/metric-alerts/metric-alerts.go
+++ b/backend/jobs/metric-alerts/metric-alerts.go
@@ -273,6 +273,8 @@ func processMetricAlert(ctx context.Context, DB *gorm.DB, MailClient *sendgrid.C
 
 	for _, bucket := range bucketsInner {
 		if bucket.MetricValue == nil {
+			alertStateChange := getAlertStateChange(curDate, false, alert.ID, strings.Join(bucket.Group, ""), lastAlerts, cooldown)
+			stateChanges = append(stateChanges, alertStateChange)
 			continue
 		}
 


### PR DESCRIPTION
## Summary
For session and error alerts, they have always have a bucket, even if no sessions/alerts are being have occurred. This was causing an issue where no `alert_state_changes` were being written to Clickhouse. Update this case, to write a normal state to Clickhouse

![Screenshot 2024-12-03 at 4 49 26 PM](https://github.com/user-attachments/assets/a94c83f3-0903-4f2f-8e01-9a9c7c83e554)

## How did you test this change?
1. Create a session/error alert which will return no data.
2. Let the alert watcher run for a couple minutes
3. Check the alert detail page
- [ ] No alerts sent
- [ ] Last checked is valid

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A