### PR TITLE
Update CTAs on website for CNCF webinar

### DIFF
--- a/highlight.io/components/common/CallToAction/OSSCallToAction.tsx
+++ b/highlight.io/components/common/CallToAction/OSSCallToAction.tsx
@@ -16,31 +16,28 @@ export const OSSCallToAction = () => {
 				}}
 			>
 				<h3 className="text-center leading-normal">
-					Check out the{' '}
+					Master OpenTelemetry with our{' '}
 					<span className={styles.highlightedText}>
-						Optimizing AI Applications with OpenTelemetry
-					</span>{' '}
-					livestream.
+						Free Comprehensive Course
+					</span>
 				</h3>
 				<div className="text-center px-2 md:px-16 mt-6">
 					<Typography type="copy1" className="leading-relaxed">
-						Join us November 5th at 9am PT to learn about optimizing
-						AI applications. We&apos;ll cover best practices,
-						performance tips, and monitoring strategies to enhance
-						AI-powered software.
+						Learn everything from basic concepts to advanced
+						implementations. Perfect for developers looking to
+						master observability and monitoring in modern
+						applications.
 					</Typography>
 				</div>
 				<div className="flex justify-center mt-8">
 					<div className="flex flex-col lg:flex-row justify-center gap-4 w-full px-5 md:w-auto">
 						<PrimaryButton
-							href="https://www.linuxfoundation.org/webinars/optimizing-ai-applications-with-opentelemetry?hsLang=en&utm_source=highlight-oss-cta"
-							target="_blank"
-							rel="noreferrer"
+							href="/otel-course-signup?utm_source=highlight-oss-cta"
 							className="md:max-w-[180px]"
 						>
 							<div className="flex justify-center items-center gap-3">
 								<Typography type="copy2" emphasis={true}>
-									Register Here
+									Start Learning
 								</Typography>
 							</div>
 						</PrimaryButton>

--- a/highlight.io/components/common/CallToAction/OSSCallToAction.tsx
+++ b/highlight.io/components/common/CallToAction/OSSCallToAction.tsx
@@ -23,10 +23,11 @@ export const OSSCallToAction = () => {
 				</h3>
 				<div className="text-center px-2 md:px-16 mt-6">
 					<Typography type="copy1" className="leading-relaxed">
-						Learn everything from basic concepts to advanced
-						implementations. Perfect for developers looking to
-						master observability and monitoring in modern
-						applications.
+						From fundamentals to advanced implementations, learn how
+						OpenTelemetry can transform your engineering team&apos;s
+						observability practices. Ideal for engineering leaders
+						and developers building production-ready monitoring
+						solutions.
 					</Typography>
 				</div>
 				<div className="flex justify-center mt-8">

--- a/highlight.io/components/common/Navbar/Navbar.tsx
+++ b/highlight.io/components/common/Navbar/Navbar.tsx
@@ -37,38 +37,21 @@ const LaunchWeekBanner = () => {
 	return <Banner>{bannerMessage}</Banner>
 }
 
-const LivestreamBanner = () => {
+const PromotionBanner = () => {
 	return (
 		<Link
-			href="https://www.linuxfoundation.org/webinars/optimizing-ai-applications-with-opentelemetry?hsLang=en&utm_source=highlight-banner"
-			target="_blank"
-			rel="noreferrer"
+			href="/otel-course-signup?utm_source=highlight-banner"
 			className="hidden md:flex text-center justify-center items-center w-full py-2.5 px-3 bg-color-primary-200 text-white hover:bg-opacity-90"
 		>
 			<Typography type="copy3">
-				Learn how to use OpenTelemetry for optimizing AI applications at
-				our livestream on November 5th at 9am PT -{' '}
-				<span className="font-semibold underline">Register here</span>
-			</Typography>
-		</Link>
-	)
-}
-
-const HFSBanner = () => {
-	return (
-		<Link
-			href="/startups"
-			className="flex justify-center items-center w-full h-[40px] bg-color-primary-200 text-white hover:bg-opacity-90"
-		>
-			<Typography type="copy3">
-				Got a startup? Apply for free Highlight credits!
+				Master OpenTelemetry with our free comprehensive course -{' '}
+				<span className="font-semibold underline">Start Learning</span>
 			</Typography>
 		</Link>
 	)
 }
 
 const Navbar = ({
-	hideFreeTrialText,
 	isDocsPage,
 	hideBanner,
 	fixed,
@@ -77,7 +60,6 @@ const Navbar = ({
 	light,
 	hideGitHubPopup,
 }: {
-	hideFreeTrialText?: boolean
 	isDocsPage?: boolean
 	hideBanner?: boolean
 	fixed?: boolean
@@ -125,7 +107,7 @@ const Navbar = ({
 				isLaunchWeek ? (
 					<LaunchWeekBanner />
 				) : (
-					<LivestreamBanner />
+					<PromotionBanner />
 				)
 			) : null}
 			<div


### PR DESCRIPTION
## Summary

We have some stale CTAs on our website pointing to the CNCF webinar that has come and gone already. This PR updates them to point to our new OTeL course.

<img width="1280" alt="Screenshot 2024-12-06 at 9 01 37 AM" src="https://github.com/user-attachments/assets/b2d33e87-3ce8-4c6f-ab6f-654f37bd6507">

<img width="1074" alt="Screenshot 2024-12-06 at 9 04 39 AM" src="https://github.com/user-attachments/assets/7e219ed3-b68b-49cf-b92f-5ad3eb9d8683">

## How did you test this change?

Local click test. Can also be confirmed in the PR preview.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A - running copy by @jay-khatri and @Vadman97 before launching.