### PR TITLE
fix playback skipping on blocking chunk load

### DIFF
--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -520,10 +520,14 @@ export const usePlayer = (
 					},
 				)
 				dispatchAction(startTime, action)
-			} else if (promises.length && blockingLoad.current) {
+			} else if (
+				promises.length &&
+				blockingLoad.current &&
+				state.replayerState === ReplayerState.Paused
+			) {
 				log(
 					'PlayerHook.tsx:ensureChunksLoaded',
-					'calling dispatchAction due to blockingLoad',
+					'calling dispatchAction due to blockingLoad and paused state',
 					{
 						target: target.current?.time,
 						startTime,

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -529,7 +529,7 @@ export const usePlayer = (
 						chunks: chunkEventsRef.current,
 					},
 				)
-				dispatchAction(undefined, blockingLoad.current)
+				dispatchAction(startTime, blockingLoad.current)
 				blockingLoad.current = undefined
 			}
 		},

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -525,11 +525,15 @@ export const usePlayer = (
 					'PlayerHook.tsx:ensureChunksLoaded',
 					'calling dispatchAction due to blockingLoad',
 					{
+						target: target.current?.time,
 						startTime,
 						chunks: chunkEventsRef.current,
 					},
 				)
-				dispatchAction(startTime, blockingLoad.current)
+				dispatchAction(
+					target.current?.time ?? startTime,
+					blockingLoad.current,
+				)
 				blockingLoad.current = undefined
 			}
 		},


### PR DESCRIPTION
## Summary

Fixes bug with blocking chunk load logic that would cause session to jump to 0:00

Closes HIG-5037

## How did you test this change?

[Reflame preview on session with blocking load at 4:53](https://preview.highlight.io/1/sessions/zmXYhJp213xt6DQlrdWdeGUfjQAe)

https://www.loom.com/share/79dfa2eb68654d3a9ccf088223b31690

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
