### PR TITLE
Show group on single group graphs

### DIFF
--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -956,8 +956,9 @@ export const useGraphSeries = (
 		const deduped = _.uniqBy(series, getSeriesKey)
 		const isMultiFunction =
 			_.uniq(series.map((s) => `${s.aggregator}_${s.column}`)).length > 1
-		const isGrouped =
-			_.uniq(series.map((s) => getGroupKey(s.groups))).length > 1
+		const isGrouped = !!series
+			.map((s) => getGroupKey(s.groups))
+			.filter((gk) => gk !== NO_GROUP_PLACEHOLDER)?.length
 
 		const named = deduped.map((d) => ({
 			...d,


### PR DESCRIPTION
## Summary
When we are grouping a graph that only has one group, it can be confusing what that group actually is, as it shows up as the function name on the legend. Update to always show the group when possible.

<img width="1706" alt="Screenshot 2024-12-10 at 11 24 35 AM" src="https://github.com/user-attachments/assets/5454b0d6-df8f-4dfe-9114-9223de5623ff">

## How did you test this change?
1. Create a new graph
2. Add filters that would result in only one group (email for sessions)
3. Group by the key
- [ ] Graph displays the correct key in the legend
- [ ] Graph displays the correct key in the tooltip

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
