### PR TITLE
escape utf8 characters in key

### DIFF
--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -742,7 +742,13 @@ export const getSeriesKey = (s: Series | undefined): string => {
 	if (s === undefined) {
 		return 'undefined'
 	}
-	return btoa(JSON.stringify([s.aggregator, s.column, s.groups]))
+	return btoa(
+		JSON.stringify([
+			s.aggregator,
+			s.column,
+			s.groups.map((g) => encodeURIComponent(g)),
+		]),
+	)
 }
 
 export const getSeriesName = (


### PR DESCRIPTION
## Summary
- `btoa` breaking when group has utf8 characters - use `encodeURIComponent`
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
