### PR TITLE
Extend duration we store attribution cookie

### DIFF
--- a/frontend/src/util/attribution.ts
+++ b/frontend/src/util/attribution.ts
@@ -7,7 +7,10 @@ export const setAttributionData = () => {
 	const originalReferrer = Cookies.get('referrer')
 
 	if (referrer && !originalReferrer) {
-		Cookies.set('referrer', referrer, { domain: 'highlight.io' })
+		Cookies.set('referrer', referrer, {
+			domain: 'highlight.io',
+			expires: 365,
+		})
 	}
 }
 

--- a/highlight.io/utils/attribution.ts
+++ b/highlight.io/utils/attribution.ts
@@ -80,6 +80,7 @@ export const setAttributionData = () => {
 	identify(clientID, referrer)
 	Cookies.set('referrer', JSON.stringify(referrer), {
 		domain,
+		expires: 365,
 	})
 
 	return referrer

--- a/highlight.io/utils/attribution.ts
+++ b/highlight.io/utils/attribution.ts
@@ -54,17 +54,22 @@ export const setAttributionData = () => {
 	if (urlParams.get('ref')) {
 		referrer = { ...referrer, referrer: urlParams.get('ref') }
 	}
-	if (urlParams.get('utm_source')) {
-		referrer = {
-			...referrer,
-			utm_source: urlParams.get('utm_source'),
-			utm_medium: urlParams.get('utm_medium'),
-			utm_campaign: urlParams.get('utm_campaign'),
-			utm_content: urlParams.get('utm_content'),
-			utm_term: urlParams.get('utm_term'),
-			device: urlParams.get('device'),
-			gclid: urlParams.get('gclid'),
-		}
+
+	const utmParams = {
+		utm_source: urlParams.get('utm_source'),
+		utm_medium: urlParams.get('utm_medium'),
+		utm_campaign: urlParams.get('utm_campaign'),
+		utm_content: urlParams.get('utm_content'),
+		utm_term: urlParams.get('utm_term'),
+		device: urlParams.get('device'),
+		gclid: urlParams.get('gclid'),
+	}
+
+	referrer = {
+		...referrer,
+		...Object.fromEntries(
+			Object.entries(utmParams).filter(([_, value]) => !!value),
+		),
 	}
 
 	const pathRef =

--- a/highlight.io/utils/attribution.ts
+++ b/highlight.io/utils/attribution.ts
@@ -51,11 +51,7 @@ export const setAttributionData = () => {
 	referrer.documentReferrer = document.referrer
 
 	const urlParams = new URLSearchParams(window.location.search)
-	if (urlParams.get('ref')) {
-		referrer = { ...referrer, referrer: urlParams.get('ref') }
-	}
-
-	const utmParams = {
+	const referrerParams = {
 		utm_source: urlParams.get('utm_source'),
 		utm_medium: urlParams.get('utm_medium'),
 		utm_campaign: urlParams.get('utm_campaign'),
@@ -63,12 +59,13 @@ export const setAttributionData = () => {
 		utm_term: urlParams.get('utm_term'),
 		device: urlParams.get('device'),
 		gclid: urlParams.get('gclid'),
+		ref: urlParams.get('ref'),
 	}
 
 	referrer = {
 		...referrer,
 		...Object.fromEntries(
-			Object.entries(utmParams).filter(([_, value]) => !!value),
+			Object.entries(referrerParams).filter(([_, value]) => !!value),
 		),
 	}
 


### PR DESCRIPTION
## Summary

According to the [js-cookie docs on the `expires` attribute](https://github.com/js-cookie/js-cookie?tab=readme-ov-file#expires):

> Define when the cookie will be removed. Value must be a Number which will be interpreted as days from time of creation or a Date instance. If omitted, the cookie becomes a session cookie.

This means our current cookie is being set as a session cookie. We want to store this longer than that.

Also updates our logic for storing UTM params to always store any available.

## How did you test this change?



## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A