### PR TITLE
correctly map the environment attribute to the top level column

### DIFF
--- a/backend/event-parse/parse_test.go
+++ b/backend/event-parse/parse_test.go
@@ -264,12 +264,14 @@ func TestSnapshot_ReplaceAssets(t *testing.T) {
 
 	// broken asset "https://static.highlight.io/dev/test.mp4?AWSAccessKeyId=asdffdsa1234"
 	// should not be stored
-	assert.Equal(t, 3, len(assets))
+	// https://app.highlight.run/public.css is not found but redirects to https://app.highlight.run/index.html
+	assert.Equal(t, 4, len(assets))
 	for _, exp := range []string{
 		// check that we store <link> tags with an href
 		"https://unpkg.com/@highlight-run/rrweb@0.9.27/dist/index.css",
 		"https://static.highlight.io/dev/BigBuckBunny.mp4?AWSAccessKeyId=asdffdsa1234",
 		"https://static.highlight.io/v6.2.0/index.js",
+		"https://app.highlight.run/public.css",
 	} {
 		matched := false
 		for _, asset := range assets {

--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/highlight-run/highlight/backend/env"
-	model "github.com/highlight-run/highlight/backend/model"
+	"github.com/highlight-run/highlight/backend/model"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/public-graph/graph"
 	"github.com/highlight/highlight/sdk/highlight-go"
@@ -295,6 +295,11 @@ func extractFields(ctx context.Context, params extractFieldsParams) (*extractedF
 	if val, ok := fields.attrs[string(semconv.DeploymentEnvironmentKey)]; ok {
 		fields.environment = val
 		delete(fields.attrs, string(semconv.DeploymentEnvironmentKey))
+	}
+
+	if val, ok := fields.attrs[highlight.EnvironmentAttribute]; ok {
+		fields.environment = val
+		delete(fields.attrs, string(highlight.EnvironmentAttribute))
 	}
 
 	if val, ok := fields.attrs[string(semconv.ServiceNameKey)]; ok {

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -39,6 +39,7 @@ const RequestIDAttribute = "highlight.trace_id"
 const SourceAttribute = "highlight.source"
 const TraceTypeAttribute = "highlight.type"
 const TraceKeyAttribute = "highlight.key"
+const EnvironmentAttribute = "environment"
 
 const LogEvent = "log"
 const LogSeverityAttribute = "log.severity"


### PR DESCRIPTION
## Summary

* Pull out `environment` attribute to the top level `Environment` column to ensure correct search on the reserved attribute.

## How did you test this change?

https://www.loom.com/share/435e9729fb804cef95f2bfb29b167ca4

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no