### PR TITLE
Fix traces/logs table height

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -905,10 +905,12 @@ const BillingBanner: React.FC = () => {
 		setHasReportedTrialExtension,
 	])
 
-	const isMaintenance = moment().isBetween(
-		systemData?.system_configuration?.maintenance_start,
-		systemData?.system_configuration?.maintenance_end,
-	)
+	const isMaintenance =
+		true ||
+		moment().isBetween(
+			systemData?.system_configuration?.maintenance_start,
+			systemData?.system_configuration?.maintenance_end,
+		)
 	if (isMaintenance) {
 		return <MaintenanceBanner />
 	}

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -905,12 +905,10 @@ const BillingBanner: React.FC = () => {
 		setHasReportedTrialExtension,
 	])
 
-	const isMaintenance =
-		true ||
-		moment().isBetween(
-			systemData?.system_configuration?.maintenance_start,
-			systemData?.system_configuration?.maintenance_end,
-		)
+	const isMaintenance = moment().isBetween(
+		systemData?.system_configuration?.maintenance_start,
+		systemData?.system_configuration?.maintenance_end,
+	)
 	if (isMaintenance) {
 		return <MaintenanceBanner />
 	}

--- a/frontend/src/components/RelatedResources/LogsPanel.tsx
+++ b/frontend/src/components/RelatedResources/LogsPanel.tsx
@@ -115,7 +115,7 @@ export const LogsPanel: React.FC<{ resource: RelatedLogs }> = ({
 						hideCreateAlert
 						productType={ProductType.Logs}
 					/>
-					<Box height="full">
+					<Box height="full" overflow="hidden">
 						{!loading && logEdges.length === 0 ? (
 							<Box
 								display="flex"
@@ -137,7 +137,6 @@ export const LogsPanel: React.FC<{ resource: RelatedLogs }> = ({
 								fetchMoreWhenScrolled={fetchMoreWhenScrolled}
 								selectedColumns={selectedColumns}
 								setSelectedColumns={setSelectedColumns}
-								bodyHeight="calc(100% - 64px)"
 							/>
 						)}
 					</Box>

--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -112,7 +112,6 @@ export type SearchFormProps = {
 	hideDatePicker?: boolean
 	hideCreateAlert?: boolean
 	savedSegmentType?: SavedSegmentEntityType
-	textAreaRef?: React.RefObject<HTMLTextAreaElement>
 	isPanelView?: boolean
 	resultFormatted?: string
 	loading?: boolean
@@ -134,7 +133,6 @@ const SearchForm: React.FC<SearchFormProps> = ({
 	hideDatePicker,
 	hideCreateAlert,
 	savedSegmentType,
-	textAreaRef,
 	isPanelView,
 	resultFormatted,
 	loading,
@@ -183,7 +181,6 @@ const SearchForm: React.FC<SearchFormProps> = ({
 		<Search
 			startDate={startDate}
 			endDate={endDate}
-			textAreaRef={textAreaRef}
 			productType={productType}
 			hideIcon={isPanelView}
 			hasAdditonalActions={!hideCreateAlert || !hideDatePicker}
@@ -333,7 +330,6 @@ export const Search: React.FC<{
 	hideIcon?: boolean
 	placeholder?: string
 	productType: ProductType
-	textAreaRef?: React.RefObject<HTMLTextAreaElement>
 	hasAdditonalActions?: boolean
 	creatables?: { [key: string]: Creatable }
 	defaultValueOptions?: string[]
@@ -345,7 +341,6 @@ export const Search: React.FC<{
 	endDate,
 	hideIcon,
 	placeholder,
-	textAreaRef,
 	productType,
 	hasAdditonalActions,
 	creatables,
@@ -371,8 +366,7 @@ export const Search: React.FC<{
 	const { project_id } = useParams()
 	const [_, setSortColumn] = useQueryParam(SORT_COLUMN, StringParam)
 	const [__, setSortDirection] = useQueryParam(SORT_DIRECTION, StringParam)
-	const defaultInputRef = useRef<HTMLTextAreaElement | null>(null)
-	const inputRef = textAreaRef || defaultInputRef
+	const inputRef = useRef<HTMLTextAreaElement | null>(null)
 	const [keys, setKeys] = useState<Keys | undefined>()
 	const [values, setValues] = useState<string[] | undefined>()
 	const [showErrors, setShowErrors] = useState(false)

--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -16,7 +16,7 @@ import { useGetLogs } from '@pages/LogsPage/useGetLogs'
 import useLocalStorage from '@rehooks/local-storage'
 import { useParams } from '@util/react-router/useParams'
 import moment from 'moment'
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { useQueryParam } from 'use-query-params'
 
@@ -88,7 +88,6 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 		return parseSearch(query).queryParts
 	}, [query])
 
-	const textAreaRef = useRef<HTMLTextAreaElement | null>(null)
 	const [
 		getAiQuerySuggestion,
 		{ data: aiData, error: aiError, loading: aiLoading },
@@ -286,7 +285,6 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 						productType={ProductType.Logs}
 						timeMode={timeMode}
 						savedSegmentType={SavedSegmentEntityType.Log}
-						textAreaRef={textAreaRef}
 						enableAIMode={
 							workspaceSettings?.workspaceSettings
 								?.ai_query_builder

--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -166,7 +166,7 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 		loading,
 		error,
 		loadingAfter,
-		// fetchMoreForward,
+		fetchMoreForward,
 		refetch,
 	} = useGetLogs({
 		query,
@@ -184,12 +184,11 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 					containerRefElement
 				//once the user has scrolled within 100px of the bottom of the table, fetch more data if there is any
 				if (scrollHeight - scrollTop - clientHeight < 100) {
-					// fetchMoreForward()
+					fetchMoreForward()
 				}
 			}
 		},
-		[],
-		// [fetchMoreForward],
+		[fetchMoreForward],
 	)
 
 	const { projectId } = useNumericProjectId()

--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -30,7 +30,6 @@ import {
 	TIME_MODE,
 } from '@/components/Search/SearchForm/constants'
 import {
-	DEFAULT_INPUT_HEIGHT,
 	FixedRangePreset,
 	PermalinkPreset,
 	QueryParam,
@@ -77,9 +76,6 @@ type Props = {
 	logCursor: string | undefined
 	presetDefault: DateRangePreset
 }
-
-const HEADERS_AND_CHARTS_HEIGHT = 189
-const LOAD_MORE_HEIGHT = 28
 
 const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 	const { project_id } = useParams<{
@@ -170,7 +166,7 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 		loading,
 		error,
 		loadingAfter,
-		fetchMoreForward,
+		// fetchMoreForward,
 		refetch,
 	} = useGetLogs({
 		query,
@@ -188,11 +184,12 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 					containerRefElement
 				//once the user has scrolled within 100px of the bottom of the table, fetch more data if there is any
 				if (scrollHeight - scrollTop - clientHeight < 100) {
-					fetchMoreForward()
+					// fetchMoreForward()
 				}
 			}
 		},
-		[fetchMoreForward],
+		[],
+		// [fetchMoreForward],
 	)
 
 	const { projectId } = useNumericProjectId()
@@ -226,21 +223,6 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 	for (const b of histogramData?.metrics.buckets ?? []) {
 		totalCount += b.metric_value ?? 0
 	}
-
-	const otherElementsHeight = useMemo(() => {
-		let height = HEADERS_AND_CHARTS_HEIGHT
-		if (textAreaRef.current) {
-			height += textAreaRef.current.clientHeight
-		} else {
-			height += DEFAULT_INPUT_HEIGHT
-		}
-
-		if (moreLogs) {
-			height += LOAD_MORE_HEIGHT
-		}
-
-		return height
-	}, [moreLogs, textAreaRef])
 
 	useEffect(() => {
 		analytics.page('Logs')
@@ -291,6 +273,8 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 					display="flex"
 					flexGrow={1}
 					border="dividerWeak"
+					height="full"
+					overflow="hidden"
 					shadow="medium"
 				>
 					<SearchForm
@@ -324,7 +308,11 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 						loading={histogramLoading}
 						metrics={histogramData}
 					/>
-					<Box borderTop="dividerWeak" height="full">
+					<Box
+						borderTop="dividerWeak"
+						height="full"
+						overflow="hidden"
+					>
 						<LogsOverageCard />
 						<IntegrationCta />
 						<LogsTable
@@ -342,7 +330,6 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 								searchTimeContext.rebaseSearchTime
 							}
 							fetchMoreWhenScrolled={fetchMoreWhenScrolled}
-							bodyHeight={`calc(100vh - ${otherElementsHeight}px)`}
 							selectedColumns={selectedColumns}
 							setSelectedColumns={setSelectedColumns}
 							pollingExpired={pollingExpired}

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -123,7 +123,6 @@ type LogsTableInnerProps = {
 	fetchMoreWhenScrolled: (target: HTMLDivElement) => void
 	// necessary for loading most recent loads
 	moreLogs?: number
-	bodyHeight: string
 	clearMoreLogs?: () => void
 	handleAdditionalLogsDateChange?: () => void
 	selectedColumns?: SerializedColumn[]
@@ -141,7 +140,6 @@ const LogsTableInner = ({
 	queryParts,
 	moreLogs,
 	pollingExpired,
-	bodyHeight,
 	clearMoreLogs,
 	handleAdditionalLogsDateChange,
 	fetchMoreWhenScrolled,
@@ -332,7 +330,7 @@ const LogsTableInner = ({
 	}
 
 	return (
-		<Table height="full" noBorder>
+		<Table display="flex" flexDirection="column" height="full" noBorder>
 			<Table.Head>
 				<Table.Row gridColumns={columnData.gridColumns}>
 					{columnData.columnHeaders.map((header) => (
@@ -366,7 +364,6 @@ const LogsTableInner = ({
 			<Table.Body
 				ref={bodyRef}
 				overflowY="auto"
-				style={{ height: bodyHeight }}
 				onScroll={handleFetchMoreWhenScrolled}
 				hiddenScroll
 			>

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceLogs.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceLogs.tsx
@@ -121,7 +121,7 @@ export const NetworkResourceLogs: React.FC<{
 						hideCreateAlert
 						productType={ProductType.Logs}
 					/>
-					<Box height="full" pt="4" px="12" pb="12">
+					<Box height="full" pt="4" px="12" pb="12" overflow="hidden">
 						{(!loading && logEdges.length === 0) || !requestId ? (
 							<NoLogsFound />
 						) : (

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceLogs.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceLogs.tsx
@@ -31,8 +31,6 @@ import { useParams } from '@/util/react-router/useParams'
 // logs for.
 const TIME_BUFFER = 200000
 
-const SEARCH_AND_HEADER_HEIGHT = 60
-
 export const NetworkResourceLogs: React.FC<{
 	resource: NetworkResource
 	sessionStartTime: number
@@ -137,7 +135,6 @@ export const NetworkResourceLogs: React.FC<{
 								loadingAfter={loadingAfter}
 								selectedCursor={undefined}
 								fetchMoreWhenScrolled={fetchMoreWhenScrolled}
-								// bodyHeight={`calc(100% - ${SEARCH_AND_HEADER_HEIGHT}px)`}
 							/>
 						)}
 					</Box>

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceLogs.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceLogs.tsx
@@ -137,7 +137,7 @@ export const NetworkResourceLogs: React.FC<{
 								loadingAfter={loadingAfter}
 								selectedCursor={undefined}
 								fetchMoreWhenScrolled={fetchMoreWhenScrolled}
-								bodyHeight={`calc(100% - ${SEARCH_AND_HEADER_HEIGHT}px)`}
+								// bodyHeight={`calc(100% - ${SEARCH_AND_HEADER_HEIGHT}px)`}
 							/>
 						)}
 					</Box>

--- a/frontend/src/pages/Traces/TracesList.tsx
+++ b/frontend/src/pages/Traces/TracesList.tsx
@@ -34,7 +34,6 @@ import {
 	SORT_DIRECTION,
 	useSearchContext,
 } from '@/components/Search/SearchContext'
-import { DEFAULT_INPUT_HEIGHT } from '@/components/Search/SearchForm/SearchForm'
 import {
 	ProductType,
 	SortDirection,
@@ -56,13 +55,10 @@ type Props = {
 	resetMoreTraces?: () => void
 	fetchMoreWhenScrolled: (target: HTMLDivElement) => void
 	loadingAfter: boolean
-	textAreaRef: React.RefObject<HTMLTextAreaElement>
 	pollingExpired: boolean
 }
 
 const LOADING_AFTER_HEIGHT = 28
-const HEADERS_AND_CHARTS_HEIGHT = 120
-const LOAD_BEFORE_HEIGHT = 28
 
 export const TracesList: React.FC<Props> = ({
 	loading,
@@ -73,7 +69,6 @@ export const TracesList: React.FC<Props> = ({
 	resetMoreTraces,
 	fetchMoreWhenScrolled,
 	loadingAfter,
-	textAreaRef,
 }) => {
 	const { query } = useSearchContext()
 	const { integrated } = useTracesIntegration()
@@ -255,21 +250,6 @@ export const TracesList: React.FC<Props> = ({
 		paddingBottom += LOADING_AFTER_HEIGHT
 	}
 
-	const otherElementsHeight = useMemo(() => {
-		let height = HEADERS_AND_CHARTS_HEIGHT
-		if (textAreaRef.current) {
-			height += textAreaRef.current.clientHeight
-		} else {
-			height += DEFAULT_INPUT_HEIGHT
-		}
-
-		if (numMoreTraces && numMoreTraces > 0) {
-			height += LOAD_BEFORE_HEIGHT
-		}
-
-		return height
-	}, [numMoreTraces, textAreaRef])
-
 	const handleFetchMoreWhenScrolled = (
 		e: React.UIEvent<HTMLDivElement, UIEvent>,
 	) => {
@@ -356,7 +336,7 @@ export const TracesList: React.FC<Props> = ({
 	}
 
 	return (
-		<Table height="full" noBorder>
+		<Table display="flex" flexDirection="column" height="full" noBorder>
 			<Table.Head>
 				<Table.Row gridColumns={columnData.gridColumns}>
 					{columnData.columnHeaders.map((header) => (
@@ -394,12 +374,8 @@ export const TracesList: React.FC<Props> = ({
 			) : (
 				<Table.Body
 					ref={bodyRef}
-					height="full"
 					overflowY="auto"
 					onScroll={handleFetchMoreWhenScrolled}
-					style={{
-						height: `calc(100% - ${otherElementsHeight}px)`,
-					}}
 					hiddenScroll
 				>
 					{paddingTop > 0 && <Box style={{ height: paddingTop }} />}

--- a/frontend/src/pages/Traces/TracesPage.tsx
+++ b/frontend/src/pages/Traces/TracesPage.tsx
@@ -12,7 +12,7 @@ import { vars } from '@highlight-run/ui/vars'
 import { useParams } from '@util/react-router/useParams'
 import { sumBy } from 'lodash'
 import moment from 'moment'
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { useNavigate } from 'react-router-dom'
 import { StringParam, useQueryParam } from 'use-query-params'
@@ -83,7 +83,6 @@ export const TracesPage: React.FC = () => {
 		span_id: string
 		trace_cursor: string
 	}>()
-	const textAreaRef = useRef<HTMLTextAreaElement | null>(null)
 	const [query, setQuery] = useQueryParam('query', QueryParam)
 	const [sortColumn] = useQueryParam(SORT_COLUMN, StringParam)
 	const [sortDirection] = useQueryParam(SORT_DIRECTION, StringParam)
@@ -351,6 +350,9 @@ export const TracesPage: React.FC = () => {
 					backgroundColor="white"
 					border="dividerWeak"
 					borderRadius="6"
+					flexDirection="column"
+					display="flex"
+					flexGrow={1}
 					height="full"
 					shadow="medium"
 					overflow="hidden"
@@ -366,7 +368,6 @@ export const TracesPage: React.FC = () => {
 						onDatesChange={searchTimeContext.updateSearchTime}
 						productType={ProductType.Traces}
 						savedSegmentType={SavedSegmentEntityType.Trace}
-						textAreaRef={textAreaRef}
 						enableAIMode={
 							workspaceSettings?.workspaceSettings
 								?.ai_query_builder
@@ -510,19 +511,20 @@ export const TracesPage: React.FC = () => {
 						</Box>
 					</Box>
 
-					<TracesList
-						loading={loading}
-						numMoreTraces={moreTraces}
-						traceEdges={traceEdges}
-						handleAdditionalTracesDateChange={
-							searchTimeContext.rebaseSearchTime
-						}
-						resetMoreTraces={clearMoreTraces}
-						fetchMoreWhenScrolled={fetchMoreWhenScrolled}
-						loadingAfter={loadingAfter}
-						textAreaRef={textAreaRef}
-						pollingExpired={pollingExpired}
-					/>
+					<Box height="full" overflow="hidden">
+						<TracesList
+							loading={loading}
+							numMoreTraces={moreTraces}
+							traceEdges={traceEdges}
+							handleAdditionalTracesDateChange={
+								searchTimeContext.rebaseSearchTime
+							}
+							resetMoreTraces={clearMoreTraces}
+							fetchMoreWhenScrolled={fetchMoreWhenScrolled}
+							loadingAfter={loadingAfter}
+							pollingExpired={pollingExpired}
+						/>
+					</Box>
 				</Box>
 			</Box>
 		</SearchContext>

--- a/packages/ui/src/components/Table/Head/Head.tsx
+++ b/packages/ui/src/components/Table/Head/Head.tsx
@@ -1,14 +1,18 @@
 import clsx from 'clsx'
 import React from 'react'
 
-import { Box } from '../../Box/Box'
+import { Box, BoxProps } from '../../Box/Box'
 import * as styles from './styles.css'
 
-export type Props = {
+export interface Props extends Omit<BoxProps, 'cssClass'> {
 	children: React.ReactNode
 	className?: string
 }
 
-export const Head: React.FC<Props> = ({ children, className }) => {
-	return <Box cssClass={clsx(styles.head, className)}>{children}</Box>
+export const Head: React.FC<Props> = ({ children, className, ...boxProps }) => {
+	return (
+		<Box cssClass={clsx(styles.head, className)} {...boxProps}>
+			{children}
+		</Box>
+	)
 }

--- a/packages/ui/src/components/Table/Table.tsx
+++ b/packages/ui/src/components/Table/Table.tsx
@@ -15,7 +15,6 @@ import * as styles from './styles.css'
 export interface Props extends Omit<BoxProps, 'cssClass'> {
 	children: React.ReactNode
 	className?: string
-	height?: BoxProps['height']
 	noBorder?: boolean
 }
 

--- a/packages/ui/src/components/Table/Table.tsx
+++ b/packages/ui/src/components/Table/Table.tsx
@@ -12,7 +12,7 @@ import { Row } from './Row/Row'
 import { Search } from './Search/Search'
 import * as styles from './styles.css'
 
-type Props = {
+export interface Props extends Omit<BoxProps, 'cssClass'> {
 	children: React.ReactNode
 	className?: string
 	height?: BoxProps['height']
@@ -22,16 +22,16 @@ type Props = {
 const TableComponent: React.FC<Props> = ({
 	children,
 	className,
-	height,
 	noBorder,
+	...boxProps
 }) => {
 	return (
 		<Box
 			cssClass={clsx(styles.table, className, {
 				[styles.noBorder]: noBorder,
 			})}
-			height={height}
 			width="full"
+			{...boxProps}
 		>
 			{children}
 		</Box>


### PR DESCRIPTION
## Summary
The traces/logs tables height is fixed depending on the elements above. However, it doesn't take into account the banner. Update the traces/logs tables to not use a fixed height and flex appropriately.

<img width="1238" alt="Screenshot 2024-12-11 at 8 37 48 PM" src="https://github.com/user-attachments/assets/c7ac7722-2e7f-48fa-8dee-7de6a31dde7c" />

<img width="1236" alt="Screenshot 2024-12-11 at 8 38 17 PM" src="https://github.com/user-attachments/assets/cff3954d-668b-47c4-b873-7e1554ba2d3d" />

<img width="1236" alt="Screenshot 2024-12-11 at 9 00 45 PM" src="https://github.com/user-attachments/assets/6fcb5ead-e1c1-4d09-a4cc-7c134e52e197" />

## How did you test this change?
1. Turn a banner on within the app
2. Navigate to the logs page
- [ ] Logs table is appropriate height
- [ ] Can scroll to bottom of table (i.e. no logs hidden below the fold)
2. Create a logs graph
3. Drill down into the logs
- [ ] Logs table is appropriate height
- [ ] Can scroll to bottom of table (i.e. no logs hidden below the fold)
4. Navigate to the traces page
- [ ] Tracces table is appropriate height
- [ ] Can scroll to bottom of table (i.e. no traces hidden below the fold)

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
