### PR TITLE
Fix query string replacement on item selection

### DIFF
--- a/frontend/src/components/JsonViewer/JsonViewerV2.tsx
+++ b/frontend/src/components/JsonViewer/JsonViewerV2.tsx
@@ -11,7 +11,6 @@ type Props = {
 	allExpanded?: boolean
 	matchedAttributes?: JsonViewerObjectProps['matchedAttributes']
 	query?: string
-	queryParts?: JsonViewerObjectProps['queryParts']
 	setQuery?: JsonViewerObjectProps['setQuery']
 }
 
@@ -20,7 +19,6 @@ export const JsonViewerV2: React.FC<Props> = ({
 	allExpanded = false,
 	matchedAttributes = {},
 	query = '',
-	queryParts = [],
 	setQuery,
 }) => {
 	return (

--- a/frontend/src/components/JsonViewer/JsonViewerV2.tsx
+++ b/frontend/src/components/JsonViewer/JsonViewerV2.tsx
@@ -10,6 +10,7 @@ type Props = {
 	attribute: JsonViewerObjectProps['attribute']
 	allExpanded?: boolean
 	matchedAttributes?: JsonViewerObjectProps['matchedAttributes']
+	query?: string
 	queryParts?: JsonViewerObjectProps['queryParts']
 	setQuery?: JsonViewerObjectProps['setQuery']
 }
@@ -18,6 +19,7 @@ export const JsonViewerV2: React.FC<Props> = ({
 	attribute,
 	allExpanded = false,
 	matchedAttributes = {},
+	query = '',
 	queryParts = [],
 	setQuery,
 }) => {
@@ -34,7 +36,7 @@ export const JsonViewerV2: React.FC<Props> = ({
 								attribute={value as object}
 								label={key}
 								matchedAttributes={matchedAttributes}
-								queryParts={queryParts}
+								query={query}
 								queryBaseKeys={[key]}
 								setQuery={setQuery}
 							/>
@@ -42,9 +44,9 @@ export const JsonViewerV2: React.FC<Props> = ({
 							<JsonViewerValue
 								label={key}
 								value={String(value)}
+								query={query}
 								queryKey={key}
 								queryMatch={matchedAttributes[key]?.match}
-								queryParts={queryParts}
 								setQuery={setQuery}
 							/>
 						)}

--- a/frontend/src/components/Search/SearchContext.tsx
+++ b/frontend/src/components/Search/SearchContext.tsx
@@ -56,8 +56,7 @@ interface SearchContext extends Partial<ReturnType<typeof useSearchTime>> {
 	aiSuggestionError?: ApolloError
 	defaultValues?: string[]
 	recentSearches: SearchEntry[]
-	handleSearch: (query: string, queryParts: SearchExpression[]) => void
-	historyLoading: boolean
+	handleSearch: (query: string) => void
 }
 
 export const [useSearchContext, SearchContextProvider] =
@@ -114,16 +113,12 @@ export const SearchContext: React.FC<Props> = ({
 	const [aiQuery, setAiQuery] = useState('')
 	const { queryParts, tokens } = parseSearch(query)
 	const tokenGroups = buildTokenGroups(tokens)
-	const { handleSearch, recentSearches, historyLoading } = useSearchHistory()
+	const { handleSearch, recentSearches } = useSearchHistory()
 	const handleSubmit = (query: string) => {
 		onSubmit(query)
 		if (query) {
-			const queryParts = parseSearch(query)?.queryParts || []
 			try {
-				const newQueryParts = JSON.parse(
-					JSON.stringify(queryParts || []),
-				)
-				handleSearch?.(query, newQueryParts)
+				handleSearch?.(query)
 			} catch (err) {
 				//do nothing
 				console.error(
@@ -164,7 +159,6 @@ export const SearchContext: React.FC<Props> = ({
 				aiSuggestionError,
 				recentSearches,
 				handleSearch,
-				historyLoading,
 				...searchTimeContext,
 			}}
 		>

--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -47,7 +47,6 @@ import {
 	BODY_KEY,
 	getActivePart,
 	quoteQueryValue,
-	stringifySearchQuery,
 } from '@/components/Search/SearchForm/utils'
 import {
 	useGetKeysLazyQuery,
@@ -427,7 +426,7 @@ export const Search: React.FC<{
 	const showOperators = !!keyMatch
 
 	const visibleRecentSearch = recentSearches.filter((history) => {
-		return stringifySearchQuery(history.queryParts).indexOf(query) > -1
+		return history.query.indexOf(query) > -1
 	})
 
 	if (showOperators) {
@@ -672,10 +671,9 @@ export const Search: React.FC<{
 	}
 
 	const handleHistorySelection = (
-		queryParts: SearchExpression[],
+		newQuery: string,
 		selectNewItem: boolean = false,
 	) => {
-		let newQuery = stringifySearchQuery(queryParts)
 		let newCursorPosition = newQuery.length
 
 		if (selectNewItem) {
@@ -972,7 +970,7 @@ export const Search: React.FC<{
 													key={index}
 													onClick={(e) => {
 														handleHistorySelection(
-															data.queryParts,
+															data.query,
 															e.metaKey ||
 																e.ctrlKey,
 														)

--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -602,6 +602,7 @@ export const Search: React.FC<{
 	) => {
 		const isValueSelect = item.type === 'Value'
 		const isExists = !!EXISTS_OPERATORS.find((eo) => eo === item.name)
+		const originalStop = activePart.stop
 		let cursorShift = 0
 
 		if (item.type === 'Operator') {
@@ -643,7 +644,11 @@ export const Search: React.FC<{
 			activePart.stop = activePart.start + activePart.key.length
 		}
 
-		let newQuery = stringifySearchQuery(queryParts)
+		let newQuery =
+			query.substring(0, activePart.start) +
+			activePart.text +
+			query.substring(originalStop + 1)
+
 		let newCursorPosition = activePart.stop + cursorShift
 
 		if (selectNewItem && isValueSelect) {

--- a/frontend/src/components/Search/SearchForm/utils.test.ts
+++ b/frontend/src/components/Search/SearchForm/utils.test.ts
@@ -4,11 +4,9 @@ import {
 	buildTokenGroups,
 	getActivePart,
 	quoteQueryValue,
-	stringifySearchQuery,
 } from './utils'
 import { parseSearch } from '@/components/Search/utils'
 
-const complexQueryString = `name:"Eric Thomas" workspace:'Chilly McWilly'  project_id:9 freetext query`
 const complexQueryParams: SearchExpression[] = [
 	{
 		key: 'name',
@@ -43,44 +41,6 @@ const complexQueryParams: SearchExpression[] = [
 		stop: 75,
 	},
 ]
-
-describe('stringifyLogsQuery', () => {
-	it('parses simple params to a query string', () => {
-		expect(
-			stringifySearchQuery([
-				{
-					key: BODY_KEY,
-					operator: '=',
-					value: 'a test query',
-					text: 'a test query',
-					start: 0,
-					stop: 12,
-				},
-			]),
-		).toEqual('a test query')
-	})
-
-	it('parses complex params to a query string', () => {
-		expect(stringifySearchQuery(complexQueryParams)).toEqual(
-			complexQueryString,
-		)
-	})
-
-	it('includes quotes for the body query', () => {
-		expect(
-			stringifySearchQuery([
-				{
-					key: BODY_KEY,
-					operator: '=',
-					value: '"Error updating filter group: Filtering out noisy error"',
-					text: '"Error updating filter group: Filtering out noisy error"',
-					start: 0,
-					stop: 62,
-				},
-			]),
-		).toEqual('"Error updating filter group: Filtering out noisy error"')
-	})
-})
 
 describe('quoteQueryValue', () => {
 	it('quotes strings with spaces', () => {

--- a/frontend/src/components/Search/SearchForm/utils.test.ts
+++ b/frontend/src/components/Search/SearchForm/utils.test.ts
@@ -168,4 +168,15 @@ describe('getActivePart', () => {
 		const { queryParts } = parseSearch(queryString)
 		expect(getActivePart(11, queryParts).text).toEqual('has_errors=')
 	})
+
+	it('handles trailing spaces on full queries', () => {
+		const queryString = 'service_name=frontend '
+		const { queryParts } = parseSearch(queryString)
+		const activePart = getActivePart(22, queryParts)
+
+		expect(activePart.key).toEqual(BODY_KEY)
+		expect(activePart.operator).toEqual('=')
+		expect(activePart.text).toEqual('')
+		expect(activePart.value).toEqual('')
+	})
 })

--- a/frontend/src/components/Search/SearchForm/utils.test.ts
+++ b/frontend/src/components/Search/SearchForm/utils.test.ts
@@ -169,6 +169,16 @@ describe('getActivePart', () => {
 		expect(getActivePart(11, queryParts).text).toEqual('has_errors=')
 	})
 
+	it('handles trailing spaces in earlier expressions correctly', () => {
+		const queryString = 'span_name = gorm.Query  service_name=frontend'
+		const { queryParts } = parseSearch(queryString)
+		const activePart = getActivePart(23, queryParts)
+		expect(activePart.key).toEqual(BODY_KEY)
+		expect(activePart.operator).toEqual('=')
+		expect(activePart.text).toEqual('')
+		expect(activePart.value).toEqual('')
+	})
+
 	it('handles trailing spaces on full queries', () => {
 		const queryString = 'service_name=frontend '
 		const { queryParts } = parseSearch(queryString)

--- a/frontend/src/components/Search/SearchForm/utils.ts
+++ b/frontend/src/components/Search/SearchForm/utils.ts
@@ -5,24 +5,6 @@ import { SearchToken } from '@/components/Search/utils'
 export const DEFAULT_OPERATOR = '=' as const
 export const BODY_KEY = 'message' as const
 
-export const stringifySearchQuery = (params: SearchExpression[]) => {
-	const querySegments: string[] = []
-	let currentOffset = 0
-
-	params.forEach(({ text, start }, index) => {
-		const spaces = Math.max(start - currentOffset, index === 0 ? 0 : 1)
-		currentOffset = start + text.length
-
-		if (spaces > 0) {
-			querySegments.push(' '.repeat(spaces))
-		}
-
-		querySegments.push(text)
-	})
-
-	return querySegments.join('').trim()
-}
-
 const NEED_QUOTE_REGEX = /["'` :=><]/
 
 export const quoteQueryValue = (value: string | number) => {

--- a/frontend/src/components/Search/SearchForm/utils.ts
+++ b/frontend/src/components/Search/SearchForm/utils.ts
@@ -176,40 +176,55 @@ export const getActivePart = (
 	cursorIndex: number,
 	queryParts: SearchExpression[],
 ): SearchExpression => {
-	let activePartIndex = 0
-
-	// Find the part that contains the cursor, including trailing spaces
-	queryParts.find((param, index) => {
-		const nextStart = queryParts[index + 1]?.start ?? 0
-
-		if (
-			nextStart === 0 ||
-			(cursorIndex >= param.start && cursorIndex < nextStart)
-		) {
-			activePartIndex = index
-			return true
-		}
-
-		return false
-	})
-
-	if (activePartIndex === undefined) {
-		const lastPartStop = Math.max(
-			queryParts[queryParts.length - 1]?.stop + 1,
-			cursorIndex,
-		)
-
-		const activePart = {
+	if (!queryParts.length) {
+		return {
 			key: BODY_KEY,
 			operator: DEFAULT_OPERATOR,
 			value: '',
 			text: '',
-			start: lastPartStop,
-			stop: lastPartStop,
+			start: 0,
+			stop: 0,
 		}
-		queryParts.push(activePart)
-		return activePart
-	} else {
-		return queryParts[activePartIndex]
+	}
+
+	// Find the part that contains the cursor
+	for (let i = 0; i < queryParts.length; i++) {
+		const currentPart = queryParts[i]
+		const nextPart = queryParts[i + 1]
+
+		// If cursor is within current part's range
+		if (
+			cursorIndex >= currentPart.start &&
+			cursorIndex <= currentPart.stop + 1
+		) {
+			return currentPart
+		}
+
+		// Handle spaces between parts
+		if (
+			nextPart &&
+			cursorIndex > currentPart.stop &&
+			cursorIndex < nextPart.start
+		) {
+			// If cursor is closer to current part, return current part
+			if (cursorIndex < nextPart.start) {
+				return currentPart
+			} else {
+				return nextPart
+			}
+		}
+	}
+
+	// If cursor is after all parts, create new part
+	const lastPart = queryParts[queryParts.length - 1]
+	const lastPartStop = Math.max(lastPart.stop + 1, cursorIndex)
+
+	return {
+		key: BODY_KEY,
+		operator: DEFAULT_OPERATOR,
+		value: '',
+		text: '',
+		start: lastPartStop,
+		stop: lastPartStop,
 	}
 }

--- a/frontend/src/components/Search/SearchForm/utils.ts
+++ b/frontend/src/components/Search/SearchForm/utils.ts
@@ -207,7 +207,16 @@ export const getActivePart = (
 			cursorIndex < nextPart.start
 		) {
 			// If cursor is closer to current part, return current part
-			if (cursorIndex < nextPart.start) {
+			if (!!currentPart.value.trim()) {
+				return {
+					key: BODY_KEY,
+					operator: DEFAULT_OPERATOR,
+					value: '',
+					text: '',
+					start: currentPart.stop + 1,
+					stop: currentPart.stop + 1,
+				}
+			} else if (cursorIndex < nextPart.start) {
 				return currentPart
 			} else {
 				return nextPart

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -25,12 +25,10 @@ import {
 } from '@/components/JsonViewer/JsonViewerObject'
 import { findMatchingAttributes } from '@/components/JsonViewer/utils'
 import { useRelatedResource } from '@/components/RelatedResources/hooks'
-import { SearchExpression } from '@/components/Search/Parser/listener'
 import { useSearchContext } from '@/components/Search/SearchContext'
 
 type Props = {
 	row: Row<LogEdgeWithResources>
-	queryParts: SearchExpression[]
 	matchedAttributes: ReturnType<typeof findMatchingAttributes>
 }
 
@@ -43,12 +41,8 @@ export const getLogURL = (projectId: string, row: Row<LogEdge>) => {
 	return { origin: currentUrl.origin, path }
 }
 
-export const LogDetails: React.FC<Props> = ({
-	matchedAttributes,
-	row,
-	queryParts,
-}) => {
-	const { disabled, onSubmit } = useSearchContext()
+export const LogDetails: React.FC<Props> = ({ matchedAttributes, row }) => {
+	const { disabled, onSubmit, query } = useSearchContext()
 	const setQuery = disabled ? undefined : onSubmit
 	const { set } = useRelatedResource()
 	const { projectId } = useProjectId()
@@ -109,7 +103,7 @@ export const LogDetails: React.FC<Props> = ({
 								attribute={value as object}
 								label={key}
 								matchedAttributes={matchedAttributes}
-								queryParts={queryParts}
+								query={query}
 								queryBaseKeys={[key]}
 								setQuery={setQuery}
 							/>
@@ -117,8 +111,8 @@ export const LogDetails: React.FC<Props> = ({
 							<JsonViewerValue
 								label={key}
 								value={String(value)}
+								query={query}
 								queryKey={key}
-								queryParts={queryParts}
 								queryMatch={matchedAttributes[key]?.match}
 								setQuery={setQuery}
 							/>
@@ -134,8 +128,8 @@ export const LogDetails: React.FC<Props> = ({
 							<JsonViewerValue
 								label={key}
 								value={value}
+								query={query}
 								queryKey={key}
-								queryParts={queryParts}
 								queryMatch={matchedAttributes[key]?.match}
 								setQuery={setQuery}
 							/>

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -458,7 +458,6 @@ const LogsTableRow: React.FC<LogsTableRowProps> = ({
 									},
 								)}
 								row={row}
-								queryParts={queryParts}
 							/>
 						</Table.Cell>
 					</>

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsoleTable/index.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsoleTable/index.tsx
@@ -420,7 +420,6 @@ const ConsoleTableRow = React.memo<ConsoleTableRowProps>(
 										},
 									)}
 									row={row}
-									queryParts={queryParts}
 								/>
 							</Table.Cell>
 						</>

--- a/frontend/src/pages/Traces/TraceSpanAttributes.tsx
+++ b/frontend/src/pages/Traces/TraceSpanAttributes.tsx
@@ -14,7 +14,7 @@ type Props = {
 export const TraceSpanAttributes: React.FC<Props> = ({ span }) => {
 	const attributes: { [key: string]: any } = { ...span }
 	const formattedSpan = formatTraceAttributes(attributes)
-	const { onSubmit, queryParts } = useSearchContext()
+	const { onSubmit, queryParts, query } = useSearchContext()
 
 	const matchedAttributes = useMemo(
 		() =>
@@ -31,7 +31,7 @@ export const TraceSpanAttributes: React.FC<Props> = ({ span }) => {
 			allExpanded
 			attribute={formattedSpan}
 			matchedAttributes={matchedAttributes}
-			queryParts={queryParts}
+			query={query}
 			setQuery={onSubmit}
 		/>
 	)


### PR DESCRIPTION
## Summary

Fixes some issues with the query builder:

1. Ensures we don't replace parenthesis and `NOT` operator in certain queries. e.g. if you enter `NOT(service_name=all)` and select `all` from the dropdown items, it would replace the query with just `service_name=all`.
2. Eliminates `stringifySearchQuery` and the need to build a search string for structured params.
3. Fixes a bug where the typeahead wasn't being shown when entering a space after a completed search param.
4. Simplified the logic for storing and filtering recent searches.

## How did you test this change?

Click tested with a number of different queries + added unit tests for bugs I encountered throughout the process. Would appreciate if the reviewer could also click test in the PR preview.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A