### PR TITLE
remove special keys from trace attributes, they're saved in other columns

### DIFF
--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -269,7 +269,7 @@ func ConvertTraceRow(traceRow *TraceRow) *ClickhouseTraceRow {
 		Duration:            traceRow.Duration,
 		ServiceName:         traceRow.ServiceName,
 		ServiceVersion:      traceRow.ServiceVersion,
-		TraceAttributes:     traceRow.TraceAttributes,
+		TraceAttributes:     filtered,
 		StatusCode:          traceRow.StatusCode,
 		StatusMessage:       traceRow.StatusMessage,
 		Environment:         traceRow.Environment,


### PR DESCRIPTION
## Summary
- now that we're saving and querying keys in other specialized columns, remove them from `TraceAttributes` to improve query perf
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ensured new traces are queryable by these attributes and show these attributes in the trace viewer (tested `http.response.body` and `db.statement`)
- validated new traces do not have the same attributes duplicated in `TraceAttributes`
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
