### PR TITLE
Sync timestamp charts

### DIFF
--- a/frontend/src/pages/Graphing/Dashboard.tsx
+++ b/frontend/src/pages/Graphing/Dashboard.tsx
@@ -608,6 +608,9 @@ export const Dashboard = () => {
 														>
 															<Graph
 																id={g.id}
+																syncId={
+																	dashboard_id
+																}
 																title={g.title}
 																viewConfig={getViewConfig(
 																	g.type,

--- a/frontend/src/pages/Graphing/components/BarChart.tsx
+++ b/frontend/src/pages/Graphing/components/BarChart.tsx
@@ -100,6 +100,7 @@ export const BarChart = ({
 		onMouseMove,
 		onMouseUp,
 		onMouseLeave,
+		onMouseOver,
 	} = useGraphCallbacks(
 		xAxisMetric,
 		setTimeRange,
@@ -108,94 +109,102 @@ export const BarChart = ({
 	)
 
 	return (
-		<ResponsiveContainer ref={chartRef}>
-			<RechartsBarChart
-				data={data}
-				syncId={syncId}
-				barCategoryGap={1}
-				onMouseDown={onMouseDown}
-				onMouseMove={onMouseMove}
-				onMouseUp={onMouseUp}
-				onMouseLeave={onMouseLeave}
-				style={tooltipCanFreeze ? { cursor: 'pointer' } : undefined}
-			>
-				{referenceArea}
-				{children}
-				<XAxis
-					dataKey={xAxisMetric}
-					fontSize={10}
-					tick={(props: any) => (
-						<CustomXAxisTick
-							x={props.x}
-							y={props.y}
-							payload={props.payload}
-							tickFormatter={xAxisTickFormatter}
-						/>
-					)}
-					tickFormatter={xAxisTickFormatter}
-					tickLine={{ visibility: 'hidden' }}
-					axisLine={{ visibility: 'hidden' }}
-					height={12}
-					domain={['dataMin', 'dataMax']}
-					hide={showXAxis === false}
-				/>
-
-				{tooltip}
-
-				<YAxis
-					fontSize={10}
-					tickLine={{ visibility: 'hidden' }}
-					axisLine={{ visibility: 'hidden' }}
-					tick={(props: any) => (
-						<CustomYAxisTick
-							y={props.y}
-							payload={props.payload}
-							tickFormatter={yAxisTickFormatter}
-						/>
-					)}
-					tickFormatter={yAxisTickFormatter}
-					tickCount={7}
-					width={32}
-					type="number"
-					hide={showYAxis === false}
-				/>
-
-				{showGrid && (
-					<CartesianGrid
-						strokeDasharray=""
-						vertical={false}
-						stroke="var(--color-gray-200)"
-					/>
-				)}
-
-				{series.length > 0 &&
-					series.map((s, idx) => {
-						if (!isActive(spotlight, idx)) {
-							return null
-						}
-
-						const isLastBar =
-							viewConfig.display !== 'Stacked' ||
-							spotlight === idx ||
-							idx === series.length - 1
-
-						const seriesKey = getSeriesKey(s)
-
-						return (
-							<Bar
-								key={seriesKey}
-								dataKey={`${seriesKey}.value`}
-								name={s.name}
-								fill={getColor(idx, seriesKey, strokeColors)}
-								isAnimationActive={false}
-								stackId={
-									viewConfig.display === 'Stacked' ? 1 : idx
-								}
-								shape={RoundedBar(id, isLastBar)}
+		<span onMouseOver={onMouseOver}>
+			<ResponsiveContainer ref={chartRef}>
+				<RechartsBarChart
+					data={data}
+					syncId={syncId}
+					barCategoryGap={1}
+					onMouseDown={onMouseDown}
+					onMouseMove={onMouseMove}
+					onMouseUp={onMouseUp}
+					onMouseLeave={onMouseLeave}
+					style={tooltipCanFreeze ? { cursor: 'pointer' } : undefined}
+				>
+					{referenceArea}
+					{children}
+					<XAxis
+						dataKey={xAxisMetric}
+						fontSize={10}
+						tick={(props: any) => (
+							<CustomXAxisTick
+								x={props.x}
+								y={props.y}
+								payload={props.payload}
+								tickFormatter={xAxisTickFormatter}
 							/>
-						)
-					})}
-			</RechartsBarChart>
-		</ResponsiveContainer>
+						)}
+						tickFormatter={xAxisTickFormatter}
+						tickLine={{ visibility: 'hidden' }}
+						axisLine={{ visibility: 'hidden' }}
+						height={12}
+						domain={['dataMin', 'dataMax']}
+						hide={showXAxis === false}
+					/>
+
+					{tooltip}
+
+					<YAxis
+						fontSize={10}
+						tickLine={{ visibility: 'hidden' }}
+						axisLine={{ visibility: 'hidden' }}
+						tick={(props: any) => (
+							<CustomYAxisTick
+								y={props.y}
+								payload={props.payload}
+								tickFormatter={yAxisTickFormatter}
+							/>
+						)}
+						tickFormatter={yAxisTickFormatter}
+						tickCount={7}
+						width={32}
+						type="number"
+						hide={showYAxis === false}
+					/>
+
+					{showGrid && (
+						<CartesianGrid
+							strokeDasharray=""
+							vertical={false}
+							stroke="var(--color-gray-200)"
+						/>
+					)}
+
+					{series.length > 0 &&
+						series.map((s, idx) => {
+							if (!isActive(spotlight, idx)) {
+								return null
+							}
+
+							const isLastBar =
+								viewConfig.display !== 'Stacked' ||
+								spotlight === idx ||
+								idx === series.length - 1
+
+							const seriesKey = getSeriesKey(s)
+
+							return (
+								<Bar
+									key={seriesKey}
+									dataKey={`${seriesKey}.value`}
+									name={s.name}
+									fill={getColor(
+										idx,
+										seriesKey,
+										strokeColors,
+									)}
+									isAnimationActive={false}
+									stackId={
+										viewConfig.display === 'Stacked'
+											? 1
+											: idx
+									}
+									shape={RoundedBar(id, isLastBar)}
+								/>
+							)
+						})}
+				</RechartsBarChart>
+			</ResponsiveContainer>
+		</span>
 	)
 }

--- a/frontend/src/pages/Graphing/components/BarChart.tsx
+++ b/frontend/src/pages/Graphing/components/BarChart.tsx
@@ -76,6 +76,7 @@ export const BarChart = ({
 	showXAxis,
 	showYAxis,
 	showGrid,
+	syncId,
 }: React.PropsWithChildren<
 	InnerChartProps<BarChartConfig> & SeriesInfo & AxisConfig
 >) => {
@@ -110,6 +111,7 @@ export const BarChart = ({
 		<ResponsiveContainer ref={chartRef}>
 			<RechartsBarChart
 				data={data}
+				syncId={syncId}
 				barCategoryGap={1}
 				onMouseDown={onMouseDown}
 				onMouseMove={onMouseMove}

--- a/frontend/src/pages/Graphing/components/BarChart.tsx
+++ b/frontend/src/pages/Graphing/components/BarChart.tsx
@@ -100,6 +100,7 @@ export const BarChart = ({
 		onMouseMove,
 		onMouseUp,
 		onMouseLeave,
+		onMouseEnter,
 	} = useGraphCallbacks(
 		xAxisMetric,
 		setTimeRange,
@@ -117,6 +118,7 @@ export const BarChart = ({
 				onMouseMove={onMouseMove}
 				onMouseUp={onMouseUp}
 				onMouseLeave={onMouseLeave}
+				onMouseEnter={onMouseEnter}
 				style={tooltipCanFreeze ? { cursor: 'pointer' } : undefined}
 			>
 				{referenceArea}

--- a/frontend/src/pages/Graphing/components/BarChart.tsx
+++ b/frontend/src/pages/Graphing/components/BarChart.tsx
@@ -100,7 +100,6 @@ export const BarChart = ({
 		onMouseMove,
 		onMouseUp,
 		onMouseLeave,
-		onMouseEnter,
 	} = useGraphCallbacks(
 		xAxisMetric,
 		setTimeRange,
@@ -118,7 +117,6 @@ export const BarChart = ({
 				onMouseMove={onMouseMove}
 				onMouseUp={onMouseUp}
 				onMouseLeave={onMouseLeave}
-				onMouseEnter={onMouseEnter}
 				style={tooltipCanFreeze ? { cursor: 'pointer' } : undefined}
 			>
 				{referenceArea}

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -138,6 +138,7 @@ export type ThresholdSettings = {
 export interface ChartProps<TConfig> {
 	id?: string
 	title: string
+	syncId?: string
 	productType: ProductType
 	projectId: string
 	startDate: Date
@@ -167,6 +168,7 @@ export interface InnerChartProps<TConfig> {
 	data: any[] | undefined
 	xAxisMetric: string
 	title?: string
+	syncId?: string
 	loading?: boolean
 	viewConfig: TConfig
 	disabled?: boolean
@@ -1044,6 +1046,7 @@ const Graph = ({
 	predictionSettings,
 	thresholdSettings,
 	expressions,
+	syncId,
 	children,
 }: React.PropsWithChildren<ChartProps<ViewConfig>>) => {
 	const { setGraphData } = useGraphContext()
@@ -1344,6 +1347,7 @@ const Graph = ({
 						loadExemplars={loadExemplars}
 						minYAxisMax={axisLimit}
 						maxYAxisMin={axisLimit}
+						syncId={syncId}
 						showGrid
 					>
 						{children}

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -279,12 +279,13 @@ export const useGraphCallbacks = (
 
 	const onMouseMove = allowDrag
 		? (e: CategoricalChartState) => {
+				setDisplayTooltip(true)
 				if (refAreaStart !== undefined && e.activeLabel !== undefined) {
 					setRefAreaEnd(Number(e.activeLabel))
 					setFrozenTooltip(undefined)
 				}
 			}
-		: undefined
+		: () => setDisplayTooltip(true)
 
 	const onMouseUp = allowDrag
 		? () => {
@@ -308,7 +309,6 @@ export const useGraphCallbacks = (
 		: undefined
 
 	const onMouseLeave = () => {
-		console.log('Mouse leave')
 		setFrozenTooltip(undefined)
 		setRefAreaStart(undefined)
 		setRefAreaEnd(undefined)
@@ -316,18 +316,9 @@ export const useGraphCallbacks = (
 	}
 
 	const onTooltipMouseLeave = () => {
-		console.log('Tooltip enter')
 		setFrozenTooltip(undefined)
 		setRefAreaStart(undefined)
 		setRefAreaEnd(undefined)
-	}
-
-	const onMouseEnter = () => {
-		console.log('Mouse enter')
-		setFrozenTooltip(undefined)
-		setRefAreaStart(undefined)
-		setRefAreaEnd(undefined)
-		setDisplayTooltip(true)
 	}
 
 	const tooltip = (
@@ -376,7 +367,6 @@ export const useGraphCallbacks = (
 		onMouseMove,
 		onMouseUp,
 		onMouseLeave,
-		onMouseEnter,
 	}
 }
 

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -24,7 +24,7 @@ import {
 import { FunnelDisplay } from '@pages/Graphing/components/types'
 import clsx from 'clsx'
 import moment from 'moment'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Area, Tooltip as RechartsTooltip, ReferenceArea } from 'recharts'
 import { CategoricalChartState } from 'recharts/types/chart/types'
 
@@ -228,7 +228,6 @@ export const useGraphCallbacks = (
 ) => {
 	const [refAreaStart, setRefAreaStart] = useState<number | undefined>()
 	const [refAreaEnd, setRefAreaEnd] = useState<number | undefined>()
-	const [displayTooltip, setDisplayTooltip] = useState(false)
 
 	const referenceArea =
 		refAreaStart && refAreaEnd ? (
@@ -243,6 +242,7 @@ export const useGraphCallbacks = (
 	const tooltipRef = useRef<HTMLDivElement>(null)
 
 	const [frozenTooltip, setFrozenTooltip] = useState<CategoricalChartState>()
+	const [displayTooltip, setDisplayTooltip] = useState(false)
 
 	const allowDrag = setTimeRange !== undefined
 
@@ -308,13 +308,25 @@ export const useGraphCallbacks = (
 		: undefined
 
 	const onMouseLeave = () => {
+		console.log('Mouse leave')
 		setFrozenTooltip(undefined)
 		setRefAreaStart(undefined)
 		setRefAreaEnd(undefined)
 		setDisplayTooltip(false)
 	}
 
+	const onTooltipMouseLeave = () => {
+		console.log('Tooltip enter')
+		setFrozenTooltip(undefined)
+		setRefAreaStart(undefined)
+		setRefAreaEnd(undefined)
+	}
+
 	const onMouseEnter = () => {
+		console.log('Mouse enter')
+		setFrozenTooltip(undefined)
+		setRefAreaStart(undefined)
+		setRefAreaEnd(undefined)
 		setDisplayTooltip(true)
 	}
 
@@ -324,7 +336,7 @@ export const useGraphCallbacks = (
 				xAxisMetric,
 				frozenTooltip,
 				tooltipRef,
-				onMouseLeave,
+				onTooltipMouseLeave,
 				loadExemplars,
 				tooltipSettings?.funnelMode,
 				displayTooltip,
@@ -501,7 +513,7 @@ const getCustomTooltip =
 		onMouseLeave?: () => void,
 		loadExemplars?: LoadExemplars,
 		funnelMode?: true,
-		displayTooltip?: false,
+		displayTooltip?: boolean,
 	) =>
 	({ active, payload, label }: any) => {
 		if (!displayTooltip) {

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -228,6 +228,7 @@ export const useGraphCallbacks = (
 ) => {
 	const [refAreaStart, setRefAreaStart] = useState<number | undefined>()
 	const [refAreaEnd, setRefAreaEnd] = useState<number | undefined>()
+	const [displayTooltip, setDisplayTooltip] = useState(false)
 
 	const referenceArea =
 		refAreaStart && refAreaEnd ? (
@@ -310,6 +311,11 @@ export const useGraphCallbacks = (
 		setFrozenTooltip(undefined)
 		setRefAreaStart(undefined)
 		setRefAreaEnd(undefined)
+		setDisplayTooltip(false)
+	}
+
+	const onMouseEnter = () => {
+		setDisplayTooltip(true)
 	}
 
 	const tooltip = (
@@ -321,6 +327,7 @@ export const useGraphCallbacks = (
 				onMouseLeave,
 				loadExemplars,
 				tooltipSettings?.funnelMode,
+				displayTooltip,
 			)}
 			cursor={
 				frozenTooltip
@@ -357,6 +364,7 @@ export const useGraphCallbacks = (
 		onMouseMove,
 		onMouseUp,
 		onMouseLeave,
+		onMouseEnter,
 	}
 }
 
@@ -493,8 +501,13 @@ const getCustomTooltip =
 		onMouseLeave?: () => void,
 		loadExemplars?: LoadExemplars,
 		funnelMode?: true,
+		displayTooltip?: false,
 	) =>
 	({ active, payload, label }: any) => {
+		if (!displayTooltip) {
+			return null
+		}
+
 		if (frozenTooltip !== undefined) {
 			active = true
 			payload = frozenTooltip.activePayload

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -1340,6 +1340,7 @@ const Graph = ({
 				innerChart = (
 					<LineChart
 						data={data}
+						syncId={syncId}
 						xAxisMetric={xAxisMetric}
 						viewConfig={viewConfig}
 						spotlight={spotlight}
@@ -1347,7 +1348,6 @@ const Graph = ({
 						loadExemplars={loadExemplars}
 						minYAxisMax={axisLimit}
 						maxYAxisMin={axisLimit}
-						syncId={syncId}
 						showGrid
 					>
 						{children}
@@ -1382,6 +1382,7 @@ const Graph = ({
 				innerChart = (
 					<BarChart
 						data={data}
+						syncId={syncId}
 						xAxisMetric={xAxisMetric}
 						viewConfig={viewConfig}
 						spotlight={spotlight}

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -279,13 +279,12 @@ export const useGraphCallbacks = (
 
 	const onMouseMove = allowDrag
 		? (e: CategoricalChartState) => {
-				setDisplayTooltip(true)
 				if (refAreaStart !== undefined && e.activeLabel !== undefined) {
 					setRefAreaEnd(Number(e.activeLabel))
 					setFrozenTooltip(undefined)
 				}
 			}
-		: () => setDisplayTooltip(true)
+		: undefined
 
 	const onMouseUp = allowDrag
 		? () => {
@@ -313,6 +312,10 @@ export const useGraphCallbacks = (
 		setRefAreaStart(undefined)
 		setRefAreaEnd(undefined)
 		setDisplayTooltip(false)
+	}
+
+	const onMouseOver = () => {
+		setDisplayTooltip(true)
 	}
 
 	const onTooltipMouseLeave = () => {
@@ -365,6 +368,7 @@ export const useGraphCallbacks = (
 		onMouseMove,
 		onMouseUp,
 		onMouseLeave,
+		onMouseOver,
 	}
 }
 

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -317,8 +317,6 @@ export const useGraphCallbacks = (
 
 	const onTooltipMouseLeave = () => {
 		setFrozenTooltip(undefined)
-		setRefAreaStart(undefined)
-		setRefAreaEnd(undefined)
 	}
 
 	const tooltip = (

--- a/frontend/src/pages/Graphing/components/LineChart.tsx
+++ b/frontend/src/pages/Graphing/components/LineChart.tsx
@@ -81,6 +81,7 @@ export const LineChart = ({
 	strokeColors,
 	minYAxisMax,
 	maxYAxisMin,
+	syncId,
 }: React.PropsWithChildren<
 	InnerChartProps<LineChartConfig> & SeriesInfo & AxisConfig
 >) => {
@@ -152,6 +153,7 @@ export const LineChart = ({
 				onMouseUp={onMouseUp}
 				onMouseLeave={onMouseLeave}
 				style={tooltipCanFreeze ? { cursor: 'pointer' } : undefined}
+				syncId={syncId}
 			>
 				{referenceArea}
 				{children}

--- a/frontend/src/pages/Graphing/components/LineChart.tsx
+++ b/frontend/src/pages/Graphing/components/LineChart.tsx
@@ -148,12 +148,12 @@ export const LineChart = ({
 		<ResponsiveContainer height="100%" width="100%" ref={chartRef}>
 			<AreaChart
 				data={filledData}
+				syncId={syncId}
 				onMouseDown={onMouseDown}
 				onMouseMove={onMouseMove}
 				onMouseUp={onMouseUp}
 				onMouseLeave={onMouseLeave}
 				style={tooltipCanFreeze ? { cursor: 'pointer' } : undefined}
-				syncId={syncId}
 			>
 				{referenceArea}
 				{children}

--- a/frontend/src/pages/Graphing/components/LineChart.tsx
+++ b/frontend/src/pages/Graphing/components/LineChart.tsx
@@ -146,186 +146,196 @@ export const LineChart = ({
 	}, [maxYAxisMin, minYAxisMax])
 
 	return (
-		<ResponsiveContainer
-			height="100%"
-			width="100%"
-			ref={chartRef}
-			onMouseLeave={onMouseLeave}
-			onMouseOver={onMouseOver}
-		>
-			<AreaChart
-				data={filledData}
-				syncId={syncId}
-				onMouseDown={onMouseDown}
-				onMouseMove={onMouseMove}
-				onMouseUp={onMouseUp}
-				onMouseLeave={onMouseLeave}
-				style={tooltipCanFreeze ? { cursor: 'pointer' } : undefined}
-			>
-				{referenceArea}
-				{children}
-				<XAxis
-					dataKey={xAxisMetric}
-					fontSize={10}
-					tick={(props: any) => (
-						<CustomXAxisTick
-							x={props.x}
-							y={props.y}
-							payload={props.payload}
-							tickFormatter={xAxisTickFormatter}
-						/>
-					)}
-					tickFormatter={xAxisTickFormatter}
-					tickLine={{ visibility: 'hidden' }}
-					axisLine={{ visibility: 'hidden' }}
-					height={12}
-					domain={['dataMin', 'dataMax']}
-					hide={showXAxis === false}
-				/>
-
-				{tooltip}
-
-				<YAxis
-					fontSize={10}
-					tickLine={{ visibility: 'hidden' }}
-					axisLine={{ visibility: 'hidden' }}
-					tick={(props: any) => (
-						<CustomYAxisTick
-							y={props.y}
-							payload={props.payload}
-							tickFormatter={yAxisTickFormatter}
-						/>
-					)}
-					tickFormatter={yAxisTickFormatter}
-					tickCount={7}
-					width={32}
-					type="number"
-					hide={showYAxis === false}
-					domain={yAxisDomain}
-				/>
-
-				{showGrid && (
-					<CartesianGrid
-						strokeDasharray=""
-						vertical={false}
-						stroke={vars.theme.static.divider.weak}
+		<span onMouseOver={onMouseOver}>
+			<ResponsiveContainer height="100%" width="100%" ref={chartRef}>
+				<AreaChart
+					data={filledData}
+					syncId={syncId}
+					onMouseDown={onMouseDown}
+					onMouseMove={onMouseMove}
+					onMouseUp={onMouseUp}
+					onMouseLeave={onMouseLeave}
+					style={tooltipCanFreeze ? { cursor: 'pointer' } : undefined}
+				>
+					{referenceArea}
+					{children}
+					<XAxis
+						dataKey={xAxisMetric}
+						fontSize={10}
+						tick={(props: any) => (
+							<CustomXAxisTick
+								x={props.x}
+								y={props.y}
+								payload={props.payload}
+								tickFormatter={xAxisTickFormatter}
+							/>
+						)}
+						tickFormatter={xAxisTickFormatter}
+						tickLine={{ visibility: 'hidden' }}
+						axisLine={{ visibility: 'hidden' }}
+						height={12}
+						domain={['dataMin', 'dataMax']}
+						hide={showXAxis === false}
 					/>
-				)}
 
-				{series.length > 0 &&
-					series.map((s, idx) => {
-						const seriesKey = getSeriesKey(s)
+					{tooltip}
 
-						if (!isActive(spotlight, idx)) {
-							return null
-						}
+					<YAxis
+						fontSize={10}
+						tickLine={{ visibility: 'hidden' }}
+						axisLine={{ visibility: 'hidden' }}
+						tick={(props: any) => (
+							<CustomYAxisTick
+								y={props.y}
+								payload={props.payload}
+								tickFormatter={yAxisTickFormatter}
+							/>
+						)}
+						tickFormatter={yAxisTickFormatter}
+						tickCount={7}
+						width={32}
+						type="number"
+						hide={showYAxis === false}
+						domain={yAxisDomain}
+					/>
 
-						const CustomizedDot = (props: any) => {
-							if (data === undefined) {
+					{showGrid && (
+						<CartesianGrid
+							strokeDasharray=""
+							vertical={false}
+							stroke={vars.theme.static.divider.weak}
+						/>
+					)}
+
+					{series.length > 0 &&
+						series.map((s, idx) => {
+							const seriesKey = getSeriesKey(s)
+
+							if (!isActive(spotlight, idx)) {
 								return null
 							}
 
-							const { cx, cy, stroke, index } = props
+							const CustomizedDot = (props: any) => {
+								if (data === undefined) {
+									return null
+								}
 
-							if (isAnomaly(props, seriesKey)) {
-								return (
-									<>
+								const { cx, cy, stroke, index } = props
+
+								if (isAnomaly(props, seriesKey)) {
+									return (
+										<>
+											<svg x={cx - 2} y={cy - 2}>
+												<g transform="translate(2 2)">
+													<circle
+														r="2"
+														fill="#E5484D"
+													/>
+												</g>
+											</svg>
+											<svg x={cx - 4} y={cy - 4}>
+												<g transform="translate(4 4)">
+													<circle
+														r="4"
+														fill="#E5484D"
+														opacity={0.5}
+													/>
+												</g>
+											</svg>
+										</>
+									)
+								}
+
+								if (
+									viewConfig.nullHandling !== 'Hidden' &&
+									viewConfig.nullHandling !== undefined
+								) {
+									return null
+								}
+
+								const hasPrev =
+									index === 0 ||
+									![null, undefined].includes(
+										data[index - 1][seriesKey],
+									)
+								const hasCur = ![null, undefined].includes(
+									data[index][seriesKey],
+								)
+								const hasNext =
+									index === data.length - 1 ||
+									![null, undefined].includes(
+										data[index + 1][seriesKey],
+									)
+
+								if (hasCur && (!hasPrev || !hasNext)) {
+									return (
 										<svg x={cx - 2} y={cy - 2}>
 											<g transform="translate(2 2)">
-												<circle r="2" fill="#E5484D" />
+												<circle r="2" fill={stroke} />
 											</g>
 										</svg>
-										<svg x={cx - 4} y={cy - 4}>
-											<g transform="translate(4 4)">
-												<circle
-													r="4"
-													fill="#E5484D"
-													opacity={0.5}
-												/>
-											</g>
-										</svg>
-									</>
-								)
-							}
+									)
+								}
 
-							if (
-								viewConfig.nullHandling !== 'Hidden' &&
-								viewConfig.nullHandling !== undefined
-							) {
 								return null
 							}
 
-							const hasPrev =
-								index === 0 ||
-								![null, undefined].includes(
-									data[index - 1][seriesKey],
-								)
-							const hasCur = ![null, undefined].includes(
-								data[index][seriesKey],
-							)
-							const hasNext =
-								index === data.length - 1 ||
-								![null, undefined].includes(
-									data[index + 1][seriesKey],
-								)
+							const ActiveDot = (props: any) => {
+								const { cx, cy, fill } = props
 
-							if (hasCur && (!hasPrev || !hasNext)) {
+								if (
+									cy === null ||
+									isAnomaly(props, seriesKey)
+								) {
+									return
+								}
+
 								return (
-									<svg x={cx - 2} y={cy - 2}>
-										<g transform="translate(2 2)">
-											<circle r="2" fill={stroke} />
+									<svg x={cx - 3} y={cy - 3}>
+										<g transform="translate(3 3)">
+											<circle r="3" fill={fill} />
 										</g>
 									</svg>
 								)
 							}
 
-							return null
-						}
-
-						const ActiveDot = (props: any) => {
-							const { cx, cy, fill } = props
-
-							if (cy === null || isAnomaly(props, seriesKey)) {
-								return
-							}
-
 							return (
-								<svg x={cx - 3} y={cy - 3}>
-									<g transform="translate(3 3)">
-										<circle r="3" fill={fill} />
-									</g>
-								</svg>
+								<Area
+									isAnimationActive={false}
+									key={seriesKey}
+									dataKey={`${seriesKey}.value`}
+									name={s.name}
+									stackId={
+										viewConfig.display === 'Stacked area'
+											? 1
+											: idx
+									}
+									strokeWidth="2px"
+									fill={getColor(
+										idx,
+										seriesKey,
+										strokeColors,
+									)}
+									stroke={getColor(
+										idx,
+										seriesKey,
+										strokeColors,
+									)}
+									fillOpacity={
+										viewConfig.display === 'Stacked area'
+											? 0.1
+											: 0
+									}
+									connectNulls={
+										viewConfig.nullHandling === 'Connected'
+									}
+									activeDot={<ActiveDot />}
+									dot={<CustomizedDot />}
+								/>
 							)
-						}
-
-						return (
-							<Area
-								isAnimationActive={false}
-								key={seriesKey}
-								dataKey={`${seriesKey}.value`}
-								name={s.name}
-								stackId={
-									viewConfig.display === 'Stacked area'
-										? 1
-										: idx
-								}
-								strokeWidth="2px"
-								fill={getColor(idx, seriesKey, strokeColors)}
-								stroke={getColor(idx, seriesKey, strokeColors)}
-								fillOpacity={
-									viewConfig.display === 'Stacked area'
-										? 0.1
-										: 0
-								}
-								connectNulls={
-									viewConfig.nullHandling === 'Connected'
-								}
-								activeDot={<ActiveDot />}
-								dot={<CustomizedDot />}
-							/>
-						)
-					})}
-			</AreaChart>
-		</ResponsiveContainer>
+						})}
+				</AreaChart>
+			</ResponsiveContainer>
+		</span>
 	)
 }

--- a/frontend/src/pages/Graphing/components/LineChart.tsx
+++ b/frontend/src/pages/Graphing/components/LineChart.tsx
@@ -116,7 +116,6 @@ export const LineChart = ({
 		onMouseMove,
 		onMouseUp,
 		onMouseLeave,
-		onMouseEnter,
 	} = useGraphCallbacks(xAxisMetric, setTimeRange, loadExemplars, {
 		dashed: true,
 	})
@@ -154,7 +153,6 @@ export const LineChart = ({
 				onMouseMove={onMouseMove}
 				onMouseUp={onMouseUp}
 				onMouseLeave={onMouseLeave}
-				onMouseEnter={onMouseEnter}
 				style={tooltipCanFreeze ? { cursor: 'pointer' } : undefined}
 			>
 				{referenceArea}

--- a/frontend/src/pages/Graphing/components/LineChart.tsx
+++ b/frontend/src/pages/Graphing/components/LineChart.tsx
@@ -116,6 +116,7 @@ export const LineChart = ({
 		onMouseMove,
 		onMouseUp,
 		onMouseLeave,
+		onMouseOver,
 	} = useGraphCallbacks(xAxisMetric, setTimeRange, loadExemplars, {
 		dashed: true,
 	})
@@ -145,7 +146,13 @@ export const LineChart = ({
 	}, [maxYAxisMin, minYAxisMax])
 
 	return (
-		<ResponsiveContainer height="100%" width="100%" ref={chartRef}>
+		<ResponsiveContainer
+			height="100%"
+			width="100%"
+			ref={chartRef}
+			onMouseLeave={onMouseLeave}
+			onMouseOver={onMouseOver}
+		>
 			<AreaChart
 				data={filledData}
 				syncId={syncId}

--- a/frontend/src/pages/Graphing/components/LineChart.tsx
+++ b/frontend/src/pages/Graphing/components/LineChart.tsx
@@ -116,6 +116,7 @@ export const LineChart = ({
 		onMouseMove,
 		onMouseUp,
 		onMouseLeave,
+		onMouseEnter,
 	} = useGraphCallbacks(xAxisMetric, setTimeRange, loadExemplars, {
 		dashed: true,
 	})
@@ -153,6 +154,7 @@ export const LineChart = ({
 				onMouseMove={onMouseMove}
 				onMouseUp={onMouseUp}
 				onMouseLeave={onMouseLeave}
+				onMouseEnter={onMouseEnter}
 				style={tooltipCanFreeze ? { cursor: 'pointer' } : undefined}
 			>
 				{referenceArea}


### PR DESCRIPTION
## Summary
When hovering over one chart, we should should the same points on other charts on the dashboard. Making it easier to relate charts to each other.

<img width="1719" alt="Screenshot 2024-12-13 at 12 39 17 PM" src="https://github.com/user-attachments/assets/5f303378-6786-47f6-9a6b-22f2324521ad" />

## How did you test this change?
1. Create multiple line charts on the same dashboard.
2. Hover over one of the line charts
- [ ] Hovers over each of the other line charts at the same timestamp

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
