### PR TITLE
Add scheduled tasks for enterprise

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -609,27 +609,8 @@ func main() {
 			go w.GetPublicWorker(kafkaqueue.TopicTypeBatched)(ctx)
 			go w.GetPublicWorker(kafkaqueue.TopicTypeDataSync)(ctx)
 			go w.GetPublicWorker(kafkaqueue.TopicTypeTraces)(ctx)
-			go w.StartLogAlertWatcher(ctx)
-			go w.StartMetricAlertWatcher(ctx)
-			go w.StartSessionDeleteJob(ctx)
-			go func() {
-				w.ReportStripeUsage(ctx)
-				for range time.Tick(time.Hour) {
-					w.ReportStripeUsage(ctx)
-				}
-			}()
-			go func() {
-				w.RefreshMaterializedViews(ctx)
-				for range time.Tick(time.Hour) {
-					w.RefreshMaterializedViews(ctx)
-				}
-			}()
-			go func() {
-				w.AutoResolveStaleErrors(ctx)
-				for range time.Tick(time.Minute) {
-					w.AutoResolveStaleErrors(ctx)
-				}
-			}()
+			go w.ScheduledTasks(ctx)
+
 			if env.IsDevEnv() && env.UseSSL() {
 				log.WithContext(ctx).
 					WithField("runtime", runtimeParsed).

--- a/backend/util/runtime.go
+++ b/backend/util/runtime.go
@@ -53,6 +53,7 @@ const (
 	PublicWorkerTraces       Handler = "public-worker-traces"
 	AutoResolveStaleErrors   Handler = "auto-resolve-stale-errors"
 	StartSessionDeleteJob    Handler = "start-session-delete-job"
+	ScheduledTasks           Handler = "scheduled-tasks"
 )
 
 func (lt Handler) IsValid() bool {

--- a/docker/compose.enterprise.yml
+++ b/docker/compose.enterprise.yml
@@ -71,13 +71,13 @@ services:
             - -runtime=worker
             - -worker-handler=public-worker-traces
 
-    backend-session-cleanup-worker:
+    backend-scheduled-tasks-worker:
         extends: backend-session-worker
-        container_name: backend-session-cleanup-worker
+        container_name: backend-scheduled-tasks-worker
         command:
             - /build/backend
             - -runtime=worker
-            - -worker-handler=start-session-delete-job
+            - -worker-handler=scheduled-tasks
 
     frontend:
         container_name: frontend


### PR DESCRIPTION
## Summary
The on-prem instances are not running the alert checks. Update the yml file to start the scheduled tasks

Note: update the all service to use the same schedule tasks logic.

<img width="835" alt="Screenshot 2024-12-16 at 1 32 59 PM" src="https://github.com/user-attachments/assets/34b1310d-0b11-400a-9b46-5574e4dd4caf" />

## How did you test this change?
1. Run the enterprise app
2. Create a log alert
3. Run an E2E app to kick off logs
- [ ] Alert is evaluated

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
