### PR TITLE
refactor / memoize dashboard dependencies to speed up rendering for related resources

### DIFF
--- a/frontend/src/components/RelatedResources/hooks.ts
+++ b/frontend/src/components/RelatedResources/hooks.ts
@@ -156,20 +156,19 @@ export const useRelatedResource = () => {
 				newResource.canGoBack = true
 			}
 
-			const params = new URLSearchParams(location.search)
-			params.set(
+			searchParams.set(
 				RELATED_RESOURCE_PARAM,
 				btoa(JSON.stringify(newResource)), // setSearchParams encodes the string
 			)
 
-			setSearchParams(Object.fromEntries(params.entries()))
+			setSearchParams(Object.fromEntries(searchParams.entries()))
 			setResource(newResource)
 
 			if (pagination !== null) {
 				panelPaginationVar(pagination)
 			}
 		},
-		[resource, setSearchParams],
+		[resource, searchParams, setSearchParams],
 	)
 
 	const remove = useCallback(() => {
@@ -233,10 +232,6 @@ export const useSetRelatedResource = () => {
 		},
 		[setSearchParams],
 	)
-
-	useEffect(() => {
-		console.log('setSearchParams')
-	}, [setSearchParams])
 
 	return set
 }

--- a/frontend/src/components/RelatedResources/hooks.ts
+++ b/frontend/src/components/RelatedResources/hooks.ts
@@ -1,7 +1,11 @@
 import { makeVar, useReactiveVar } from '@apollo/client'
 import useLocalStorage from '@rehooks/local-storage'
 import { useCallback, useEffect, useState } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import {
+	createSearchParams,
+	useNavigate,
+	useSearchParams,
+} from 'react-router-dom'
 
 import { PlayerSearchParameters } from '@/pages/Player/PlayerHook/utils'
 
@@ -152,19 +156,20 @@ export const useRelatedResource = () => {
 				newResource.canGoBack = true
 			}
 
-			searchParams.set(
+			const params = new URLSearchParams(location.search)
+			params.set(
 				RELATED_RESOURCE_PARAM,
 				btoa(JSON.stringify(newResource)), // setSearchParams encodes the string
 			)
 
-			setSearchParams(Object.fromEntries(searchParams.entries()))
+			setSearchParams(Object.fromEntries(params.entries()))
 			setResource(newResource)
 
 			if (pagination !== null) {
 				panelPaginationVar(pagination)
 			}
 		},
-		[resource, searchParams, setSearchParams],
+		[resource, setSearchParams],
 	)
 
 	const remove = useCallback(() => {
@@ -198,4 +203,40 @@ export const useRelatedResource = () => {
 		setResource,
 		updateQuery,
 	}
+}
+
+export const useSetRelatedResource = () => {
+	const navigate = useNavigate()
+	const setSearchParams = useCallback(
+		(newParams: URLSearchParams) => {
+			const newSearchParams = createSearchParams(newParams)
+			navigate('?' + newSearchParams)
+		},
+		[navigate],
+	)
+
+	const set = useCallback(
+		(
+			newResource: RelatedResource,
+			pagination: PanelPagination | null = null,
+		) => {
+			const params = new URLSearchParams(location.search)
+			params.set(
+				RELATED_RESOURCE_PARAM,
+				btoa(JSON.stringify(newResource)), // setSearchParams encodes the string
+			)
+			setSearchParams(params)
+
+			if (pagination !== null) {
+				panelPaginationVar(pagination)
+			}
+		},
+		[setSearchParams],
+	)
+
+	useEffect(() => {
+		console.log('setSearchParams')
+	}, [setSearchParams])
+
+	return set
 }

--- a/frontend/src/hooks/useSearchTime.ts
+++ b/frontend/src/hooks/useSearchTime.ts
@@ -63,21 +63,20 @@ export function useSearchTime({
 			: new Date(params.start_date!),
 	)
 
-	const updateSearchTime = (
-		start: Date,
-		end: Date,
-		preset?: DateRangePreset,
-	) => {
-		setStartDate(start)
-		setEndDate(end)
-		setSelectedPreset(preset)
-	}
+	const updateSearchTime = useCallback(
+		(start: Date, end: Date, preset?: DateRangePreset) => {
+			setStartDate(start)
+			setEndDate(end)
+			setSelectedPreset(preset)
+		},
+		[],
+	)
 
-	const resetSearchTime = () => {
+	const resetSearchTime = useCallback(() => {
 		const start = presetStartDate(defaultPreset)
 		const end = moment().toDate()
 		updateSearchTime(start, end, defaultPreset)
-	}
+	}, [defaultPreset, updateSearchTime])
 
 	const rebaseSearchTime = useCallback(() => {
 		if (selectedPreset) {

--- a/frontend/src/pages/Alerts/AlertGraph/index.tsx
+++ b/frontend/src/pages/Alerts/AlertGraph/index.tsx
@@ -9,12 +9,11 @@ import {
 	ThresholdType,
 } from '@/graph/generated/schemas'
 import { useProjectId } from '@/hooks/useProjectId'
-import Graph, {
-	getViewConfig,
-	SetTimeRange,
-} from '@/pages/Graphing/components/Graph'
+import Graph, { SetTimeRange } from '@/pages/Graphing/components/Graph'
 
 import * as style from './styles.css'
+import { BarChartConfig } from '@/pages/Graphing/components/BarChart'
+import { LineChartConfig } from '@/pages/Graphing/components/LineChart'
 
 type Props = {
 	alertName: string
@@ -31,6 +30,19 @@ type Props = {
 	endDate: Date
 	selectedPreset?: DateRangePreset
 	updateSearchTime: SetTimeRange
+}
+
+const BAR_CONFIG: BarChartConfig = {
+	type: 'Bar chart',
+	showLegend: true,
+	display: 'Stacked',
+}
+
+const LINE_CONFIG: LineChartConfig = {
+	type: 'Line chart',
+	showLegend: true,
+	display: 'Line',
+	nullHandling: 'Zero',
 }
 
 export const AlertGraph: React.FC<Props> = ({
@@ -54,9 +66,7 @@ export const AlertGraph: React.FC<Props> = ({
 		productType === ProductType.Sessions &&
 		thresholdType === ThresholdType.Constant
 
-	const viewConfig = sessionsProduct
-		? getViewConfig('Bar chart', 'Stacked', 'Zero')
-		: getViewConfig('Line chart', 'Line', 'Zero')
+	const viewConfig = sessionsProduct ? BAR_CONFIG : LINE_CONFIG
 
 	return (
 		<Box cssClass={style.graphWrapper} shadow="small">

--- a/frontend/src/pages/Graphing/Dashboard.tsx
+++ b/frontend/src/pages/Graphing/Dashboard.tsx
@@ -17,6 +17,7 @@ import {
 	Box,
 	Button,
 	DateRangePicker,
+	DateRangePreset,
 	DEFAULT_TIME_PRESETS,
 	IconSolidChartBar,
 	IconSolidCheveronRight,
@@ -47,7 +48,7 @@ import { useProjectId } from '@/hooks/useProjectId'
 import { useSearchTime } from '@/hooks/useSearchTime'
 import { DashboardCard } from '@/pages/Graphing/components/DashboardCard'
 import { EmptyDashboardCallout } from '@/pages/Graphing/components/EmptyDashboardCallout'
-import Graph, { getViewConfig } from '@/pages/Graphing/components/Graph'
+import Graph, { useGetViewConfig } from '@/pages/Graphing/components/Graph'
 import { useParams } from '@/util/react-router/useParams'
 
 import * as style from './Dashboard.css'
@@ -62,6 +63,228 @@ import { exportGraph } from '@pages/Graphing/hooks/exportGraph'
 
 export const HeaderDivider = () => <Box cssClass={style.headerDivider} />
 
+type DashboardCellProps = {
+	g: TGraph
+	startDate: Date
+	endDate: Date
+	selectedPreset: DateRangePreset | undefined
+	updateSearchTime: (start: Date, end: Date, preset?: DateRangePreset) => void
+}
+
+const DashboardCell = ({
+	g,
+	startDate,
+	endDate,
+	selectedPreset,
+	updateSearchTime,
+}: DashboardCellProps) => {
+	const { projectId } = useProjectId()
+	const { dashboard_id } = useParams<{
+		dashboard_id: string
+	}>()
+
+	const isTemp = g.id.startsWith('temp-')
+	const [deleteGraph] = useDeleteGraphMutation()
+	const [upsertGraph] = useUpsertGraphMutation()
+	const tempId = useId()
+
+	const graphContext = useGraphData()
+
+	const { values } = useGraphingVariables(dashboard_id!)
+
+	const navigate = useNavigate()
+
+	const onDownload = useCallback(
+		(g: TGraph) =>
+			exportGraph(
+				g.id,
+				g.title,
+				g.expressions.at(0)?.aggregator ?? '',
+				g.expressions.at(0)?.column ?? '',
+				graphContext.graphData.current
+					? graphContext.graphData.current[g.id]
+					: [],
+			),
+		[graphContext.graphData],
+	)
+
+	const viewConfig = useGetViewConfig(
+		g.type,
+		g.display ?? undefined,
+		g.nullHandling ?? undefined,
+	)
+
+	return (
+		<DashboardCard
+			id={g.id}
+			key={g.id}
+			onClone={
+				isTemp
+					? undefined
+					: () => {
+							const graphInput: GraphInput = {
+								visualizationId: dashboard_id!,
+								afterGraphId: g.id,
+								bucketByKey: g.bucketByKey,
+								bucketCount: g.bucketCount,
+								bucketInterval: g.bucketInterval,
+								display: g.display,
+								groupByKeys: g.groupByKeys,
+								limit: g.limit,
+								limitFunctionType: g.limitFunctionType,
+								limitMetric: g.limitMetric,
+								funnelSteps: g.funnelSteps,
+								nullHandling: g.nullHandling,
+								productType: g.productType,
+								query: g.query,
+								title: g.title,
+								type: g.type,
+								expressions: g.expressions,
+							}
+
+							upsertGraph({
+								variables: {
+									graph: graphInput,
+								},
+								optimisticResponse: {
+									upsertGraph: {
+										...graphInput,
+										id: `temp-${tempId}`,
+										__typename: 'Graph',
+									},
+								},
+								update(cache, result) {
+									const vizId = cache.identify({
+										id: dashboard_id,
+										__typename: 'Visualization',
+									})
+									const afterGraphId = cache.identify({
+										id: g.id,
+										__typename: 'Graph',
+									})
+									const graphId = cache.identify({
+										id: result.data?.upsertGraph.id,
+										__typename: 'Graph',
+									})
+									cache.modify({
+										id: vizId,
+										fields: {
+											graphs(existing = []) {
+												const idx = existing.findIndex(
+													(e: any) =>
+														e.__ref ===
+														afterGraphId,
+												)
+												const clone = [...existing]
+												clone.splice(idx, 0, {
+													__ref: graphId,
+												})
+												return clone
+											},
+										},
+									})
+								},
+							})
+								.then(() => {
+									toast.success(`Metric view cloned`)
+								})
+								.catch(() => {
+									toast.error('Failed to clone metric view')
+								})
+						}
+			}
+			onDelete={
+				isTemp
+					? undefined
+					: () => {
+							deleteGraph({
+								variables: {
+									id: g.id,
+								},
+								optimisticResponse: {
+									deleteGraph: true,
+								},
+								update(cache) {
+									const vizId = cache.identify({
+										id: dashboard_id,
+										__typename: 'Visualization',
+									})
+									const graphId = cache.identify({
+										id: g.id,
+										__typename: 'Graph',
+									})
+									cache.modify({
+										id: vizId,
+										fields: {
+											graphs(existing = []) {
+												const filtered =
+													existing.filter(
+														(e: any) =>
+															e.__ref !== graphId,
+													)
+												return filtered
+											},
+										},
+									})
+								},
+							})
+								.then(() =>
+									toast.success('Metric view deleted'),
+								)
+								.catch(() =>
+									toast.error('Failed to delete metric view'),
+								)
+						}
+			}
+			onExpand={
+				isTemp
+					? undefined
+					: () => {
+							navigate({
+								pathname: `view/${g.id}`,
+								search: location.search,
+							})
+						}
+			}
+			onEdit={
+				isTemp
+					? undefined
+					: () => {
+							navigate({
+								pathname: `edit/${g.id}`,
+								search: location.search,
+							})
+						}
+			}
+			onDownload={() => onDownload(g)}
+		>
+			<Graph
+				id={g.id}
+				title={g.title}
+				viewConfig={viewConfig}
+				productType={g.productType}
+				projectId={projectId}
+				selectedPreset={selectedPreset}
+				startDate={startDate}
+				endDate={endDate}
+				query={g.query}
+				expressions={g.expressions}
+				bucketByKey={g.bucketByKey ?? undefined}
+				bucketByWindow={g.bucketInterval ?? undefined}
+				bucketCount={g.bucketCount ?? undefined}
+				groupByKeys={g.groupByKeys ?? undefined}
+				limit={g.limit ?? undefined}
+				limitFunctionType={g.limitFunctionType ?? undefined}
+				limitMetric={g.limitMetric ?? undefined}
+				funnelSteps={(g.funnelSteps ?? []).map(loadFunnelStep)}
+				setTimeRange={updateSearchTime}
+				variables={values}
+				height={280}
+			/>
+		</DashboardCard>
+	)
+}
+
 export const Dashboard = () => {
 	const { dashboard_id } = useParams<{
 		dashboard_id: string
@@ -73,6 +296,8 @@ export const Dashboard = () => {
 			coordinateGetter: sortableKeyboardCoordinates,
 		}),
 	)
+
+	const graphContext = useGraphData()
 
 	const [showSettingsModal, setShowSettingsModal] = useState(false)
 
@@ -157,8 +382,6 @@ export const Dashboard = () => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [data])
 
-	const { values } = useGraphingVariables(dashboard_id!)
-
 	const [upsertViz] = useUpsertVisualizationMutation()
 
 	const { presets, minDate } = useRetentionPresets()
@@ -171,27 +394,7 @@ export const Dashboard = () => {
 
 	const navigate = useNavigate()
 
-	const [deleteGraph] = useDeleteGraphMutation()
-	const [upsertGraph] = useUpsertGraphMutation()
-	const tempId = useId()
-
-	const graphContext = useGraphData()
-
 	const noGraphs = graphs?.length === 0
-
-	const onDownload = useCallback(
-		(g: TGraph) =>
-			exportGraph(
-				g.id,
-				g.title,
-				g.expressions.at(0)?.aggregator ?? '',
-				g.expressions.at(0)?.column ?? '',
-				graphContext.graphData.current
-					? graphContext.graphData.current[g.id]
-					: [],
-			),
-		[graphContext.graphData],
-	)
 
 	return (
 		<>
@@ -365,321 +568,20 @@ export const Dashboard = () => {
 												items={graphs ?? []}
 												strategy={rectSortingStrategy}
 											>
-												{graphs?.map((g) => {
-													const isTemp =
-														g.id.startsWith('temp-')
-													return (
-														<DashboardCard
-															id={g.id}
-															key={g.id}
-															onClone={
-																isTemp
-																	? undefined
-																	: () => {
-																			const graphInput: GraphInput =
-																				{
-																					visualizationId:
-																						dashboard_id!,
-																					afterGraphId:
-																						g.id,
-																					bucketByKey:
-																						g.bucketByKey,
-																					bucketCount:
-																						g.bucketCount,
-																					bucketInterval:
-																						g.bucketInterval,
-																					display:
-																						g.display,
-																					groupByKeys:
-																						g.groupByKeys,
-																					limit: g.limit,
-																					limitFunctionType:
-																						g.limitFunctionType,
-																					limitMetric:
-																						g.limitMetric,
-																					funnelSteps:
-																						g.funnelSteps,
-																					nullHandling:
-																						g.nullHandling,
-																					productType:
-																						g.productType,
-																					query: g.query,
-																					title: g.title,
-																					type: g.type,
-																					expressions:
-																						g.expressions,
-																				}
-
-																			upsertGraph(
-																				{
-																					variables:
-																						{
-																							graph: graphInput,
-																						},
-																					optimisticResponse:
-																						{
-																							upsertGraph:
-																								{
-																									...graphInput,
-																									id: `temp-${tempId}`,
-																									__typename:
-																										'Graph',
-																								},
-																						},
-																					update(
-																						cache,
-																						result,
-																					) {
-																						const vizId =
-																							cache.identify(
-																								{
-																									id: dashboard_id,
-																									__typename:
-																										'Visualization',
-																								},
-																							)
-																						const afterGraphId =
-																							cache.identify(
-																								{
-																									id: g.id,
-																									__typename:
-																										'Graph',
-																								},
-																							)
-																						const graphId =
-																							cache.identify(
-																								{
-																									id: result
-																										.data
-																										?.upsertGraph
-																										.id,
-																									__typename:
-																										'Graph',
-																								},
-																							)
-																						cache.modify(
-																							{
-																								id: vizId,
-																								fields: {
-																									graphs(
-																										existing = [],
-																									) {
-																										const idx =
-																											existing.findIndex(
-																												(
-																													e: any,
-																												) =>
-																													e.__ref ===
-																													afterGraphId,
-																											)
-																										const clone =
-																											[
-																												...existing,
-																											]
-																										clone.splice(
-																											idx,
-																											0,
-																											{
-																												__ref: graphId,
-																											},
-																										)
-																										return clone
-																									},
-																								},
-																							},
-																						)
-																					},
-																				},
-																			)
-																				.then(
-																					() => {
-																						toast.success(
-																							`Metric view cloned`,
-																						)
-																					},
-																				)
-																				.catch(
-																					() => {
-																						toast.error(
-																							'Failed to clone metric view',
-																						)
-																					},
-																				)
-																		}
-															}
-															onDelete={
-																isTemp
-																	? undefined
-																	: () => {
-																			deleteGraph(
-																				{
-																					variables:
-																						{
-																							id: g.id,
-																						},
-																					optimisticResponse:
-																						{
-																							deleteGraph:
-																								true,
-																						},
-																					update(
-																						cache,
-																					) {
-																						const vizId =
-																							cache.identify(
-																								{
-																									id: dashboard_id,
-																									__typename:
-																										'Visualization',
-																								},
-																							)
-																						const graphId =
-																							cache.identify(
-																								{
-																									id: g.id,
-																									__typename:
-																										'Graph',
-																								},
-																							)
-																						cache.modify(
-																							{
-																								id: vizId,
-																								fields: {
-																									graphs(
-																										existing = [],
-																									) {
-																										const filtered =
-																											existing.filter(
-																												(
-																													e: any,
-																												) =>
-																													e.__ref !==
-																													graphId,
-																											)
-																										return filtered
-																									},
-																								},
-																							},
-																						)
-																					},
-																				},
-																			)
-																				.then(
-																					() =>
-																						toast.success(
-																							'Metric view deleted',
-																						),
-																				)
-																				.catch(
-																					() =>
-																						toast.error(
-																							'Failed to delete metric view',
-																						),
-																				)
-																		}
-															}
-															onExpand={
-																isTemp
-																	? undefined
-																	: () => {
-																			navigate(
-																				{
-																					pathname: `view/${g.id}`,
-																					search: location.search,
-																				},
-																			)
-																		}
-															}
-															onEdit={
-																isTemp
-																	? undefined
-																	: () => {
-																			navigate(
-																				{
-																					pathname: `edit/${g.id}`,
-																					search: location.search,
-																				},
-																			)
-																		}
-															}
-															onDownload={() =>
-																onDownload(g)
-															}
-														>
-															<Graph
-																id={g.id}
-																title={g.title}
-																viewConfig={getViewConfig(
-																	g.type,
-																	g.display ??
-																		undefined,
-																	g.nullHandling ??
-																		undefined,
-																)}
-																productType={
-																	g.productType
-																}
-																projectId={
-																	projectId
-																}
-																selectedPreset={
-																	selectedPreset
-																}
-																startDate={
-																	startDate
-																}
-																endDate={
-																	endDate
-																}
-																query={g.query}
-																expressions={
-																	g.expressions
-																}
-																bucketByKey={
-																	g.bucketByKey ??
-																	undefined
-																}
-																bucketByWindow={
-																	g.bucketInterval ??
-																	undefined
-																}
-																bucketCount={
-																	g.bucketCount ??
-																	undefined
-																}
-																groupByKeys={
-																	g.groupByKeys ??
-																	undefined
-																}
-																limit={
-																	g.limit ??
-																	undefined
-																}
-																limitFunctionType={
-																	g.limitFunctionType ??
-																	undefined
-																}
-																limitMetric={
-																	g.limitMetric ??
-																	undefined
-																}
-																funnelSteps={(
-																	g.funnelSteps ??
-																	[]
-																).map(
-																	loadFunnelStep,
-																)}
-																setTimeRange={
-																	updateSearchTime
-																}
-																variables={
-																	values
-																}
-																height={280}
-															/>
-														</DashboardCard>
-													)
-												})}
+												{graphs?.map((g) => (
+													<DashboardCell
+														key={g.id}
+														g={g}
+														startDate={startDate}
+														endDate={endDate}
+														selectedPreset={
+															selectedPreset
+														}
+														updateSearchTime={
+															updateSearchTime
+														}
+													/>
+												))}
 											</SortableContext>
 										</DndContext>
 									</GraphContextProvider>

--- a/frontend/src/pages/Graphing/ExpandedGraph.tsx
+++ b/frontend/src/pages/Graphing/ExpandedGraph.tsx
@@ -17,7 +17,7 @@ import { Link, useNavigate } from 'react-router-dom'
 import { useGetVisualizationQuery } from '@/graph/generated/hooks'
 import { useProjectId } from '@/hooks/useProjectId'
 import { useSearchTime } from '@/hooks/useSearchTime'
-import Graph, { getViewConfig } from '@/pages/Graphing/components/Graph'
+import Graph, { useGetViewConfig } from '@/pages/Graphing/components/Graph'
 import { HeaderDivider } from '@/pages/Graphing/Dashboard'
 import { GraphBackgroundWrapper } from '@/pages/Graphing/GraphingEditor'
 import { useParams } from '@/util/react-router/useParams'
@@ -54,6 +54,13 @@ export const ExpandedGraph = () => {
 	const { values } = useGraphingVariables(dashboard_id!)
 
 	const g = data?.visualization.graphs.find((g) => g.id === graph_id)
+
+	const viewConfig = useGetViewConfig(
+		g?.type ?? '',
+		g?.display,
+		g?.nullHandling,
+	)
+
 	if (g === undefined) {
 		return null
 	}
@@ -154,11 +161,7 @@ export const ExpandedGraph = () => {
 							<Box px="16" py="12" width="full" height="full">
 								<Graph
 									title={g.title}
-									viewConfig={getViewConfig(
-										g.type,
-										g.display,
-										g.nullHandling,
-									)}
+									viewConfig={viewConfig}
 									productType={g.productType}
 									projectId={projectId}
 									startDate={startDate}

--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -47,8 +47,8 @@ import { useProjectId } from '@/hooks/useProjectId'
 import { useSearchTime } from '@/hooks/useSearchTime'
 import { BAR_DISPLAY, BarDisplay } from '@/pages/Graphing/components/BarChart'
 import Graph, {
-	getViewConfig,
 	TIMESTAMP_KEY,
+	useGetViewConfig,
 	View,
 	VIEW_OPTIONS,
 } from '@/pages/Graphing/components/Graph'
@@ -568,7 +568,7 @@ export const GraphingEditor: React.FC = () => {
 	} else if (viewType === 'Table') {
 		nullHandling = tableNullHandling
 	}
-	const viewConfig = getViewConfig(viewType, display, nullHandling)
+	const viewConfig = useGetViewConfig(viewType, display, nullHandling)
 
 	const searchOptionsConfig = useMemo(() => {
 		return {

--- a/frontend/src/pages/Graphing/components/BarChart.tsx
+++ b/frontend/src/pages/Graphing/components/BarChart.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react'
+import { memo, useId } from 'react'
 import {
 	Bar,
 	CartesianGrid,
@@ -64,7 +64,7 @@ const RoundedBar = (id: string, isLast: boolean) => (props: any) => {
 	)
 }
 
-export const BarChart = ({
+const BarChartImpl = ({
 	data,
 	xAxisMetric,
 	spotlight,
@@ -197,3 +197,5 @@ export const BarChart = ({
 		</ResponsiveContainer>
 	)
 }
+
+export const BarChart = memo(BarChartImpl)

--- a/frontend/src/pages/Graphing/components/FunnelChart.tsx
+++ b/frontend/src/pages/Graphing/components/FunnelChart.tsx
@@ -16,6 +16,7 @@ import {
 	SeriesInfo,
 } from '@/pages/Graphing/components/Graph'
 import { FunnelDisplay } from '@pages/Graphing/components/types'
+import { memo } from 'react'
 
 const getCustomLabel = () => (props: LabelProps) => {
 	return (
@@ -78,7 +79,7 @@ export type FunnelChartConfig = {
 	display?: FunnelDisplay
 }
 
-export const FunnelChart = ({
+const FunnelChartImpl = ({
 	data,
 	children,
 }: React.PropsWithChildren<
@@ -109,3 +110,5 @@ export const FunnelChart = ({
 		</ResponsiveContainer>
 	)
 }
+
+export const FunnelChart = memo(FunnelChartImpl)

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -1145,6 +1145,7 @@ const Graph = ({
 
 	const set = useSetRelatedResource()
 
+	const replacedQuery = replaceQueryVariables(query, variables)
 	const loadExemplars = useCallback(
 		(
 			bucketMin: number | undefined,
@@ -1158,6 +1159,7 @@ const Graph = ({
 				| 'sessions'
 				| 'traces'
 				| 'events'
+
 			switch (productType) {
 				case ProductType.Errors:
 					relatedResourceType = 'errors'
@@ -1181,10 +1183,7 @@ const Graph = ({
 					return
 			}
 
-			let relatedResourceQuery = replaceQueryVariables(
-				stepQuery || query,
-				variables,
-			)
+			let relatedResourceQuery = stepQuery || replacedQuery
 			if (
 				productType !== ProductType.Events &&
 				groupByKeys !== undefined &&
@@ -1231,10 +1230,9 @@ const Graph = ({
 			endDate,
 			groupByKeys,
 			productType,
-			query,
+			replacedQuery,
 			set,
 			startDate,
-			variables,
 		],
 	)
 
@@ -1348,7 +1346,6 @@ const Graph = ({
 					) as unknown as number
 				}
 			})
-
 		return () => {
 			if (!!pollTimeout.current) {
 				clearTimeout(pollTimeout.current)

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -24,12 +24,11 @@ import {
 import { FunnelDisplay } from '@pages/Graphing/components/types'
 import clsx from 'clsx'
 import moment from 'moment'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Area, Tooltip as RechartsTooltip, ReferenceArea } from 'recharts'
 import { CategoricalChartState } from 'recharts/types/chart/types'
 
 import { loadingIcon } from '@/components/Button/style.css'
-import { useRelatedResource } from '@/components/RelatedResources/hooks'
 import { TIME_FORMAT } from '@/components/Search/SearchForm/constants'
 import {
 	GetMetricsQueryResult,
@@ -68,6 +67,7 @@ import { EventSelectionStep } from '@pages/Graphing/util'
 import { useGraphContext } from '../context/GraphContext'
 import { TIME_METRICS } from '@pages/Graphing/constants'
 import _ from 'lodash'
+import { useSetRelatedResource } from '@/components/RelatedResources/hooks'
 
 export type View = 'Line chart' | 'Bar chart' | 'Funnel chart' | 'Table'
 
@@ -684,44 +684,46 @@ export const CustomXAxisTick = ({
 export const isActive = (spotlight: number | undefined, idx: number) =>
 	spotlight === undefined || spotlight === idx
 
-export const getViewConfig = (
+export const useGetViewConfig = (
 	viewType: string,
 	display?: Maybe<string>,
 	nullHandling?: Maybe<string>,
 ): ViewConfig => {
-	let viewConfig: ViewConfig
-	if (viewType === 'Line chart') {
-		viewConfig = {
-			type: viewType,
-			showLegend: true,
-			display: display as LineDisplay,
-			nullHandling: nullHandling as LineNullHandling,
+	return useMemo(() => {
+		let viewConfig: ViewConfig
+		if (viewType === 'Line chart') {
+			viewConfig = {
+				type: viewType,
+				showLegend: true,
+				display: display as LineDisplay,
+				nullHandling: nullHandling as LineNullHandling,
+			}
+		} else if (viewType === 'Bar chart') {
+			viewConfig = {
+				type: viewType,
+				showLegend: true,
+				display: display as BarDisplay,
+			}
+		} else if (viewType === 'Funnel chart') {
+			viewConfig = {
+				type: viewType,
+				showLegend: true,
+				display: display as FunnelDisplay,
+			}
+		} else if (viewType === 'Table') {
+			viewConfig = {
+				type: viewType,
+				showLegend: false,
+				nullHandling: nullHandling as TableNullHandling,
+			}
+		} else {
+			viewConfig = {
+				type: 'Line chart',
+				showLegend: true,
+			}
 		}
-	} else if (viewType === 'Bar chart') {
-		viewConfig = {
-			type: viewType,
-			showLegend: true,
-			display: display as BarDisplay,
-		}
-	} else if (viewType === 'Funnel chart') {
-		viewConfig = {
-			type: viewType,
-			showLegend: true,
-			display: display as FunnelDisplay,
-		}
-	} else if (viewType === 'Table') {
-		viewConfig = {
-			type: viewType,
-			showLegend: false,
-			nullHandling: nullHandling as TableNullHandling,
-		}
-	} else {
-		viewConfig = {
-			type: 'Line chart',
-			showLegend: true,
-		}
-	}
-	return viewConfig
+		return viewConfig
+	}, [display, nullHandling, viewType])
 }
 
 export const getGroupKey = (groups: string[]) => {
@@ -1019,6 +1021,91 @@ const matchParamVariables = (
 	}
 }
 
+const FUNNEL_BAR_CONFIG: BarChartConfig = {
+	shadeToPrevious: true,
+	showLegend: true,
+	type: 'Bar chart',
+	display: 'Stacked',
+	tooltipSettings: { funnelMode: true },
+}
+
+const FUNNEL_LINE_CONFIG: LineChartConfig = {
+	showLegend: true,
+	type: 'Line chart',
+	display: 'Stacked area',
+	tooltipSettings: { funnelMode: true },
+}
+
+type LegendProps = {
+	series: NamedSeries[]
+	spotlight: number | undefined
+	setSpotlight: React.Dispatch<React.SetStateAction<number | undefined>>
+}
+
+const Legend = memo(({ series, spotlight, setSpotlight }: LegendProps) => {
+	return (
+		<Box position="relative" cssClass={style.legendWrapper}>
+			{series.map((s, idx) => {
+				const seriesKey = getSeriesKey(s)
+				return (
+					<Button
+						kind="secondary"
+						emphasis="low"
+						size="xSmall"
+						key={seriesKey}
+						onClick={() => {
+							if (spotlight === idx) {
+								setSpotlight(undefined)
+							} else {
+								setSpotlight(idx)
+							}
+						}}
+						cssClass={style.legendTextButton}
+					>
+						<Tooltip
+							delayed
+							trigger={
+								<>
+									<Box
+										style={{
+											backgroundColor: isActive(
+												spotlight,
+												idx,
+											)
+												? getColor(
+														idx,
+														seriesKey,
+														strokeColors,
+													)
+												: undefined,
+										}}
+										cssClass={style.legendDot}
+									></Box>
+									<Box cssClass={style.legendTextWrapper}>
+										<Text
+											lines="1"
+											color={
+												isActive(spotlight, idx)
+													? undefined
+													: 'n8'
+											}
+											align="left"
+										>
+											{s.name}
+										</Text>
+									</Box>
+								</>
+							}
+						>
+							{s.name}
+						</Tooltip>
+					</Button>
+				)
+			})}
+		</Box>
+	)
+})
+
 const Graph = ({
 	productType,
 	projectId,
@@ -1056,85 +1143,100 @@ const Graph = ({
 	const [results, setResults] = useState<GetMetricsQuery[]>()
 	const [loading, setLoading] = useState<boolean>(true)
 
-	const { set } = useRelatedResource()
+	const set = useSetRelatedResource()
 
-	const loadExemplars = (
-		bucketMin: number | undefined,
-		bucketMax: number | undefined,
-		groups: string[] | undefined,
-		stepQuery: string | undefined,
-	) => {
-		let relatedResourceType:
-			| 'logs'
-			| 'errors'
-			| 'sessions'
-			| 'traces'
-			| 'events'
-		switch (productType) {
-			case ProductType.Errors:
-				relatedResourceType = 'errors'
-				break
-			case ProductType.Logs:
-				relatedResourceType = 'logs'
-				break
-			case ProductType.Sessions:
-				relatedResourceType = 'sessions'
-				break
-			case ProductType.Traces:
-				relatedResourceType = 'traces'
-				break
-			case ProductType.Metrics:
-				relatedResourceType = 'sessions'
-				break
-			case ProductType.Events:
-				relatedResourceType = 'events'
-				groupByKeys = undefined
-				break
-			default:
-				return
-		}
-
-		let relatedResourceQuery = replaceQueryVariables(
-			stepQuery || query,
-			variables,
-		)
-		if (groupByKeys !== undefined && groupByKeys.length > 0) {
-			groups?.forEach((group, idx) => {
-				if (!groupByKeys) {
+	const loadExemplars = useCallback(
+		(
+			bucketMin: number | undefined,
+			bucketMax: number | undefined,
+			groups: string[] | undefined,
+			stepQuery: string | undefined,
+		) => {
+			let relatedResourceType:
+				| 'logs'
+				| 'errors'
+				| 'sessions'
+				| 'traces'
+				| 'events'
+			switch (productType) {
+				case ProductType.Errors:
+					relatedResourceType = 'errors'
+					break
+				case ProductType.Logs:
+					relatedResourceType = 'logs'
+					break
+				case ProductType.Sessions:
+					relatedResourceType = 'sessions'
+					break
+				case ProductType.Traces:
+					relatedResourceType = 'traces'
+					break
+				case ProductType.Metrics:
+					relatedResourceType = 'sessions'
+					break
+				case ProductType.Events:
+					relatedResourceType = 'events'
+					break
+				default:
 					return
-				}
-				if (group !== NO_GROUP_PLACEHOLDER && group !== '') {
-					relatedResourceQuery += ` ${groupByKeys[idx]}="${group}"`
-				} else {
-					relatedResourceQuery += ` ${groupByKeys[idx]} not exists`
-				}
-			})
-		}
-		if (![undefined, TIMESTAMP_KEY].includes(bucketByKey)) {
-			if (relatedResourceQuery !== '') {
-				relatedResourceQuery += ' '
 			}
-			relatedResourceQuery += `${bucketByKey}>=${bucketMin} ${bucketByKey}<${bucketMax}`
-		}
 
-		let startDateStr = moment(startDate).toISOString()
-		let endDateStr = moment(endDate).toISOString()
-		if (bucketByKey === TIMESTAMP_KEY && bucketMin && bucketMax) {
-			startDateStr = (
-				bucketMin ? new Date(bucketMin * 1000) : startDate
-			).toISOString()
-			endDateStr = (
-				bucketMax ? new Date(bucketMax * 1000) : endDate
-			).toISOString()
-		}
+			let relatedResourceQuery = replaceQueryVariables(
+				stepQuery || query,
+				variables,
+			)
+			if (
+				productType !== ProductType.Events &&
+				groupByKeys !== undefined &&
+				groupByKeys.length > 0
+			) {
+				groups?.forEach((group, idx) => {
+					if (!groupByKeys) {
+						return
+					}
+					if (group !== NO_GROUP_PLACEHOLDER && group !== '') {
+						relatedResourceQuery += ` ${groupByKeys[idx]}="${group}"`
+					} else {
+						relatedResourceQuery += ` ${groupByKeys[idx]} not exists`
+					}
+				})
+			}
+			if (![undefined, TIMESTAMP_KEY].includes(bucketByKey)) {
+				if (relatedResourceQuery !== '') {
+					relatedResourceQuery += ' '
+				}
+				relatedResourceQuery += `${bucketByKey}>=${bucketMin} ${bucketByKey}<${bucketMax}`
+			}
 
-		set({
-			type: relatedResourceType,
-			query: relatedResourceQuery,
-			startDate: startDateStr,
-			endDate: endDateStr,
-		})
-	}
+			let startDateStr = moment(startDate).toISOString()
+			let endDateStr = moment(endDate).toISOString()
+			if (bucketByKey === TIMESTAMP_KEY && bucketMin && bucketMax) {
+				startDateStr = (
+					bucketMin ? new Date(bucketMin * 1000) : startDate
+				).toISOString()
+				endDateStr = (
+					bucketMax ? new Date(bucketMax * 1000) : endDate
+				).toISOString()
+			}
+
+			set({
+				type: relatedResourceType,
+				query: relatedResourceQuery,
+				startDate: startDateStr,
+				endDate: endDateStr,
+			})
+		},
+		[
+			bucketByKey,
+			endDate,
+			groupByKeys,
+			productType,
+			query,
+			set,
+			startDate,
+			variables,
+		],
+	)
 
 	const [getMetrics, { called }] = useGetMetricsLazyQuery({})
 
@@ -1306,6 +1408,39 @@ const Graph = ({
 		}
 	}
 
+	const lineChildren = useMemo(
+		() => (
+			<>
+				{children}
+				<Area
+					isAnimationActive={false}
+					dataKey={YHAT_LOWER_REGION_KEY}
+					strokeWidth="2px"
+					strokeDasharray="8 8"
+					strokeLinecap="round"
+					stroke="#C8C7CB"
+					fillOpacity={0}
+					stackId={-1}
+					connectNulls
+					activeDot={<></>}
+				/>
+				<Area
+					isAnimationActive={false}
+					dataKey={YHAT_UPPER_REGION_KEY}
+					strokeWidth="2px"
+					strokeDasharray="8 8"
+					strokeLinecap="round"
+					fill="#F9F8F9"
+					stroke="#C8C7CB"
+					stackId={-1}
+					connectNulls
+					activeDot={<></>}
+				/>
+			</>
+		),
+		[children],
+	)
+
 	let innerChart: JSX.Element | null = null
 	if (isEmpty) {
 		innerChart = (
@@ -1346,31 +1481,7 @@ const Graph = ({
 						maxYAxisMin={axisLimit}
 						showGrid
 					>
-						{children}
-						<Area
-							isAnimationActive={false}
-							dataKey={YHAT_LOWER_REGION_KEY}
-							strokeWidth="2px"
-							strokeDasharray="8 8"
-							strokeLinecap="round"
-							stroke="#C8C7CB"
-							fillOpacity={0}
-							stackId={-1}
-							connectNulls
-							activeDot={<></>}
-						/>
-						<Area
-							isAnimationActive={false}
-							dataKey={YHAT_UPPER_REGION_KEY}
-							strokeWidth="2px"
-							strokeDasharray="8 8"
-							strokeLinecap="round"
-							fill="#F9F8F9"
-							stroke="#C8C7CB"
-							stackId={-1}
-							connectNulls
-							activeDot={<></>}
-						/>
+						{lineChildren}
 					</LineChart>
 				)
 				break
@@ -1395,13 +1506,7 @@ const Graph = ({
 						<BarChart
 							data={data}
 							xAxisMetric={xAxisMetric}
-							viewConfig={{
-								shadeToPrevious: true,
-								showLegend: true,
-								type: 'Bar chart',
-								display: 'Stacked',
-								tooltipSettings: { funnelMode: true },
-							}}
+							viewConfig={FUNNEL_BAR_CONFIG}
 							spotlight={spotlight}
 							setTimeRange={setTimeRange}
 							loadExemplars={loadExemplars}
@@ -1415,12 +1520,7 @@ const Graph = ({
 						<LineChart
 							data={data}
 							xAxisMetric={xAxisMetric}
-							viewConfig={{
-								showLegend: true,
-								type: 'Line chart',
-								display: 'Stacked area',
-								tooltipSettings: { funnelMode: true },
-							}}
+							viewConfig={FUNNEL_LINE_CONFIG}
 							spotlight={spotlight}
 							setTimeRange={setTimeRange}
 							loadExemplars={loadExemplars}
@@ -1458,11 +1558,7 @@ const Graph = ({
 		}
 	}
 
-	const showLegend =
-		viewConfig.showLegend &&
-		// ZANETODO
-		// series.join('') !== yAxisFunction &&
-		series.join('') !== ''
+	const showLegend = viewConfig.showLegend && series.join('') !== ''
 	return (
 		<Box
 			position="relative"
@@ -1523,69 +1619,11 @@ const Graph = ({
 					<Box position="relative" cssClass={style.legendLoading} />
 				)}
 			{showLegend && (
-				<Box position="relative" cssClass={style.legendWrapper}>
-					{series.map((s, idx) => {
-						const seriesKey = getSeriesKey(s)
-						return (
-							<Button
-								kind="secondary"
-								emphasis="low"
-								size="xSmall"
-								key={seriesKey}
-								onClick={() => {
-									if (spotlight === idx) {
-										setSpotlight(undefined)
-									} else {
-										setSpotlight(idx)
-									}
-								}}
-								cssClass={style.legendTextButton}
-							>
-								<Tooltip
-									delayed
-									trigger={
-										<>
-											<Box
-												style={{
-													backgroundColor: isActive(
-														spotlight,
-														idx,
-													)
-														? getColor(
-																idx,
-																seriesKey,
-																strokeColors,
-															)
-														: undefined,
-												}}
-												cssClass={style.legendDot}
-											></Box>
-											<Box
-												cssClass={
-													style.legendTextWrapper
-												}
-											>
-												<Text
-													lines="1"
-													color={
-														isActive(spotlight, idx)
-															? undefined
-															: 'n8'
-													}
-													align="left"
-												>
-													{s.name}
-												</Text>
-											</Box>
-										</>
-									}
-								>
-									{s.name}
-								</Tooltip>
-							</Button>
-						)
-					})}
-				</Box>
+				<Legend
+					series={series}
+					spotlight={spotlight}
+					setSpotlight={setSpotlight}
+				/>
 			)}
 		</Box>
 	)

--- a/frontend/src/pages/Graphing/components/LineChart.tsx
+++ b/frontend/src/pages/Graphing/components/LineChart.tsx
@@ -1,5 +1,5 @@
 import { vars } from '@highlight-run/ui/vars'
-import { useMemo } from 'react'
+import { memo, useMemo } from 'react'
 import {
 	Area,
 	AreaChart,
@@ -67,7 +67,7 @@ const isAnomaly = (props: any, key: string) => {
 	return false
 }
 
-export const LineChart = ({
+const LineChartImpl = ({
 	data,
 	xAxisMetric,
 	spotlight,
@@ -320,3 +320,5 @@ export const LineChart = ({
 		</ResponsiveContainer>
 	)
 }
+
+export const LineChart = memo(LineChartImpl)

--- a/frontend/src/pages/Graphing/components/Table.tsx
+++ b/frontend/src/pages/Graphing/components/Table.tsx
@@ -24,6 +24,7 @@ import {
 import * as style from './Table.css'
 import useLocalStorage from '@rehooks/local-storage'
 import _ from 'lodash'
+import { memo } from 'react'
 
 export type TableNullHandling = 'Hide row' | 'Blank' | 'Zero'
 export const TABLE_NULL_HANDLING: TableNullHandling[] = [
@@ -45,7 +46,7 @@ const formatXAxisMetric = (xAxisMetric: string) => {
 	return xAxisMetric
 }
 
-export const MetricTable = ({
+const MetricTableImpl = ({
 	data,
 	xAxisMetric,
 	viewConfig,
@@ -269,3 +270,5 @@ export const MetricTable = ({
 		</Box>
 	)
 }
+
+export const MetricTable = memo(MetricTableImpl)

--- a/frontend/src/pages/Graphing/hooks/useGraphingVariables.tsx
+++ b/frontend/src/pages/Graphing/hooks/useGraphingVariables.tsx
@@ -22,19 +22,20 @@ export function useGraphingVariables(
 
 	const [params, setParams] = useSearchParams()
 
+	const valuesImpl = new Map<string, string[]>()
+	data?.visualization.variables.forEach((v) => {
+		const paramMarshalled = params.get(getQueryKey(v.key))
+		if (paramMarshalled === null) {
+			valuesImpl.set(v.key, v.defaultValues)
+		} else {
+			valuesImpl.set(v.key, JSON.parse(paramMarshalled))
+		}
+	})
+
 	const values = useMemo(() => {
-		const values = new Map<string, string[]>()
-		data?.visualization.variables.forEach((v) => {
-			const paramMarshalled = params.get(getQueryKey(v.key))
-			if (paramMarshalled === null) {
-				values.set(v.key, v.defaultValues)
-			} else {
-				values.set(v.key, JSON.parse(paramMarshalled))
-			}
-		})
-		return values
+		return valuesImpl
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [data?.visualization.variables])
+	}, [JSON.stringify(Object.fromEntries(valuesImpl.entries()))])
 
 	const defaultValues = useMemo(() => {
 		const defaultValues = new Map<string, string[]>()

--- a/frontend/src/pages/Traces/CustomColumns/renderers.tsx
+++ b/frontend/src/pages/Traces/CustomColumns/renderers.tsx
@@ -168,6 +168,7 @@ const SessionColumnRenderer: React.FC<ColumnRendererProps> = ({
 					kind="secondary"
 					shape="basic"
 					iconLeft={<IconSolidPlayCircle />}
+					style={{ cursor: 'pointer' }}
 				>
 					<Text lines="1">{secureSessionID}</Text>
 				</Tag>


### PR DESCRIPTION
## Summary
- unnecessary dependencies were causing graphs to rerender when opening the related resources panel
- memoize graphs and certain props to limit react rendering
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- used the react profiler locally to make sure graphs weren't rerendering + clicktesting in preview env
![Screenshot 2024-12-13 at 2 01 07 PM](https://github.com/user-attachments/assets/5b53537e-1595-4f80-b01e-364fc16f4d83)

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
