### PR TITLE
Add a python logging OTEL quickstart guide

### DIFF
--- a/docs-content/getting-started/5_backend-logging/03_python/1_overview.md
+++ b/docs-content/getting-started/5_backend-logging/03_python/1_overview.md
@@ -18,7 +18,7 @@ If you don't see one of your languages / frameworks below, reach out to us in ou
     <DocsCard title="logging" href="./other.md">
         {"Integrate with Python native logging."}
     </DocsCard>
-    <DocsCard title="Python OpenTelemetry" href="../../7_native-opentelemetry/3_logging.md">
+    <DocsCard title="Python OpenTelemetry" href="./otel.md">
         {"Integrate logging with Native OpenTelemetry."}
     </DocsCard>
 </DocsCardGroup>

--- a/docs-content/getting-started/5_backend-logging/03_python/otel.md
+++ b/docs-content/getting-started/5_backend-logging/03_python/otel.md
@@ -1,0 +1,9 @@
+---
+title: OpenTelemetry
+heading: Logging in Python with OpenTelemetry
+slug: otel
+quickstart: true
+---
+
+<QuickStart content={quickStartContent["backend-logging"]["python"]["otel"]}/>
+

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -55,6 +55,7 @@ import { JSWinstonHTTPJSONLogContent } from './logging/js/winston'
 import { OTLPLoggingContent } from './logging/otlp'
 import { PHPOtherLogContent } from './logging/php/other'
 import { PythonLoguruLogContent } from './logging/python/loguru'
+import { PythonOtelLogContent } from './logging/python/otel'
 import { PythonOtherLogContent } from './logging/python/other'
 import { RubyOtherLogContent } from './logging/ruby/other'
 import { RubyRailsLogContent } from './logging/ruby/rails'
@@ -135,6 +136,7 @@ export enum QuickStartType {
 	PythonDjango = 'django',
 	PythonFastAPI = 'fastapi',
 	PythonLoguru = 'loguru',
+	PythonOtel = 'otel',
 	PythonOther = 'other',
 	PythonAWSFn = 'aws-lambda-python',
 	PythonAzureFn = 'azure-functions',
@@ -304,6 +306,7 @@ export const quickStartContent = {
 			logoUrl: siteUrl('/images/quickstart/python.svg'),
 			[QuickStartType.PythonLoguru]: PythonLoguruLogContent,
 			[QuickStartType.PythonOther]: PythonOtherLogContent,
+			[QuickStartType.PythonOtel]: PythonOtelLogContent,
 		},
 		go: {
 			title: 'Go',

--- a/highlight.io/components/QuickstartContent/logging/python/otel.tsx
+++ b/highlight.io/components/QuickstartContent/logging/python/otel.tsx
@@ -64,7 +64,7 @@ logger.addHandler(console_handler)`,
 			title: 'Send logs using OpenTelemetry!',
 			content:
 				'Logs are reported automatically from OpenTelemetry logging methods. ' +
-				'Visit the [highlight logs portal](http://app.highlight.io/logs) and check that backend logs are coming in.',
+				'Visit the [highlight logs portal](https://app.highlight.io/logs) and check that backend logs are coming in.',
 			code: [
 				{
 					text: `import logging

--- a/highlight.io/components/QuickstartContent/logging/python/otel.tsx
+++ b/highlight.io/components/QuickstartContent/logging/python/otel.tsx
@@ -6,7 +6,7 @@ export const PythonOtelLogContent: QuickStartContent = {
 	title: 'Sending and Filtering Python Logs with OpenTelemetry',
 	subtitle:
 		'Learn how to set up highlight.io with logs from Python using OpenTelemetry.',
-	logoUrl: siteUrl('/images/quickstart/python-otel.png'),
+	logoUrl: siteUrl('/images/quickstart/python.svg'),
 	entries: [
 		{
 			title: 'Set up OpenTelemetry for logging.',

--- a/highlight.io/components/QuickstartContent/logging/python/otel.tsx
+++ b/highlight.io/components/QuickstartContent/logging/python/otel.tsx
@@ -1,0 +1,85 @@
+import { siteUrl } from '../../../../utils/urls'
+import { QuickStartContent } from '../../QuickstartContent'
+import { verifyLogs } from '../shared-snippets'
+
+export const PythonOtelLogContent: QuickStartContent = {
+	title: 'Sending and Filtering Python Logs with OpenTelemetry',
+	subtitle:
+		'Learn how to set up highlight.io with logs from Python using OpenTelemetry.',
+	logoUrl: siteUrl('/images/quickstart/python-otel.png'),
+	entries: [
+		{
+			title: 'Set up OpenTelemetry for logging.',
+			content:
+				'Configure OpenTelemetry to send logs to highlight.io without requiring the Highlight SDK.',
+			code: [
+				{
+					text: `import logging
+from opentelemetry import trace
+from opentelemetry._logs import set_logger_provider
+from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
+import sys
+
+# Define the service name and environment
+service_name = "my-service"
+environment = "production"
+
+# Create a resource with service name and highlight project ID
+resource = Resource.create({
+    "service.name": service_name,
+    "highlight.project_id": "<YOUR_PROJECT_ID>",
+    "environment": environment
+})
+
+# Set up the logger provider with the resource
+logger_provider = LoggerProvider(resource=resource)
+set_logger_provider(logger_provider)
+
+# Configure the OTLP log exporter
+exporter = OTLPLogExporter(endpoint="https://otel.highlight.io:4317", insecure=True)
+logger_provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
+
+# Set up the logger
+logger = logging.getLogger(service_name)
+logger.setLevel(logging.DEBUG)
+
+# Add the OpenTelemetry logging handler
+handler = LoggingHandler(level=logging.DEBUG, logger_provider=logger_provider)
+logger.addHandler(handler)
+
+# Add console handler for stdout
+console_handler = logging.StreamHandler(sys.stdout)
+console_handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+console_handler.setFormatter(formatter)
+logger.addHandler(console_handler)`,
+					language: 'python',
+				},
+			],
+		},
+		{
+			title: 'Send logs using OpenTelemetry!',
+			content:
+				'Logs are reported automatically from OpenTelemetry logging methods. ' +
+				'Visit the [highlight logs portal](http://app.highlight.io/logs) and check that backend logs are coming in.',
+			code: [
+				{
+					text: `import logging
+from opentelemetry import trace
+
+tracer = trace.get_tracer(__name__)
+
+def main():
+    with tracer.start_as_current_span("example-span"):
+        logger.info('hello, world!')
+        logger.warning('whoa there', {'key': 'value'})`,
+					language: 'python',
+				},
+			],
+		},
+		verifyLogs,
+	],
+}

--- a/highlight.io/components/QuickstartContent/logging/python/otel.tsx
+++ b/highlight.io/components/QuickstartContent/logging/python/otel.tsx
@@ -50,7 +50,7 @@ logger.setLevel(logging.DEBUG)
 handler = LoggingHandler(level=logging.DEBUG, logger_provider=logger_provider)
 logger.addHandler(handler)
 
-# Add console handler for stdout
+# Add console handler for stdout (optional)
 console_handler = logging.StreamHandler(sys.stdout)
 console_handler.setLevel(logging.DEBUG)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
## Summary

Adds a simple python logging OTEL quickstart guide.

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

n/a

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

n/a

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

n/a
<!--
 Request review from julian-highlight / our design team 
-->
