### PR TITLE
Project and workspace settings admin validation

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -889,8 +889,8 @@ type ComplexityRoot struct {
 		DeleteSessionComment                  func(childComplexity int, id int) int
 		DeleteSessions                        func(childComplexity int, projectID int, params model.QueryInput, sessionCount int) int
 		DeleteVisualization                   func(childComplexity int, id int) int
-		EditProject                           func(childComplexity int, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, filterChromeExtension *bool) int
-		EditProjectSettings                   func(childComplexity int, projectID int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, filterChromeExtension *bool, filterSessionsWithoutError *bool, autoResolveStaleErrorsDayInterval *int, sampling *model.SamplingInput) int
+		EditProject                           func(childComplexity int, id int, name *string, billingEmail *string) int
+		EditProjectSettings                   func(childComplexity int, projectID int, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, filterChromeExtension *bool, filterSessionsWithoutError *bool, autoResolveStaleErrorsDayInterval *int, sampling *model.SamplingInput) int
 		EditSavedSegment                      func(childComplexity int, id int, projectID int, name string, entityType model.SavedSegmentEntityType, query string) int
 		EditServiceGithubSettings             func(childComplexity int, id int, projectID int, githubRepoPath *string, buildPrefix *string, githubPrefix *string) int
 		EditWorkspace                         func(childComplexity int, id int, name *string) int
@@ -1790,8 +1790,8 @@ type MutationResolver interface {
 	CreateAdmin(ctx context.Context) (*model1.Admin, error)
 	CreateProject(ctx context.Context, name string, workspaceID int) (*model1.Project, error)
 	CreateWorkspace(ctx context.Context, name string, promoCode *string) (*model1.Workspace, error)
-	EditProject(ctx context.Context, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, filterChromeExtension *bool) (*model1.Project, error)
-	EditProjectSettings(ctx context.Context, projectID int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, filterChromeExtension *bool, filterSessionsWithoutError *bool, autoResolveStaleErrorsDayInterval *int, sampling *model.SamplingInput) (*model.AllProjectSettings, error)
+	EditProject(ctx context.Context, id int, name *string, billingEmail *string) (*model1.Project, error)
+	EditProjectSettings(ctx context.Context, projectID int, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, filterChromeExtension *bool, filterSessionsWithoutError *bool, autoResolveStaleErrorsDayInterval *int, sampling *model.SamplingInput) (*model.AllProjectSettings, error)
 	EditWorkspace(ctx context.Context, id int, name *string) (*model1.Workspace, error)
 	EditWorkspaceSettings(ctx context.Context, workspaceID int, aiApplication *bool, aiInsights *bool, aiQueryBuilder *bool) (*model1.AllWorkspaceSettings, error)
 	ExportSession(ctx context.Context, sessionSecureID string) (bool, error)
@@ -6168,7 +6168,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.EditProject(childComplexity, args["id"].(int), args["name"].(*string), args["billing_email"].(*string), args["excluded_users"].(pq.StringArray), args["error_filters"].(pq.StringArray), args["error_json_paths"].(pq.StringArray), args["rage_click_window_seconds"].(*int), args["rage_click_radius_pixels"].(*int), args["rage_click_count"].(*int), args["filter_chrome_extension"].(*bool)), true
+		return e.complexity.Mutation.EditProject(childComplexity, args["id"].(int), args["name"].(*string), args["billing_email"].(*string)), true
 
 	case "Mutation.editProjectSettings":
 		if e.complexity.Mutation.EditProjectSettings == nil {
@@ -6180,7 +6180,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.EditProjectSettings(childComplexity, args["projectId"].(int), args["name"].(*string), args["billing_email"].(*string), args["excluded_users"].(pq.StringArray), args["error_filters"].(pq.StringArray), args["error_json_paths"].(pq.StringArray), args["rage_click_window_seconds"].(*int), args["rage_click_radius_pixels"].(*int), args["rage_click_count"].(*int), args["filter_chrome_extension"].(*bool), args["filterSessionsWithoutError"].(*bool), args["autoResolveStaleErrorsDayInterval"].(*int), args["sampling"].(*model.SamplingInput)), true
+		return e.complexity.Mutation.EditProjectSettings(childComplexity, args["projectId"].(int), args["excluded_users"].(pq.StringArray), args["error_filters"].(pq.StringArray), args["error_json_paths"].(pq.StringArray), args["rage_click_window_seconds"].(*int), args["rage_click_radius_pixels"].(*int), args["rage_click_count"].(*int), args["filter_chrome_extension"].(*bool), args["filterSessionsWithoutError"].(*bool), args["autoResolveStaleErrorsDayInterval"].(*int), args["sampling"].(*model.SamplingInput)), true
 
 	case "Mutation.editSavedSegment":
 		if e.complexity.Mutation.EditSavedSegment == nil {
@@ -14407,22 +14407,9 @@ type Mutation {
 	createAdmin: Admin!
 	createProject(name: String!, workspace_id: ID!): Project
 	createWorkspace(name: String!, promo_code: String): Workspace
-	editProject(
-		id: ID!
-		name: String
-		billing_email: String
-		excluded_users: StringArray
-		error_filters: StringArray
-		error_json_paths: StringArray
-		rage_click_window_seconds: Int
-		rage_click_radius_pixels: Int
-		rage_click_count: Int
-		filter_chrome_extension: Boolean
-	): Project
+	editProject(id: ID!, name: String, billing_email: String): Project
 	editProjectSettings(
 		projectId: ID!
-		name: String
-		billing_email: String
 		excluded_users: StringArray
 		error_filters: StringArray
 		error_json_paths: StringArray
@@ -16553,114 +16540,96 @@ func (ec *executionContext) field_Mutation_editProjectSettings_args(ctx context.
 		}
 	}
 	args["projectId"] = arg0
-	var arg1 *string
-	if tmp, ok := rawArgs["name"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
-		arg1, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["name"] = arg1
-	var arg2 *string
-	if tmp, ok := rawArgs["billing_email"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("billing_email"))
-		arg2, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["billing_email"] = arg2
-	var arg3 pq.StringArray
+	var arg1 pq.StringArray
 	if tmp, ok := rawArgs["excluded_users"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("excluded_users"))
+		arg1, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["excluded_users"] = arg1
+	var arg2 pq.StringArray
+	if tmp, ok := rawArgs["error_filters"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("error_filters"))
+		arg2, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["error_filters"] = arg2
+	var arg3 pq.StringArray
+	if tmp, ok := rawArgs["error_json_paths"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("error_json_paths"))
 		arg3, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["excluded_users"] = arg3
-	var arg4 pq.StringArray
-	if tmp, ok := rawArgs["error_filters"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("error_filters"))
-		arg4, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["error_filters"] = arg4
-	var arg5 pq.StringArray
-	if tmp, ok := rawArgs["error_json_paths"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("error_json_paths"))
-		arg5, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["error_json_paths"] = arg5
-	var arg6 *int
+	args["error_json_paths"] = arg3
+	var arg4 *int
 	if tmp, ok := rawArgs["rage_click_window_seconds"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_window_seconds"))
+		arg4, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["rage_click_window_seconds"] = arg4
+	var arg5 *int
+	if tmp, ok := rawArgs["rage_click_radius_pixels"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_radius_pixels"))
+		arg5, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["rage_click_radius_pixels"] = arg5
+	var arg6 *int
+	if tmp, ok := rawArgs["rage_click_count"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_count"))
 		arg6, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["rage_click_window_seconds"] = arg6
-	var arg7 *int
-	if tmp, ok := rawArgs["rage_click_radius_pixels"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_radius_pixels"))
-		arg7, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["rage_click_radius_pixels"] = arg7
-	var arg8 *int
-	if tmp, ok := rawArgs["rage_click_count"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_count"))
-		arg8, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["rage_click_count"] = arg8
-	var arg9 *bool
+	args["rage_click_count"] = arg6
+	var arg7 *bool
 	if tmp, ok := rawArgs["filter_chrome_extension"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("filter_chrome_extension"))
-		arg9, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		arg7, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["filter_chrome_extension"] = arg9
-	var arg10 *bool
+	args["filter_chrome_extension"] = arg7
+	var arg8 *bool
 	if tmp, ok := rawArgs["filterSessionsWithoutError"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("filterSessionsWithoutError"))
-		arg10, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		arg8, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["filterSessionsWithoutError"] = arg10
-	var arg11 *int
+	args["filterSessionsWithoutError"] = arg8
+	var arg9 *int
 	if tmp, ok := rawArgs["autoResolveStaleErrorsDayInterval"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("autoResolveStaleErrorsDayInterval"))
-		arg11, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		arg9, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["autoResolveStaleErrorsDayInterval"] = arg11
-	var arg12 *model.SamplingInput
+	args["autoResolveStaleErrorsDayInterval"] = arg9
+	var arg10 *model.SamplingInput
 	if tmp, ok := rawArgs["sampling"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sampling"))
-		arg12, err = ec.unmarshalOSamplingInput2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSamplingInput(ctx, tmp)
+		arg10, err = ec.unmarshalOSamplingInput2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSamplingInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["sampling"] = arg12
+	args["sampling"] = arg10
 	return args, nil
 }
 
@@ -16694,69 +16663,6 @@ func (ec *executionContext) field_Mutation_editProject_args(ctx context.Context,
 		}
 	}
 	args["billing_email"] = arg2
-	var arg3 pq.StringArray
-	if tmp, ok := rawArgs["excluded_users"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("excluded_users"))
-		arg3, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["excluded_users"] = arg3
-	var arg4 pq.StringArray
-	if tmp, ok := rawArgs["error_filters"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("error_filters"))
-		arg4, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["error_filters"] = arg4
-	var arg5 pq.StringArray
-	if tmp, ok := rawArgs["error_json_paths"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("error_json_paths"))
-		arg5, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["error_json_paths"] = arg5
-	var arg6 *int
-	if tmp, ok := rawArgs["rage_click_window_seconds"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_window_seconds"))
-		arg6, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["rage_click_window_seconds"] = arg6
-	var arg7 *int
-	if tmp, ok := rawArgs["rage_click_radius_pixels"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_radius_pixels"))
-		arg7, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["rage_click_radius_pixels"] = arg7
-	var arg8 *int
-	if tmp, ok := rawArgs["rage_click_count"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_count"))
-		arg8, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["rage_click_count"] = arg8
-	var arg9 *bool
-	if tmp, ok := rawArgs["filter_chrome_extension"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("filter_chrome_extension"))
-		arg9, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["filter_chrome_extension"] = arg9
 	return args, nil
 }
 
@@ -46815,7 +46721,7 @@ func (ec *executionContext) _Mutation_editProject(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().EditProject(rctx, fc.Args["id"].(int), fc.Args["name"].(*string), fc.Args["billing_email"].(*string), fc.Args["excluded_users"].(pq.StringArray), fc.Args["error_filters"].(pq.StringArray), fc.Args["error_json_paths"].(pq.StringArray), fc.Args["rage_click_window_seconds"].(*int), fc.Args["rage_click_radius_pixels"].(*int), fc.Args["rage_click_count"].(*int), fc.Args["filter_chrome_extension"].(*bool))
+		return ec.resolvers.Mutation().EditProject(rctx, fc.Args["id"].(int), fc.Args["name"].(*string), fc.Args["billing_email"].(*string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -46897,7 +46803,7 @@ func (ec *executionContext) _Mutation_editProjectSettings(ctx context.Context, f
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().EditProjectSettings(rctx, fc.Args["projectId"].(int), fc.Args["name"].(*string), fc.Args["billing_email"].(*string), fc.Args["excluded_users"].(pq.StringArray), fc.Args["error_filters"].(pq.StringArray), fc.Args["error_json_paths"].(pq.StringArray), fc.Args["rage_click_window_seconds"].(*int), fc.Args["rage_click_radius_pixels"].(*int), fc.Args["rage_click_count"].(*int), fc.Args["filter_chrome_extension"].(*bool), fc.Args["filterSessionsWithoutError"].(*bool), fc.Args["autoResolveStaleErrorsDayInterval"].(*int), fc.Args["sampling"].(*model.SamplingInput))
+		return ec.resolvers.Mutation().EditProjectSettings(rctx, fc.Args["projectId"].(int), fc.Args["excluded_users"].(pq.StringArray), fc.Args["error_filters"].(pq.StringArray), fc.Args["error_json_paths"].(pq.StringArray), fc.Args["rage_click_window_seconds"].(*int), fc.Args["rage_click_radius_pixels"].(*int), fc.Args["rage_click_count"].(*int), fc.Args["filter_chrome_extension"].(*bool), fc.Args["filterSessionsWithoutError"].(*bool), fc.Args["autoResolveStaleErrorsDayInterval"].(*int), fc.Args["sampling"].(*model.SamplingInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -2644,22 +2644,9 @@ type Mutation {
 	createAdmin: Admin!
 	createProject(name: String!, workspace_id: ID!): Project
 	createWorkspace(name: String!, promo_code: String): Workspace
-	editProject(
-		id: ID!
-		name: String
-		billing_email: String
-		excluded_users: StringArray
-		error_filters: StringArray
-		error_json_paths: StringArray
-		rage_click_window_seconds: Int
-		rage_click_radius_pixels: Int
-		rage_click_count: Int
-		filter_chrome_extension: Boolean
-	): Project
+	editProject(id: ID!, name: String, billing_email: String): Project
 	editProjectSettings(
 		projectId: ID!
-		name: String
-		billing_email: String
 		excluded_users: StringArray
 		error_filters: StringArray
 		error_json_paths: StringArray

--- a/e2e/tests/pyproject.toml
+++ b/e2e/tests/pyproject.toml
@@ -5,6 +5,7 @@ description = ""
 authors = ["Vadim Korolik <vkorolik@gmail.com>"]
 license = "Apache-2.0"
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 black = "^24.3.0"

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -1475,40 +1475,11 @@ export type CreateWorkspaceMutationOptions = Apollo.BaseMutationOptions<
 	Types.CreateWorkspaceMutationVariables
 >
 export const EditProjectDocument = gql`
-	mutation EditProject(
-		$id: ID!
-		$name: String
-		$billing_email: String
-		$excluded_users: StringArray
-		$error_filters: StringArray
-		$error_json_paths: StringArray
-		$filter_chrome_extension: Boolean
-		$rage_click_window_seconds: Int
-		$rage_click_radius_pixels: Int
-		$rage_click_count: Int
-	) {
-		editProject(
-			id: $id
-			name: $name
-			billing_email: $billing_email
-			excluded_users: $excluded_users
-			error_filters: $error_filters
-			error_json_paths: $error_json_paths
-			filter_chrome_extension: $filter_chrome_extension
-			rage_click_window_seconds: $rage_click_window_seconds
-			rage_click_radius_pixels: $rage_click_radius_pixels
-			rage_click_count: $rage_click_count
-		) {
+	mutation EditProject($id: ID!, $name: String, $billing_email: String) {
+		editProject(id: $id, name: $name, billing_email: $billing_email) {
 			id
 			name
 			billing_email
-			excluded_users
-			error_filters
-			error_json_paths
-			filter_chrome_extension
-			rage_click_window_seconds
-			rage_click_radius_pixels
-			rage_click_count
 		}
 	}
 `
@@ -1533,13 +1504,6 @@ export type EditProjectMutationFn = Apollo.MutationFunction<
  *      id: // value for 'id'
  *      name: // value for 'name'
  *      billing_email: // value for 'billing_email'
- *      excluded_users: // value for 'excluded_users'
- *      error_filters: // value for 'error_filters'
- *      error_json_paths: // value for 'error_json_paths'
- *      filter_chrome_extension: // value for 'filter_chrome_extension'
- *      rage_click_window_seconds: // value for 'rage_click_window_seconds'
- *      rage_click_radius_pixels: // value for 'rage_click_radius_pixels'
- *      rage_click_count: // value for 'rage_click_count'
  *   },
  * });
  */
@@ -1566,8 +1530,6 @@ export type EditProjectMutationOptions = Apollo.BaseMutationOptions<
 export const EditProjectSettingsDocument = gql`
 	mutation EditProjectSettings(
 		$projectId: ID!
-		$name: String
-		$billing_email: String
 		$excluded_users: StringArray
 		$error_filters: StringArray
 		$error_json_paths: StringArray
@@ -1581,8 +1543,6 @@ export const EditProjectSettingsDocument = gql`
 	) {
 		editProjectSettings(
 			projectId: $projectId
-			name: $name
-			billing_email: $billing_email
 			excluded_users: $excluded_users
 			error_filters: $error_filters
 			error_json_paths: $error_json_paths
@@ -1642,8 +1602,6 @@ export type EditProjectSettingsMutationFn = Apollo.MutationFunction<
  * const [editProjectSettingsMutation, { data, loading, error }] = useEditProjectSettingsMutation({
  *   variables: {
  *      projectId: // value for 'projectId'
- *      name: // value for 'name'
- *      billing_email: // value for 'billing_email'
  *      excluded_users: // value for 'excluded_users'
  *      error_filters: // value for 'error_filters'
  *      error_json_paths: // value for 'error_json_paths'

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -252,37 +252,19 @@ export type EditProjectMutationVariables = Types.Exact<{
 	id: Types.Scalars['ID']
 	name?: Types.Maybe<Types.Scalars['String']>
 	billing_email?: Types.Maybe<Types.Scalars['String']>
-	excluded_users?: Types.Maybe<Types.Scalars['StringArray']>
-	error_filters?: Types.Maybe<Types.Scalars['StringArray']>
-	error_json_paths?: Types.Maybe<Types.Scalars['StringArray']>
-	filter_chrome_extension?: Types.Maybe<Types.Scalars['Boolean']>
-	rage_click_window_seconds?: Types.Maybe<Types.Scalars['Int']>
-	rage_click_radius_pixels?: Types.Maybe<Types.Scalars['Int']>
-	rage_click_count?: Types.Maybe<Types.Scalars['Int']>
 }>
 
 export type EditProjectMutation = { __typename?: 'Mutation' } & {
 	editProject?: Types.Maybe<
 		{ __typename?: 'Project' } & Pick<
 			Types.Project,
-			| 'id'
-			| 'name'
-			| 'billing_email'
-			| 'excluded_users'
-			| 'error_filters'
-			| 'error_json_paths'
-			| 'filter_chrome_extension'
-			| 'rage_click_window_seconds'
-			| 'rage_click_radius_pixels'
-			| 'rage_click_count'
+			'id' | 'name' | 'billing_email'
 		>
 	>
 }
 
 export type EditProjectSettingsMutationVariables = Types.Exact<{
 	projectId: Types.Scalars['ID']
-	name?: Types.Maybe<Types.Scalars['String']>
-	billing_email?: Types.Maybe<Types.Scalars['String']>
 	excluded_users?: Types.Maybe<Types.Scalars['StringArray']>
 	error_filters?: Types.Maybe<Types.Scalars['StringArray']>
 	error_json_paths?: Types.Maybe<Types.Scalars['StringArray']>

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1564,26 +1564,17 @@ export type MutationDeleteVisualizationArgs = {
 
 export type MutationEditProjectArgs = {
 	billing_email?: InputMaybe<Scalars['String']>
-	error_filters?: InputMaybe<Scalars['StringArray']>
-	error_json_paths?: InputMaybe<Scalars['StringArray']>
-	excluded_users?: InputMaybe<Scalars['StringArray']>
-	filter_chrome_extension?: InputMaybe<Scalars['Boolean']>
 	id: Scalars['ID']
 	name?: InputMaybe<Scalars['String']>
-	rage_click_count?: InputMaybe<Scalars['Int']>
-	rage_click_radius_pixels?: InputMaybe<Scalars['Int']>
-	rage_click_window_seconds?: InputMaybe<Scalars['Int']>
 }
 
 export type MutationEditProjectSettingsArgs = {
 	autoResolveStaleErrorsDayInterval?: InputMaybe<Scalars['Int']>
-	billing_email?: InputMaybe<Scalars['String']>
 	error_filters?: InputMaybe<Scalars['StringArray']>
 	error_json_paths?: InputMaybe<Scalars['StringArray']>
 	excluded_users?: InputMaybe<Scalars['StringArray']>
 	filterSessionsWithoutError?: InputMaybe<Scalars['Boolean']>
 	filter_chrome_extension?: InputMaybe<Scalars['Boolean']>
-	name?: InputMaybe<Scalars['String']>
 	projectId: Scalars['ID']
 	rage_click_count?: InputMaybe<Scalars['Int']>
 	rage_click_radius_pixels?: InputMaybe<Scalars['Int']>

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -218,47 +218,16 @@ mutation CreateWorkspace($name: String!, $promo_code: String) {
 	}
 }
 
-mutation EditProject(
-	$id: ID!
-	$name: String
-	$billing_email: String
-	$excluded_users: StringArray
-	$error_filters: StringArray
-	$error_json_paths: StringArray
-	$filter_chrome_extension: Boolean
-	$rage_click_window_seconds: Int
-	$rage_click_radius_pixels: Int
-	$rage_click_count: Int
-) {
-	editProject(
-		id: $id
-		name: $name
-		billing_email: $billing_email
-		excluded_users: $excluded_users
-		error_filters: $error_filters
-		error_json_paths: $error_json_paths
-		filter_chrome_extension: $filter_chrome_extension
-		rage_click_window_seconds: $rage_click_window_seconds
-		rage_click_radius_pixels: $rage_click_radius_pixels
-		rage_click_count: $rage_click_count
-	) {
+mutation EditProject($id: ID!, $name: String, $billing_email: String) {
+	editProject(id: $id, name: $name, billing_email: $billing_email) {
 		id
 		name
 		billing_email
-		excluded_users
-		error_filters
-		error_json_paths
-		filter_chrome_extension
-		rage_click_window_seconds
-		rage_click_radius_pixels
-		rage_click_count
 	}
 }
 
 mutation EditProjectSettings(
 	$projectId: ID!
-	$name: String
-	$billing_email: String
 	$excluded_users: StringArray
 	$error_filters: StringArray
 	$error_json_paths: StringArray
@@ -272,8 +241,6 @@ mutation EditProjectSettings(
 ) {
 	editProjectSettings(
 		projectId: $projectId
-		name: $name
-		billing_email: $billing_email
 		excluded_users: $excluded_users
 		error_filters: $error_filters
 		error_json_paths: $error_json_paths

--- a/frontend/src/pages/ProjectSettings/DangerForm/DangerForm.tsx
+++ b/frontend/src/pages/ProjectSettings/DangerForm/DangerForm.tsx
@@ -8,6 +8,8 @@ import { useParams } from '@util/react-router/useParams'
 import clsx from 'clsx'
 import { useState } from 'react'
 import { Navigate } from 'react-router-dom'
+import { useAuthContext } from '@/authentication/AuthContext'
+import { AdminRole } from '@/graph/generated/schemas'
 
 import commonStyles from '../../../Common.module.css'
 import Button from '../../../components/Button/Button/Button'
@@ -20,6 +22,9 @@ export const DangerForm = () => {
 		skip: !project_id,
 	})
 	const [confirmationText, setConfirmationText] = useState('')
+
+	const { workspaceRole } = useAuthContext()
+	const isAdminRole = workspaceRole === AdminRole.Admin
 
 	const [deleteProject, { loading: deleteLoading, data: deleteData }] =
 		useDeleteProjectMutation({
@@ -37,51 +42,58 @@ export const DangerForm = () => {
 		<>
 			<FieldsBox id="project">
 				<h3>Project Properties</h3>
-				<FieldsForm />
+				<FieldsForm
+					defaultName={data?.project?.name}
+					defaultEmail={data?.project?.billing_email}
+					disabled={!isAdminRole}
+				/>
 			</FieldsBox>
-			<FieldsBox id="danger">
-				<h3>Danger Zone</h3>
+			{isAdminRole && (
+				<FieldsBox id="danger">
+					<h3>Danger Zone</h3>
 
-				<form onSubmit={onSubmit}>
-					{loading ? (
-						<LoadingBox />
-					) : (
-						<>
-							<p className={styles.dangerSubTitle}>
-								This will immediately delete all session and
-								errors in this project. Please type '
-								{`${data?.project?.name}`}' to confirm.
-							</p>
-							<div className={styles.dangerRow}>
-								<Input
-									placeholder={`${data?.project?.name}`}
-									name="text"
-									value={confirmationText}
-									onChange={(e) => {
-										setConfirmationText(e.target.value)
-									}}
-								/>
-								<Button
-									trackingId="DeleteProject"
-									danger
-									type="primary"
-									className={clsx(
-										commonStyles.submitButton,
-										styles.deleteButton,
-									)}
-									disabled={
-										confirmationText !== data?.project?.name
-									}
-									htmlType="submit"
-									loading={deleteLoading}
-								>
-									Delete
-								</Button>
-							</div>
-						</>
-					)}
-				</form>
-			</FieldsBox>
+					<form onSubmit={onSubmit}>
+						{loading ? (
+							<LoadingBox />
+						) : (
+							<>
+								<p className={styles.dangerSubTitle}>
+									This will immediately delete all session and
+									errors in this project. Please type '
+									{`${data?.project?.name}`}' to confirm.
+								</p>
+								<div className={styles.dangerRow}>
+									<Input
+										placeholder={`${data?.project?.name}`}
+										name="text"
+										value={confirmationText}
+										onChange={(e) => {
+											setConfirmationText(e.target.value)
+										}}
+									/>
+									<Button
+										trackingId="DeleteProject"
+										danger
+										type="primary"
+										className={clsx(
+											commonStyles.submitButton,
+											styles.deleteButton,
+										)}
+										disabled={
+											confirmationText !==
+											data?.project?.name
+										}
+										htmlType="submit"
+										loading={deleteLoading}
+									>
+										Delete
+									</Button>
+								</div>
+							</>
+						)}
+					</form>
+				</FieldsBox>
+			)}
 		</>
 	)
 }

--- a/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.module.css
+++ b/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.module.css
@@ -13,7 +13,3 @@
 	display: flex;
 	height: 100%;
 }
-
-.saveButton {
-	width: max-content;
-}

--- a/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
@@ -4,12 +4,18 @@ import { AdminRole } from '@graph/schemas'
 import { Box } from '@highlight-run/ui/components'
 import { AutoJoinForm } from '@pages/WorkspaceTeam/components/AutoJoinForm'
 import { Authorization } from '@util/authorization/authorization'
+import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
+import { useAuthContext } from '@/authentication/AuthContext'
 
 import layoutStyles from '../../components/layout/LeadAlignLayout.module.css'
 import { FieldsForm } from './FieldsForm/FieldsForm'
 import styles from './WorkspaceSettings.module.css'
 
 const WorkspaceSettings = () => {
+	const { currentWorkspace } = useApplicationContext()
+	const { workspaceRole } = useAuthContext()
+	const isAdminRole = workspaceRole === AdminRole.Admin
+
 	return (
 		<Box>
 			<Box style={{ maxWidth: 560 }} my="40" mx="auto">
@@ -23,7 +29,10 @@ const WorkspaceSettings = () => {
 						</div>
 					</div>
 					<FieldsBox id="workspace">
-						<FieldsForm />
+						<FieldsForm
+							defaultName={currentWorkspace?.name}
+							disabled={!isAdminRole}
+						/>
 					</FieldsBox>
 					<FieldsBox id="autojoin">
 						<h3>Auto Join</h3>

--- a/packages/predictions/pyproject.toml
+++ b/packages/predictions/pyproject.toml
@@ -5,6 +5,7 @@ description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
 packages = [{ include = "src" }]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.12"

--- a/packages/predictions/pyproject.toml
+++ b/packages/predictions/pyproject.toml
@@ -5,7 +5,6 @@ description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
 packages = [{ include = "src" }]
-package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.12"


### PR DESCRIPTION
## Summary
Member level users should not be able to edit the names of workspaces/projects or delete projects.

Frontend:
Add frontend level validation to not allow member level edits of these properties. Give a tooltip to explain why the fields are disabled with next steps. Hides delete input entirely to non admin roles.

Also made a couple small tweaks to clean up and low effect style changes to better match other forms.

https://www.loom.com/share/aeadfb8096824627901b1aab0f848954?sid=d4e63bed-8974-48d6-afef-8704c1bec783

Backend:
1. [DeleteProject](https://github.com/highlight/highlight/blob/main/backend/private-graph/graph/schema.resolvers.go#L911) - already limited to only admin level roles
2. EditProject - limit to only admin level roles (only use for name and billing email)
3. EditProjectSettings - no longer calls EditProject and updates project directly for relevant fields that can be edited by all members
4. EditWorkspace - limit to only admin level roles

## How did you test this change?
1. As an admin, edit the name and email of the project
- [ ] Able to save the project name and email
- [ ] Name and email are loaded in when visiting page
- [ ] Able to edit other project settings
2. As an admin, edit the workspace name
- [ ] Able to save the workspace name
- [ ] Name is loaded into input
3. As a member, try to edit the name and email of the project
- [ ] Inputs and save button are disabled
- [ ] Informative tooltip over save button
- [ ] Able to edit other project settings
4. As a member, try to edit the workspace name
- [ ] Inputs and save button are disabled
- [ ] Informative tooltip over save button

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
