### PR TITLE
Update Python / OTEL Copy

### DIFF
--- a/highlight.io/components/QuickstartContent/logging/python/otel.tsx
+++ b/highlight.io/components/QuickstartContent/logging/python/otel.tsx
@@ -3,7 +3,7 @@ import { QuickStartContent } from '../../QuickstartContent'
 import { verifyLogs } from '../shared-snippets'
 
 export const PythonOtelLogContent: QuickStartContent = {
-	title: 'Sending and Filtering Python Logs with OpenTelemetry',
+	title: 'Logging with OpenTelemetry in Python',
 	subtitle:
 		'Learn how to set up highlight.io with logs from Python using OpenTelemetry.',
 	logoUrl: siteUrl('/images/quickstart/python.svg'),


### PR DESCRIPTION
## Summary

Update the copy for the Python / OTEL / Logging text so it reads nicer in the tutorial / docs. 

Before this change it looked like this:
<img width="632" alt="image" src="https://github.com/user-attachments/assets/276ff1ca-c3a8-4c96-ae41-7b7a50ab499c" />


<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
