### PR TITLE
Sync timestamp graphs

### DIFF
--- a/frontend/src/pages/Graphing/components/BarChart.tsx
+++ b/frontend/src/pages/Graphing/components/BarChart.tsx
@@ -22,6 +22,7 @@ import {
 	useGraphCallbacks,
 	useGraphSeries,
 } from '@/pages/Graphing/components/Graph'
+import { syncTimestamp } from '@/pages/Graphing/components/utils'
 
 export type BarDisplay = 'Grouped' | 'Stacked'
 export const BAR_DISPLAY: BarDisplay[] = ['Grouped', 'Stacked']
@@ -114,6 +115,7 @@ const BarChartImpl = ({
 				<RechartsBarChart
 					data={data}
 					syncId={syncId}
+					syncMethod={syncTimestamp}
 					barCategoryGap={1}
 					onMouseDown={onMouseDown}
 					onMouseMove={onMouseMove}

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -1162,6 +1162,7 @@ const Graph = ({
 }: React.PropsWithChildren<ChartProps<ViewConfig>>) => {
 	const { setGraphData } = useGraphContext()
 	const queriedBucketCount = bucketByKey !== undefined ? bucketCount : 1
+	const bucketByTimestamp = bucketByKey === TIMESTAMP_KEY
 
 	const pollTimeout = useRef<number>()
 	const [pollInterval, setPollInterval] = useState<number>(0)
@@ -1496,7 +1497,7 @@ const Graph = ({
 				innerChart = (
 					<LineChart
 						data={data}
-						syncId={syncId}
+						syncId={bucketByTimestamp ? syncId : undefined}
 						xAxisMetric={xAxisMetric}
 						viewConfig={viewConfig}
 						spotlight={spotlight}
@@ -1514,7 +1515,7 @@ const Graph = ({
 				innerChart = (
 					<BarChart
 						data={data}
-						syncId={syncId}
+						syncId={bucketByTimestamp ? syncId : undefined}
 						xAxisMetric={xAxisMetric}
 						viewConfig={viewConfig}
 						spotlight={spotlight}

--- a/frontend/src/pages/Graphing/components/LineChart.tsx
+++ b/frontend/src/pages/Graphing/components/LineChart.tsx
@@ -8,6 +8,7 @@ import {
 	XAxis,
 	YAxis,
 } from 'recharts'
+import { AxisDomain } from 'recharts/types/util/types'
 
 import {
 	AxisConfig,
@@ -25,7 +26,7 @@ import {
 	YHAT_LOWER_KEY,
 	YHAT_UPPER_KEY,
 } from '@/pages/Graphing/components/Graph'
-import { AxisDomain } from 'recharts/types/util/types'
+import { syncTimestamp } from '@/pages/Graphing/components/utils'
 
 export type LineNullHandling = 'Hidden' | 'Connected' | 'Zero'
 export const LINE_NULL_HANDLING: LineNullHandling[] = [
@@ -151,6 +152,7 @@ const LineChartImpl = ({
 				<AreaChart
 					data={filledData}
 					syncId={syncId}
+					syncMethod={syncTimestamp}
 					onMouseDown={onMouseDown}
 					onMouseMove={onMouseMove}
 					onMouseUp={onMouseUp}

--- a/frontend/src/pages/Graphing/components/utils.ts
+++ b/frontend/src/pages/Graphing/components/utils.ts
@@ -1,0 +1,22 @@
+import { isNumber } from 'lodash'
+
+export const syncTimestamp = (ticks: any[], activePoint: any) => {
+	{
+		const activeTimestamp = activePoint?.activeLabel
+		if (!activeTimestamp || !isNumber(activeTimestamp)) {
+			return
+		}
+
+		let closestTick = ticks?.[0]
+		ticks?.forEach((tick: any) => {
+			if (
+				Math.abs(tick.value - activeTimestamp) <
+				Math.abs(closestTick.value - activeTimestamp)
+			) {
+				closestTick = tick
+			}
+		})
+
+		return closestTick?.index
+	}
+}


### PR DESCRIPTION
## Summary
Sync the timestamps of dashboards by the closest value of the timestamp - do not sync graphs that are not bucketed by timestamp.

https://www.loom.com/share/8678ed33fec14ce9aaef0ee96c865f11?sid=4341add1-f031-4c28-96b3-5463a68769e0

## How did you test this change?
1. Create a line chart that is grouped by timestamp and 30 minute intervals
2. Create a line chart that is grouped by timestamp and 1 hour intervals
3. Create a bar chart that is grouped by timestamp and 30 minute intervals
4. Create a line chart that is grouped by something other than timestamp
- [ ] the charts grouped by timestamp show cursor on closest active timestamp when hovering over other charts
- [ ] the chart not grouped by timestamp shows no cursor when hovering over other charts

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
