### PR TITLE
cleanup noisy backend logs

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -3,16 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
+	publicModel "github.com/highlight-run/highlight/backend/public-graph/graph/model"
 	"io"
 	"math/rand"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/highlight-run/highlight/backend/enterprise"
-	"github.com/highlight-run/highlight/backend/env"
-	"github.com/highlight-run/highlight/backend/pricing"
 
 	ghandler "github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/extension"
@@ -33,6 +30,8 @@ import (
 	"github.com/highlight-run/highlight/backend/clickhouse"
 	dd "github.com/highlight-run/highlight/backend/datadog"
 	"github.com/highlight-run/highlight/backend/embeddings"
+	"github.com/highlight-run/highlight/backend/enterprise"
+	"github.com/highlight-run/highlight/backend/env"
 	highlightHttp "github.com/highlight-run/highlight/backend/http"
 	"github.com/highlight-run/highlight/backend/integrations"
 	kafkaqueue "github.com/highlight-run/highlight/backend/kafka-queue"
@@ -42,6 +41,7 @@ import (
 	"github.com/highlight-run/highlight/backend/openai_client"
 	"github.com/highlight-run/highlight/backend/otel"
 	"github.com/highlight-run/highlight/backend/phonehome"
+	"github.com/highlight-run/highlight/backend/pricing"
 	private "github.com/highlight-run/highlight/backend/private-graph/graph"
 	privategen "github.com/highlight-run/highlight/backend/private-graph/graph/generated"
 	public "github.com/highlight-run/highlight/backend/public-graph/graph"
@@ -546,7 +546,7 @@ func main() {
 			})
 
 			publicServer.Use(htrace.NewGraphqlTracer(string(util.PublicGraph)))
-			publicServer.SetErrorPresenter(htrace.GraphQLErrorPresenter(string(util.PublicGraph)))
+			publicServer.SetErrorPresenter(htrace.GraphQLErrorPresenter(string(util.PublicGraph), htrace.WithGraphQLErrorPresenterIgnoredErrors(e.New(string(publicModel.PublicGraphErrorBillingQuotaExceeded)))))
 			publicServer.SetRecoverFunc(htrace.GraphQLRecoverFunc())
 			r.HandleFunc("/cors", assets.HandleAsset)
 			r.Handle("/",

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -49,13 +49,13 @@ func (k *KafkaWorker) log(ctx context.Context, task kafkaqueue.RetryableMessage,
 	if m == nil {
 		return
 	}
-	if m.Partition == 408 || m.Partition == 58 || m.Partition == 289 {
+	if m.Partition%100 == 0 {
 		log.WithContext(ctx).
 			WithField("key", string(m.Key)).
 			WithField("offset", m.Offset).
 			WithField("taskType", task.GetType()).
 			WithField("partition", m.Partition).
-			Info(msg...)
+			Debug(msg...)
 	}
 }
 
@@ -84,7 +84,7 @@ func (k *KafkaWorker) ProcessMessages(ctx context.Context) {
 
 			s2, _ := util.StartSpanFromContext(sCtx, "worker.kafka.processMessage")
 			for i := 0; i <= task.GetMaxRetries(); i++ {
-				k.log(ctx, task, "starting processing", i)
+				k.log(ctx, task, "starting processing ", i)
 				start := time.Now()
 				publicWorkerMessage, ok := task.(*kafka_queue.Message)
 				if !ok {
@@ -97,7 +97,7 @@ func (k *KafkaWorker) ProcessMessages(ctx context.Context) {
 					break
 				}
 			}
-			k.log(ctx, task, "finished processing", task.GetFailures())
+			k.log(ctx, task, "finished processing ", task.GetFailures())
 			s.SetAttribute("taskFailures", task.GetFailures())
 			s2.Finish(err)
 
@@ -131,12 +131,12 @@ func (k *KafkaBatchWorker) log(ctx context.Context, fields log.Fields, msg ...in
 	}
 
 	partitionId := *k.lastPartitionId
-	if partitionId%25 == 0 {
+	if partitionId%10 == 0 {
 		log.WithContext(ctx).
 			WithField("worker_name", k.Name).
 			WithField("partition", partitionId).
 			WithFields(fields).
-			Info(msg...)
+			Debug(msg...)
 	}
 }
 

--- a/sdk/highlight-go/log/console_messages_parser.go
+++ b/sdk/highlight-go/log/console_messages_parser.go
@@ -44,7 +44,9 @@ func ParseConsoleMessages(messages string) ([]*Message, error) {
 			AttributesRaw: message.AttributesRaw,
 			Attributes:    map[string]any{},
 		}
-		if attrString, ok := message.AttributesRaw.(string); ok && attrString != "" {
+		if message.AttributesRaw == nil {
+			// no attributes
+		} else if attrString, ok := message.AttributesRaw.(string); ok && attrString != "" {
 			if err := json.Unmarshal([]byte(attrString), &msg.Attributes); err != nil {
 				log.WithField("attributes.raw", message.AttributesRaw).WithError(err).Warn("error decoding message attributes")
 				msg.Attributes["attributes.raw"] = message.AttributesRaw


### PR DESCRIPTION
## Summary

Removes a number of noisy logs based on 
https://app.highlight.io/1/metrics/21286/view/48313?relative_time=last_7_days and https://app.highlight.io/1/metrics/21286/view/48358?relative_time=last_7_days

These are currently adding substantially to our CloudWatch bill.

## How did you test this change?

![Screenshot from 2025-01-08 00-02-39](https://github.com/user-attachments/assets/5028437e-932b-4381-9021-aaebe58ef2ee)
![Screenshot from 2025-01-08 00-02-33](https://github.com/user-attachments/assets/85dde9b1-b548-4080-ad81-bd84fb440727)


Local deploy still working correctly
![Screenshot from 2025-01-07 23-24-50](https://github.com/user-attachments/assets/2a24c8a7-d5c6-4658-9a49-4193102d1080)
![Screenshot from 2025-01-07 23-28-05](https://github.com/user-attachments/assets/f3a30915-1148-4cc6-951d-6d5583ea5002)
![Screenshot from 2025-01-07 23-27-02](https://github.com/user-attachments/assets/51744c02-6b34-4554-8ff9-3eea3e664185)
![Screenshot from 2025-01-07 23-26-57](https://github.com/user-attachments/assets/3db4b67c-e9c3-407d-a230-795e8a45609d)


## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
