### PR TITLE
fix [object Object] in graph csv export

### DIFF
--- a/frontend/src/pages/Graphing/Dashboard.tsx
+++ b/frontend/src/pages/Graphing/Dashboard.tsx
@@ -57,7 +57,7 @@ import { VariablesBar } from '@/pages/Graphing/components/VariablesBar'
 import { useGraphingVariables } from '@/pages/Graphing/hooks/useGraphingVariables'
 import { useRetentionPresets } from '@/components/Search/SearchForm/hooks'
 import { loadFunnelStep } from '@pages/Graphing/util'
-import { GraphContextProvider } from './context/GraphContext'
+import { GraphContextProvider, useGraphContext } from './context/GraphContext'
 import { useGraphData } from '@pages/Graphing/hooks/useGraphData'
 import { exportGraph } from '@pages/Graphing/hooks/exportGraph'
 import { useGraphTime } from '@/pages/Graphing/hooks/useGraphTime'
@@ -82,28 +82,27 @@ const DashboardCell = ({
 		dashboard_id: string
 	}>()
 
+	const graphContext = useGraphContext()
+
 	const isTemp = g.id.startsWith('temp-')
 	const [deleteGraph] = useDeleteGraphMutation()
 	const [upsertGraph] = useUpsertGraphMutation()
 	const tempId = useId()
-
-	const graphContext = useGraphData()
 
 	const { values } = useGraphingVariables(dashboard_id!)
 
 	const navigate = useNavigate()
 
 	const onDownload = useCallback(
-		(g: TGraph) =>
-			exportGraph(
+		(g: TGraph) => {
+			return exportGraph(
 				g.id,
 				g.title,
-				g.expressions.at(0)?.aggregator ?? '',
-				g.expressions.at(0)?.column ?? '',
 				graphContext.graphData.current
 					? graphContext.graphData.current[g.id]
 					: [],
-			),
+			)
+		},
 		[graphContext.graphData],
 	)
 

--- a/frontend/src/pages/Graphing/hooks/exportGraph.ts
+++ b/frontend/src/pages/Graphing/hooks/exportGraph.ts
@@ -1,14 +1,95 @@
-import { exportFile, processRows } from '@util/session/report'
+import { getSeriesName } from '@/pages/Graphing/components/Graph'
+import { TIME_METRICS } from '@/pages/Graphing/constants'
+import { exportFile } from '@util/session/report'
 import moment from 'moment'
+
+interface GraphSeries {
+	aggregator: string
+	column: string
+	groups: string[]
+}
+
+interface GraphValue {
+	series: GraphSeries
+	value: number | null
+}
+
+interface GraphData {
+	[k: string]: number | string[] | GraphValue
+}
+
+interface GraphKey {
+	name: string
+	index: number
+}
 
 export const exportGraph = async (
 	graphID: string,
 	graphTitle: string,
-	functionType: string,
-	metric: string,
-	data: any[],
+	data: GraphData[],
 ) => {
-	const rows = processRows(data, new Set(['BucketMin', 'BucketMax']), metric)
+	const ignoreKeys = new Set(['BucketMin', 'BucketMax', 'Percent', 'Query'])
+
+	const rows: any[][] = []
+	if (data.length) {
+		const keys = {} as {
+			[key in string]: GraphKey
+		}
+
+		for (const input of data) {
+			Object.entries(input).forEach(([key, value], idx) => {
+				if (ignoreKeys.has(key)) {
+					return
+				}
+
+				if (!key.length) {
+					key = 'Value'
+				}
+				if (!keys.hasOwnProperty(key)) {
+					if (typeof value === 'number' || Array.isArray(value)) {
+						keys[key] = { name: key, index: -1 } // -1 index so this grouping / bucketing column is first
+					} else {
+						const metric = value.series.column
+						let suffix = ''
+						if (metric && Object.hasOwn(TIME_METRICS, metric)) {
+							suffix = ` (${TIME_METRICS[metric as keyof typeof TIME_METRICS]})`
+						}
+						keys[key] = {
+							name:
+								getSeriesName(
+									value.series,
+									true,
+									value.series.groups.length > 0,
+								) + suffix,
+							index: idx,
+						}
+					}
+				}
+			})
+		}
+
+		const sortedKeys = Object.entries(keys).sort(
+			([, key1], [_, key2]) => key1.index - key2.index,
+		)
+
+		rows.push(sortedKeys.map(([_, v]) => v.name))
+
+		for (const input of data) {
+			const row: any[] = []
+			for (const [k] of sortedKeys) {
+				const value = Object.hasOwn(input, k) ? input[k] : null
+				if (value === null || typeof value === 'number') {
+					row.push(value)
+				} else if (Array.isArray(value)) {
+					row.push(value.join(', '))
+				} else {
+					row.push(value.value)
+				}
+			}
+			rows.push(row)
+		}
+	}
+
 	const csvContent = rows
 		.map((rowArray) =>
 			rowArray
@@ -25,7 +106,7 @@ export const exportGraph = async (
 		.join('\r\n')
 	console.info(
 		`exporting graph with ${rows.length} rows, ${csvContent.length} long string.`,
-		{ graphID, graphTitle, functionType, metric, rows },
+		{ graphID, graphTitle, rows },
 	)
 	await exportFile(`graph_${graphID} ${graphTitle}.csv`, csvContent)
 }

--- a/frontend/src/util/session/report.ts
+++ b/frontend/src/util/session/report.ts
@@ -7,14 +7,12 @@ import {
 import { Maybe, Session, SessionsReportRow } from '@graph/schemas'
 import { useProjectId } from '@hooks/useProjectId'
 import moment from 'moment/moment'
-import { TIME_METRICS } from '@pages/Graphing/constants'
 
 export const processRows = <
 	T extends { __typename?: Maybe<string>; user_properties?: Maybe<string> },
 >(
 	inputs: T[],
 	ignoreKeys: Set<keyof T> = new Set<keyof T>([]),
-	metric?: string,
 ) => {
 	ignoreKeys.add('user_properties')
 	ignoreKeys.add('__typename')
@@ -32,11 +30,7 @@ export const processRows = <
 		} catch (e) {}
 		Object.keys(input).forEach((key, idx) => {
 			if (!key.length) {
-				let suffix = ''
-				if (metric && Object.hasOwn(TIME_METRICS, metric)) {
-					suffix = ` (${TIME_METRICS[metric as keyof typeof TIME_METRICS]})`
-				}
-				key = metric ? `${metric}${suffix}` : 'Value'
+				key = 'Value'
 			}
 			if (!keys.hasOwnProperty(key)) {
 				keys[key as keyof T] = idx


### PR DESCRIPTION
## Summary
- splits the session csv and graph csv `processRows` logic into 2 to account for the new format for graph data
- `useGraphContext` to make sure context is shared between all `DashboardCell` instances now
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally with different graph permutations
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
