### PR TITLE
hide use drilldown hint when user is aware

### DIFF
--- a/frontend/src/pages/Graphing/components/DashboardCard.tsx
+++ b/frontend/src/pages/Graphing/components/DashboardCard.tsx
@@ -18,6 +18,7 @@ import clsx from 'clsx'
 
 import * as style from './DashboardCard.css'
 import { useState } from 'react'
+import useLocalStorage from '@rehooks/local-storage'
 
 export const DashboardCard = ({
 	id,
@@ -51,6 +52,11 @@ export const DashboardCard = ({
 	}
 
 	const [graphHover, setGraphHover] = useState(false)
+
+	const [hasDrilledDown] = useLocalStorage<boolean>(
+		'highlight-used-drilldown',
+		false,
+	)
 
 	return (
 		<Box
@@ -191,13 +197,15 @@ export const DashboardCard = ({
 								</Menu>
 							)}
 						</Box>
-						<Badge
-							variant="gray"
-							size="small"
-							iconStart={<IconSolidCursorClick />}
-							label="Click to drilldown"
-							cssClass={style.drilldownHint}
-						/>
+						{!hasDrilledDown && (
+							<Badge
+								variant="gray"
+								size="small"
+								iconStart={<IconSolidCursorClick />}
+								label="Click to drilldown"
+								cssClass={style.drilldownHint}
+							/>
+						)}
 					</Box>
 				)}
 				{children}

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -73,6 +73,7 @@ import { useGraphContext } from '../context/GraphContext'
 import { TIME_METRICS } from '@pages/Graphing/constants'
 import _ from 'lodash'
 import { useSetRelatedResource } from '@/components/RelatedResources/hooks'
+import useLocalStorage from '@rehooks/local-storage'
 
 export type View = 'Line chart' | 'Bar chart' | 'Funnel chart' | 'Table'
 
@@ -1163,6 +1164,12 @@ const Graph = ({
 	const set = useSetRelatedResource()
 
 	const replacedQuery = replaceQueryVariables(query, variables)
+
+	const [hasDrilledDown, setHasDrilledDown] = useLocalStorage<boolean>(
+		'highlight-used-drilldown',
+		false,
+	)
+
 	const loadExemplars = useCallback(
 		(
 			bucketMin: number | undefined,
@@ -1170,6 +1177,10 @@ const Graph = ({
 			groups: string[] | undefined,
 			stepQuery: string | undefined,
 		) => {
+			if (!hasDrilledDown) {
+				setHasDrilledDown(true)
+			}
+
 			let relatedResourceType:
 				| 'logs'
 				| 'errors'
@@ -1246,9 +1257,11 @@ const Graph = ({
 			bucketByKey,
 			endDate,
 			groupByKeys,
+			hasDrilledDown,
 			productType,
 			replacedQuery,
 			set,
+			setHasDrilledDown,
 			startDate,
 		],
 	)


### PR DESCRIPTION
## Summary
- store state in local storage to track if user has used drilldown already
- if so, don't show the `click to drilldown` hint
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
