### PR TITLE
Fix bug when switching between threshold and anomaly alerts

### DIFF
--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -227,6 +227,15 @@ export const AlertForm: React.FC = () => {
 			setThresholdValue(DEFAULT_CONFIDENCE_OPTION.value)
 		} else if (value === ThresholdType.Constant) {
 			setThresholdValue(DEFAULT_THRESHOLD)
+
+			// errors and sessions are currently only grouped by secure_id
+			if (
+				productType === ProductType.Sessions ||
+				productType === ProductType.Errors
+			) {
+				setGroupByEnabled(true)
+				setGroupByKey('secure_id')
+			}
 		}
 
 		setThresholdTypeImpl(value)
@@ -752,7 +761,9 @@ export const AlertForm: React.FC = () => {
 											<OptionDropdown<ThresholdType>
 												options={THRESHOLD_TYPE_OPTIONS}
 												selection={thresholdType}
-												setSelection={setThresholdType}
+												setSelection={
+													handleThresholdTypeChange
+												}
 											/>
 										</LabeledRow>
 										{(isAnomaly || !isSessionAlert) && (

--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -761,9 +761,7 @@ export const AlertForm: React.FC = () => {
 											<OptionDropdown<ThresholdType>
 												options={THRESHOLD_TYPE_OPTIONS}
 												selection={thresholdType}
-												setSelection={
-													handleThresholdTypeChange
-												}
+												setSelection={setThresholdType}
 											/>
 										</LabeledRow>
 										{(isAnomaly || !isSessionAlert) && (


### PR DESCRIPTION
## Summary
Constant threshold alerts for errors and sessions only support grouping by `secure_id`. However, if you switch to anomaly alerts, you can clear/change the group by key. Update the form to reset the `group_by_key` to `secure_id` for constant threshold alerts for errors and sessions.

## How did you test this change?
1. Create a constant threshold alert for sessions/errors
2. Switch it to an anomaly alert
3. Clear the Group By field
4. Switch back to a constant threshold alert
5. Save
- [ ] Alert in DB is saved with `group_by_key = 'secure_id'`

## Are there any deployment considerations?
Check the Prod DB for any alerts that are out of sync

## Does this work require review from our design team?
N/A
