### PR TITLE
improve enterprise deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
               uses: actions/checkout@v4
             - name: Install dependencies
               run: |
-                  sudo yum -y install gnupg gpg
+                  sudo yum -y install gnupg2
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
@@ -45,7 +45,7 @@ jobs:
               uses: actions/checkout@v4
             - name: Install dependencies
               run: |
-                  sudo yum -y install gnupg gpg
+                  sudo yum -y install gnupg2
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
@@ -105,7 +105,7 @@ jobs:
               uses: actions/checkout@v4
             - name: Install dependencies
               run: |
-                  sudo yum -y install gnupg gpg
+                  sudo yum -y install gnupg2
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
@@ -147,7 +147,7 @@ jobs:
               uses: actions/checkout@v4
             - name: Install dependencies
               run: |
-                  sudo yum -y install gnupg gpg
+                  sudo yum -y install gnupg2
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
@@ -195,7 +195,7 @@ jobs:
               uses: actions/checkout@v4
             - name: Install dependencies
               run: |
-                  sudo yum -y install gnupg gpg
+                  sudo yum -y install gnupg2
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
@@ -237,7 +237,7 @@ jobs:
               uses: actions/checkout@v4
             - name: Install dependencies
               run: |
-                  sudo yum -y install gnupg gpg
+                  sudo yum -y install gnupg2
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
@@ -273,7 +273,7 @@ jobs:
               uses: actions/checkout@v4
             - name: Install dependencies
               run: |
-                  sudo yum -y install gnupg gpg
+                  sudo yum -y install gnupg2
             - name: Setup Go
               uses: actions/setup-go@v5
               with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,16 +20,16 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
-            - name: Install dependencies
+            - name: Install Doppler
               run: |
-                  sudo yum -y install gnupg2
+                  sudo rpm --import 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key'
+                  curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/config.rpm.txt' | sudo tee /etc/yum.repos.d/doppler-cli.repo
+                  sudo yum update -y && sudo yum install doppler
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
                   go-version-file: 'backend/go.mod'
                   cache-dependency-path: 'backend/go.sum'
-            - name: Install Doppler CLI
-              uses: dopplerhq/cli-action@v3
             - name: Migrate database
               run: |
                   cd backend/
@@ -43,16 +43,16 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
-            - name: Install dependencies
+            - name: Install Doppler
               run: |
-                  sudo yum -y install gnupg2
+                  sudo rpm --import 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key'
+                  curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/config.rpm.txt' | sudo tee /etc/yum.repos.d/doppler-cli.repo
+                  sudo yum update -y && sudo yum install doppler
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
                   go-version-file: 'backend/go.mod'
                   cache-dependency-path: 'backend/go.sum'
-            - name: Install Doppler CLI
-              uses: dopplerhq/cli-action@v3
             - name: Build and zip
               run: |
                   cd backend/
@@ -103,16 +103,16 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
-            - name: Install dependencies
+            - name: Install Doppler
               run: |
-                  sudo yum -y install gnupg2
+                  sudo rpm --import 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key'
+                  curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/config.rpm.txt' | sudo tee /etc/yum.repos.d/doppler-cli.repo
+                  sudo yum update -y && sudo yum install doppler
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
                   go-version-file: 'backend/go.mod'
                   cache-dependency-path: 'backend/go.sum'
-            - name: Install Doppler CLI
-              uses: dopplerhq/cli-action@v3
             - name: Build and zip
               run: |
                   cd backend/
@@ -145,16 +145,16 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
-            - name: Install dependencies
+            - name: Install Doppler
               run: |
-                  sudo yum -y install gnupg2
+                  sudo rpm --import 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key'
+                  curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/config.rpm.txt' | sudo tee /etc/yum.repos.d/doppler-cli.repo
+                  sudo yum update -y && sudo yum install doppler
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
                   go-version-file: 'backend/go.mod'
                   cache-dependency-path: 'backend/go.sum'
-            - name: Install Doppler CLI
-              uses: dopplerhq/cli-action@v3
             - name: Build and zip
               run: |
                   cd backend/
@@ -193,16 +193,16 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
-            - name: Install dependencies
+            - name: Install Doppler
               run: |
-                  sudo yum -y install gnupg2
+                  sudo rpm --import 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key'
+                  curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/config.rpm.txt' | sudo tee /etc/yum.repos.d/doppler-cli.repo
+                  sudo yum update -y && sudo yum install doppler
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
                   go-version-file: 'backend/go.mod'
                   cache-dependency-path: 'backend/go.sum'
-            - name: Install Doppler CLI
-              uses: dopplerhq/cli-action@v3
             - name: Build and zip
               run: |
                   cd backend/
@@ -235,16 +235,16 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
-            - name: Install dependencies
+            - name: Install Doppler
               run: |
-                  sudo yum -y install gnupg2
+                  sudo rpm --import 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key'
+                  curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/config.rpm.txt' | sudo tee /etc/yum.repos.d/doppler-cli.repo
+                  sudo yum update -y && sudo yum install doppler
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
                   go-version-file: 'backend/go.mod'
                   cache-dependency-path: 'backend/go.sum'
-            - name: Install Doppler CLI
-              uses: dopplerhq/cli-action@v3
             - name: Build and zip
               run: |
                   cd backend/
@@ -271,16 +271,16 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
-            - name: Install dependencies
+            - name: Install Doppler
               run: |
-                  sudo yum -y install gnupg2
+                  sudo rpm --import 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key'
+                  curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/config.rpm.txt' | sudo tee /etc/yum.repos.d/doppler-cli.repo
+                  sudo yum update -y && sudo yum install doppler
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
                   go-version-file: 'backend/go.mod'
                   cache-dependency-path: 'backend/go.sum'
-            - name: Install Doppler CLI
-              uses: dopplerhq/cli-action@v3
             - name: Build and zip
               run: |
                   cd backend/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
               run: |
                   sudo rpm --import 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key'
                   curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/config.rpm.txt' | sudo tee /etc/yum.repos.d/doppler-cli.repo
-                  sudo yum update -y && sudo yum install doppler
+                  sudo yum update -y && sudo yum -y install doppler
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
@@ -47,7 +47,7 @@ jobs:
               run: |
                   sudo rpm --import 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key'
                   curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/config.rpm.txt' | sudo tee /etc/yum.repos.d/doppler-cli.repo
-                  sudo yum update -y && sudo yum install doppler
+                  sudo yum update -y && sudo yum -y install doppler
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
@@ -107,7 +107,7 @@ jobs:
               run: |
                   sudo rpm --import 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key'
                   curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/config.rpm.txt' | sudo tee /etc/yum.repos.d/doppler-cli.repo
-                  sudo yum update -y && sudo yum install doppler
+                  sudo yum update -y && sudo yum -y install doppler
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
@@ -149,7 +149,7 @@ jobs:
               run: |
                   sudo rpm --import 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key'
                   curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/config.rpm.txt' | sudo tee /etc/yum.repos.d/doppler-cli.repo
-                  sudo yum update -y && sudo yum install doppler
+                  sudo yum update -y && sudo yum -y install doppler
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
@@ -197,7 +197,7 @@ jobs:
               run: |
                   sudo rpm --import 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key'
                   curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/config.rpm.txt' | sudo tee /etc/yum.repos.d/doppler-cli.repo
-                  sudo yum update -y && sudo yum install doppler
+                  sudo yum update -y && sudo yum -y install doppler
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
@@ -239,7 +239,7 @@ jobs:
               run: |
                   sudo rpm --import 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key'
                   curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/config.rpm.txt' | sudo tee /etc/yum.repos.d/doppler-cli.repo
-                  sudo yum update -y && sudo yum install doppler
+                  sudo yum update -y && sudo yum -y install doppler
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
@@ -275,7 +275,7 @@ jobs:
               run: |
                   sudo rpm --import 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key'
                   curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/config.rpm.txt' | sudo tee /etc/yum.repos.d/doppler-cli.repo
-                  sudo yum update -y && sudo yum install doppler
+                  sudo yum update -y && sudo yum -y install doppler
             - name: Setup Go
               uses: actions/setup-go@v5
               with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,9 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
+            - name: Install dependencies
+              run: |
+                  sudo yum -y install gnupg gpg
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
@@ -40,6 +43,9 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
+            - name: Install dependencies
+              run: |
+                  sudo yum -y install gnupg gpg
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
@@ -97,6 +103,9 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
+            - name: Install dependencies
+              run: |
+                  sudo yum -y install gnupg gpg
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
@@ -136,6 +145,9 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
+            - name: Install dependencies
+              run: |
+                  sudo yum -y install gnupg gpg
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
@@ -181,6 +193,9 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
+            - name: Install dependencies
+              run: |
+                  sudo yum -y install gnupg gpg
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
@@ -220,6 +235,9 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
+            - name: Install dependencies
+              run: |
+                  sudo yum -y install gnupg gpg
             - name: Setup Go
               uses: actions/setup-go@v5
               with:
@@ -253,6 +271,9 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
+            - name: Install dependencies
+              run: |
+                  sudo yum -y install gnupg gpg
             - name: Setup Go
               uses: actions/setup-go@v5
               with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,14 +63,14 @@ jobs:
                   IMAGE_TAG=$(echo ${{ github.ref_name }} | sed 's/\//-/g')-${{ github.sha }}
                   IMAGE_TAG=ghcr.io/highlight/$IMAGE_NAME:$IMAGE_TAG
                   if [[ ${{ github.event_name }} == 'release' ]]; then
-                    IMAGE_TAG=ghcr.io/highlight/$IMAGE_NAME:latest
-                    PUSH="--push"
+                    IMAGE_TAG=${{ github.event.release.tag_name }}
+                    IMAGE_TAG=ghcr.io/highlight/$IMAGE_NAME:$IMAGE_TAG
+                    PUSH="--push -t $IMAGE_TAG -t ghcr.io/highlight/$IMAGE_NAME:latest"
                   elif [[ ${REF} == 'refs/heads/main' || ${REPO} == 'highlight/highlight' ]]; then
-                    PUSH="--push"
+                    PUSH="--push -t $IMAGE_TAG"
                   else
                     PUSH=""
                   fi
-                  PUSH="$PUSH -t $IMAGE_TAG"
 
                   export PUSH
                   export PLATFORM="--platform linux/arm64,linux/amd64"

--- a/docker/.env
+++ b/docker/.env
@@ -2,10 +2,12 @@
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_PROJECT_NAME=highlight
 COMPOSE_FILE=compose.yml
-# docker images
-BACKEND_IMAGE_NAME=ghcr.io/highlight/highlight-backend:latest
+# docker images for highlight app
+# check https://github.com/highlight/highlight/releases for the latest tag
+BACKEND_IMAGE_NAME=ghcr.io/highlight/highlight-backend:docker-v0.4.10
+FRONTEND_IMAGE_NAME=ghcr.io/highlight/highlight-frontend:docker-v0.4.10
+# docker images for dependencies
 CLICKHOUSE_IMAGE_NAME=clickhouse/clickhouse-server:24.3.15.72-alpine
-FRONTEND_IMAGE_NAME=ghcr.io/highlight/highlight-frontend:latest
 KAFKA_IMAGE_NAME=confluentinc/cp-kafka:7.7.0
 OTEL_COLLECTOR_BUILD_IMAGE_NAME=alpine:3.20.2
 OTEL_COLLECTOR_IMAGE_NAME=otel/opentelemetry-collector-contrib:0.117.0

--- a/docker/compose.enterprise.yml
+++ b/docker/compose.enterprise.yml
@@ -71,6 +71,14 @@ services:
             - -runtime=worker
             - -worker-handler=public-worker-traces
 
+    backend-public-worker-metrics:
+        extends: backend-session-worker
+        container_name: backend-public-worker-metrics
+        command:
+            - /build/backend
+            - -runtime=worker
+            - -worker-handler=public-worker-metrics
+
     backend-scheduled-tasks-worker:
         extends: backend-session-worker
         container_name: backend-scheduled-tasks-worker

--- a/docker/compose.enterprise.yml
+++ b/docker/compose.enterprise.yml
@@ -71,13 +71,29 @@ services:
             - -runtime=worker
             - -worker-handler=public-worker-traces
 
-    backend-public-worker-metrics:
+    backend-public-worker-metric-sum:
         extends: backend-session-worker
-        container_name: backend-public-worker-metrics
+        container_name: backend-public-worker-metric-sum
         command:
             - /build/backend
             - -runtime=worker
-            - -worker-handler=public-worker-metrics
+            - -worker-handler=public-worker-metric-sum
+
+    backend-public-worker-metric-histogram:
+        extends: backend-session-worker
+        container_name: backend-public-worker-metric-histogram
+        command:
+            - /build/backend
+            - -runtime=worker
+            - -worker-handler=public-worker-metric-histogram
+
+    backend-public-worker-metric-summary:
+        extends: backend-session-worker
+        container_name: backend-public-worker-metric-summary
+        command:
+            - /build/backend
+            - -runtime=worker
+            - -worker-handler=public-worker-metric-summary
 
     backend-scheduled-tasks-worker:
         extends: backend-session-worker

--- a/docker/env.sh
+++ b/docker/env.sh
@@ -9,7 +9,7 @@ if [[ "$LICENSE_KEY" != "" ]]; then
 fi
 
 # setup env
-$(cat .env | grep -vE '^#' | grep -E '\S+' | sed -e 's/^/export /')
+$(cat .env | grep -vE '^#' | grep -v BACKEND_IMAGE_NAME | grep -v FRONTEND_IMAGE_NAME | grep -E '\S+' | sed -e 's/^/export /')
 export IN_DOCKER=true
 export BACKEND_HEALTH_URI=$(echo "$REACT_APP_PUBLIC_GRAPH_URI" | sed -e 's/\/public/\/health/')
 export LICENSE_KEY=$LICENSE_KEY_OVERRIDE


### PR DESCRIPTION
## Summary

* Support pinning docker images in the `docker/.env` 
* Fix how metrics workers are spun up in the enterprise deploy
* Push dedicated images for each versioned release (each docker-tag).

## How did you test this change?

CI

## Are there any deployment considerations?

will be released with new tag

## Does this work require review from our design team?

no