### PR TITLE
display admin emails on workspace members page

### DIFF
--- a/frontend/src/pages/WorkspaceTeam/WorkspaceTeam.tsx
+++ b/frontend/src/pages/WorkspaceTeam/WorkspaceTeam.tsx
@@ -53,7 +53,7 @@ const WorkspaceTeam = () => {
 
 	return (
 		<Box>
-			<Box style={{ maxWidth: 720 }} my="40" mx="auto">
+			<Box style={{ maxWidth: 1080 }} my="40" mx="auto">
 				<div className={styles.titleContainer}>
 					<h3>Members</h3>
 					<p className={layoutStyles.subTitle}>

--- a/frontend/src/pages/WorkspaceTeam/WorkspaceTeam.tsx
+++ b/frontend/src/pages/WorkspaceTeam/WorkspaceTeam.tsx
@@ -53,7 +53,7 @@ const WorkspaceTeam = () => {
 
 	return (
 		<Box>
-			<Box style={{ maxWidth: 560 }} my="40" mx="auto">
+			<Box style={{ maxWidth: 720 }} my="40" mx="auto">
 				<div className={styles.titleContainer}>
 					<h3>Members</h3>
 					<p className={layoutStyles.subTitle}>

--- a/frontend/src/pages/WorkspaceTeam/components/AllMembers.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AllMembers.tsx
@@ -182,7 +182,7 @@ export const RoleOptions: Option[] = [
 	},
 ]
 
-const GRID_COLUMNS = ['3fr', '2fr', '1fr', '30px']
+const GRID_COLUMNS = ['3fr', '3fr', '1fr', '1fr', '30px']
 
 const DISABLED_REASON_NOT_ADMIN =
 	'You must have Admin role to update user access.'
@@ -260,6 +260,7 @@ const AllMembers = ({
 			<Table.Head>
 				<Table.Row gridColumns={GRID_COLUMNS}>
 					<Table.Header>User</Table.Header>
+					<Table.Header>Email</Table.Header>
 					<Table.Header>Project Access</Table.Header>
 					<Table.Header>Role</Table.Header>
 					<Table.Header></Table.Header>

--- a/frontend/src/pages/WorkspaceTeam/components/AllMembers.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AllMembers.tsx
@@ -182,7 +182,7 @@ export const RoleOptions: Option[] = [
 	},
 ]
 
-const GRID_COLUMNS = ['3fr', '3fr', '1fr', '1fr', '30px']
+const GRID_COLUMNS = ['3fr', '3fr', 'auto', '1fr', '30px']
 
 const DISABLED_REASON_NOT_ADMIN =
 	'You must have Admin role to update user access.'

--- a/frontend/src/pages/WorkspaceTeam/components/AllMembers.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AllMembers.tsx
@@ -304,22 +304,26 @@ const AllMembers = ({
 										}}
 									/>
 									<Stack gap="4">
-										<Tooltip
-											delayed
-											trigger={
-												<Text color="default" lines="1">
-													{admin.name
-														? admin.name
-														: getDisplayNameFromEmail(
-																admin.email,
-															)}{' '}
-													{isSelf && '(You)'}
-												</Text>
-											}
-										>
-											{admin.email}
-										</Tooltip>
+										<Text color="default" lines="1">
+											{admin.name
+												? admin.name
+												: getDisplayNameFromEmail(
+														admin.email,
+													)}{' '}
+											{isSelf && '(You)'}
+										</Text>
 									</Stack>
+								</Stack>
+							</Table.Cell>
+							<Table.Cell>
+								<Stack
+									direction="row"
+									gap="6"
+									alignItems="center"
+								>
+									<Text color="default" lines="1">
+										{admin.email}
+									</Text>
 								</Stack>
 							</Table.Cell>
 							<Table.Cell padding="0">


### PR DESCRIPTION
## Summary

Update styling of workspace members page to make it possible to see user emails in the list.
Feedback from customer who found it hard to audit project level access by email.

## How did you test this change?

[reflame](https://preview.highlight.io/w/27699/team?%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201JHVCVRHJDMJG9MFXCFA84T8N%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22vadim%2Fworkspace-page-improvements%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D)

## Are there any deployment considerations?

no

## Does this work require review from our design team?

yes