### PR TITLE
avoid sending alert modification notifications for pagerduty

### DIFF
--- a/backend/alerts/v2/destinations/email/messages.go
+++ b/backend/alerts/v2/destinations/email/messages.go
@@ -266,7 +266,7 @@ func SendNotifications(ctx context.Context, mailClient *sendgrid.Client, lambdaC
 
 var alertModifyNotificationIgnored = regexp.MustCompile(`.+@(.+\.)?pagerduty.com`)
 
-func isModifyIgnored(item model.AlertDestination, index int) bool {
+func shouldKeepDestination(item model.AlertDestination, _ int) bool {
 	return !alertModifyNotificationIgnored.MatchString(item.TypeID)
 }
 
@@ -290,7 +290,7 @@ func sendAlertCreatedNotification(ctx context.Context, mailClient *sendgrid.Clie
 		},
 	}
 
-	deliverAlerts(ctx, mailClient, lambdaClient, emailData, lo.Filter(destinations, isModifyIgnored))
+	deliverAlerts(ctx, mailClient, lambdaClient, emailData, lo.Filter(destinations, shouldKeepDestination))
 }
 
 func sendAlertUpdatedNotification(ctx context.Context, mailClient *sendgrid.Client, lambdaClient *lambda.Client, notificationInput destinationsV2.NotificationInput, destinations []model.AlertDestination) {
@@ -313,7 +313,7 @@ func sendAlertUpdatedNotification(ctx context.Context, mailClient *sendgrid.Clie
 		},
 	}
 
-	deliverAlerts(ctx, mailClient, lambdaClient, emailData, lo.Filter(destinations, isModifyIgnored))
+	deliverAlerts(ctx, mailClient, lambdaClient, emailData, lo.Filter(destinations, shouldKeepDestination))
 }
 
 func deliverAlerts(ctx context.Context, mailClient *sendgrid.Client, lambdaClient *lambda.Client, emailTemplate *EmailData, destinations []model.AlertDestination) {

--- a/backend/alerts/v2/destinations/email/messages.go
+++ b/backend/alerts/v2/destinations/email/messages.go
@@ -3,12 +3,11 @@ package emailV2
 import (
 	"context"
 	"fmt"
-	"github.com/samber/lo"
-	"strings"
-
 	"github.com/pkg/errors"
+	"github.com/samber/lo"
 	"github.com/sendgrid/sendgrid-go"
 	log "github.com/sirupsen/logrus"
+	"regexp"
 
 	destinationsV2 "github.com/highlight-run/highlight/backend/alerts/v2/destinations"
 	Email "github.com/highlight-run/highlight/backend/email"
@@ -266,17 +265,10 @@ func SendNotifications(ctx context.Context, mailClient *sendgrid.Client, lambdaC
 	}
 }
 
-var alertModifyNotificationIgnoredDomains = map[string]bool{
-	"steelhouse.pagerduty.com": true,
-}
+var alertModifyNotificationIgnored = regexp.MustCompile(`.+@(.+\.)?pagerduty.com`)
 
 func isModifyIgnored(item model.AlertDestination, index int) bool {
-	domain := item.TypeID
-	at := strings.LastIndex(domain, "@")
-	if at >= 0 {
-		domain = item.TypeID[at+1:]
-	}
-	return !alertModifyNotificationIgnoredDomains[domain]
+	return !alertModifyNotificationIgnored.MatchString(item.TypeID)
 }
 
 func sendAlertCreatedNotification(ctx context.Context, mailClient *sendgrid.Client, lambdaClient *lambda.Client, notificationInput destinationsV2.NotificationInput, destinations []model.AlertDestination) {

--- a/backend/alerts/v2/destinations/email/messages.go
+++ b/backend/alerts/v2/destinations/email/messages.go
@@ -3,12 +3,6 @@ package emailV2
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/samber/lo"
-	"github.com/sendgrid/sendgrid-go"
-	log "github.com/sirupsen/logrus"
-	"regexp"
-
 	destinationsV2 "github.com/highlight-run/highlight/backend/alerts/v2/destinations"
 	Email "github.com/highlight-run/highlight/backend/email"
 	"github.com/highlight-run/highlight/backend/env"
@@ -16,6 +10,11 @@ import (
 	"github.com/highlight-run/highlight/backend/model"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/util"
+	"github.com/pkg/errors"
+	"github.com/samber/lo"
+	"github.com/sendgrid/sendgrid-go"
+	log "github.com/sirupsen/logrus"
+	"regexp"
 )
 
 type EmailData struct {

--- a/backend/alerts/v2/destinations/email/messages.go
+++ b/backend/alerts/v2/destinations/email/messages.go
@@ -264,7 +264,7 @@ func SendNotifications(ctx context.Context, mailClient *sendgrid.Client, lambdaC
 	}
 }
 
-var alertModifyNotificationIgnored = regexp.MustCompile(`.+@(.+\.)?pagerduty.com`)
+var alertModifyNotificationIgnored = regexp.MustCompile(`.+@(.+\.)?pagerduty\.com`)
 
 func shouldKeepDestination(item model.AlertDestination, _ int) bool {
 	return !alertModifyNotificationIgnored.MatchString(item.TypeID)


### PR DESCRIPTION
## Summary

Creating / updating alerts would trigger a notification to pagerduty resulting in a false alarm.
Avoid sending modification alerts to `steelhouse.pagerduty.com` emails.

## How did you test this change?

checking filtering logic
<img width="586" alt="Screenshot 2025-01-22 at 18 33 56" src="https://github.com/user-attachments/assets/98012359-24ab-449b-a71e-e6eca75d4fd6" />
<img width="363" alt="Screenshot 2025-01-22 at 18 34 10" src="https://github.com/user-attachments/assets/25081ae6-db51-40ca-9dec-697bfbdf62c1" />

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
