### PR TITLE
fix: nextjs sdk proxy configuration

### DIFF
--- a/.changeset/neat-foxes-pull.md
+++ b/.changeset/neat-foxes-pull.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/next': minor
+---
+
+automatically use /highlight-events proxy URL on the frontend when proxying is configured

--- a/sdk/highlight-next/src/next-client.tsx
+++ b/sdk/highlight-next/src/next-client.tsx
@@ -1,6 +1,7 @@
 import { HighlightOptions, H as localH } from 'highlight.run'
 import Cookies from 'js-cookie'
 import { useEffect } from 'react'
+import getConfig from 'next/config'
 
 export { ErrorBoundary } from '@highlight-run/react'
 export { localH as H }
@@ -23,9 +24,19 @@ export function HighlightInit({
 			)
 
 		if (shouldRender) {
+			let highlightInitOptions = { ...highlightOptions }
+
+			const { configureHighlightProxy } = getConfig()
+			if (configureHighlightProxy) {
+				highlightInitOptions = {
+					...highlightOptions,
+					backendUrl: '/highlight-events',
+				}
+			}
+
 			const { sessionSecureID } = localH.init(
 				projectId,
-				highlightOptions,
+				highlightInitOptions,
 			) || { sessionSecureID: '' }
 
 			if (sessionSecureID) {

--- a/sdk/highlight-next/src/next-client.tsx
+++ b/sdk/highlight-next/src/next-client.tsx
@@ -1,7 +1,6 @@
-import { HighlightOptions, H as localH } from 'highlight.run'
+import { H as localH, HighlightOptions } from 'highlight.run'
 import Cookies from 'js-cookie'
 import { useEffect } from 'react'
-import getConfig from 'next/config'
 
 export { ErrorBoundary } from '@highlight-run/react'
 export { localH as H }
@@ -26,7 +25,8 @@ export function HighlightInit({
 		if (shouldRender) {
 			let highlightInitOptions = { ...highlightOptions }
 
-			const { configureHighlightProxy } = getConfig()
+			const configureHighlightProxy =
+				process.env.configureHighlightProxy === 'true'
 			if (configureHighlightProxy) {
 				highlightInitOptions = {
 					...highlightOptions,

--- a/sdk/highlight-next/src/util/with-highlight-config.ts
+++ b/sdk/highlight-next/src/util/with-highlight-config.ts
@@ -193,7 +193,12 @@ const getHighlightConfig = async (
 
 	return {
 		...config,
-		configureHighlightProxy: defaultOpts.configureHighlightProxy,
+		env: {
+			...config.env,
+			configureHighlightProxy: defaultOpts.configureHighlightProxy
+				? 'true'
+				: '',
+		},
 		productionBrowserSourceMaps:
 			defaultOpts.uploadSourceMaps || config.productionBrowserSourceMaps,
 		rewrites: newRewrites,

--- a/sdk/highlight-next/src/util/with-highlight-config.ts
+++ b/sdk/highlight-next/src/util/with-highlight-config.ts
@@ -193,6 +193,7 @@ const getHighlightConfig = async (
 
 	return {
 		...config,
+		configureHighlightProxy: defaultOpts.configureHighlightProxy,
 		productionBrowserSourceMaps:
 			defaultOpts.uploadSourceMaps || config.productionBrowserSourceMaps,
 		rewrites: newRewrites,


### PR DESCRIPTION
## Summary

The getHighlightConfig function also returns configureHighlightProxy.
In the component, set the backendUrl to /highlight-events if configureHighlightProxy is enabled in the next config. The properties of the next config can be accessed using the getInfo function from next/config.

Supercedes https://github.com/highlight/highlight/pull/9710
Closes #9042
Closes HIG-4835

## How did you test this change?

local deploy

<img width="316" alt="Screenshot 2025-01-21 at 11 46 30" src="https://github.com/user-attachments/assets/43fa3d02-527d-46c6-99a7-fb5fa1949895" />

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
