### PR TITLE
Fix table latency on dashboards

### DIFF
--- a/frontend/src/pages/Graphing/components/Table.tsx
+++ b/frontend/src/pages/Graphing/components/Table.tsx
@@ -86,7 +86,7 @@ const MetricTableImpl = ({
 		<IconSolidSortDescending size={14} />
 	)
 
-	const filteredData = useMemo(() => {
+	const orderedData = useMemo(() => {
 		const sortedData = _.sortBy(data, (d: any) => {
 			if (sortColumn === -1) {
 				return d[xAxisMetric]
@@ -96,7 +96,7 @@ const MetricTableImpl = ({
 			return d[seriesKey]?.value
 		})
 
-		return sortedData.filter((d) => {
+		const filteredData = sortedData.filter((d) => {
 			// If every value for the bucket is null, skip this row
 			return (
 				viewConfig.nullHandling !== 'Hide row' ||
@@ -108,20 +108,25 @@ const MetricTableImpl = ({
 					) !== undefined
 			)
 		})
-	}, [data, series, sortColumn, viewConfig.nullHandling, xAxisMetric])
+
+		return sortAsc ? filteredData : filteredData.reverse()
+	}, [
+		data,
+		series,
+		sortAsc,
+		sortColumn,
+		viewConfig.nullHandling,
+		xAxisMetric,
+	])
 
 	const rowVirtualizer = useVirtualizer({
-		count: filteredData?.length,
+		count: orderedData?.length,
 		estimateSize: () => 25,
 		getScrollElement: () => bodyRef.current,
 		overscan: 50,
 	})
 
 	const virtualRows = rowVirtualizer.getVirtualItems()
-
-	if (!sortAsc) {
-		filteredData.reverse()
-	}
 
 	return (
 		<Box height="full" cssClass={style.tableWrapper}>
@@ -166,7 +171,7 @@ const MetricTableImpl = ({
 				>
 					<Table.Body ref={bodyRef}>
 						{virtualRows?.map((virtualRow) => {
-							const d = filteredData[virtualRow.index]
+							const d = orderedData[virtualRow.index]
 
 							return (
 								<Table.Row

--- a/frontend/src/pages/Graphing/components/Table.tsx
+++ b/frontend/src/pages/Graphing/components/Table.tsx
@@ -174,117 +174,16 @@ const MetricTableImpl = ({
 							const d = orderedData[virtualRow.index]
 
 							return (
-								<Table.Row
+								<MetricTableRow
+									row={d}
 									key={virtualRow.index}
-									className={style.tableRow}
-								>
-									{showXAxisColumn && (
-										<Table.Cell
-											key={virtualRow.index}
-											onClick={
-												loadExemplars
-													? () =>
-															loadExemplars(
-																d[
-																	BUCKET_MIN_KEY
-																],
-																d[
-																	BUCKET_MAX_KEY
-																],
-																d[GROUPS_KEY],
-															)
-													: undefined
-											}
-										>
-											<Tooltip
-												delayed
-												trigger={
-													<Text
-														size="small"
-														color="default"
-														lines="1"
-														cssClass={
-															style.firstCell
-														}
-													>
-														{xAxisTickFormatter(
-															d[xAxisMetric],
-														)}
-													</Text>
-												}
-											>
-												{xAxisTickFormatter(
-													d[xAxisMetric],
-												)}
-											</Tooltip>
-										</Table.Cell>
-									)}
-									{series.map((s, i) => {
-										const seriesKey = getSeriesKey(s)
-										let value = d[seriesKey]?.value
-
-										if (
-											value === null ||
-											value === undefined
-										) {
-											switch (viewConfig.nullHandling) {
-												case 'Blank':
-												case 'Hide row':
-													value = ''
-													break
-												case 'Zero':
-													value = 0
-													break
-											}
-										}
-
-										if (value !== '') {
-											value = getTickFormatter(s.column)(
-												value,
-											)
-										}
-
-										const groups =
-											GROUPS_KEY in d
-												? d[GROUPS_KEY]
-												: s.groups
-
-										return (
-											<Table.Cell
-												key={i}
-												onClick={
-													loadExemplars
-														? () =>
-																loadExemplars(
-																	d[
-																		BUCKET_MIN_KEY
-																	],
-																	d[
-																		BUCKET_MAX_KEY
-																	],
-																	groups,
-																)
-														: undefined
-												}
-											>
-												<Tooltip
-													delayed
-													trigger={
-														<Text
-															size="small"
-															color="default"
-															lines="1"
-														>
-															{value}
-														</Text>
-													}
-												>
-													{value}
-												</Tooltip>
-											</Table.Cell>
-										)
-									})}
-								</Table.Row>
+									showXAxisColumn={showXAxisColumn}
+									loadExemplars={loadExemplars}
+									xAxisTickFormatter={xAxisTickFormatter}
+									xAxisMetric={xAxisMetric}
+									series={series}
+									nullHandling={viewConfig.nullHandling}
+								/>
 							)
 						})}
 					</Table.Body>
@@ -295,3 +194,97 @@ const MetricTableImpl = ({
 }
 
 export const MetricTable = memo(MetricTableImpl)
+
+const MetricTableRow = ({
+	row,
+	showXAxisColumn,
+	loadExemplars,
+	xAxisTickFormatter,
+	xAxisMetric,
+	series,
+	nullHandling,
+}: any) => {
+	return (
+		<Table.Row className={style.tableRow}>
+			{showXAxisColumn && (
+				<Table.Cell
+					onClick={
+						loadExemplars
+							? () =>
+									loadExemplars(
+										row[BUCKET_MIN_KEY],
+										row[BUCKET_MAX_KEY],
+										row[GROUPS_KEY],
+									)
+							: undefined
+					}
+				>
+					<Tooltip
+						delayed
+						trigger={
+							<Text
+								size="small"
+								color="default"
+								lines="1"
+								cssClass={style.firstCell}
+							>
+								{xAxisTickFormatter(row[xAxisMetric])}
+							</Text>
+						}
+					>
+						{xAxisTickFormatter(row[xAxisMetric])}
+					</Tooltip>
+				</Table.Cell>
+			)}
+			{series.map((s: any, i: number) => {
+				const seriesKey = getSeriesKey(s)
+				let value = row[seriesKey]?.value
+
+				if (value === null || value === undefined) {
+					switch (nullHandling) {
+						case 'Blank':
+						case 'Hide row':
+							value = ''
+							break
+						case 'Zero':
+							value = 0
+							break
+					}
+				}
+
+				if (value !== '') {
+					value = getTickFormatter(s.column)(value)
+				}
+
+				const groups = GROUPS_KEY in row ? row[GROUPS_KEY] : s.groups
+
+				return (
+					<Table.Cell
+						key={i}
+						onClick={
+							loadExemplars
+								? () =>
+										loadExemplars(
+											row[BUCKET_MIN_KEY],
+											row[BUCKET_MAX_KEY],
+											groups,
+										)
+								: undefined
+						}
+					>
+						<Tooltip
+							delayed
+							trigger={
+								<Text size="small" color="default" lines="1">
+									{value}
+								</Text>
+							}
+						>
+							{value}
+						</Tooltip>
+					</Table.Cell>
+				)
+			})}
+		</Table.Row>
+	)
+}

--- a/frontend/src/pages/Graphing/components/Table.tsx
+++ b/frontend/src/pages/Graphing/components/Table.tsx
@@ -283,17 +283,11 @@ const MetricTableRow = ({
 										)
 								: undefined
 						}
+						title={value}
 					>
-						<Tooltip
-							delayed
-							trigger={
-								<Text size="small" color="default" lines="1">
-									{value}
-								</Text>
-							}
-						>
+						<Text size="small" color="default" lines="1">
 							{value}
-						</Tooltip>
+						</Text>
 					</Table.Cell>
 				)
 			})}

--- a/frontend/src/pages/Graphing/components/Table.tsx
+++ b/frontend/src/pages/Graphing/components/Table.tsx
@@ -5,7 +5,6 @@ import {
 	Stack,
 	Table,
 	Text,
-	Tooltip,
 } from '@highlight-run/ui/components'
 import clsx from 'clsx'
 
@@ -216,6 +215,8 @@ const MetricTableRow = ({
 	series,
 	nullHandling,
 }: MetricTableRowProps) => {
+	const xAxisTitle = xAxisTickFormatter(row[xAxisMetric])
+
 	return (
 		<Table.Row className={style.tableRow}>
 			{showXAxisColumn && (
@@ -230,22 +231,16 @@ const MetricTableRow = ({
 									)
 							: undefined
 					}
+					title={xAxisTitle}
 				>
-					<Tooltip
-						delayed
-						trigger={
-							<Text
-								size="small"
-								color="default"
-								lines="1"
-								cssClass={style.firstCell}
-							>
-								{xAxisTickFormatter(row[xAxisMetric])}
-							</Text>
-						}
+					<Text
+						size="small"
+						color="default"
+						lines="1"
+						cssClass={style.firstCell}
 					>
-						{xAxisTickFormatter(row[xAxisMetric])}
-					</Tooltip>
+						{xAxisTitle}
+					</Text>
 				</Table.Cell>
 			)}
 			{series.map((s, i) => {

--- a/frontend/src/pages/Graphing/components/Table.tsx
+++ b/frontend/src/pages/Graphing/components/Table.tsx
@@ -16,6 +16,8 @@ import {
 	getTickFormatter,
 	GROUPS_KEY,
 	InnerChartProps,
+	LoadExemplars,
+	NamedSeries,
 	SeriesInfo,
 	useGraphSeries,
 	VizId,
@@ -195,6 +197,16 @@ const MetricTableImpl = ({
 
 export const MetricTable = memo(MetricTableImpl)
 
+interface MetricTableRowProps {
+	row: any
+	showXAxisColumn?: boolean
+	loadExemplars?: LoadExemplars
+	xAxisTickFormatter: (value: any) => string
+	xAxisMetric: string
+	series: NamedSeries[]
+	nullHandling?: TableNullHandling
+}
+
 const MetricTableRow = ({
 	row,
 	showXAxisColumn,
@@ -203,7 +215,7 @@ const MetricTableRow = ({
 	xAxisMetric,
 	series,
 	nullHandling,
-}: any) => {
+}: MetricTableRowProps) => {
 	return (
 		<Table.Row className={style.tableRow}>
 			{showXAxisColumn && (
@@ -236,7 +248,7 @@ const MetricTableRow = ({
 					</Tooltip>
 				</Table.Cell>
 			)}
-			{series.map((s: any, i: number) => {
+			{series.map((s, i) => {
 				const seriesKey = getSeriesKey(s)
 				let value = row[seriesKey]?.value
 


### PR DESCRIPTION
## Summary
Some dashboard tables are causing frontend performance issues. Optimize by:
- virtualize the table
- memoize data sorting and filtering
- break out row into new component to avoid re-rendering
- remove tooltips for titles

## How did you test this change?
1. Create a table or view a table with lots of rows
2. Load the page
- [ ] No lagging

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
