### PR TITLE
updated next.js fullstack framework documentation

### DIFF
--- a/docs-content/getting-started/fullstack-frameworks/next-js/3_app-router.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/3_app-router.md
@@ -3,9 +3,8 @@ title: Next.js App Router Guide
 slug: environment
 heading: Next.js App Router Guide
 createdAt: 2023-10-03T00:00:00.000Z
-updatedAt: 2023-10-03T00:00:00.000Z
+updatedAt: 2025-01-21T00:00:00.000Z
 ---
-
 
 <EmbeddedVideo 
   src="https://www.youtube.com/embed/g6mhBMMVdU0"
@@ -15,8 +14,20 @@ updatedAt: 2023-10-03T00:00:00.000Z
 
 ## Installation
 
+
 ```shell
+# with npm
 npm install @highlight-run/next
+```
+
+```shell
+# with yarn
+yarn add @highlight-run/next
+```
+
+```shell
+# with pnpm
+pnpm add @highlight-run/next
 ```
 
 ## Client instrumentation
@@ -141,7 +152,11 @@ function ThrowerOfErrors({
 
 ## Enable server-side tracing
 
-We use `experimental.instrumentationHook` to capture [Next.js's automatic instrumentation](https://nextjs.org/docs/app/building-your-application/optimizing/open-telemetry). This method captures detailed API route tracing as well as server-side errors.
+We use [`instrumentation.js`](https://nextjs.org/docs/app/api-reference/file-conventions/instrumentation) to to capture [Next.js's automatic instrumentation](https://nextjs.org/docs/app/building-your-application/optimizing/open-telemetry). This method captures detailed API route tracing as well as server-side errors.
+
+```hint
+ If you are below Next.js 15 you need to manually acticate this by activating instrumentationHook as experimental feature. **From Next.js 15 upwards this is already activated by default and you can skip this step.**
+```
 
 1. Enable `experimental.instrumentationHook` in `next.config.js`.
 2. Setup the `withHighlightConfig` wrapper for auto-upload of your [sourcemaps](../../../general/6_product-features/2_error-monitoring/sourcemaps.md). 


### PR DESCRIPTION
Updated the documentation to include change for Next.js activation of instrumentation.js

## Summary

I was going through the setup for my next.js app and realized the experimental step isn't needed anymore. So I updated the doc. I also added installation commands for yarn and pnpm at the top.

## How did you test this change?

I didn't  - just did some doc changes and corrected spelling mistakes

## Are there any deployment considerations?

None

## Does this work require review from our design team?

No
