### PR TITLE
fix frontend rendering of missing webvitals

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5782,6 +5782,10 @@ func (r *queryResolver) WebVitals(ctx context.Context, sessionSecureID string) (
 	if err != nil {
 		return nil, err
 	}
+	
+	if webVitals.BucketCount == 0 {
+		return nil, nil
+	}
 
 	return webVitals, nil
 }

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5782,7 +5782,7 @@ func (r *queryResolver) WebVitals(ctx context.Context, sessionSecureID string) (
 	if err != nil {
 		return nil, err
 	}
-	
+
 	if webVitals.BucketCount == 0 {
 		return nil, nil
 	}

--- a/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
+++ b/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
@@ -75,13 +75,16 @@ const EventStreamV2 = function () {
 	useEffect(() => {
 		const events = [...replayerEvents]
 		if (data?.web_vitals?.buckets) {
+			const filteredVitals = data.web_vitals.buckets
+				.filter((bucket) => bucket.bucket_id != 0)
+				.map((bucket) => ({
+					name: bucket.group,
+					value: bucket.metric_value,
+				}))
 			const webVitalEvent = {
 				data: {
 					payload: {
-						vitals: data.web_vitals.buckets.map((bucket) => ({
-							name: bucket.group,
-							value: bucket.metric_value,
-						})),
+						vitals: filteredVitals,
 					},
 					tag: 'Web Vitals',
 				},


### PR DESCRIPTION
## Summary

Sessions like /26425/sessions/owVTdWNf043ha1xxtUwlhN5gu8RF
would crash rendering because they were missing web vitals and the new
query path would require web vitals to be present.

## How did you test this change?

[reflame](https://preview.highlight.io/26425/sessions/owVTdWNf043ha1xxtUwlhN5gu8RF)
checking web vitals loading correctly

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no