### PR TITLE
correctly render session web vitals fetched via metrics

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5775,7 +5775,7 @@ func (r *queryResolver) WebVitals(ctx context.Context, sessionSecureID string) (
 	}
 
 	webVitalNames := []string{
-		"CLS", "FCP", "FID", "LCP", "TTFB",
+		"CLS", "FCP", "FID", "LCP", "TTFB", "INP",
 	}
 
 	webVitals, err := r.ClickhouseClient.QuerySessionCustomMetrics(ctx, s.ProjectID, sessionSecureID, s.CreatedAt, webVitalNames)

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2052,7 +2052,7 @@ func (r *Resolver) PushMetricsImpl(ctx context.Context, projectVerboseID *string
 			MetricSumRow: metricRow,
 		})
 	}
-	return r.TracesQueue.Submit(ctx, "", messages...)
+	return r.MetricSumQueue.Submit(ctx, "", messages...)
 }
 
 func (r *Resolver) GetProjectMetricRetention(ctx context.Context, projectID int) uint8 {

--- a/frontend/src/pages/Player/StreamElement/Renderers/WebVitals/utils/WebVitalsUtils.ts
+++ b/frontend/src/pages/Player/StreamElement/Renderers/WebVitals/utils/WebVitalsUtils.ts
@@ -10,6 +10,7 @@ export enum WebVitalName {
 	FID = 'First Input Delay',
 	LCP = 'Largest Contentful Paint',
 	TTFB = 'Time to First Byte',
+	INP = 'Interaction to Next Paint',
 }
 
 export const WEB_VITALS_CONFIGURATION: {
@@ -67,6 +68,17 @@ export const WEB_VITALS_CONFIGURATION: {
 		poor_value: 0,
 		units: 'ms',
 		help_article: 'https://web.dev/ttfb',
+		chart_type: DashboardChartType.Timeline,
+		aggregator: MetricAggregator.P50,
+	},
+	INP: {
+		max_good_value: 200,
+		name: 'INP',
+		description: WebVitalName.INP,
+		max_needs_improvement_value: 500,
+		poor_value: 0,
+		units: 'ms',
+		help_article: 'https://web.dev/inp',
 		chart_type: DashboardChartType.Timeline,
 		aggregator: MetricAggregator.P50,
 	},

--- a/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
+++ b/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
@@ -76,7 +76,7 @@ const EventStreamV2 = function () {
 		const events = [...replayerEvents]
 		if (data?.web_vitals?.buckets) {
 			const filteredVitals = data.web_vitals.buckets
-				.filter((bucket) => bucket.bucket_id != 0)
+				.filter((bucket) => bucket.bucket_min != 0)
 				.map((bucket) => ({
 					name: bucket.group,
 					value: bucket.metric_value,


### PR DESCRIPTION
## Summary

Correct web vitals filtering logic on the frontend to make sure sessions with web vitals have their metrics loaded.
Add `INP` as another web vital rendered for sessions

## How did you test this change?

<img width="355" alt="Screenshot 2025-01-24 at 12 45 00" src="https://github.com/user-attachments/assets/9c4f38e4-0095-4dcf-8fc0-633fdafc6c87" />

<img width="414" alt="Screenshot 2025-01-24 at 12 44 52" src="https://github.com/user-attachments/assets/6828615e-b07a-41ef-8dee-278aa307d5fa" />

in [reflame](https://preview.highlight.io/1/sessions/O7HqhjYdzmg7vCRIEvfXr0GTW4YB?%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201JJCT1Y85VXY8NZ82YZX1HFQT%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22vadim%2Ffix-session-web-vitals%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D)

<img width="304" alt="Screenshot 2025-01-24 at 14 43 30" src="https://github.com/user-attachments/assets/fe57ca24-aed6-4a86-a21a-3fea456b2b3e" />


## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
