### PR TITLE
add basic opentelemetry metrics support to highlight.run

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,6 +13,7 @@
 		"@highlight-run/client",
 		"@highlight-run/component-preview",
 		"@highlight-run/frontend",
+		"react-native",
 		"rrdom",
 		"rrdom-nodejs",
 		"rrweb",

--- a/.changeset/fair-dryers-behave.md
+++ b/.changeset/fair-dryers-behave.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': minor
+---
+
+introduce otlp native metrics export

--- a/cypress/e2e/login.cy.js
+++ b/cypress/e2e/login.cy.js
@@ -4,6 +4,12 @@ describe('login spec', () => {
 		cy.intercept('POST', '/public', (req) => {
 			req.alias = req.body.operationName
 		})
+		cy.intercept('POST', '/v1/traces', (req) => {
+			req.alias = 'oteltraces'
+		})
+		cy.intercept('POST', '/v1/metrics', (req) => {
+			req.alias = 'otelmetrics'
+		})
 	})
 
 	it('allows you to log in using ADMIN_PASSWORD', () => {
@@ -18,9 +24,12 @@ describe('login spec', () => {
 		cy.get('button[type="submit"]').click().wait(5000)
 
 		// Ensure client requests are made
-		cy.wait('@pushMetrics')
-			.its('request.body.variables')
-			.should('have.property', 'metrics')
+		cy.wait('@otelmetrics')
+			.its('request.body.resourceMetrics.0.scopeMetrics.0.metrics.0')
+			.should('have.property', 'name')
+		cy.wait('@oteltraces')
+			.its('request.body.resourceSpans.0.scopeSpans.0.spans.0')
+			.should('have.property', 'name')
 		cy.wait('@initializeSession')
 			.its('request.body.variables')
 			.should('have.property', 'session_secure_id')

--- a/cypress/pages/local.html
+++ b/cypress/pages/local.html
@@ -7,6 +7,7 @@
 		<script>
 			H.init('1', {
 				backendUrl: 'http://localhost:8082/public',
+				otlpEndpoint: 'http://localhost:4318',
 				environment: 'test',
 				networkRecording: {
 					enabled: true,

--- a/e2e/react-native/package.json
+++ b/e2e/react-native/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "react-native",
+	"private": true,
 	"main": "expo-router/entry",
 	"version": "1.0.0",
 	"scripts": {

--- a/e2e/react-native/package.json
+++ b/e2e/react-native/package.json
@@ -61,6 +61,5 @@
 		"jest-expo": "~52.0.2",
 		"react-test-renderer": "18.3.1",
 		"typescript": "^5.3.3"
-	},
-	"private": true
+	}
 }

--- a/frontend/src/pages/Buttons/Buttons.tsx
+++ b/frontend/src/pages/Buttons/Buttons.tsx
@@ -353,6 +353,31 @@ export const Buttons = () => {
 					</button>
 					<button
 						className={commonStyles.submitButton}
+						onClick={async () => {
+							H.gauge({
+								name: 'client-highlight-gauge',
+								value: Math.random(),
+							})
+						}}
+					>
+						H.gauge
+					</button>
+					<button
+						className={commonStyles.submitButton}
+						onClick={async () => {
+							const { metrics } = await import(
+								'@opentelemetry/api'
+							)
+							const meter = metrics.getMeter('Buttons.tsx')
+							const gauge =
+								meter.createGauge('client-meter-gauge')
+							gauge.record(Math.random())
+						}}
+					>
+						otel metrics gauge
+					</button>
+					<button
+						className={commonStyles.submitButton}
 						onClick={() => {
 							H.consumeError(
 								new Error('Highlight H.consumeError', {

--- a/frontend/src/pages/Buttons/Buttons.tsx
+++ b/frontend/src/pages/Buttons/Buttons.tsx
@@ -354,13 +354,56 @@ export const Buttons = () => {
 					<button
 						className={commonStyles.submitButton}
 						onClick={async () => {
-							H.gauge({
+							H.recordMetric({
 								name: 'client-highlight-gauge',
 								value: Math.random(),
 							})
 						}}
 					>
-						H.gauge
+						H.recordMetric
+					</button>
+					<button
+						className={commonStyles.submitButton}
+						onClick={async () => {
+							H.recordCount({
+								name: 'client-highlight-count',
+								value: Math.random(),
+							})
+						}}
+					>
+						H.recordCount
+					</button>
+					<button
+						className={commonStyles.submitButton}
+						onClick={async () => {
+							H.recordIncr({
+								name: 'client-highlight-incr',
+							})
+						}}
+					>
+						H.recordIncr
+					</button>
+					<button
+						className={commonStyles.submitButton}
+						onClick={async () => {
+							H.recordHistogram({
+								name: 'client-highlight-histogram',
+								value: Math.random(),
+							})
+						}}
+					>
+						H.recordHistogram
+					</button>
+					<button
+						className={commonStyles.submitButton}
+						onClick={async () => {
+							H.recordUpDownCounter({
+								name: 'client-highlight-updown',
+								value: Math.random() > 0.5 ? 1 : -1,
+							})
+						}}
+					>
+						H.recordUpDownCounter
 					</button>
 					<button
 						className={commonStyles.submitButton}

--- a/packages/mock-otel-server/package.json
+++ b/packages/mock-otel-server/package.json
@@ -5,6 +5,8 @@
 	"type": "module",
 	"packageManager": "yarn@3.5.0",
 	"dependencies": {
+		"@opentelemetry/api": "^1.9.0",
+		"@opentelemetry/otlp-transformer": "^0.57.1",
 		"express": "^4.19.2"
 	},
 	"scripts": {

--- a/packages/mock-otel-server/src/index.ts
+++ b/packages/mock-otel-server/src/index.ts
@@ -6,7 +6,7 @@ import {
 	IExportTraceServiceRequest,
 	IResourceSpans,
 	ISpan,
-} from '@opentelemetry/otlp-transformer'
+} from '@opentelemetry/otlp-transformer/build/esm/trace/internal-types'
 
 const DEFAULT_PORT = 3101
 const RESOURCE_SPANS_BY_PORT = new Map<number, IResourceSpans[]>()

--- a/sdk/client/package.json
+++ b/sdk/client/package.json
@@ -49,16 +49,18 @@
 	},
 	"dependencies": {
 		"@opentelemetry/api": "^1.9.0",
-		"@opentelemetry/exporter-trace-otlp-http": ">=0.53.0",
-		"@opentelemetry/instrumentation": ">=0.53.0",
-		"@opentelemetry/instrumentation-document-load": ">=0.40.0",
-		"@opentelemetry/instrumentation-fetch": ">=0.53.0",
-		"@opentelemetry/instrumentation-user-interaction": ">=0.40.0",
-		"@opentelemetry/instrumentation-xml-http-request": ">=0.53.0",
-		"@opentelemetry/otlp-exporter-base": ">=0.53.0",
-		"@opentelemetry/resources": "^1.26.0",
-		"@opentelemetry/sdk-trace-web": "^1.26.0",
-		"@opentelemetry/semantic-conventions": "^1.27.0",
+		"@opentelemetry/exporter-metrics-otlp-http": ">=0.57.1",
+		"@opentelemetry/exporter-trace-otlp-http": ">=0.57.1",
+		"@opentelemetry/instrumentation": ">=0.57.1",
+		"@opentelemetry/instrumentation-document-load": ">=0.44.0",
+		"@opentelemetry/instrumentation-fetch": ">=0.57.1",
+		"@opentelemetry/instrumentation-user-interaction": ">=0.44.0",
+		"@opentelemetry/instrumentation-xml-http-request": ">=0.57.1",
+		"@opentelemetry/otlp-exporter-base": ">=0.57.1",
+		"@opentelemetry/resources": "^1.30.1",
+		"@opentelemetry/sdk-metrics": "^1.30.1",
+		"@opentelemetry/sdk-trace-web": "^1.30.1",
+		"@opentelemetry/semantic-conventions": "^1.28.0",
 		"@rrweb/rrweb-plugin-sequential-id-record": "workspace:*",
 		"error-stack-parser": "2.0.6",
 		"fflate": "^0.8.1",
@@ -69,7 +71,8 @@
 		"json-stringify-safe": "^5.0.1",
 		"rrweb": "workspace:*",
 		"stacktrace-js": "2.0.2",
-		"web-vitals": "^3.5.0"
+		"web-vitals": "^3.5.0",
+		"zone.js": "^0.15.0"
 	},
 	"size-limit": [
 		{

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -695,14 +695,12 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 
 			const { getDeviceDetails } = getPerformanceMethods()
 			if (getDeviceDetails) {
-				this.recordMetric([
-					{
-						name: MetricName.DeviceMemory,
-						value: getDeviceDetails().deviceMemory,
-						category: MetricCategory.Device,
-						group: window.location.href,
-					},
-				])
+				this.recordGauge({
+					name: MetricName.DeviceMemory,
+					value: getDeviceDetails().deviceMemory,
+					category: MetricCategory.Device,
+					group: window.location.href,
+				})
 			}
 
 			const emit = (
@@ -971,14 +969,12 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			this.listeners.push(
 				WebVitalsListener((data) => {
 					const { name, value } = data
-					this.recordMetric([
-						{
-							name,
-							value,
-							group: window.location.href,
-							category: MetricCategory.WebVital,
-						},
-					])
+					this.recordGauge({
+						name,
+						value,
+						group: window.location.href,
+						category: MetricCategory.WebVital,
+					})
 				}),
 			)
 
@@ -995,39 +991,27 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 				this.listeners.push(
 					PerformanceListener((payload: PerformancePayload) => {
 						this.addCustomEvent('Performance', stringify(payload))
-						this.recordMetric(
-							Object.entries(payload)
-								.map(([name, value]) =>
-									value
-										? {
-												name,
-												value,
-												category:
-													MetricCategory.Performance,
-												group: window.location.href,
-											}
-										: undefined,
-								)
-								.filter((m) => m) as {
-								name: string
-								value: any
-								category: MetricCategory
-								group: string
-							}[],
+						Object.entries(payload).forEach(
+							([name, value]) =>
+								value &&
+								this.recordGauge({
+									name,
+									value,
+									category: MetricCategory.Performance,
+									group: window.location.href,
+								}),
 						)
 					}, this._recordingStartTime),
 				)
 				this.listeners.push(
 					JankListener((payload: JankPayload) => {
 						this.addCustomEvent('Jank', stringify(payload))
-						this.recordMetric([
-							{
-								name: 'Jank',
-								value: payload.jankAmount,
-								category: MetricCategory.WebVital,
-								group: payload.querySelector,
-							},
-						])
+						this.recordGauge({
+							name: 'Jank',
+							value: payload.jankAmount,
+							category: MetricCategory.WebVital,
+							group: payload.querySelector,
+						})
 					}, this._recordingStartTime),
 				)
 			}
@@ -1106,38 +1090,36 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 		availHeight,
 		availWidth,
 	}: ViewportResizeListenerArgs) {
-		this.recordMetric([
-			{
-				name: MetricName.ViewportHeight,
-				value: height,
-				category: MetricCategory.Device,
-				group: window.location.href,
-			},
-			{
-				name: MetricName.ViewportWidth,
-				value: width,
-				category: MetricCategory.Device,
-				group: window.location.href,
-			},
-			{
-				name: MetricName.ScreenHeight,
-				value: availHeight,
-				category: MetricCategory.Device,
-				group: window.location.href,
-			},
-			{
-				name: MetricName.ScreenWidth,
-				value: availWidth,
-				category: MetricCategory.Device,
-				group: window.location.href,
-			},
-			{
-				name: MetricName.ViewportArea,
-				value: height * width,
-				category: MetricCategory.Device,
-				group: window.location.href,
-			},
-		])
+		this.recordGauge({
+			name: MetricName.ViewportHeight,
+			value: height,
+			category: MetricCategory.Device,
+			group: window.location.href,
+		})
+		this.recordGauge({
+			name: MetricName.ViewportWidth,
+			value: width,
+			category: MetricCategory.Device,
+			group: window.location.href,
+		})
+		this.recordGauge({
+			name: MetricName.ScreenHeight,
+			value: availHeight,
+			category: MetricCategory.Device,
+			group: window.location.href,
+		})
+		this.recordGauge({
+			name: MetricName.ScreenWidth,
+			value: availWidth,
+			category: MetricCategory.Device,
+			group: window.location.href,
+		})
+		this.recordGauge({
+			name: MetricName.ViewportArea,
+			value: height * width,
+			category: MetricCategory.Device,
+			group: window.location.href,
+		})
 	}
 
 	recordGauge(metric: RecordMetric) {

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -1148,10 +1148,11 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			gauge = meter.createGauge(metric.name)
 			this._gauges.set(metric.name, gauge)
 		}
-		gauge.record(
-			metric.value,
-			metric.tags?.reduce((a, b) => ({ ...a, [b.name]: b.value }), {}),
-		)
+		gauge.record(metric.value, {
+			...metric.tags?.reduce((a, b) => ({ ...a, [b.name]: b.value }), {}),
+			group: metric.group,
+			category: metric.category,
+		})
 	}
 
 	recordMetric(
@@ -1165,9 +1166,9 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 	) {
 		for (const m of metrics.map((m) => ({
 			...m,
-			tags: m.tags || [],
-			group: m.group || window.location.href,
-			category: m.category || MetricCategory.Frontend,
+			tags: m.tags ?? [],
+			group: m.group ?? window.location.href,
+			category: m.category ?? MetricCategory.Frontend,
 			timestamp: new Date(),
 		}))) {
 			this.gauge(m)

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -1163,6 +1163,9 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			tags?: { name: string; value: string }[]
 		}[],
 	) {
+		for (const m of metrics) {
+			this.gauge(m)
+		}
 		this._worker.postMessage({
 			message: {
 				type: MessageType.Metrics,

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -1163,21 +1163,15 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			tags?: { name: string; value: string }[]
 		}[],
 	) {
-		for (const m of metrics) {
+		for (const m of metrics.map((m) => ({
+			...m,
+			tags: m.tags || [],
+			group: m.group || window.location.href,
+			category: m.category || MetricCategory.Frontend,
+			timestamp: new Date(),
+		}))) {
 			this.gauge(m)
 		}
-		this._worker.postMessage({
-			message: {
-				type: MessageType.Metrics,
-				metrics: metrics.map((m) => ({
-					...m,
-					tags: m.tags || [],
-					group: m.group || window.location.href,
-					category: m.category || MetricCategory.Frontend,
-					timestamp: new Date(),
-				})),
-			},
-		})
 	}
 
 	/**

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -65,7 +65,7 @@ import {
 } from './listeners/viewport-resize-listener'
 import { WebVitalsListener } from './listeners/web-vitals-listener/web-vitals-listener'
 import { Logger } from './logger'
-import { getTracer, setupBrowserTracing } from './otel'
+import { getMeter, getTracer, setupBrowserTracing } from './otel'
 import {
 	HighlightIframeMessage,
 	HighlightIframeReponse,
@@ -1437,6 +1437,7 @@ export {
 	GenerateSecureID,
 	getPreviousSessionData,
 	getTracer,
+	getMeter,
 	MetricCategory,
 	setupBrowserTracing,
 }

--- a/sdk/client/src/otel/exporter.ts
+++ b/sdk/client/src/otel/exporter.ts
@@ -2,8 +2,14 @@ import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http'
 import { MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS } from '../utils/graph'
 import { ExportResult, ExportResultCode } from '@opentelemetry/core'
+import { AggregationTemporalityPreference } from '@opentelemetry/exporter-metrics-otlp-http/build/src/OTLPMetricExporterOptions'
 
-type ExporterConfig = ConstructorParameters<typeof OTLPTraceExporter>[0]
+export type TraceExporterConfig = ConstructorParameters<
+	typeof OTLPTraceExporter
+>[0]
+export type MetricExporterConfig = ConstructorParameters<
+	typeof OTLPMetricExporter
+>[0]
 
 // This custom exporter is a temporary workaround for an issue we are having
 // with requests stalling in the browser using the sendBeacon API. There is work
@@ -16,7 +22,7 @@ type ExporterConfig = ConstructorParameters<typeof OTLPTraceExporter>[0]
 export class OTLPTraceExporterBrowserWithXhrRetry extends OTLPTraceExporter {
 	private readonly xhrTraceExporter: OTLPTraceExporter
 
-	constructor(config?: ExporterConfig) {
+	constructor(config?: TraceExporterConfig) {
 		super(config)
 		this.xhrTraceExporter = new OTLPTraceExporter({
 			...(config ?? {}),
@@ -49,10 +55,11 @@ export class OTLPTraceExporterBrowserWithXhrRetry extends OTLPTraceExporter {
 export class OTLPMetricExporterBrowser extends OTLPMetricExporter {
 	private readonly xhrMeterExporter: OTLPMetricExporter
 
-	constructor(config?: ExporterConfig) {
+	constructor(config?: MetricExporterConfig) {
 		super(config)
 		this.xhrMeterExporter = new OTLPMetricExporter({
 			...(config ?? {}),
+			temporalityPreference: AggregationTemporalityPreference.DELTA,
 			headers: {}, // a truthy value enables sending with XHR instead of beacon
 		})
 	}

--- a/sdk/client/src/otel/exporter.ts
+++ b/sdk/client/src/otel/exporter.ts
@@ -1,10 +1,9 @@
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
-import type { ReadableSpan } from '@opentelemetry/sdk-trace-web'
-import { OTLPExporterError } from '@opentelemetry/otlp-exporter-base'
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http'
 import { MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS } from '../utils/graph'
+import { ExportResult, ExportResultCode } from '@opentelemetry/core'
 
 type ExporterConfig = ConstructorParameters<typeof OTLPTraceExporter>[0]
-type SendOnErrorCallback = Parameters<OTLPTraceExporter['send']>[2]
 
 // This custom exporter is a temporary workaround for an issue we are having
 // with requests stalling in the browser using the sendBeacon API. There is work
@@ -25,25 +24,57 @@ export class OTLPTraceExporterBrowserWithXhrRetry extends OTLPTraceExporter {
 		})
 	}
 
-	send(
-		items: ReadableSpan[],
-		onSuccess: () => void,
-		onError: SendOnErrorCallback,
-	): void {
+	export(items: any, resultCallback: (result: ExportResult) => void) {
 		let retries = 0
-		const retry = (error: OTLPExporterError) => {
+		const retry = (result: ExportResult) => {
 			retries++
 			if (retries > MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS) {
 				console.error(
-					`[highlight.io] failed to export OTeL traces: ${error.message}`,
-					error,
+					`[highlight.io] failed to export OTeL traces: ${result.error?.message}`,
+					result.error,
 				)
-				onError(error)
+				resultCallback({
+					code: ExportResultCode.FAILED,
+					error: result.error,
+				})
 			} else {
-				this.xhrTraceExporter.send(items, onSuccess, retry)
+				this.xhrTraceExporter.export(items, resultCallback)
 			}
 		}
 
-		super.send(items, onSuccess, retry)
+		super.export(items, retry)
+	}
+}
+
+export class OTLPMetricExporterBrowser extends OTLPMetricExporter {
+	private readonly xhrMeterExporter: OTLPMetricExporter
+
+	constructor(config?: ExporterConfig) {
+		super(config)
+		this.xhrMeterExporter = new OTLPMetricExporter({
+			...(config ?? {}),
+			headers: {}, // a truthy value enables sending with XHR instead of beacon
+		})
+	}
+
+	export(items: any, resultCallback: (result: ExportResult) => void) {
+		let retries = 0
+		const retry = (result: ExportResult) => {
+			retries++
+			if (retries > MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS) {
+				console.error(
+					`[highlight.io] failed to export OTeL metrics: ${result.error?.message}`,
+					result.error,
+				)
+				resultCallback({
+					code: ExportResultCode.FAILED,
+					error: result.error,
+				})
+			} else {
+				this.xhrMeterExporter.export(items, resultCallback)
+			}
+		}
+
+		super.export(items, retry)
 	}
 }

--- a/sdk/client/src/otel/exporter.ts
+++ b/sdk/client/src/otel/exporter.ts
@@ -59,7 +59,6 @@ export class OTLPMetricExporterBrowser extends OTLPMetricExporter {
 		super(config)
 		this.xhrMeterExporter = new OTLPMetricExporter({
 			...(config ?? {}),
-			temporalityPreference: AggregationTemporalityPreference.DELTA,
 			headers: {}, // a truthy value enables sending with XHR instead of beacon
 		})
 	}

--- a/sdk/client/src/otel/exporter.ts
+++ b/sdk/client/src/otel/exporter.ts
@@ -2,7 +2,6 @@ import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http'
 import { MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS } from '../utils/graph'
 import { ExportResult, ExportResultCode } from '@opentelemetry/core'
-import { AggregationTemporalityPreference } from '@opentelemetry/exporter-metrics-otlp-http/build/src/OTLPMetricExporterOptions'
 
 export type TraceExporterConfig = ConstructorParameters<
 	typeof OTLPTraceExporter

--- a/sdk/client/src/otel/user-interaction.ts
+++ b/sdk/client/src/otel/user-interaction.ts
@@ -1,3 +1,5 @@
+/// <reference types="zone.js" />
+
 import { InstrumentationBase, isWrapped } from '@opentelemetry/instrumentation'
 
 import * as api from '@opentelemetry/api'

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -3,6 +3,7 @@ import {
 	ConsoleMethods,
 	DebugOptions,
 	IntegrationOptions,
+	MetricCategory,
 	NetworkRecordingOptions,
 	SessionShortcutOptions,
 } from './client.js'
@@ -15,6 +16,14 @@ export declare interface Metadata {
 export declare interface Metric {
 	name: string
 	value: number
+	tags?: { name: string; value: string }[]
+}
+
+export interface RecordMetric {
+	name: string
+	value: number
+	category?: MetricCategory
+	group?: string
 	tags?: { name: string; value: string }[]
 }
 
@@ -270,9 +279,40 @@ export declare interface HighlightPublicInterface {
 	 */
 	metrics: (metrics: Metric[]) => void
 	/**
-	 * Reports a metric value via the OpenTelemetry metrics export.
+	 * Record arbitrary metric values via as a Gauge.
+	 * A Gauge records any point-in-time measurement, such as the current CPU utilization %.
+	 * Values with the same metric name and attributes are aggregated via the OTel SDK.
+	 * See https://opentelemetry.io/docs/specs/otel/metrics/data-model/ for more details.
 	 */
-	gauge: (metric: Metric) => void
+	recordMetric: (metric: Metric) => void
+	/**
+	 * Record arbitrary metric values via as a Counter.
+	 * A Counter efficiently records an increment in a metric, such as number of cache hits.
+	 * Values with the same metric name and attributes are aggregated via the OTel SDK.
+	 * See https://opentelemetry.io/docs/specs/otel/metrics/data-model/ for more details.
+	 */
+	recordCount: (metric: Metric) => void
+	/**
+	 * Record arbitrary metric values via as a Counter.
+	 * A Counter efficiently records an increment in a metric, such as number of cache hits.
+	 * Values with the same metric name and attributes are aggregated via the OTel SDK.
+	 * See https://opentelemetry.io/docs/specs/otel/metrics/data-model/ for more details.
+	 */
+	recordIncr: (metric: Metric) => void
+	/**
+	 * Record arbitrary metric values via as a Histogram.
+	 * A Histogram efficiently records near-by point-in-time measurement into a bucketed aggregate.
+	 * Values with the same metric name and attributes are aggregated via the OTel SDK.
+	 * See https://opentelemetry.io/docs/specs/otel/metrics/data-model/ for more details.
+	 */
+	recordHistogram: (metric: Metric) => void
+	/**
+	 * Record arbitrary metric values via as a UpDownCounter.
+	 * A UpDownCounter efficiently records an increment or decrement in a metric, such as number of paying customers.
+	 * Values with the same metric name and attributes are aggregated via the OTel SDK.
+	 * See https://opentelemetry.io/docs/specs/otel/metrics/data-model/ for more details.
+	 */
+	recordUpDownCounter: (metric: Metric) => void
 	/**
 	 * Starts a new span for tracing in Highlight. The span will be ended when the
 	 * callback function returns.

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -298,7 +298,7 @@ export declare interface HighlightPublicInterface {
 	 * Values with the same metric name and attributes are aggregated via the OTel SDK.
 	 * See https://opentelemetry.io/docs/specs/otel/metrics/data-model/ for more details.
 	 */
-	recordIncr: (metric: Metric) => void
+	recordIncr: (metric: Omit<Metric, 'value'>) => void
 	/**
 	 * Record arbitrary metric values via as a Histogram.
 	 * A Histogram efficiently records near-by point-in-time measurement into a bucketed aggregate.

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -270,6 +270,10 @@ export declare interface HighlightPublicInterface {
 	 */
 	metrics: (metrics: Metric[]) => void
 	/**
+	 * Reports a metric value via the OpenTelemetry metrics export.
+	 */
+	gauge: (metric: Metric) => void
+	/**
 	 * Starts a new span for tracing in Highlight. The span will be ended when the
 	 * callback function returns.
 	 *

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -391,7 +391,7 @@ const H: HighlightPublicInterface = {
 			HighlightWarning('recordCount', e)
 		}
 	},
-	recordIncr: (metric: Metric) => {
+	recordIncr: (metric: Omit<Metric, 'value'>) => {
 		try {
 			H.onHighlightReady(() => {
 				highlight_obj.recordIncr(metric)

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -28,14 +28,7 @@ import {
 	loadCookieSessionData,
 } from '@highlight-run/client/src/utils/sessionStorage/highlightSession.js'
 import { setCookieWriteEnabled } from '@highlight-run/client/src/utils/storage'
-import {
-	Context,
-	Span,
-	SpanOptions,
-	Tracer,
-	Meter,
-	Gauge,
-} from '@opentelemetry/api'
+import { Context, Span, SpanOptions, Tracer } from '@opentelemetry/api'
 import firstloadVersion from './__generated/version.js'
 import { listenToChromeExtensionMessage } from './browserExtension/extensionListener.js'
 import configureElectronHighlight from './environments/electron.js'
@@ -369,27 +362,60 @@ const H: HighlightPublicInterface = {
 	metrics: (metrics: Metric[]) => {
 		try {
 			for (const m of metrics) {
-				H.gauge(m)
+				H.recordMetric(m)
 			}
-			H.onHighlightReady(() =>
-				highlight_obj.recordMetric(
-					metrics.map((m) => ({
-						...m,
-						category: MetricCategory.Frontend,
-					})),
-				),
-			)
 		} catch (e) {
 			HighlightWarning('metrics', e)
 		}
 	},
-	gauge: (metric: Metric) => {
+	recordMetric: (metric: Metric) => {
 		try {
 			H.onHighlightReady(() => {
-				highlight_obj.gauge(metric)
+				highlight_obj.recordGauge({
+					...metric,
+					tags: metric.tags ?? [],
+					group: window.location.href,
+					category: MetricCategory.Frontend,
+				})
 			})
 		} catch (e) {
-			HighlightWarning('metrics', e)
+			HighlightWarning('recordMetric', e)
+		}
+	},
+	recordCount: (metric: Metric) => {
+		try {
+			H.onHighlightReady(() => {
+				highlight_obj.recordCount(metric)
+			})
+		} catch (e) {
+			HighlightWarning('recordCount', e)
+		}
+	},
+	recordIncr: (metric: Metric) => {
+		try {
+			H.onHighlightReady(() => {
+				highlight_obj.recordIncr(metric)
+			})
+		} catch (e) {
+			HighlightWarning('recordIncr', e)
+		}
+	},
+	recordHistogram: (metric: Metric) => {
+		try {
+			H.onHighlightReady(() => {
+				highlight_obj.recordHistogram(metric)
+			})
+		} catch (e) {
+			HighlightWarning('recordHistogram', e)
+		}
+	},
+	recordUpDownCounter: (metric: Metric) => {
+		try {
+			H.onHighlightReady(() => {
+				highlight_obj.recordUpDownCounter(metric)
+			})
+		} catch (e) {
+			HighlightWarning('recordUpDownCounter', e)
 		}
 	},
 	startSpan: (

--- a/turbo.json
+++ b/turbo.json
@@ -14,22 +14,16 @@
 			"dependsOn": [
 				"rrweb#build",
 				"@rrweb/rrweb-plugin-sequential-id-record#build",
-				"@rrweb/types#build"
+				"@rrweb/types#build",
+				"@highlight-run/client#typegen"
 			],
-			"inputs": [
-				"../client/src/**/*.tsx",
-				"../client/src/**/*.ts",
-				"src/**/*.tsx",
-				"src/**/*.ts",
-				"tsconfig.json"
-			],
+			"inputs": ["src/**/*.tsx", "src/**/*.ts", "tsconfig.json"],
 			"outputs": ["dist/**/*.d.ts"]
 		},
 		"highlight.io#build": {
 			"dependsOn": ["^build"],
 			"outputs": [".next/**"],
-			"env": ["GRAPHCMS_TOKEN"],
-			"cache": true
+			"env": ["GRAPHCMS_TOKEN"]
 		},
 		"highlight.io#lint": {
 			"dependsOn": ["^build"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -10455,16 +10455,18 @@ __metadata:
     "@graphql-codegen/typescript-graphql-request": "npm:^6.0.1"
     "@graphql-codegen/typescript-operations": "npm:^4.0.1"
     "@opentelemetry/api": "npm:^1.9.0"
-    "@opentelemetry/exporter-trace-otlp-http": "npm:>=0.53.0"
-    "@opentelemetry/instrumentation": "npm:>=0.53.0"
-    "@opentelemetry/instrumentation-document-load": "npm:>=0.40.0"
-    "@opentelemetry/instrumentation-fetch": "npm:>=0.53.0"
-    "@opentelemetry/instrumentation-user-interaction": "npm:>=0.40.0"
-    "@opentelemetry/instrumentation-xml-http-request": "npm:>=0.53.0"
-    "@opentelemetry/otlp-exporter-base": "npm:>=0.53.0"
-    "@opentelemetry/resources": "npm:^1.26.0"
-    "@opentelemetry/sdk-trace-web": "npm:^1.26.0"
-    "@opentelemetry/semantic-conventions": "npm:^1.27.0"
+    "@opentelemetry/exporter-metrics-otlp-http": "npm:>=0.57.1"
+    "@opentelemetry/exporter-trace-otlp-http": "npm:>=0.57.1"
+    "@opentelemetry/instrumentation": "npm:>=0.57.1"
+    "@opentelemetry/instrumentation-document-load": "npm:>=0.44.0"
+    "@opentelemetry/instrumentation-fetch": "npm:>=0.57.1"
+    "@opentelemetry/instrumentation-user-interaction": "npm:>=0.44.0"
+    "@opentelemetry/instrumentation-xml-http-request": "npm:>=0.57.1"
+    "@opentelemetry/otlp-exporter-base": "npm:>=0.57.1"
+    "@opentelemetry/resources": "npm:^1.30.1"
+    "@opentelemetry/sdk-metrics": "npm:^1.30.1"
+    "@opentelemetry/sdk-trace-web": "npm:^1.30.1"
+    "@opentelemetry/semantic-conventions": "npm:^1.28.0"
     "@rrweb/rrweb-plugin-sequential-id-record": "workspace:*"
     "@rrweb/types": "workspace:*"
     "@size-limit/file": "npm:^8.1.0"
@@ -10487,6 +10489,7 @@ __metadata:
     vite: "npm:^5.2.12"
     vitest: "npm:^1.6.0"
     web-vitals: "npm:^3.5.0"
+    zone.js: "npm:^0.15.0"
   languageName: unknown
   linkType: soft
 
@@ -10830,9 +10833,9 @@ __metadata:
     "@cloudflare/workers-types": "npm:4.20230214.0"
     "@opentelemetry/api": "npm:^1.8.0"
     "@opentelemetry/core": "npm:^1.22.0"
-    "@opentelemetry/instrumentation": "npm:>=0.49.1"
+    "@opentelemetry/instrumentation": "npm:^0.53.0"
     "@opentelemetry/otlp-exporter-base": "npm:^0.53.0"
-    "@opentelemetry/otlp-transformer": "npm:>=0.49.1"
+    "@opentelemetry/otlp-transformer": "npm:^0.53.0"
     "@opentelemetry/resources": "npm:^1.22.0"
     "@opentelemetry/sdk-trace-base": "npm:^1.22.0"
     "@opentelemetry/semantic-conventions": "npm:^1.22.0"
@@ -13336,6 +13339,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/api-logs@npm:0.57.1":
+  version: 0.57.1
+  resolution: "@opentelemetry/api-logs@npm:0.57.1"
+  dependencies:
+    "@opentelemetry/api": "npm:^1.3.0"
+  checksum: 10/4e06b34797f40245e8b51f52092cd74a44a5755a89bb80108428f7ef5490b8c812451fff3138d24d9b57e1f53a3b9815c40300dcf9852deacd64dad93990f736
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/api@npm:^1.0.0, @opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:^1.7.0, @opentelemetry/api@npm:^1.8.0, @opentelemetry/api@npm:^1.9.0":
   version: 1.9.0
   resolution: "@opentelemetry/api@npm:1.9.0"
@@ -13503,6 +13515,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/exporter-metrics-otlp-http@npm:>=0.57.1":
+  version: 0.57.1
+  resolution: "@opentelemetry/exporter-metrics-otlp-http@npm:0.57.1"
+  dependencies:
+    "@opentelemetry/core": "npm:1.30.1"
+    "@opentelemetry/otlp-exporter-base": "npm:0.57.1"
+    "@opentelemetry/otlp-transformer": "npm:0.57.1"
+    "@opentelemetry/resources": "npm:1.30.1"
+    "@opentelemetry/sdk-metrics": "npm:1.30.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10/2578813ca1f0ab341d6350de9476051cacfa7909bdfc4723918f01ca43f3afb8113a21783d29e8afec42f82527843eca7dbb0c2dda6c1dce9ebb6fa81d599cb9
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/exporter-trace-otlp-grpc@npm:0.53.0":
   version: 0.53.0
   resolution: "@opentelemetry/exporter-trace-otlp-grpc@npm:0.53.0"
@@ -13519,7 +13546,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/exporter-trace-otlp-http@npm:0.53.0, @opentelemetry/exporter-trace-otlp-http@npm:>=0.53.0":
+"@opentelemetry/exporter-trace-otlp-http@npm:0.53.0":
   version: 0.53.0
   resolution: "@opentelemetry/exporter-trace-otlp-http@npm:0.53.0"
   dependencies:
@@ -13531,6 +13558,21 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.0.0
   checksum: 10/28c75e25564833bc448b5733415730483c9f28714577acb679087d5ccfc46d74b3f24996c41f2c93bf6a6406edb1cad7e8cf2a76b61096e3f417f90044e1d795
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/exporter-trace-otlp-http@npm:>=0.53.0, @opentelemetry/exporter-trace-otlp-http@npm:>=0.57.1":
+  version: 0.57.1
+  resolution: "@opentelemetry/exporter-trace-otlp-http@npm:0.57.1"
+  dependencies:
+    "@opentelemetry/core": "npm:1.30.1"
+    "@opentelemetry/otlp-exporter-base": "npm:0.57.1"
+    "@opentelemetry/otlp-transformer": "npm:0.57.1"
+    "@opentelemetry/resources": "npm:1.30.1"
+    "@opentelemetry/sdk-trace-base": "npm:1.30.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10/94c1a0f70b1272c338a3cace0e2ec2d3958fe407ef8d6245d9f497a19cec95430c1226750a3148cd1f069c5e1b9871fa9889844c88094b3e1b81c7a3a2e25012
   languageName: node
   linkType: hard
 
@@ -13679,18 +13721,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/instrumentation-document-load@npm:>=0.40.0":
-  version: 0.40.0
-  resolution: "@opentelemetry/instrumentation-document-load@npm:0.40.0"
+"@opentelemetry/instrumentation-document-load@npm:>=0.44.0":
+  version: 0.44.0
+  resolution: "@opentelemetry/instrumentation-document-load@npm:0.44.0"
   dependencies:
     "@opentelemetry/core": "npm:^1.8.0"
-    "@opentelemetry/instrumentation": "npm:^0.53.0"
-    "@opentelemetry/sdk-trace-base": "npm:^1.0.0"
+    "@opentelemetry/instrumentation": "npm:^0.57.0"
     "@opentelemetry/sdk-trace-web": "npm:^1.15.0"
     "@opentelemetry/semantic-conventions": "npm:^1.27.0"
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
-  checksum: 10/801413cee4137af9f3deb751a0cba8fde0c1fe8a113597c4d94dab7b592dcc154282b1457a530e0ab0ce1273ab5ad1353441470683f0176a278e65ef46693329
+  checksum: 10/960743bf94f69968564c19bef39aae4ce1a79415722103821b112babd9dc2a546ff54d42ed32061d702ea82b1fe358d1b5bf4ce8a035b6030938f5f15adc3c7e
   languageName: node
   linkType: hard
 
@@ -13720,17 +13761,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/instrumentation-fetch@npm:>=0.53.0":
-  version: 0.53.0
-  resolution: "@opentelemetry/instrumentation-fetch@npm:0.53.0"
+"@opentelemetry/instrumentation-fetch@npm:>=0.57.1":
+  version: 0.57.1
+  resolution: "@opentelemetry/instrumentation-fetch@npm:0.57.1"
   dependencies:
-    "@opentelemetry/core": "npm:1.26.0"
-    "@opentelemetry/instrumentation": "npm:0.53.0"
-    "@opentelemetry/sdk-trace-web": "npm:1.26.0"
-    "@opentelemetry/semantic-conventions": "npm:1.27.0"
+    "@opentelemetry/core": "npm:1.30.1"
+    "@opentelemetry/instrumentation": "npm:0.57.1"
+    "@opentelemetry/sdk-trace-web": "npm:1.30.1"
+    "@opentelemetry/semantic-conventions": "npm:1.28.0"
   peerDependencies:
-    "@opentelemetry/api": ^1.0.0
-  checksum: 10/422e9c749523a2be4cd6b82304f20b3208ced12a14990b1cfee273c7485252c94618336c94342a0b0ad72863ec5519d3b1c31f0d09395c29926ecbc0986c9b15
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10/e736a62a5952aff0a0a7bfa1d04f67912f57945e151b798e6d7e7fddd2c3a293b44f36ae1b0a612495da8d3b7b235bb46a9fd18e64c5a6b5319f1b7296d6170f
   languageName: node
   linkType: hard
 
@@ -14073,17 +14114,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/instrumentation-user-interaction@npm:>=0.40.0":
-  version: 0.40.0
-  resolution: "@opentelemetry/instrumentation-user-interaction@npm:0.40.0"
+"@opentelemetry/instrumentation-user-interaction@npm:>=0.44.0":
+  version: 0.44.0
+  resolution: "@opentelemetry/instrumentation-user-interaction@npm:0.44.0"
   dependencies:
     "@opentelemetry/core": "npm:^1.8.0"
-    "@opentelemetry/instrumentation": "npm:^0.53.0"
+    "@opentelemetry/instrumentation": "npm:^0.57.0"
     "@opentelemetry/sdk-trace-web": "npm:^1.8.0"
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
-    zone.js: ^0.11.4 || ^0.13.0 || ^0.14.0
-  checksum: 10/c60ed3dcaffe093ff5953283c89651b6049fb0ac191ef226ef7163f38f1997b2801974d3e7fb2dbe8357ee681b36ab82e79a10df935df7b1f609e2348c1feeec
+    zone.js: ^0.11.4 || ^0.13.0 || ^0.14.0 || ^0.15.0
+  checksum: 10/a2bfc8575371e7f76cde0cdb3260ac1e9c7f696fb178299081105b37dd9464cd6441162dbaa4afc9d326591f4fcd39a63d2f6292d2db8c47ca82699a513c4af7
   languageName: node
   linkType: hard
 
@@ -14099,17 +14140,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/instrumentation-xml-http-request@npm:>=0.53.0":
-  version: 0.53.0
-  resolution: "@opentelemetry/instrumentation-xml-http-request@npm:0.53.0"
+"@opentelemetry/instrumentation-xml-http-request@npm:>=0.57.1":
+  version: 0.57.1
+  resolution: "@opentelemetry/instrumentation-xml-http-request@npm:0.57.1"
   dependencies:
-    "@opentelemetry/core": "npm:1.26.0"
-    "@opentelemetry/instrumentation": "npm:0.53.0"
-    "@opentelemetry/sdk-trace-web": "npm:1.26.0"
-    "@opentelemetry/semantic-conventions": "npm:1.27.0"
+    "@opentelemetry/core": "npm:1.30.1"
+    "@opentelemetry/instrumentation": "npm:0.57.1"
+    "@opentelemetry/sdk-trace-web": "npm:1.30.1"
+    "@opentelemetry/semantic-conventions": "npm:1.28.0"
   peerDependencies:
-    "@opentelemetry/api": ^1.0.0
-  checksum: 10/82c7e3d9f54fafccfabfe02033b11ca39b052134ec6e8902ac3c54993745fc02503f60e7d223b74319e855091c5f961e78483857a690633958fb61852c041749
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10/dad99f2d37c550177575a621c4538677a173c607bcc43133095c58fe8c36101d38e3e0cc84158bd717e4ad925dcec4788f30ae5592fdf27cc71e411990544473
   languageName: node
   linkType: hard
 
@@ -14129,7 +14170,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/instrumentation@npm:>=0.49.1, @opentelemetry/instrumentation@npm:>=0.53.0, @opentelemetry/instrumentation@npm:^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0":
+"@opentelemetry/instrumentation@npm:0.57.1, @opentelemetry/instrumentation@npm:>=0.53.0, @opentelemetry/instrumentation@npm:>=0.57.1, @opentelemetry/instrumentation@npm:^0.57.0":
+  version: 0.57.1
+  resolution: "@opentelemetry/instrumentation@npm:0.57.1"
+  dependencies:
+    "@opentelemetry/api-logs": "npm:0.57.1"
+    "@types/shimmer": "npm:^1.2.0"
+    import-in-the-middle: "npm:^1.8.1"
+    require-in-the-middle: "npm:^7.1.1"
+    semver: "npm:^7.5.2"
+    shimmer: "npm:^1.2.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10/8f21a1b69aab5b48f8d85da2dd944d12f498757b890d4da062f7736a2254b19fb2c678db1807889e0526d3bbb653455c24c0d89523662d358fdb4e615f099fcf
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation@npm:^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0":
   version: 0.56.0
   resolution: "@opentelemetry/instrumentation@npm:0.56.0"
   dependencies:
@@ -14145,7 +14202,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/otlp-exporter-base@npm:0.53.0, @opentelemetry/otlp-exporter-base@npm:>=0.53.0, @opentelemetry/otlp-exporter-base@npm:^0.53.0":
+"@opentelemetry/otlp-exporter-base@npm:0.53.0, @opentelemetry/otlp-exporter-base@npm:^0.53.0":
   version: 0.53.0
   resolution: "@opentelemetry/otlp-exporter-base@npm:0.53.0"
   dependencies:
@@ -14154,6 +14211,18 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.0.0
   checksum: 10/ca59d73ae8f83946062b060a9a382fc7db6154c892ed56b6ab7f545530ba4850b4d0a748daaa30d1177ef6a8c2a0fddd34a199080f4474ec445944cece86f1ef
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/otlp-exporter-base@npm:0.57.1, @opentelemetry/otlp-exporter-base@npm:>=0.57.1":
+  version: 0.57.1
+  resolution: "@opentelemetry/otlp-exporter-base@npm:0.57.1"
+  dependencies:
+    "@opentelemetry/core": "npm:1.30.1"
+    "@opentelemetry/otlp-transformer": "npm:0.57.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10/973d92d99f85926f9f19d9a7ef5d549aa72d91707299608ae6494c38cb4dba44baabc8c0f35ced116a5c851fb5cb354c650b292cb7a0efcdc39aa34a0917564b
   languageName: node
   linkType: hard
 
@@ -14171,7 +14240,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/otlp-transformer@npm:0.53.0, @opentelemetry/otlp-transformer@npm:>=0.49.1":
+"@opentelemetry/otlp-transformer@npm:0.53.0, @opentelemetry/otlp-transformer@npm:^0.53.0":
   version: 0.53.0
   resolution: "@opentelemetry/otlp-transformer@npm:0.53.0"
   dependencies:
@@ -14185,6 +14254,23 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
   checksum: 10/578cf13d7984a0b1ba1db3d86d1e358bf70e8b534166f8327a10fccca0afd3900896a80e5e73caae61837b0cbc99d81b44784edee68a3517d73f5330a3624ccd
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/otlp-transformer@npm:0.57.1":
+  version: 0.57.1
+  resolution: "@opentelemetry/otlp-transformer@npm:0.57.1"
+  dependencies:
+    "@opentelemetry/api-logs": "npm:0.57.1"
+    "@opentelemetry/core": "npm:1.30.1"
+    "@opentelemetry/resources": "npm:1.30.1"
+    "@opentelemetry/sdk-logs": "npm:0.57.1"
+    "@opentelemetry/sdk-metrics": "npm:1.30.1"
+    "@opentelemetry/sdk-trace-base": "npm:1.30.1"
+    protobufjs: "npm:^7.3.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10/49f77a22466faeda94cb87583fa71e8aa07ae3e218f320b877d48de37947df828d9f6c70e24a9ff03406198e687ce36d2b3c016936b20c77b9cb6e0bfce23573
   languageName: node
   linkType: hard
 
@@ -14341,7 +14427,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/resources@npm:1.30.1, @opentelemetry/resources@npm:^1.0.0, @opentelemetry/resources@npm:^1.10.0, @opentelemetry/resources@npm:^1.10.1, @opentelemetry/resources@npm:^1.22.0, @opentelemetry/resources@npm:^1.24.0, @opentelemetry/resources@npm:^1.26.0, @opentelemetry/resources@npm:^1.30.0, @opentelemetry/resources@npm:^1.8.0":
+"@opentelemetry/resources@npm:1.30.1, @opentelemetry/resources@npm:^1.0.0, @opentelemetry/resources@npm:^1.10.0, @opentelemetry/resources@npm:^1.10.1, @opentelemetry/resources@npm:^1.22.0, @opentelemetry/resources@npm:^1.24.0, @opentelemetry/resources@npm:^1.26.0, @opentelemetry/resources@npm:^1.30.0, @opentelemetry/resources@npm:^1.30.1, @opentelemetry/resources@npm:^1.8.0":
   version: 1.30.1
   resolution: "@opentelemetry/resources@npm:1.30.1"
   dependencies:
@@ -14379,6 +14465,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/sdk-logs@npm:0.57.1":
+  version: 0.57.1
+  resolution: "@opentelemetry/sdk-logs@npm:0.57.1"
+  dependencies:
+    "@opentelemetry/api-logs": "npm:0.57.1"
+    "@opentelemetry/core": "npm:1.30.1"
+    "@opentelemetry/resources": "npm:1.30.1"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.4.0 <1.10.0"
+  checksum: 10/e1dc32ea4520436640b2aabfa81396c8977276ceebc9708a84d96742cc86866344d73b49d61dc6448984c741cc766c1653539caeacb9c4594c6d9f0e532840fc
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/sdk-metrics@npm:1.21.0":
   version: 1.21.0
   resolution: "@opentelemetry/sdk-metrics@npm:1.21.0"
@@ -14392,7 +14491,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/sdk-metrics@npm:1.26.0, @opentelemetry/sdk-metrics@npm:^1.9.1":
+"@opentelemetry/sdk-metrics@npm:1.26.0":
   version: 1.26.0
   resolution: "@opentelemetry/sdk-metrics@npm:1.26.0"
   dependencies:
@@ -14401,6 +14500,18 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.3.0 <1.10.0"
   checksum: 10/e48e4dd1fed1e501750460e1320f89507c19287c5059cfaccc8268ad8cc3e1de40feeee6584b23626e01f9cde0f10301d08edf6a65bbd1346ef94f70ae8844f5
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-metrics@npm:1.30.1, @opentelemetry/sdk-metrics@npm:^1.30.1, @opentelemetry/sdk-metrics@npm:^1.9.1":
+  version: 1.30.1
+  resolution: "@opentelemetry/sdk-metrics@npm:1.30.1"
+  dependencies:
+    "@opentelemetry/core": "npm:1.30.1"
+    "@opentelemetry/resources": "npm:1.30.1"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: 10/cfdbef083eab77ee62cf4d3f29508a0f444a2a2413554b2977632ea1e238fbd472c964b48e09eb48e2131f6cdc1957ff079838d53de5777207a041b594dd917a
   languageName: node
   linkType: hard
 
@@ -14456,7 +14567,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/sdk-trace-base@npm:^1.0.0, @opentelemetry/sdk-trace-base@npm:^1.22.0, @opentelemetry/sdk-trace-base@npm:^1.26.0, @opentelemetry/sdk-trace-base@npm:^1.30.0":
+"@opentelemetry/sdk-trace-base@npm:1.30.1, @opentelemetry/sdk-trace-base@npm:^1.22.0, @opentelemetry/sdk-trace-base@npm:^1.26.0, @opentelemetry/sdk-trace-base@npm:^1.30.0":
   version: 1.30.1
   resolution: "@opentelemetry/sdk-trace-base@npm:1.30.1"
   dependencies:
@@ -14485,16 +14596,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/sdk-trace-web@npm:1.26.0, @opentelemetry/sdk-trace-web@npm:^1.15.0, @opentelemetry/sdk-trace-web@npm:^1.26.0, @opentelemetry/sdk-trace-web@npm:^1.8.0":
-  version: 1.26.0
-  resolution: "@opentelemetry/sdk-trace-web@npm:1.26.0"
+"@opentelemetry/sdk-trace-web@npm:1.30.1, @opentelemetry/sdk-trace-web@npm:^1.15.0, @opentelemetry/sdk-trace-web@npm:^1.30.1, @opentelemetry/sdk-trace-web@npm:^1.8.0":
+  version: 1.30.1
+  resolution: "@opentelemetry/sdk-trace-web@npm:1.30.1"
   dependencies:
-    "@opentelemetry/core": "npm:1.26.0"
-    "@opentelemetry/sdk-trace-base": "npm:1.26.0"
-    "@opentelemetry/semantic-conventions": "npm:1.27.0"
+    "@opentelemetry/core": "npm:1.30.1"
+    "@opentelemetry/sdk-trace-base": "npm:1.30.1"
+    "@opentelemetry/semantic-conventions": "npm:1.28.0"
   peerDependencies:
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
-  checksum: 10/2882863d02510151460850575269129c603f2b3e44f5b2c34bede4128d7f724b7bb8bb8253469848110725e2b2af9340d13a81d565ea9e0c80cf57804b02d65f
+  checksum: 10/43e73a70201d936dbc69934107a92dcdbeaf4c1043935e1c8803462226ff6bf6dfc4be83c110efbaf041209af8365530cbe5b9734867091e565ef11d7a534b7a
   languageName: node
   linkType: hard
 
@@ -14512,7 +14623,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/semantic-conventions@npm:1.28.0, @opentelemetry/semantic-conventions@npm:^1.22.0, @opentelemetry/semantic-conventions@npm:^1.27.0":
+"@opentelemetry/semantic-conventions@npm:1.28.0, @opentelemetry/semantic-conventions@npm:^1.22.0, @opentelemetry/semantic-conventions@npm:^1.27.0, @opentelemetry/semantic-conventions@npm:^1.28.0":
   version: 1.28.0
   resolution: "@opentelemetry/semantic-conventions@npm:1.28.0"
   checksum: 10/c182a3206769b5d5a8ab89a5c674d046fd789421cef27ea55af179990e314732433c98e5017aa23e99f15fd2b0e13cb129bb6c2282da6860ce9419adf32b2e87
@@ -64871,6 +64982,13 @@ __metadata:
   version: 3.24.1
   resolution: "zod@npm:3.24.1"
   checksum: 10/54e25956495dec22acb9399c168c6ba657ff279801a7fcd0530c414d867f1dcca279335e160af9b138dd70c332e17d548be4bc4d2f7eaf627dead50d914fec27
+  languageName: node
+  linkType: hard
+
+"zone.js@npm:^0.15.0":
+  version: 0.15.0
+  resolution: "zone.js@npm:0.15.0"
+  checksum: 10/99b9381edcf1ca3da147375a9776f8ad5e6570b9e2cbd33095284a67904d94b5083448440ffcb8ec1e418a505020de0e37837db04d6a0303e111b054a8b752a2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14257,7 +14257,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/otlp-transformer@npm:0.57.1":
+"@opentelemetry/otlp-transformer@npm:0.57.1, @opentelemetry/otlp-transformer@npm:^0.57.1":
   version: 0.57.1
   resolution: "@opentelemetry/otlp-transformer@npm:0.57.1"
   dependencies:
@@ -47893,6 +47893,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "mock-otel-server@workspace:packages/mock-otel-server"
   dependencies:
+    "@opentelemetry/api": "npm:^1.9.0"
+    "@opentelemetry/otlp-transformer": "npm:^0.57.1"
     express: "npm:^4.19.2"
     tsx: "npm:^4.6.2"
   languageName: unknown


### PR DESCRIPTION
## Summary

Introduces OTLP metrics export to the highlight.run SDK.
Adds a `H.gauge` function to supercede the legacy `pushMetrics` GraphQL export.
Migrates existing auto-reported metrics to the new export format.

## How did you test this change?

![Screenshot from 2025-01-26 19-33-48](https://github.com/user-attachments/assets/2f9bb43b-d673-4a3b-b715-d49b2c1d4004)

![Screenshot from 2025-01-26 19-46-38](https://github.com/user-attachments/assets/027ed337-2904-4db4-b97b-502857c66584)


## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no