### PR TITLE
fix: update bar chart hover opacity to 5% (#9811)

### DIFF
--- a/packages/ui/src/css/theme.css.ts
+++ b/packages/ui/src/css/theme.css.ts
@@ -111,7 +111,7 @@ export const themeVars = createGlobalTheme('.highlight-light-theme', {
 			},
 			secondary: {
 				enabled: 'rgba(238, 237, 239, 0.0)',
-				hover: '#eeedef',
+				hover: 'rgba(22, 22, 24, 0.05)',
 				pressed: '#e9e8ea',
 				disabled: 'rgba(238, 237, 239, 0.0)',
 				selected: {


### PR DESCRIPTION
# Fix Bar Chart Hover Opacity (#9811)

## Changes
- Updated the secondary overlay hover opacity in `packages/ui/src/css/theme.css.ts`
- Changed the hover color in the `interactive.overlay.secondary` theme from `rgba(238, 237, 239, 0.05)` to `rgba(22, 22, 24, 0.05)` (#1616180D)
- This affects all components using the secondary overlay hover state, including bar charts

## Location of Change
```tsx
// packages/ui/src/css/theme.css.ts
secondary: {
  enabled: 'rgba(238, 237, 239, 0.0)',
  hover: 'rgba(22, 22, 24, 0.05)', // Updated this line to use 5% opacity
  pressed: '#e9e8ea',
  ...
}
Fixes #9811 