### PR TITLE
reduce noisy ErrorStackParser.parse failures when failing to parse provided error

### DIFF
--- a/.changeset/loud-pandas-tease.md
+++ b/.changeset/loud-pandas-tease.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+reduce noisy ErrorStackParser.parse failures when failing to parse provided error

--- a/__generated/rr/rrweb/rr.js
+++ b/__generated/rr/rrweb/rr.js
@@ -63,10 +63,12 @@ function getUntaintedPrototype$1(key) {
     const iframeEl = document.createElement("iframe");
     document.body.appendChild(iframeEl);
     const win = iframeEl.contentWindow;
-    if (!win) return defaultObj.prototype;
+    if (!win)
+      return defaultObj.prototype;
     const untaintedObject = win[key].prototype;
     document.body.removeChild(iframeEl);
-    if (!untaintedObject) return defaultPrototype;
+    if (!untaintedObject)
+      return defaultPrototype;
     return untaintedBasePrototype$1[key] = untaintedObject;
   } catch {
     return defaultPrototype;
@@ -85,7 +87,8 @@ function getUntaintedAccessor$1(key, instance, accessor) {
     untaintedPrototype,
     accessor
   )) == null ? void 0 : _a2.get;
-  if (!untaintedAccessor) return instance[accessor];
+  if (!untaintedAccessor)
+    return instance[accessor];
   untaintedAccessorCache$1[cacheKey] = untaintedAccessor;
   return untaintedAccessor.call(instance);
 }
@@ -98,7 +101,8 @@ function getUntaintedMethod$1(key, instance, method) {
     );
   const untaintedPrototype = getUntaintedPrototype$1(key);
   const untaintedMethod = untaintedPrototype[method];
-  if (typeof untaintedMethod !== "function") return instance[method];
+  if (typeof untaintedMethod !== "function")
+    return instance[method];
   untaintedMethodCache$1[cacheKey] = untaintedMethod;
   return untaintedMethod.bind(instance);
 }
@@ -121,14 +125,16 @@ function getRootNode$1(n2) {
   return getUntaintedMethod$1("Node", n2, "getRootNode")();
 }
 function host$1(n2) {
-  if (!n2 || !("host" in n2)) return null;
+  if (!n2 || !("host" in n2))
+    return null;
   return getUntaintedAccessor$1("ShadowRoot", n2, "host");
 }
 function styleSheets$1(n2) {
   return n2.styleSheets;
 }
 function shadowRoot$1(n2) {
-  if (!n2 || !("shadowRoot" in n2)) return null;
+  if (!n2 || !("shadowRoot" in n2))
+    return null;
   return getUntaintedAccessor$1("Element", n2, "shadowRoot");
 }
 function querySelector$1(n2, selectors) {
@@ -10377,10 +10383,12 @@ function getUntaintedPrototype(key) {
     const iframeEl = document.createElement("iframe");
     document.body.appendChild(iframeEl);
     const win = iframeEl.contentWindow;
-    if (!win) return defaultObj.prototype;
+    if (!win)
+      return defaultObj.prototype;
     const untaintedObject = win[key].prototype;
     document.body.removeChild(iframeEl);
-    if (!untaintedObject) return defaultPrototype;
+    if (!untaintedObject)
+      return defaultPrototype;
     return untaintedBasePrototype[key] = untaintedObject;
   } catch {
     return defaultPrototype;
@@ -10399,7 +10407,8 @@ function getUntaintedAccessor(key, instance, accessor) {
     untaintedPrototype,
     accessor
   )) == null ? void 0 : _a2.get;
-  if (!untaintedAccessor) return instance[accessor];
+  if (!untaintedAccessor)
+    return instance[accessor];
   untaintedAccessorCache[cacheKey] = untaintedAccessor;
   return untaintedAccessor.call(instance);
 }
@@ -10412,7 +10421,8 @@ function getUntaintedMethod(key, instance, method) {
     );
   const untaintedPrototype = getUntaintedPrototype(key);
   const untaintedMethod = untaintedPrototype[method];
-  if (typeof untaintedMethod !== "function") return instance[method];
+  if (typeof untaintedMethod !== "function")
+    return instance[method];
   untaintedMethodCache[cacheKey] = untaintedMethod;
   return untaintedMethod.bind(instance);
 }
@@ -10435,14 +10445,16 @@ function getRootNode(n2) {
   return getUntaintedMethod("Node", n2, "getRootNode")();
 }
 function host(n2) {
-  if (!n2 || !("host" in n2)) return null;
+  if (!n2 || !("host" in n2))
+    return null;
   return getUntaintedAccessor("ShadowRoot", n2, "host");
 }
 function styleSheets(n2) {
   return n2.styleSheets;
 }
 function shadowRoot(n2) {
-  if (!n2 || !("shadowRoot" in n2)) return null;
+  if (!n2 || !("shadowRoot" in n2))
+    return null;
   return getUntaintedAccessor("Element", n2, "shadowRoot");
 }
 function querySelector(n2, selectors) {

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -1,6 +1,5 @@
 import { getRecordSequentialIdPlugin } from '@rrweb/rrweb-plugin-sequential-id-record'
 import { eventWithTime, listenerHandler } from '@rrweb/types'
-import ErrorStackParser from 'error-stack-parser'
 import { print } from 'graphql'
 import { GraphQLClient } from 'graphql-request'
 import stringify from 'json-stringify-safe'

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -97,6 +97,7 @@ import { getDefaultDataURLOptions } from './utils/utils'
 import type { HighlightClientRequestWorker } from './workers/highlight-client-worker'
 import HighlightClientWorker from './workers/highlight-client-worker?worker&inline'
 import { MessageType, PropertyType, Source } from './workers/types'
+import { parseError } from './utils/errors'
 
 export const HighlightWarning = (context: string, msg: any) => {
 	console.warn(`Highlight Warning: (${context}): `, { output: msg })
@@ -480,7 +481,7 @@ export class Highlight {
 		if (type === 'React.ErrorBoundary') {
 			event = 'ErrorBoundary: ' + event
 		}
-		const res = ErrorStackParser.parse(error)
+		const res = parseError(error)
 		this._firstLoadListeners.errors.push({
 			event,
 			type: type ?? 'custom',

--- a/sdk/client/src/listeners/console-listener.tsx
+++ b/sdk/client/src/listeners/console-listener.tsx
@@ -1,4 +1,4 @@
-import ErrorStackParser from 'error-stack-parser'
+import type { StackFrame } from 'error-stack-parser'
 import { ConsoleMethods } from '../types/client'
 import { ConsoleMessage } from '../types/shared-types'
 import { patch, stringify } from '../utils/utils'
@@ -72,7 +72,7 @@ export function ConsoleListener(
 		if (window) {
 			const errorHandler = (event: ErrorEvent) => {
 				const { message, error } = event
-				let trace: ErrorStackParser.StackFrame[] = []
+				let trace: StackFrame[] = []
 				if (error) {
 					trace = parseError(error)
 				}

--- a/sdk/client/src/listeners/console-listener.tsx
+++ b/sdk/client/src/listeners/console-listener.tsx
@@ -2,6 +2,7 @@ import ErrorStackParser from 'error-stack-parser'
 import { ConsoleMethods } from '../types/client'
 import { ConsoleMessage } from '../types/shared-types'
 import { patch, stringify } from '../utils/utils'
+import { parseError } from '../utils/errors'
 
 export type StringifyOptions = {
 	// limit of string length
@@ -71,9 +72,9 @@ export function ConsoleListener(
 		if (window) {
 			const errorHandler = (event: ErrorEvent) => {
 				const { message, error } = event
-				let trace: any[] = []
+				let trace: ErrorStackParser.StackFrame[] = []
 				if (error) {
-					trace = ErrorStackParser.parse(error)
+					trace = parseError(error)
 				}
 				const payload = [
 					stringify(message, logOptions.stringifyOptions),
@@ -114,7 +115,7 @@ export function ConsoleListener(
 				// @ts-expect-error
 				original.apply(this, data)
 				try {
-					const trace = ErrorStackParser.parse(new Error())
+					const trace = parseError(new Error())
 					const message = logOptions.serializeConsoleAttributes
 						? data.map((o) =>
 								typeof o === 'object'

--- a/sdk/client/src/listeners/error-listener.tsx
+++ b/sdk/client/src/listeners/error-listener.tsx
@@ -1,6 +1,7 @@
 import ErrorStackParser from 'error-stack-parser'
 import stringify from 'json-stringify-safe'
 import { ErrorMessage } from '../types/shared-types'
+import { parseError } from '../utils/errors'
 
 interface HighlightPromise<T> extends Promise<T> {
 	promiseCreationError: Error
@@ -13,12 +14,7 @@ function handleError(
 	source: string | undefined,
 	error?: Error,
 ) {
-	let res: ErrorStackParser.StackFrame[] = []
-	try {
-		res = ErrorStackParser.parse(error ?? event)
-	} catch (e) {
-		res = ErrorStackParser.parse(new Error())
-	}
+	let res = parseError(error ?? event)
 	let payload: Object = {}
 	if (event instanceof Error) {
 		event = event.message

--- a/sdk/client/src/listeners/error-listener.tsx
+++ b/sdk/client/src/listeners/error-listener.tsx
@@ -1,4 +1,4 @@
-import ErrorStackParser from 'error-stack-parser'
+import type { StackFrame } from 'error-stack-parser'
 import stringify from 'json-stringify-safe'
 import { ErrorMessage } from '../types/shared-types'
 import { parseError } from '../utils/errors'
@@ -106,9 +106,7 @@ export const ErrorListener = (
 	}
 }
 
-const removeHighlightFrameIfExists = (
-	frames: ErrorStackParser.StackFrame[],
-): ErrorStackParser.StackFrame[] => {
+const removeHighlightFrameIfExists = (frames: StackFrame[]): StackFrame[] => {
 	if (frames.length === 0) {
 		return frames
 	}

--- a/sdk/client/src/utils/errors.ts
+++ b/sdk/client/src/utils/errors.ts
@@ -1,0 +1,17 @@
+import ErrorStackParser from 'error-stack-parser'
+
+export function parseError(err: Error) {
+	try {
+		return ErrorStackParser.parse(err)
+	} catch (originalError) {
+		try {
+			return ErrorStackParser.parse(new Error())
+		} catch (secondaryError) {
+			console.warn(`Highlight Warning: failed to parse error`, {
+				originalError,
+				secondaryError,
+			})
+			return []
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Consolidate the `ErrorStackParser.parse` logic and ensure exceptions raised by the method are caught.

## How did you test this change?

local sdk testing catching errors
![Screenshot from 2025-01-28 13-19-54](https://github.com/user-attachments/assets/5ef23918-135b-43e7-90fb-1d50f6df2eb1)
![Screenshot from 2025-01-28 13-19-49](https://github.com/user-attachments/assets/95e9e388-dfaa-414a-9a63-a003f72286b5)
![Screenshot from 2025-01-28 13-19-40](https://github.com/user-attachments/assets/bfe36c1d-b1ec-4480-9cdd-c8c7e4325912)
![Screenshot from 2025-01-28 13-19-36](https://github.com/user-attachments/assets/1be8dbd1-b805-45a5-a7c5-0d70bdeb81ea)
![Screenshot from 2025-01-28 13-19-27](https://github.com/user-attachments/assets/82ded259-7f01-4650-b2e8-2bd7213cb90c)


## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no