### PR TITLE
update TTL of raw metrics tables

### DIFF
--- a/backend/clickhouse/migrations/000141_metrics_table_reduce_raw_ttl.down.sql
+++ b/backend/clickhouse/migrations/000141_metrics_table_reduce_raw_ttl.down.sql
@@ -1,4 +1,4 @@
 
-ALTER TABLE default.metrics_sum MODIFY TTL toDateTime(Timestamp) + toIntervalDay(RetentionDays);
-ALTER TABLE default.metrics_histogram MODIFY TTL toDateTime(Timestamp) + toIntervalDay(RetentionDays);
-ALTER TABLE default.metrics_summary MODIFY TTL toDateTime(Timestamp) + toIntervalDay(RetentionDays);
+ALTER TABLE metrics_sum MODIFY TTL toDateTime(Timestamp) + toIntervalDay(RetentionDays);
+ALTER TABLE metrics_histogram MODIFY TTL toDateTime(Timestamp) + toIntervalDay(RetentionDays);
+ALTER TABLE metrics_summary MODIFY TTL toDateTime(Timestamp) + toIntervalDay(RetentionDays);

--- a/backend/clickhouse/migrations/000141_metrics_table_reduce_raw_ttl.down.sql
+++ b/backend/clickhouse/migrations/000141_metrics_table_reduce_raw_ttl.down.sql
@@ -1,0 +1,4 @@
+
+ALTER TABLE default.metrics_sum MODIFY TTL toDateTime(Timestamp) + toIntervalDay(RetentionDays);
+ALTER TABLE default.metrics_histogram MODIFY TTL toDateTime(Timestamp) + toIntervalDay(RetentionDays);
+ALTER TABLE default.metrics_summary MODIFY TTL toDateTime(Timestamp) + toIntervalDay(RetentionDays);

--- a/backend/clickhouse/migrations/000141_metrics_table_reduce_raw_ttl.up.sql
+++ b/backend/clickhouse/migrations/000141_metrics_table_reduce_raw_ttl.up.sql
@@ -1,3 +1,3 @@
-ALTER TABLE default.metrics_sum MODIFY TTL toDateTime(Timestamp) + INTERVAL 1 DAY;
-ALTER TABLE default.metrics_histogram MODIFY TTL toDateTime(Timestamp) + INTERVAL 1 DAY;
-ALTER TABLE default.metrics_summary MODIFY TTL toDateTime(Timestamp) + INTERVAL 1 DAY;
+ALTER TABLE metrics_sum MODIFY TTL toDateTime(Timestamp) + INTERVAL 1 HOUR;
+ALTER TABLE metrics_histogram MODIFY TTL toDateTime(Timestamp) + INTERVAL 1 HOUR;
+ALTER TABLE metrics_summary MODIFY TTL toDateTime(Timestamp) + INTERVAL 1 HOUR;

--- a/backend/clickhouse/migrations/000141_metrics_table_reduce_raw_ttl.up.sql
+++ b/backend/clickhouse/migrations/000141_metrics_table_reduce_raw_ttl.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE default.metrics_sum MODIFY TTL toDateTime(Timestamp) + INTERVAL 1 DAY;
+ALTER TABLE default.metrics_histogram MODIFY TTL toDateTime(Timestamp) + INTERVAL 1 DAY;
+ALTER TABLE default.metrics_summary MODIFY TTL toDateTime(Timestamp) + INTERVAL 1 DAY;


### PR DESCRIPTION
## Summary

Ingest metrics tables have high granularity data that is rolled up into the `metrics` table via MVs.
The retention based TTL should only be applied to the destination `metrics` table.

## How did you test this change?

local deploy

## Are there any deployment considerations?

will help reduce storage cost of metrics

## Does this work require review from our design team?

no
