### PR TITLE
fix project ids sent by frontend with member project level access

### DIFF
--- a/frontend/src/pages/WorkspaceTeam/components/AllMembers.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AllMembers.tsx
@@ -37,11 +37,12 @@ import * as style from './AllMembers.css'
 
 type Option = {
 	key: string
+	value: AdminRole
 	render: string
 }
 
 const ALL_KEY = 'All'
-const ALL_OPTION = { key: ALL_KEY, render: ALL_KEY }
+const ALL_OPTION = { key: ALL_KEY, value: AdminRole.Member, render: ALL_KEY }
 
 export const PopoverCell = <T extends string[] | string>({
 	options,
@@ -174,10 +175,12 @@ export const PopoverCell = <T extends string[] | string>({
 export const RoleOptions: Option[] = [
 	{
 		key: AdminRole.Member,
+		value: AdminRole.Member,
 		render: 'Member',
 	},
 	{
 		key: AdminRole.Admin,
+		value: AdminRole.Admin,
 		render: 'Admin',
 	},
 ]
@@ -188,7 +191,7 @@ const DISABLED_REASON_NOT_ADMIN =
 	'You must have Admin role to update user access.'
 const DISABLED_REASON_IS_SELF = 'You cannot update your own access.'
 export const DISABLED_REASON_IS_ADMIN = 'Admins have access to all projects.'
-const DISABLED_REASON_NOT_ENTERPRISE =
+export const DISABLED_REASON_NOT_ENTERPRISE =
 	'Manage project access with an enterprise plan.'
 
 const AllMembers = ({

--- a/frontend/src/pages/WorkspaceTeam/components/AllMembers.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AllMembers.tsx
@@ -229,6 +229,7 @@ const AllMembers = ({
 
 	const projectOptions = projects?.map((p) => ({
 		key: p.id,
+		value: AdminRole.Admin,
 		render: p.name,
 	}))
 

--- a/frontend/src/pages/WorkspaceTeam/components/InviteMemberModal.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/InviteMemberModal.tsx
@@ -88,8 +88,6 @@ function InviteMemberModal({
 				? (allProjects?.map((p) => p?.id).filter(Boolean) as string[])
 				: newProjectIds
 
-		console.log('vadim', { projectIdsToSend, newAdminRole })
-
 		sendInviteEmail({
 			variables: {
 				workspace_id: workspaceId!,

--- a/frontend/src/pages/WorkspaceTeam/components/InviteMemberModal.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/InviteMemberModal.tsx
@@ -136,7 +136,7 @@ function InviteMemberModal({
 		}
 
 		const projectIdsToSend =
-			newAdminRole !== AdminRole.Admin && newProjectIds.length === 0
+			newAdminRole !== AdminRole.Admin && !newProjectIds?.length
 				? (allProjects?.map((p) => p?.id).filter(Boolean) as string[])
 				: newProjectIds.map((p: { id: string }) => p.id)
 


### PR DESCRIPTION
## Summary

Corrects an issue in the new member invite modal that would send
all project IDs for a `MEMBER` invite when specific projects were selected.

## How did you test this change?

<img width="804" alt="Screenshot 2025-02-03 at 09 42 39" src="https://github.com/user-attachments/assets/426836c0-4722-4249-96b7-a66f9b756103" />
<img width="835" alt="Screenshot 2025-02-03 at 09 42 57" src="https://github.com/user-attachments/assets/007c2b22-baef-4410-bdd2-e26e5c7e9756" />

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
