### PR TITLE
add internet speed instrumentation to the highlight.run web sdk

### DIFF
--- a/.changeset/swift-bears-compete.md
+++ b/.changeset/swift-bears-compete.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': minor
+---
+
+add a network performance listener to report network connection properties

--- a/cypress/e2e/client.cy.js
+++ b/cypress/e2e/client.cy.js
@@ -102,12 +102,29 @@ describe('client recording spec', () => {
 						)
 					}
 					const payload = JSON.parse(customEvent.data.payload)
-					if (
-						(customEvent.data.tag !== 'Track' &&
-							customEvent.data.tag !== 'Performance') ||
-						payload.foo !== 'bar' ||
-						payload.event !== 'MyTrackEvent'
-					) {
+					if (customEvent.data.tag === 'Track') {
+						if (
+							payload.foo !== 'bar' ||
+							payload.event !== 'MyTrackEvent'
+						) {
+							throw new Error(
+								'invalid Track customEvent: ' +
+									JSON.stringify(customEvent),
+							)
+						}
+					} else if (customEvent.data.tag === 'Performance') {
+						if (
+							!Number.isFinite(payload.jsHeapSizeLimit) ||
+							!Number.isFinite(payload.usedJSHeapSize) ||
+							!Number.isFinite(payload.fps) ||
+							!Number.isFinite(payload.relativeTimestamp)
+						) {
+							throw new Error(
+								'invalid Performance customEvent: ' +
+									JSON.stringify(customEvent),
+							)
+						}
+					} else {
 						throw new Error(
 							'invalid customEvent: ' +
 								JSON.stringify(customEvent),

--- a/cypress/e2e/client.cy.js
+++ b/cypress/e2e/client.cy.js
@@ -103,7 +103,8 @@ describe('client recording spec', () => {
 					}
 					const payload = JSON.parse(customEvent.data.payload)
 					if (
-						customEvent.data.tag !== 'Track' ||
+						(customEvent.data.tag !== 'Track' &&
+							customEvent.data.tag !== 'Performance') ||
 						payload.foo !== 'bar' ||
 						payload.event !== 'MyTrackEvent'
 					) {

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -65,6 +65,7 @@ import {
 	type ViewportResizeListenerArgs,
 } from './listeners/viewport-resize-listener'
 import { WebVitalsListener } from './listeners/web-vitals-listener/web-vitals-listener'
+import { NetworkPerformanceListener } from './listeners/network-listener/performance-listener'
 import { Logger } from './logger'
 import { getMeter, getTracer, setupBrowserTracing } from './otel'
 import {
@@ -976,6 +977,21 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 						category: MetricCategory.WebVital,
 					})
 				}),
+			)
+
+			this.listeners.push(
+				NetworkPerformanceListener((payload: PerformancePayload) => {
+					Object.entries(payload).forEach(
+						([name, value]) =>
+							value &&
+							this.recordGauge({
+								name,
+								value,
+								category: MetricCategory.Performance,
+								group: window.location.href,
+							}),
+					)
+				}, this._recordingStartTime),
 			)
 
 			if (this.sessionShortcut) {

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -65,7 +65,10 @@ import {
 	type ViewportResizeListenerArgs,
 } from './listeners/viewport-resize-listener'
 import { WebVitalsListener } from './listeners/web-vitals-listener/web-vitals-listener'
-import { NetworkPerformanceListener } from './listeners/network-listener/performance-listener'
+import {
+	NetworkPerformanceListener,
+	NetworkPerformancePayload,
+} from './listeners/network-listener/performance-listener'
 import { Logger } from './logger'
 import { getMeter, getTracer, setupBrowserTracing } from './otel'
 import {
@@ -980,18 +983,42 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			)
 
 			this.listeners.push(
-				NetworkPerformanceListener((payload: PerformancePayload) => {
-					Object.entries(payload).forEach(
-						([name, value]) =>
-							value &&
-							this.recordGauge({
-								name,
-								value,
-								category: MetricCategory.Performance,
-								group: window.location.href,
-							}),
-					)
-				}, this._recordingStartTime),
+				NetworkPerformanceListener(
+					(payload: NetworkPerformancePayload) => {
+						const tags: { name: string; value: string }[] = []
+						if (payload.saveData !== undefined) {
+							tags.push({
+								name: 'saveData',
+								value: payload.saveData.toString(),
+							})
+						}
+						if (payload.effectiveType !== undefined) {
+							tags.push({
+								name: 'effectiveType',
+								value: payload.effectiveType.toString(),
+							})
+						}
+						if (payload.type !== undefined) {
+							tags.push({
+								name: 'type',
+								value: payload.type.toString(),
+							})
+						}
+						Object.entries(payload).forEach(
+							([name, value]) =>
+								value &&
+								typeof value === 'number' &&
+								this.recordGauge({
+									name,
+									value: value as number,
+									category: MetricCategory.Performance,
+									group: window.location.href,
+									tags,
+								}),
+						)
+					},
+					this._recordingStartTime,
+				),
 			)
 
 			if (this.sessionShortcut) {

--- a/sdk/client/src/listeners/network-listener/performance-listener.ts
+++ b/sdk/client/src/listeners/network-listener/performance-listener.ts
@@ -48,7 +48,7 @@ export const NetworkPerformanceListener = (
 	let intervalId: number | undefined = undefined
 	intervalId = setInterval(() => {
 		worker()
-	}, 1000 * 5) as unknown as number
+	}, 1000) as unknown as number
 
 	return () => {
 		clearInterval(intervalId)

--- a/sdk/client/src/listeners/network-listener/performance-listener.ts
+++ b/sdk/client/src/listeners/network-listener/performance-listener.ts
@@ -1,0 +1,56 @@
+type NetworkInformation = {
+	downlink: number
+	downlinkMax: number
+	effectiveType: 'slow-2g' | '2g' | '3g' | '4g'
+	rtt: number
+	saveData: boolean
+	type:
+		| 'bluetooth'
+		| 'cellular'
+		| 'ethernet'
+		| 'none'
+		| 'wifi'
+		| 'wimax'
+		| 'other'
+		| 'unknown'
+}
+
+export type NetworkPerformancePayload = Partial<NetworkInformation> & {
+	/** Timestamp relative to the current session. If a measurement was taking 5 seconds into the session, then the timestamp will be 5. */
+	relativeTimestamp: number
+}
+
+const conn: NetworkInformation =
+	typeof navigator !== 'undefined' && 'connection' in navigator
+		? (navigator.connection as any)
+		: {}
+
+export const NetworkPerformanceListener = (
+	callback: (payload: NetworkPerformancePayload) => void,
+	recordingStartTime: number,
+) => {
+	const worker = () => {
+		const now = new Date().getTime()
+		const relativeTimestamp = (now - recordingStartTime) / 1000
+		callback({
+			relativeTimestamp,
+			downlink: conn.downlink,
+			downlinkMax: conn.downlinkMax,
+			effectiveType: conn.effectiveType,
+			rtt: conn.rtt,
+			saveData: conn.saveData,
+			type: conn.type,
+		})
+	}
+
+	worker()
+
+	let intervalId: number | undefined = undefined
+	intervalId = setInterval(() => {
+		worker()
+	}, 1000 * 5) as unknown as number
+
+	return () => {
+		clearInterval(intervalId)
+	}
+}

--- a/sdk/client/src/listeners/network-listener/performance-listener.ts
+++ b/sdk/client/src/listeners/network-listener/performance-listener.ts
@@ -1,9 +1,9 @@
 type NetworkInformation = {
 	downlink: number
 	downlinkMax: number
-	effectiveType: 'slow-2g' | '2g' | '3g' | '4g'
 	rtt: number
 	saveData: boolean
+	effectiveType: 'slow-2g' | '2g' | '3g' | '4g'
 	type:
 		| 'bluetooth'
 		| 'cellular'

--- a/sdk/client/src/listeners/performance-listener/performance-listener.ts
+++ b/sdk/client/src/listeners/performance-listener/performance-listener.ts
@@ -43,7 +43,7 @@ export const PerformanceListener = (
 	let intervalId: number | undefined = undefined
 	intervalId = setInterval(() => {
 		memoryWorker()
-	}, 1000 * 5) as unknown as number
+	}, 1000) as unknown as number
 
 	let frameCount = 0
 	let lastTime = Date.now()


### PR DESCRIPTION
## Summary

Adds a new `navigator.connection` periodic listener that emits metrics throughout the session
showing browser estimates of network performance along with connection attributes.

## How did you test this change?

<img width="654" alt="image" src="https://github.com/user-attachments/assets/b07156c3-9164-4f73-b73f-7db843568ccf" />

<img width="1093" alt="Screenshot 2025-02-03 at 11 12 51" src="https://github.com/user-attachments/assets/93ecc9a9-78e8-44cc-b0b0-e17c0e03156c" />

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no