### PR TITLE
support session and error j/k shortcuts crossing page boundary

### DIFF
--- a/frontend/src/components/KeyboardShortcutsEducation/KeyboardShortcutsEducation.tsx
+++ b/frontend/src/components/KeyboardShortcutsEducation/KeyboardShortcutsEducation.tsx
@@ -340,11 +340,11 @@ export const PlayerKeyboardShortcuts: ShortcutItem[] = [
 	DevToolsShortcut,
 	{
 		description: `Play the next session`,
-		shortcut: ['shift', 'N'],
+		shortcut: ['J'],
 	},
 	{
 		description: `Play the previous session`,
-		shortcut: ['shift', 'P'],
+		shortcut: ['K'],
 	},
 	{
 		description: `Decrease the playback speed`,

--- a/frontend/src/components/Search/SearchContext.tsx
+++ b/frontend/src/components/Search/SearchContext.tsx
@@ -46,6 +46,7 @@ interface SearchContext extends Partial<ReturnType<typeof useSearchTime>> {
 	resetMoreResults: () => void
 	histogramBucketSize?: DateHistogramBucketSize
 	pollingExpired: boolean
+	changeResultIndex?: (index: number) => void
 	aiMode: boolean
 	setAiMode: (aiMode: boolean) => void
 	aiQuery: string
@@ -77,6 +78,7 @@ interface Props extends Partial<ReturnType<typeof useSearchTime>> {
 	moreResults?: SearchContext['moreResults']
 	resetMoreResults?: SearchContext['resetMoreResults']
 	pollingExpired?: SearchContext['pollingExpired']
+	changeResultIndex?: SearchContext['changeResultIndex']
 	aiMode?: SearchContext['aiMode']
 	setAiMode?: SearchContext['setAiMode']
 	onAiSubmit?: SearchContext['onAiSubmit']
@@ -100,6 +102,7 @@ export const SearchContext: React.FC<Props> = ({
 	resetMoreResults = () => null,
 	setPage = () => null,
 	pollingExpired = false,
+	changeResultIndex = () => null,
 	aiMode = false,
 	setAiMode = () => null,
 	onAiSubmit = () => null,
@@ -149,6 +152,7 @@ export const SearchContext: React.FC<Props> = ({
 				setPage,
 				resetMoreResults,
 				pollingExpired,
+				changeResultIndex,
 				aiMode,
 				aiQuery,
 				setAiQuery,

--- a/frontend/src/components/SearchPagination/SearchPagination.tsx
+++ b/frontend/src/components/SearchPagination/SearchPagination.tsx
@@ -10,10 +10,12 @@ import { clamp, range } from '@util/numbers'
 import React, { useEffect, useMemo } from 'react'
 
 import * as style from './style.css'
+import { NumberParam, withDefault } from 'use-query-params'
 
 export const PAGE_SIZE = 10
 export const DEFAULT_SIBLING_COUNT = 2
 export const START_PAGE = 1
+export const PAGE_PARAM = withDefault(NumberParam, START_PAGE)
 
 const OPENSEARCH_MAX_RESULTS = 10000
 const MAX_PAGES = Math.floor(OPENSEARCH_MAX_RESULTS / PAGE_SIZE) - 1

--- a/frontend/src/pages/Alerts/AlertPage/index.tsx
+++ b/frontend/src/pages/Alerts/AlertPage/index.tsx
@@ -47,7 +47,6 @@ import SearchPagination, {
 import { useQueryParam } from 'use-query-params'
 import { useGraphTime } from '@/pages/Graphing/hooks/useGraphTime'
 
-const START_PAGE = 1
 const PAGE_SIZE = 10
 
 export const AlertPage: React.FC = () => {

--- a/frontend/src/pages/Alerts/AlertPage/index.tsx
+++ b/frontend/src/pages/Alerts/AlertPage/index.tsx
@@ -41,13 +41,14 @@ import { AlertHeader } from './AlertHeader'
 import { AlertInfo } from './AlertInfo'
 import { AlertTable } from './AlertTable'
 import * as style from './styles.css'
-import SearchPagination from '@/components/SearchPagination/SearchPagination'
-import { NumberParam, useQueryParam, withDefault } from 'use-query-params'
+import SearchPagination, {
+	PAGE_PARAM,
+} from '@/components/SearchPagination/SearchPagination'
+import { useQueryParam } from 'use-query-params'
 import { useGraphTime } from '@/pages/Graphing/hooks/useGraphTime'
 
 const START_PAGE = 1
 const PAGE_SIZE = 10
-const PAGE_PARAM = withDefault(NumberParam, START_PAGE)
 
 export const AlertPage: React.FC = () => {
 	const { projectId } = useProjectId()

--- a/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
@@ -45,7 +45,6 @@ import { useHotkeys } from 'react-hotkeys-hook'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { apiObject } from 'rudder-sdk-js'
 import {
-	NumberParam,
 	StringParam,
 	useQueryParam,
 	useQueryParams,
@@ -55,7 +54,10 @@ import {
 import { DEMO_PROJECT_ID } from '@/components/DemoWorkspaceButton/DemoWorkspaceButton'
 import { AiSuggestion, SearchContext } from '@/components/Search/SearchContext'
 import { useRetentionPresets } from '@/components/Search/SearchForm/hooks'
-import { START_PAGE } from '@/components/SearchPagination/SearchPagination'
+import {
+	PAGE_PARAM,
+	START_PAGE,
+} from '@/components/SearchPagination/SearchPagination'
 import { GetErrorGroupQuery } from '@/graph/generated/operations'
 import {
 	ErrorState as ErrorStateEnum,
@@ -80,7 +82,6 @@ import * as styles from './styles.css'
 
 type Params = { project_id: string; error_secure_id: string; referrer?: string }
 
-const PAGE_PARAM = withDefault(NumberParam, START_PAGE)
 const ERROR_QUERY_PARAM = withDefault(
 	StringParam,
 	`status=${ErrorStateEnum.Open} `,

--- a/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
@@ -56,6 +56,7 @@ import { AiSuggestion, SearchContext } from '@/components/Search/SearchContext'
 import { useRetentionPresets } from '@/components/Search/SearchForm/hooks'
 import {
 	PAGE_PARAM,
+	PAGE_SIZE,
 	START_PAGE,
 } from '@/components/SearchPagination/SearchPagination'
 import { GetErrorGroupQuery } from '@/graph/generated/operations'
@@ -141,7 +142,11 @@ export default function ErrorsV2() {
 	const location = useLocation()
 	const { showSearch } = useShowSearchParam()
 	const [muteErrorCommentThread] = useMuteErrorCommentThreadMutation()
-	const navigation = useErrorPageNavigation(getErrorsData.errorGroupSecureIds)
+	const navigation = useErrorPageNavigation(
+		getErrorsData.changeErrorGroupIndex,
+		getErrorsData.errorGroupSecureIds,
+		getErrorsData.totalCount,
+	)
 
 	const dragHandleRef = useRef<HTMLDivElement>(null)
 	const dragging = useRef(false)
@@ -279,6 +284,7 @@ export default function ErrorsV2() {
 			histogramBucketSize={getErrorsData.histogramBucketSize}
 			page={page}
 			setPage={setPage}
+			changeResultIndex={getErrorsData.changeErrorGroupIndex}
 			pollingExpired={getErrorsData.pollingExpired}
 			aiMode={aiMode}
 			setAiMode={setAiMode}
@@ -389,9 +395,9 @@ function TopBar({
 		showLeftPanel,
 		canMoveBackward,
 		canMoveForward,
-		nextSecureId,
-		previousSecureId,
-		goToErrorGroup,
+		next,
+		prev,
+		changeErrorGroupIndex,
 	} = navigation
 
 	return (isLoggedIn || projectId === DEMO_PROJECT_ID) && !isBlocked ? (
@@ -428,8 +434,8 @@ function TopBar({
 				<PreviousNextGroup
 					canMoveBackward={canMoveBackward}
 					canMoveForward={canMoveForward}
-					onPrev={() => goToErrorGroup(previousSecureId)}
-					onNext={() => goToErrorGroup(nextSecureId)}
+					onPrev={() => changeErrorGroupIndex(prev)}
+					onNext={() => changeErrorGroupIndex(next)}
 				/>
 			</Box>
 			<Box>
@@ -458,30 +464,30 @@ function useAllHotKeys({
 	setShowLeftPanel,
 	canMoveBackward,
 	canMoveForward,
-	nextSecureId,
-	previousSecureId,
-	goToErrorGroup,
+	next,
+	prev,
+	changeErrorGroupIndex,
 }: ReturnType<typeof useErrorPageNavigation>) {
 	useHotkeys(
 		'j',
 		() => {
-			if (canMoveForward) {
+			if (canMoveForward && changeErrorGroupIndex) {
 				analytics.track('NextErrorGroupKeyboardShortcut')
-				goToErrorGroup(nextSecureId)
+				changeErrorGroupIndex(next)
 			}
 		},
-		[canMoveForward, nextSecureId],
+		[canMoveForward, next, changeErrorGroupIndex],
 	)
 
 	useHotkeys(
 		'k',
 		() => {
-			if (canMoveBackward) {
+			if (canMoveBackward && changeErrorGroupIndex) {
 				analytics.track('PrevErrorGroupKeyboardShortcut')
-				goToErrorGroup(previousSecureId)
+				changeErrorGroupIndex(prev)
 			}
 		},
-		[canMoveBackward, previousSecureId],
+		[canMoveBackward, prev, changeErrorGroupIndex],
 	)
 
 	useHotkeys(
@@ -622,33 +628,21 @@ export function useErrorGroup(errorSecureId?: string) {
 	return { data, loading, errorQueryingErrorGroup }
 }
 
-export function useErrorPageNavigation(secureIds: string[] = []) {
-	const navigate = useNavigate()
-	const location = useLocation()
-	const { project_id, error_secure_id } = useParams<Params>()
+export function useErrorPageNavigation(
+	changeErrorGroupIndex: (index: number) => void = () => null,
+	secureIds: string[] = [],
+	totalCount: number = 0,
+) {
+	const [page] = useQueryParam('page', PAGE_PARAM)
+	const { error_secure_id } = useParams<Params>()
 	const { showLeftPanel, setShowLeftPanel } = usePlayerConfiguration()
-	const goToErrorGroup = useCallback(
-		(secureId: string) => {
-			navigate(
-				{
-					pathname: `/${project_id}/errors/${secureId}`,
-					search: location.search,
-				},
-				{
-					replace: true,
-				},
-			)
-		},
-		[navigate, project_id, location.search],
-	)
 	const currentSearchResultIndex = secureIds.findIndex(
 		(secureId) => secureId === error_secure_id,
 	)
-	const canMoveForward =
-		!!secureIds.length && currentSearchResultIndex < secureIds.length - 1
-	const canMoveBackward = !!secureIds.length && currentSearchResultIndex > 0
-	const nextSecureId = secureIds[currentSearchResultIndex + 1]
-	const previousSecureId = secureIds[currentSearchResultIndex - 1]
+	const next = currentSearchResultIndex + 1
+	const prev = currentSearchResultIndex - 1
+	const canMoveForward = (page - 1) * PAGE_SIZE + next < totalCount
+	const canMoveBackward = prev >= 0 || page > 1
 
 	const [leftPanelWidth, setLeftPanelWidth] = useLocalStorage(
 		LOCAL_STORAGE_PANEL_WIDTH_KEY,
@@ -662,9 +656,9 @@ export function useErrorPageNavigation(secureIds: string[] = []) {
 		setShowLeftPanel,
 		canMoveBackward,
 		canMoveForward,
-		nextSecureId,
-		previousSecureId,
-		goToErrorGroup,
+		next,
+		prev,
+		changeErrorGroupIndex,
 	}
 }
 

--- a/frontend/src/pages/ErrorsV2/useGetErrorGroups.ts
+++ b/frontend/src/pages/ErrorsV2/useGetErrorGroups.ts
@@ -63,9 +63,18 @@ export const useGetErrorGroups = ({
 
 	const navigate = useNavigate()
 	const goToErrorGroup = useCallback(
-		(secureId: string, page?: number) => {
+		(secureId: string, page?: number, query?: string) => {
+			// preserve query string
+			const queryStringParts = []
+			if (page) {
+				queryStringParts.push(`page=${page}`)
+			}
+			if (query) {
+				queryStringParts.push(`query=${query}`)
+			}
+			const queryString = queryStringParts.join('&')
 			navigate(
-				`/${project_id}/errors/${secureId}${page ? `?page=${page}` : ''}`,
+				`/${project_id}/errors/${secureId}${queryString ? `?${queryString}` : ''}`,
 			)
 		},
 		[navigate, project_id],

--- a/frontend/src/pages/ErrorsV2/useGetErrorGroups.ts
+++ b/frontend/src/pages/ErrorsV2/useGetErrorGroups.ts
@@ -88,7 +88,7 @@ export const useGetErrorGroups = ({
 
 			let eg = data?.error_groups?.error_groups?.at(index)
 			if (index >= 0 && eg !== undefined) {
-				goToErrorGroup(eg.secure_id, p)
+				goToErrorGroup(eg.secure_id, p, query)
 			} else {
 				// session must be in the next page; find secure id in the next page
 				const { data } = await paginationQuery({
@@ -101,13 +101,14 @@ export const useGetErrorGroups = ({
 				const newIndex = index % PAGE_SIZE
 				eg = data?.error_groups?.error_groups?.at(newIndex)
 				if (eg !== undefined) {
-					goToErrorGroup(eg.secure_id, p)
+					goToErrorGroup(eg.secure_id, p, query)
 				}
 			}
 		},
 		[
 			data?.error_groups?.error_groups,
 			page,
+			query,
 			setPage,
 			paginationQuery,
 			variables,

--- a/frontend/src/pages/ErrorsV2/useGetErrorGroups.ts
+++ b/frontend/src/pages/ErrorsV2/useGetErrorGroups.ts
@@ -8,7 +8,7 @@ import {
 } from '@graph/hooks'
 import { usePollQuery } from '@util/search'
 import moment from 'moment'
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { TIME_FORMAT } from '@/components/Search/SearchForm/constants'
 import { GetHistogramBucketSize } from '@/components/SearchResultsHistogram/SearchResultsHistogram'
@@ -35,18 +35,21 @@ export const useGetErrorGroups = ({
 	disablePolling?: boolean
 }) => {
 	const [, setPage] = useQueryParam('page', PAGE_PARAM)
-	const variables = {
-		project_id: project_id!,
-		count: PAGE_SIZE,
-		page,
-		params: {
-			query,
-			date_range: {
-				start_date: moment(startDate).format(TIME_FORMAT),
-				end_date: moment(endDate).format(TIME_FORMAT),
+	const variables = useMemo(
+		() => ({
+			project_id: project_id!,
+			count: PAGE_SIZE,
+			page,
+			params: {
+				query,
+				date_range: {
+					start_date: moment(startDate).format(TIME_FORMAT),
+					end_date: moment(endDate).format(TIME_FORMAT),
+				},
 			},
-		},
-	}
+		}),
+		[endDate, page, project_id, query, startDate],
+	)
 	const { data, loading, error, refetch } = useGetErrorGroupsQuery({
 		variables,
 		fetchPolicy: 'cache-and-network',

--- a/frontend/src/pages/Player/PlayerHook/utils/index.tsx
+++ b/frontend/src/pages/Player/PlayerHook/utils/index.tsx
@@ -650,13 +650,16 @@ export const changeSession = (
 	navigate: NavigateFunction,
 	session: Session | null,
 	successMessageText?: string,
+	page?: number,
 ) => {
 	if (!session) {
 		toast.success('No more sessions to play.')
 		return
 	}
 
-	navigate(`/${projectId}/sessions/${session.secure_id}`)
+	navigate(
+		`/${projectId}/sessions/${session.secure_id}${page ? `?page=${page}` : ''}`,
+	)
 	if (successMessageText?.length) {
 		toast.success(successMessageText)
 	}

--- a/frontend/src/pages/Player/PlayerHook/utils/index.tsx
+++ b/frontend/src/pages/Player/PlayerHook/utils/index.tsx
@@ -649,20 +649,27 @@ export const changeSession = (
 	projectId: string,
 	navigate: NavigateFunction,
 	session: Session | null,
-	successMessageText?: string,
-	page?: number,
+	options?: { successMessageText?: string; page?: number; query?: string },
 ) => {
 	if (!session) {
 		toast.success('No more sessions to play.')
 		return
 	}
 
-	// TODO(vkorolik) preserve query string
+	// preserve query string
+	const queryStringParts = []
+	if (options?.page) {
+		queryStringParts.push(`page=${options?.page}`)
+	}
+	if (options?.query) {
+		queryStringParts.push(`query=${options?.query}`)
+	}
+	const queryString = queryStringParts.join('&')
 	navigate(
-		`/${projectId}/sessions/${session.secure_id}${page ? `?page=${page}` : ''}`,
+		`/${projectId}/sessions/${session.secure_id}${queryString ? `?${queryString}` : ''}`,
 	)
-	if (successMessageText?.length) {
-		toast.success(successMessageText)
+	if (options?.successMessageText?.length) {
+		toast.success(options?.successMessageText)
 	}
 }
 

--- a/frontend/src/pages/Player/PlayerHook/utils/index.tsx
+++ b/frontend/src/pages/Player/PlayerHook/utils/index.tsx
@@ -657,6 +657,7 @@ export const changeSession = (
 		return
 	}
 
+	// TODO(vkorolik) preserve query string
 	navigate(
 		`/${projectId}/sessions/${session.secure_id}${page ? `?page=${page}` : ''}`,
 	)

--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -34,12 +34,7 @@ import React, {
 } from 'react'
 import { Helmet } from 'react-helmet'
 import { useNavigate } from 'react-router-dom'
-import {
-	NumberParam,
-	StringParam,
-	useQueryParam,
-	withDefault,
-} from 'use-query-params'
+import { StringParam, useQueryParam, withDefault } from 'use-query-params'
 
 import {
 	DEMO_PROJECT_ID,
@@ -47,7 +42,10 @@ import {
 } from '@/components/DemoWorkspaceButton/DemoWorkspaceButton'
 import { AiSuggestion, SearchContext } from '@/components/Search/SearchContext'
 import { useRetentionPresets } from '@/components/Search/SearchForm/hooks'
-import { START_PAGE } from '@/components/SearchPagination/SearchPagination'
+import {
+	PAGE_PARAM,
+	START_PAGE,
+} from '@/components/SearchPagination/SearchPagination'
 import {
 	useGetAiQuerySuggestionLazyQuery,
 	useGetBillingDetailsForProjectQuery,
@@ -68,8 +66,6 @@ import {
 import { SessionView } from './SessionView'
 import * as style from './styles.css'
 import { formatResult } from '@pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/helpers'
-
-const PAGE_PARAM = withDefault(NumberParam, START_PAGE)
 
 const PlayerPageBase: React.FC<{ playerRef: RefObject<HTMLDivElement> }> = ({
 	playerRef,
@@ -333,6 +329,7 @@ export const PlayerPage = () => {
 						page={page}
 						setPage={setPage}
 						pollingExpired={getSessionsData.pollingExpired}
+						changeResultIndex={getSessionsData.changeSessionIndex}
 						aiMode={aiMode}
 						setAiMode={setAiMode}
 						onAiSubmit={onAiSubmit}

--- a/frontend/src/pages/Player/SessionLevelBar/SessionLevelBarV2.tsx
+++ b/frontend/src/pages/Player/SessionLevelBar/SessionLevelBarV2.tsx
@@ -26,14 +26,12 @@ import {
 	RightPanelView,
 	usePlayerUIContext,
 } from '@pages/Player/context/PlayerUIContext'
-import { changeSession } from '@pages/Player/PlayerHook/utils'
 import usePlayerConfiguration from '@pages/Player/PlayerHook/utils/usePlayerConfiguration'
 import { useReplayerContext } from '@pages/Player/ReplayerContext'
 import analytics from '@util/analytics'
 import { delay } from 'lodash'
 import React, { useMemo, useRef, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
-import { useNavigate } from 'react-router-dom'
 
 import { PlayerModeSwitch } from '@/pages/Player/SessionLevelBar/PlayerModeSwitch/PlayerModeSwitch'
 import { useSessionParams } from '@/pages/Sessions/utils'
@@ -56,7 +54,6 @@ export const SessionLevelBarV2: React.FC<
 	}
 > = (props) => {
 	const [page] = useQueryParam('page', PAGE_PARAM)
-	const navigate = useNavigate()
 	const { projectId } = useProjectId()
 	const { sessionSecureId } = useSessionParams()
 	const { sessionResults, session } = useReplayerContext()
@@ -150,25 +147,17 @@ export const SessionLevelBarV2: React.FC<
 					)}
 					<PreviousNextGroup
 						onPrev={() => {
-							if (projectId) {
-								changeSession(
-									projectId,
-									navigate,
-									sessionResults.sessions[prev],
-								)
+							if (projectId && changeResultIndex) {
+								changeResultIndex(prev)
 							}
 						}}
-						canMoveBackward={!!canMoveBackward}
+						canMoveBackward={canMoveBackward}
 						onNext={() => {
-							if (projectId) {
-								changeSession(
-									projectId,
-									navigate,
-									sessionResults.sessions[next],
-								)
+							if (projectId && changeResultIndex) {
+								changeResultIndex(next)
 							}
 						}}
-						canMoveForward={!!canMoveForward}
+						canMoveForward={canMoveForward}
 						size="small"
 					/>
 					<SessionViewportMetadata />

--- a/frontend/src/pages/Player/SessionLevelBar/SessionLevelBarV2.tsx
+++ b/frontend/src/pages/Player/SessionLevelBar/SessionLevelBarV2.tsx
@@ -41,6 +41,12 @@ import { ProductType } from '@/graph/generated/schemas'
 
 import SessionShareButtonV2 from '../SessionShareButton/SessionShareButtonV2'
 import * as styles from './SessionLevelBarV2.css'
+import { useSearchContext } from '@components/Search/SearchContext'
+import { useQueryParam } from 'use-query-params'
+import {
+	PAGE_PARAM,
+	PAGE_SIZE,
+} from '@components/SearchPagination/SearchPagination'
 
 const DEFAULT_RIGHT_PANEL_VIEWS = [RightPanelView.Event, RightPanelView.Session]
 
@@ -49,10 +55,12 @@ export const SessionLevelBarV2: React.FC<
 		width: number | string
 	}
 > = (props) => {
+	const [page] = useQueryParam('page', PAGE_PARAM)
 	const navigate = useNavigate()
 	const { projectId } = useProjectId()
 	const { sessionSecureId } = useSessionParams()
 	const { sessionResults, session } = useReplayerContext()
+	const { changeResultIndex } = useSearchContext()
 
 	const { isLoggedIn } = useAuthContext()
 	const {
@@ -87,37 +95,30 @@ export const SessionLevelBarV2: React.FC<
 	)
 	const [prev, next] = [sessionIdx - 1, sessionIdx + 1]
 
-	const canMoveForward = !!projectId && sessionResults.sessions[next]
-	const canMoveBackward = !!projectId && sessionResults.sessions[prev]
+	const canMoveForward =
+		!!projectId && (page - 1) * PAGE_SIZE + next < sessionResults.totalCount
+	const canMoveBackward = !!projectId && (prev >= 0 || page > 1)
 
 	useHotkeys(
 		'j',
 		() => {
-			if (canMoveForward && projectId) {
+			if (canMoveForward && projectId && changeResultIndex) {
 				analytics.track('NextSessionKeyboardShortcut')
-				changeSession(
-					projectId,
-					navigate,
-					sessionResults.sessions[next],
-				)
+				changeResultIndex(next)
 			}
 		},
-		[canMoveForward, next],
+		[canMoveForward, next, changeResultIndex],
 	)
 
 	useHotkeys(
 		'k',
 		() => {
-			if (canMoveBackward && projectId) {
+			if (canMoveBackward && projectId && changeResultIndex) {
 				analytics.track('PrevSessionKeyboardShortcut')
-				changeSession(
-					projectId,
-					navigate,
-					sessionResults.sessions[prev],
-				)
+				changeResultIndex(prev)
 			}
 		},
-		[canMoveBackward, prev],
+		[canMoveBackward, prev, changeResultIndex],
 	)
 
 	return (

--- a/frontend/src/pages/Player/utils/PlayerHooks.tsx
+++ b/frontend/src/pages/Player/utils/PlayerHooks.tsx
@@ -10,10 +10,6 @@ import usePlayerConfiguration, {
 import analytics from '@util/analytics'
 import { useEffect, useRef, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
-import { useNavigate } from 'react-router-dom'
-
-import { useProjectId } from '@/hooks/useProjectId'
-import { useSessionParams } from '@/pages/Sessions/utils'
 
 import { ReplayerState, useReplayerContext } from '../ReplayerContext'
 
@@ -45,15 +41,8 @@ export const getNewTimeWithSkip = ({
 }
 
 export const usePlayerKeyboardShortcuts = () => {
-	const {
-		state,
-		play,
-		pause,
-		time,
-		replayer,
-		sessionResults,
-		sessionMetadata,
-	} = useReplayerContext()
+	const { state, play, pause, time, replayer, sessionMetadata } =
+		useReplayerContext()
 	const { setIsPlayerFullscreen, setRightPanelView } = usePlayerUIContext()
 	const {
 		setPlayerSpeedIdx,
@@ -68,9 +57,6 @@ export const usePlayerKeyboardShortcuts = () => {
 		setShowHistogram,
 		showHistogram,
 	} = usePlayerConfiguration()
-	const { projectId } = useProjectId()
-	const { sessionSecureId } = useSessionParams()
-	const navigate = useNavigate()
 
 	/**
 	 * This function needs to be called before each hot key.

--- a/frontend/src/pages/Player/utils/PlayerHooks.tsx
+++ b/frontend/src/pages/Player/utils/PlayerHooks.tsx
@@ -3,11 +3,7 @@ import {
 	RightPanelView,
 	usePlayerUIContext,
 } from '@pages/Player/context/PlayerUIContext'
-import {
-	changeSession,
-	findNextSessionInList,
-	findPreviousSessionInList,
-} from '@pages/Player/PlayerHook/utils'
+
 import usePlayerConfiguration, {
 	PLAYBACK_SPEED_OPTIONS,
 } from '@pages/Player/PlayerHook/utils/usePlayerConfiguration'
@@ -183,50 +179,6 @@ export const usePlayerKeyboardShortcuts = () => {
 			}
 		},
 		[time, replayer, state, pause, play],
-	)
-
-	useHotkeys(
-		'shift+n',
-		(e) => {
-			if (sessionResults.sessions.length > 0 && !!sessionSecureId) {
-				analytics.track('PlayerSkipToNextSessionKeyboardShortcut')
-				moveFocusToDocument(e)
-
-				const nextSession = findNextSessionInList(
-					sessionResults.sessions,
-					sessionSecureId,
-				)
-				changeSession(
-					projectId!,
-					navigate,
-					nextSession,
-					'Playing the next session.',
-				)
-			}
-		},
-		[sessionSecureId, sessionResults.sessions],
-	)
-
-	useHotkeys(
-		'shift+p',
-		(e) => {
-			if (sessionResults.sessions.length > 0 && !!sessionSecureId) {
-				analytics.track('PlayerSkipToPreviousSessionKeyboardShortcut')
-				moveFocusToDocument(e)
-
-				const nextSession = findPreviousSessionInList(
-					sessionResults.sessions,
-					sessionSecureId,
-				)
-				changeSession(
-					projectId!,
-					navigate,
-					nextSession,
-					'Playing the previous session.',
-				)
-			}
-		},
-		[sessionSecureId, sessionResults.sessions],
 	)
 
 	useHotkeys(

--- a/frontend/src/pages/Sessions/useGetSessions.ts
+++ b/frontend/src/pages/Sessions/useGetSessions.ts
@@ -37,18 +37,6 @@ export const useGetSessions = ({
 	presetSelected: boolean
 }) => {
 	const [, setPage] = useQueryParam('page', PAGE_PARAM)
-	// Using these rounded dates to ensure the cache is hit on initial load. The
-	// query will still be sent and the data in the cache will be updated.
-	const roundedStartDate = moment(startDate)
-		.startOf('minute')
-		.subtract(moment(startDate).minute() % 10, 'minutes')
-	const momentEndDate = presetSelected
-		? moment(endDate).add(10, 'minutes')
-		: moment(endDate)
-	const roundedEndDate = momentEndDate
-		.startOf('minute')
-		.subtract(moment(endDate).minute() % 10, 'minutes')
-
 	const variables = useMemo(
 		() => ({
 			project_id: project_id!,
@@ -57,13 +45,13 @@ export const useGetSessions = ({
 			params: {
 				query,
 				date_range: {
-					start_date: roundedStartDate.format(TIME_FORMAT),
-					end_date: roundedEndDate.format(TIME_FORMAT),
+					start_date: moment(startDate).format(TIME_FORMAT),
+					end_date: moment(endDate).format(TIME_FORMAT),
 				},
 			},
 			sort_desc: sortDesc,
 		}),
-		[page, project_id, query, roundedEndDate, roundedStartDate, sortDesc],
+		[page, project_id, query, startDate, endDate, sortDesc],
 	)
 	const { data, loading, error, refetch } = useGetSessionsQuery({
 		variables,

--- a/frontend/src/pages/Sessions/useGetSessions.ts
+++ b/frontend/src/pages/Sessions/useGetSessions.ts
@@ -49,19 +49,22 @@ export const useGetSessions = ({
 		.startOf('minute')
 		.subtract(moment(endDate).minute() % 10, 'minutes')
 
-	const variables = {
-		project_id: project_id!,
-		count: PAGE_SIZE,
-		page,
-		params: {
-			query,
-			date_range: {
-				start_date: roundedStartDate.format(TIME_FORMAT),
-				end_date: roundedEndDate.format(TIME_FORMAT),
+	const variables = useMemo(
+		() => ({
+			project_id: project_id!,
+			count: PAGE_SIZE,
+			page,
+			params: {
+				query,
+				date_range: {
+					start_date: roundedStartDate.format(TIME_FORMAT),
+					end_date: roundedEndDate.format(TIME_FORMAT),
+				},
 			},
-		},
-		sort_desc: sortDesc,
-	}
+			sort_desc: sortDesc,
+		}),
+		[page, project_id, query, roundedEndDate, roundedStartDate, sortDesc],
+	)
 	const { data, loading, error, refetch } = useGetSessionsQuery({
 		variables,
 		fetchPolicy: 'cache-and-network',

--- a/frontend/src/pages/Sessions/useGetSessions.ts
+++ b/frontend/src/pages/Sessions/useGetSessions.ts
@@ -36,6 +36,7 @@ export const useGetSessions = ({
 	presetSelected: boolean
 }) => {
 	const [, setPage] = useQueryParam('page', PAGE_PARAM)
+
 	const variables = useMemo(
 		() => ({
 			project_id: project_id!,
@@ -85,7 +86,10 @@ export const useGetSessions = ({
 
 			let session = data?.sessions?.sessions?.at(index)
 			if (index >= 0 && session !== undefined) {
-				changeSession(project_id!, navigate, session, { page: p })
+				changeSession(project_id!, navigate, session, {
+					page: p,
+					query,
+				})
 			} else {
 				// session must be in the next page; find secure id in the next page
 				const { data } = await paginationQuery({
@@ -98,7 +102,10 @@ export const useGetSessions = ({
 				const newIndex = index % PAGE_SIZE
 				session = data?.sessions?.sessions?.at(newIndex)
 				if (session !== undefined) {
-					changeSession(project_id!, navigate, session, { page: p })
+					changeSession(project_id!, navigate, session, {
+						page: p,
+						query,
+					})
 				}
 			}
 		},
@@ -107,6 +114,7 @@ export const useGetSessions = ({
 			navigate,
 			project_id,
 			page,
+			query,
 			setPage,
 			paginationQuery,
 			variables,

--- a/frontend/src/pages/Sessions/useGetSessions.ts
+++ b/frontend/src/pages/Sessions/useGetSessions.ts
@@ -85,7 +85,7 @@ export const useGetSessions = ({
 
 			let session = data?.sessions?.sessions?.at(index)
 			if (index >= 0 && session !== undefined) {
-				changeSession(project_id!, navigate, session, undefined, p)
+				changeSession(project_id!, navigate, session, { page: p })
 			} else {
 				// session must be in the next page; find secure id in the next page
 				const { data } = await paginationQuery({
@@ -98,7 +98,7 @@ export const useGetSessions = ({
 				const newIndex = index % PAGE_SIZE
 				session = data?.sessions?.sessions?.at(newIndex)
 				if (session !== undefined) {
-					changeSession(project_id!, navigate, session, undefined, p)
+					changeSession(project_id!, navigate, session, { page: p })
 				}
 			}
 		},

--- a/frontend/src/pages/Sessions/useGetSessions.ts
+++ b/frontend/src/pages/Sessions/useGetSessions.ts
@@ -97,6 +97,7 @@ export const useGetSessions = ({
 			if (index >= 0 && session !== undefined) {
 				changeSession(project_id!, navigate, session, undefined, p)
 			} else {
+				// session must be in the next page; find secure id in the next page
 				const { data } = await paginationQuery({
 					variables: {
 						...variables,
@@ -106,23 +107,10 @@ export const useGetSessions = ({
 				})
 				const newIndex = index % PAGE_SIZE
 				session = data?.sessions?.sessions?.at(newIndex)
-				console.log('vadim', 'internal', {
-					session,
-					index,
-					newIndex,
-					data,
-				})
 				if (session !== undefined) {
 					changeSession(project_id!, navigate, session, undefined, p)
 				}
 			}
-
-			console.log('vadim', 'useGetSessions', {
-				index,
-				p,
-				session,
-				page,
-			})
 		},
 		[
 			data?.sessions?.sessions,

--- a/frontend/src/pages/Sessions/useGetSessions.ts
+++ b/frontend/src/pages/Sessions/useGetSessions.ts
@@ -25,7 +25,6 @@ export const useGetSessions = ({
 	page = 1,
 	disablePolling,
 	sortDesc,
-	presetSelected,
 }: {
 	query: string
 	project_id: string | undefined


### PR DESCRIPTION
## Summary

`j` and `k` buttons would switch between next/previous sessions and error groups.
When a page boundary is encountered, the next/previous resource would not be loaded
as the frontend relies on the contents of the current page to include the resource.

Updates the logic to rely on the resource index, loading the desired page to find the necessary resource.
The logic can be summarized as follows:

```
Instead of thinking in terms of “page 1, element 5”, you maintain a single state that represents the absolute index of the selected item in the overall list. For example, if each page shows 10 items, then:
•	The first page contains indices 0–9.
•	The second page contains indices 10–19.
•	And so on.
* When the user hits the next key:
•	You increment the absolute index.
•	Then you calculate the page number based on that index.
•	Finally, you ensure that the page is loaded (or fetch it if needed) and that the correct element is highlighted.
```

## How did you test this change?

[reflame preview](https://preview.highlight.io/1/sessions/tw5mCgimzXI0pHIYPlDwaF6XX6v2?%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201JK6B0GQK08K1X9HEY83ZB3CM%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22sup-127-fix-session-player-jk-shortcuts-not-crossing-page-boundary%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D)

(results changing bug shown in loom fixed via 4d916afc074232ef82da40b574b6398a387aec71 and 6ef233c1d11e84a4982242d705c06ce319c9dde7)
https://www.loom.com/share/ca87cbf52cbc4a36b6b25ec502a6f325

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
