### PR TITLE
SQL builder - support more complex queries

### DIFF
--- a/backend/clickhouse/migrations/000139_create_readonly_user.up.sql
+++ b/backend/clickhouse/migrations/000139_create_readonly_user.up.sql
@@ -1,6 +1,7 @@
 CREATE USER IF NOT EXISTS highlight_readonly IDENTIFIED BY '' SETTINGS readonly = 1;
 CREATE ROLE IF NOT EXISTS highlight_readonly_role;
-ALTER ROLE highlight_readonly_role SETTINGS SQL_highlight_project_id CHANGEABLE_IN_READONLY;
+ALTER ROLE highlight_readonly_role SETTINGS SQL_highlight_project_id CHANGEABLE_IN_READONLY,
+splitby_max_substrings_includes_remaining_string CHANGEABLE_IN_READONLY;
 GRANT SELECT ON error_groups TO highlight_readonly_role;
 GRANT SELECT ON error_objects TO highlight_readonly_role;
 GRANT SELECT ON errors_joined_vw TO highlight_readonly_role;

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -204,6 +204,18 @@ func transformSql(
 	}
 	expr := statements[0]
 
+	settingsVisitor := sqlparser.DefaultASTVisitor{}
+	settingsVisitor.Visit = func(expr sqlparser.Expr) error {
+		_, found := expr.(*sqlparser.SettingsClause)
+		if found {
+			return e.New("SQL statement cannot include a settings clause.")
+		}
+		return nil
+	}
+	if err := expr.Accept(&settingsVisitor); err != nil {
+		return "", err
+	}
+
 	priorVisit := map[sqlparser.Expr]bool{}
 
 	selectVisitor := sqlparser.DefaultASTVisitor{}

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nqd/flat"
 	e "github.com/pkg/errors"
 	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
 	"go.openly.dev/pointy"
 
 	sqlparser "github.com/AfterShip/clickhouse-sql-parser/parser"
@@ -185,196 +186,283 @@ func readObjects[TObj interface{}](ctx context.Context, client *Client, config m
 	return getConnection(edges, pagination), nil
 }
 
-type BuilderInfo struct {
-	Builder *sqlbuilder.SelectBuilder
-	Fields  []string
-}
-
 func builderFromSql(
 	config model.TableConfig,
 	input ReadMetricsInput,
-) (*BuilderInfo, error) {
-	if len(input.ProjectIDs) != 1 {
-		return nil, e.Errorf("SQL queries must use 1 project id, %d found", len(input.ProjectIDs))
-	}
-	projectId := input.ProjectIDs[0]
-
+) (string, error) {
 	if input.Sql == nil {
-		return nil, e.Errorf("Sql input cannot be nil")
+		return "", e.Errorf("Sql input cannot be nil")
 	}
 
 	parser := sqlparser.NewParser(*input.Sql)
 	statements, err := parser.ParseStmts()
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	if len(statements) != 1 {
-		return nil, e.Errorf("Expected 1 SQL statement, found %d", len(statements))
+		return "", e.Errorf("Expected 1 SQL statement, found %d", len(statements))
 	}
-	stmt := statements[0]
+	expr := statements[0]
 
-	selectQuery, ok := stmt.(*sqlparser.SelectQuery)
-	if !ok {
-		return nil, e.New("SQL statement must be SelectQuery")
-	}
+	priorVisit := map[sqlparser.Expr]bool{}
 
-	tableReplacementVisitor := sqlparser.DefaultASTVisitor{}
-	tableReplacementVisitor.Visit = func(expr sqlparser.Expr) error {
-		switch typed := expr.(type) {
-		case *sqlparser.TableIdentifier:
-			typed.Table.Name = config.TableName
+	selectVisitor := sqlparser.DefaultASTVisitor{}
+	selectVisitor.Visit = func(expr sqlparser.Expr) error {
+		selectQuery, ok := expr.(*sqlparser.SelectQuery)
+		if !ok {
+			return nil
 		}
-		return nil
-	}
 
-	// Ignore function, alias, and table names
-	ignoreList := []sqlparser.Expr{}
-	ignoreVisitor := sqlparser.DefaultASTVisitor{}
-	ignoreVisitor.Visit = func(expr sqlparser.Expr) error {
-		switch typed := expr.(type) {
-		case *sqlparser.SelectItem:
-			ignoreList = append(ignoreList, typed.Alias)
-		case *sqlparser.FunctionExpr:
-			ignoreList = append(ignoreList, typed.Name)
-		case *sqlparser.AliasExpr:
-			ignoreList = append(ignoreList, typed.Alias)
-		case *sqlparser.TableIdentifier:
-			ignoreList = append(ignoreList, typed.Table)
-		}
-		return nil
-	}
-
-	sb := sqlbuilder.ClickHouse.NewSelectBuilder()
-
-	fields := []string{}
-	columnReplacementVisitor := sqlparser.DefaultASTVisitor{}
-	columnReplacementVisitor.Visit = func(expr sqlparser.Expr) error {
-		switch typed := expr.(type) {
-		case *sqlparser.Ident:
-			if typed.Name == "*" || lo.Contains(ignoreList, expr) {
-				break
+		isSystemTable := false
+		if selectQuery.From != nil {
+			fromExpr, ok := selectQuery.From.Expr.(*sqlparser.JoinTableExpr)
+			if !ok || fromExpr == nil || fromExpr.Table == nil {
+				return e.New("Expected FROM expression to be JoinTableExpr")
 			}
-			if col, found := config.KeysToColumns[typed.Name]; found {
-				typed.Name = col
+
+			tableIdentifier, ok := fromExpr.Table.Expr.(*sqlparser.TableIdentifier)
+			if ok && tableIdentifier != nil && tableIdentifier.Table != nil && strings.HasPrefix(config.TableName, tableIdentifier.Table.Name) {
+				isSystemTable = true
+			}
+		}
+
+		// Ignore function, alias, and table names
+		ignoreList := map[sqlparser.Expr]bool{}
+		aliases := map[string]bool{}
+		ignoreVisitor := sqlparser.DefaultASTVisitor{}
+		ignoreVisitor.Visit = func(expr sqlparser.Expr) error {
+			if priorVisit[expr] {
+				return nil
+			}
+			switch typed := expr.(type) {
+			case *sqlparser.SelectItem:
+				ignoreList[typed.Alias] = true
+				if typed.Alias != nil {
+					aliases[typed.Alias.Name] = true
+				}
+			case *sqlparser.FunctionExpr:
+				ignoreList[typed.Name] = true
+			case *sqlparser.AliasExpr:
+				ignoreList[typed.Alias] = true
+				if typed.Alias != nil {
+					aliases[typed.Alias.String()] = true
+				}
+			case *sqlparser.TableIdentifier:
+				ignoreList[typed.Table] = true
+			case *sqlparser.IntervalExpr:
+				ignoreList[typed.Unit] = true
+			}
+
+			return nil
+		}
+
+		fields := []string{}
+		columnReplacementVisitor := sqlparser.DefaultASTVisitor{}
+		columnReplacementVisitor.Visit = func(expr sqlparser.Expr) error {
+			if priorVisit[expr] {
+				return nil
+			}
+			switch typed := expr.(type) {
+			case *sqlparser.Ident:
+				if typed.Name == "*" || ignoreList[expr] || aliases[typed.Name] {
+					break
+				}
+				if col, found := config.KeysToColumns[typed.Name]; found {
+					typed.Name = col
+				} else {
+					fields = append(fields, typed.Name)
+					typed.Name = fmt.Sprintf("%s['%s']", model.GetAttributesColumn(config.AttributesColumns, typed.Name), typed.Name)
+				}
+			}
+			return nil
+		}
+
+		functionReplacementVisitor := sqlparser.DefaultASTVisitor{}
+		functionReplacementVisitor.Visit = func(expr sqlparser.Expr) error {
+			if priorVisit[expr] {
+				return nil
+			}
+			switch typed := expr.(type) {
+			case *sqlparser.FunctionExpr:
+				if typed.Name != nil && typed.Name.Name == "$time_interval" {
+					// Replace toStartOfInterval with the relevant $time_interval
+					typed.Name.Name = "toStartOfInterval"
+					if typed.Params.Items == nil {
+						return e.New("$time_interval called with empty argument list")
+					}
+
+					if len(typed.Params.Items.Items) != 1 {
+						return e.Errorf("Expecting 1 argument for $time_interval, found %d", len(typed.Params.Items.Items))
+					}
+
+					columnExpr, ok := typed.Params.Items.Items[0].(*sqlparser.ColumnExpr)
+					if !ok {
+						return e.Errorf("Expecting $time_interval argument to be a string literal.")
+					}
+					stringLiteral, ok := columnExpr.Expr.(*sqlparser.StringLiteral)
+					if !ok {
+						return e.Errorf("Expecting $time_interval argument to be a string literal.")
+					}
+
+					typed.Params.Items.Items = []sqlparser.Expr{
+						&sqlparser.ColumnExpr{
+							Expr: &sqlparser.Ident{Name: "Timestamp"},
+						},
+						&sqlparser.IntervalExpr{
+							Expr: stringLiteral,
+							Unit: &sqlparser.Ident{},
+						},
+					}
+				} else if typed.Name != nil {
+					// Apply _sample_factor to count or sum functions
+					isSample := strings.Contains(strings.ToLower(config.TableName), "sample")
+					funcLower := strings.ToLower(typed.Name.Name)
+					if isSample && (strings.Contains(funcLower, "sum") || strings.Contains(funcLower, "count")) {
+						typed.Name.Name = fmt.Sprintf("any(_sample_factor) * %s", typed.Name.Name)
+					}
+				}
+			}
+			return nil
+		}
+
+		tableReplacementVisitor := sqlparser.DefaultASTVisitor{}
+		tableReplacementVisitor.Visit = func(expr sqlparser.Expr) error {
+			if priorVisit[expr] {
+				return nil
+			}
+			switch typed := expr.(type) {
+			case *sqlparser.TableIdentifier:
+				typed.Table.Name = config.TableName
+			}
+			return nil
+		}
+
+		priorVisitVisitor := sqlparser.DefaultASTVisitor{}
+		priorVisitVisitor.Visit = func(expr sqlparser.Expr) error {
+			priorVisit[expr] = true
+			return nil
+		}
+
+		if isSystemTable {
+			if err := selectQuery.Accept(&ignoreVisitor); err != nil {
+				return err
+			}
+			if err := selectQuery.Accept(&columnReplacementVisitor); err != nil {
+				return err
+			}
+			if err := selectQuery.Accept(&functionReplacementVisitor); err != nil {
+				return err
+			}
+			if err := selectQuery.Accept(&tableReplacementVisitor); err != nil {
+				return err
+			}
+
+			if len(input.ProjectIDs) != 1 {
+				return e.Errorf("SQL queries must use 1 project id, %d found", len(input.ProjectIDs))
+			}
+			projectId := input.ProjectIDs[0]
+
+			projectIdCol := "ProjectId"
+			if config.TableName == "sessions" || config.TableName == "errors" {
+				projectIdCol = "ProjectID"
+			}
+
+			appendedWhere := &sqlparser.BinaryOperation{
+				LeftExpr: &sqlparser.BinaryOperation{
+					LeftExpr: &sqlparser.Ident{
+						Name: projectIdCol,
+					},
+					RightExpr: &sqlparser.NumberLiteral{
+						Literal: strconv.Itoa(projectId),
+					},
+					Operation: "=",
+				},
+				RightExpr: &sqlparser.BinaryOperation{
+					LeftExpr: &sqlparser.BinaryOperation{
+						LeftExpr: &sqlparser.Ident{
+							Name: "Timestamp",
+						},
+						RightExpr: &sqlparser.FunctionExpr{
+							Name: &sqlparser.Ident{
+								Name: "toDateTime",
+							},
+							Params: &sqlparser.ParamExprList{
+								Items: &sqlparser.ColumnExprList{
+									Items: []sqlparser.Expr{&sqlparser.NumberLiteral{
+										Literal: strconv.FormatInt(input.Params.DateRange.StartDate.Unix(), 10),
+									}},
+								},
+							},
+						},
+						Operation: ">=",
+					},
+					RightExpr: &sqlparser.BinaryOperation{
+						LeftExpr: &sqlparser.Ident{
+							Name: "Timestamp",
+						},
+						RightExpr: &sqlparser.FunctionExpr{
+							Name: &sqlparser.Ident{
+								Name: "toDateTime",
+							},
+							Params: &sqlparser.ParamExprList{
+								Items: &sqlparser.ColumnExprList{
+									Items: []sqlparser.Expr{&sqlparser.NumberLiteral{
+										Literal: strconv.FormatInt(input.Params.DateRange.EndDate.Unix(), 10),
+									}},
+								},
+							},
+						},
+						Operation: "<=",
+					},
+					Operation: "AND",
+				},
+				Operation: "AND",
+			}
+
+			addAttributesParser(config, fields, projectId, input.Params, selectQuery)
+
+			if selectQuery.Where == nil {
+				selectQuery.Where = &sqlparser.WhereClause{
+					Expr: appendedWhere,
+				}
 			} else {
-				fields = append(fields, typed.Name)
-				typed.Name = fmt.Sprintf("%s['%s']", model.GetAttributesColumn(config.AttributesColumns, typed.Name), typed.Name)
+				copiedClause := selectQuery.Where.Expr
+				selectQuery.Where.Expr = &sqlparser.BinaryOperation{
+					LeftExpr: &sqlparser.ParamExprList{
+						Items: &sqlparser.ColumnExprList{
+							Items: []sqlparser.Expr{copiedClause},
+						}},
+					Operation: "AND",
+					RightExpr: appendedWhere,
+				}
 			}
 		}
+
+		if err := selectQuery.Accept(&priorVisitVisitor); err != nil {
+			return err
+		}
+
 		return nil
 	}
 
-	functionReplacementVisitor := sqlparser.DefaultASTVisitor{}
-	functionReplacementVisitor.Visit = func(expr sqlparser.Expr) error {
-		switch typed := expr.(type) {
-		case *sqlparser.FunctionExpr:
-			if typed.Name != nil && typed.Name.Name == "$time_interval" {
-				// Replace toStartOfInterval with the relevant $time_interval
-				typed.Name.Name = "toStartOfInterval"
-				if typed.Params.Items == nil {
-					return e.New("$time_interval called with empty argument list")
-				}
-
-				if len(typed.Params.Items.Items) != 1 {
-					return e.Errorf("Expecting 1 argument for $time_interval, found %d", len(typed.Params.Items.Items))
-				}
-
-				columnExpr, ok := typed.Params.Items.Items[0].(*sqlparser.ColumnExpr)
-				if !ok {
-					return e.Errorf("Expecting $time_interval argument to be a string literal.")
-				}
-				stringLiteral, ok := columnExpr.Expr.(*sqlparser.StringLiteral)
-				if !ok {
-					return e.Errorf("Expecting $time_interval argument to be a string literal.")
-				}
-
-				typed.Params.Items.Items = []sqlparser.Expr{
-					&sqlparser.ColumnExpr{
-						Expr: &sqlparser.Ident{Name: "Timestamp"},
-					},
-					&sqlparser.IntervalExpr{
-						Expr: stringLiteral,
-						Unit: &sqlparser.Ident{},
-					},
-				}
-			} else if typed.Name != nil {
-				// Apply _sample_factor to count or sum functions
-				isSample := strings.Contains(strings.ToLower(config.TableName), "sample")
-				funcLower := strings.ToLower(typed.Name.Name)
-				if isSample && (strings.Contains(funcLower, "sum") || strings.Contains(funcLower, "count")) {
-					typed.Name.Name = fmt.Sprintf("any(_sample_factor) * %s", typed.Name.Name)
-				}
-			}
-		}
-		return nil
+	if err := expr.Accept(&selectVisitor); err != nil {
+		return "", err
 	}
 
-	if err := stmt.Accept(&tableReplacementVisitor); err != nil {
-		return nil, err
-	}
-	if err := stmt.Accept(&ignoreVisitor); err != nil {
-		return nil, err
-	}
-	if err := stmt.Accept(&columnReplacementVisitor); err != nil {
-		return nil, err
-	}
-	if err := stmt.Accept(&functionReplacementVisitor); err != nil {
-		return nil, err
-	}
+	sql := expr.String()
+	logrus.Info(sql)
 
-	selectStrs := []string{}
-	for _, item := range selectQuery.SelectItems {
-		selectStrs = append(selectStrs, item.String())
-	}
-	sb.Select(selectStrs...)
-	if selectQuery.From != nil {
-		sb.From(strings.TrimPrefix(selectQuery.From.String(), "FROM "))
-	}
-	if selectQuery.Where != nil {
-		sb.Where("(" + strings.TrimPrefix(selectQuery.Where.String(), "WHERE ") + ")")
-	}
-	if selectQuery.GroupBy != nil {
-		sb.GroupBy(strings.TrimPrefix(selectQuery.GroupBy.String(), "GROUP BY "))
-	}
-	if selectQuery.Having != nil {
-		sb.Having(strings.TrimPrefix(selectQuery.Having.String(), "HAVING "))
-	}
-	if selectQuery.OrderBy != nil {
-		sb.OrderBy(strings.TrimPrefix(selectQuery.OrderBy.String(), "ORDER BY "))
-	}
+	return sql, nil
+}
 
-	sb.Limit(1000) // Limit to 1000 results by default
-	if selectQuery.Limit != nil {
-		if selectQuery.Limit.Limit != nil {
-			limitInt, err := strconv.Atoi(selectQuery.Limit.Limit.String())
-			if err != nil {
-				return nil, err
-			}
-			sb.Limit(limitInt)
-		}
-		if selectQuery.Limit.Offset != nil {
-			offsetInt, err := strconv.Atoi(selectQuery.Limit.Offset.String())
-			if err != nil {
-				return nil, err
-			}
-			sb.Offset(offsetInt)
-		}
-	}
-
-	if config.TableName == "sessions" || config.TableName == "errors" {
-		sb.Where(sb.Equal("ProjectID", projectId))
-	} else {
-		sb.Where(sb.Equal("ProjectId", projectId))
-	}
-
-	sb.Where(sb.GreaterEqualThan("Timestamp", input.Params.DateRange.StartDate))
-	sb.Where(sb.LessEqualThan("Timestamp", input.Params.DateRange.EndDate))
-
-	return &BuilderInfo{
-		Builder: sb,
-		Fields:  fields,
-	}, nil
+var systemTables = map[string]bool{
+	"sessions": true,
+	"errors":   true,
+	"logs":     true,
+	"traces":   true,
+	"events":   true,
+	"metrics":  true,
 }
 
 func GetTables(sql string) ([]string, error) {
@@ -394,7 +482,7 @@ func GetTables(sql string) ([]string, error) {
 	visitor.Visit = func(expr sqlparser.Expr) error {
 		switch typed := expr.(type) {
 		case *sqlparser.TableIdentifier:
-			if typed.Table != nil {
+			if typed.Table != nil && systemTables[typed.Table.Name] {
 				tables = append(tables, typed.Table.Name)
 			}
 		}
@@ -1285,14 +1373,10 @@ func (client *Client) getSamplingStats(ctx context.Context, tables []string, pro
 }
 
 func (client *Client) readMetricsSql(ctx context.Context, input ReadMetricsInput, config model.TableConfig) (*modelInputs.MetricsBuckets, error) {
-	builderInfo, err := builderFromSql(config, input)
+	sql, err := builderFromSql(config, input)
 	if err != nil {
 		return nil, err
 	}
-	applyBlockFilter(builderInfo.Builder, input)
-	addAttributes(config, builderInfo.Fields, input.ProjectIDs, input.Params, builderInfo.Builder, true)
-
-	sql, args := builderInfo.Builder.BuildWithFlavor(sqlbuilder.ClickHouse)
 
 	if strings.Contains(sql, projectIdSetting) {
 		return nil, e.New("User cannot modify project id setting in query")
@@ -1300,7 +1384,6 @@ func (client *Client) readMetricsSql(ctx context.Context, input ReadMetricsInput
 
 	span, ctx := util.StartSpanFromContext(ctx, "readMetric.sql.query")
 	span.SetAttribute("sql", sql)
-	span.SetAttribute("args", args)
 
 	chCtx := clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
 		projectIdSetting: clickhouse.CustomSetting{Value: strconv.Itoa(input.ProjectIDs[0])},
@@ -1309,7 +1392,6 @@ func (client *Client) readMetricsSql(ctx context.Context, input ReadMetricsInput
 	rows, err := client.connReadonly.Query(
 		chCtx,
 		sql,
-		args...,
 	)
 
 	span.Finish(err)
@@ -1619,7 +1701,7 @@ func (client *Client) ReadMetrics(ctx context.Context, input ReadMetricsInput) (
 	groupByCols = append(groupByCols, groupAliases...)
 	orderByCols = append(orderByCols, groupAliases...)
 
-	addAttributes(config, attributeFields, input.ProjectIDs, input.Params, fromSb, false)
+	addAttributes(config, attributeFields, input.ProjectIDs, input.Params, fromSb)
 
 	innerSb := fromSb
 	fromSb = sqlbuilder.NewSelectBuilder()

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -24,7 +24,6 @@ import (
 	"github.com/nqd/flat"
 	e "github.com/pkg/errors"
 	"github.com/samber/lo"
-	"github.com/sirupsen/logrus"
 	"go.openly.dev/pointy"
 
 	sqlparser "github.com/AfterShip/clickhouse-sql-parser/parser"
@@ -186,7 +185,7 @@ func readObjects[TObj interface{}](ctx context.Context, client *Client, config m
 	return getConnection(edges, pagination), nil
 }
 
-func builderFromSql(
+func transformSql(
 	config model.TableConfig,
 	input ReadMetricsInput,
 ) (string, error) {
@@ -451,7 +450,6 @@ func builderFromSql(
 	}
 
 	sql := expr.String()
-	logrus.Info(sql)
 
 	return sql, nil
 }
@@ -1373,7 +1371,7 @@ func (client *Client) getSamplingStats(ctx context.Context, tables []string, pro
 }
 
 func (client *Client) readMetricsSql(ctx context.Context, input ReadMetricsInput, config model.TableConfig) (*modelInputs.MetricsBuckets, error) {
-	sql, err := builderFromSql(config, input)
+	sql, err := transformSql(config, input)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -796,14 +796,21 @@ func addAttributesParser(config model.TableConfig, attributeFields []string, pro
 			},
 		}
 
+		aliased := &sqlparser.AliasExpr{
+			Expr: &sqlparser.ParamExprList{
+				Items: &sqlparser.ColumnExprList{
+					Items: []sqlparser.Expr{attributeSelect},
+				},
+			},
+			Alias: &sqlparser.Ident{
+				Name: "join",
+			},
+		}
+
 		join := &sqlparser.JoinExpr{
 			Left: query.From.Expr,
 			Right: &sqlparser.JoinExpr{
-				Left: &sqlparser.ParamExprList{
-					Items: &sqlparser.ColumnExprList{
-						Items: []sqlparser.Expr{attributeSelect},
-					},
-				},
+				Left:      aliased,
 				Modifiers: []string{"INNER", "JOIN"},
 				Constraints: &sqlparser.OnClause{
 					On: &sqlparser.ColumnExprList{

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	e "github.com/pkg/errors"
 	"strconv"
 	"strings"
 	"time"
+
+	e "github.com/pkg/errors"
 
 	"github.com/highlight-run/highlight/backend/parser"
 	"github.com/highlight-run/highlight/backend/parser/listener"
@@ -21,6 +22,8 @@ import (
 	"github.com/huandu/go-sqlbuilder"
 	"github.com/openlyinc/pointy"
 	"golang.org/x/sync/errgroup"
+
+	sqlparser "github.com/AfterShip/clickhouse-sql-parser/parser"
 )
 
 const timeFormat = "2006-01-02T15:04:05.000Z"
@@ -674,12 +677,9 @@ func getAttributeFields(config model.TableConfig, filters listener.Filters) []st
 	return attributeFields
 }
 
-func addAttributes(config model.TableConfig, attributeFields []string, projectIds []int, params modelInputs.QueryInput, sb *sqlbuilder.SelectBuilder, castToMap bool) {
+func addAttributes(config model.TableConfig, attributeFields []string, projectIds []int, params modelInputs.QueryInput, sb *sqlbuilder.SelectBuilder) {
 	if config.AttributesTable != "" {
 		innerExpr := "groupArray(tuple(Name, Value))"
-		if castToMap {
-			innerExpr = "CAST(groupArray(tuple(Name, Value)), 'Map(String, String)')"
-		}
 
 		joinSb := sqlbuilder.NewSelectBuilder()
 		joinSb.From(config.AttributesTable).
@@ -690,6 +690,140 @@ func addAttributes(config model.TableConfig, attributeFields []string, projectId
 			Where(joinSb.In("Name", attributeFields)).
 			GroupBy("SessionID")
 		sb.JoinWithOption(sqlbuilder.InnerJoin, sb.BuilderAs(joinSb, "join"), "ID = SessionID")
+	}
+}
+
+func addAttributesParser(config model.TableConfig, attributeFields []string, projectId int, params modelInputs.QueryInput, query *sqlparser.SelectQuery) {
+	if config.AttributesTable != "" && len(attributeFields) > 0 {
+		attributeSelect := &sqlparser.SelectQuery{
+			SelectItems: []*sqlparser.SelectItem{
+				{
+					Expr: &sqlparser.Ident{
+						Name: "SessionID",
+					},
+				},
+				{
+					Expr: &sqlparser.Ident{
+						Name: "CAST(groupArray(tuple(Name, Value)), 'Map(String, String)')",
+					},
+					Alias: &sqlparser.Ident{
+						Name: model.GetAttributesColumn(config.AttributesColumns, ""),
+					},
+				},
+			},
+			From: &sqlparser.FromClause{
+				Expr: &sqlparser.TableExpr{
+					Expr: &sqlparser.Ident{
+						Name: config.AttributesTable,
+					},
+				},
+			},
+			Where: &sqlparser.WhereClause{
+				Expr: &sqlparser.BinaryOperation{
+					LeftExpr: &sqlparser.BinaryOperation{
+						LeftExpr: &sqlparser.BinaryOperation{
+							LeftExpr: &sqlparser.Ident{
+								Name: "ProjectID",
+							},
+							RightExpr: &sqlparser.NumberLiteral{
+								Literal: strconv.Itoa(projectId),
+							},
+							Operation: "=",
+						},
+						RightExpr: &sqlparser.BinaryOperation{
+							LeftExpr: &sqlparser.Ident{
+								Name: "Name",
+							},
+							RightExpr: &sqlparser.ParamExprList{
+								Items: &sqlparser.ColumnExprList{
+									Items: lo.Map(attributeFields, func(field string, _ int) sqlparser.Expr {
+										return &sqlparser.StringLiteral{
+											Literal: field,
+										}
+									}),
+								},
+							},
+							Operation: "IN",
+						},
+						Operation: "AND",
+					},
+					RightExpr: &sqlparser.BinaryOperation{
+						LeftExpr: &sqlparser.BinaryOperation{
+							LeftExpr: &sqlparser.Ident{
+								Name: "SessionCreatedAt",
+							},
+							RightExpr: &sqlparser.FunctionExpr{
+								Name: &sqlparser.Ident{
+									Name: "toDateTime",
+								},
+								Params: &sqlparser.ParamExprList{
+									Items: &sqlparser.ColumnExprList{
+										Items: []sqlparser.Expr{&sqlparser.NumberLiteral{
+											Literal: strconv.FormatInt(params.DateRange.StartDate.Unix(), 10),
+										}},
+									},
+								},
+							},
+							Operation: ">=",
+						},
+						RightExpr: &sqlparser.BinaryOperation{
+							LeftExpr: &sqlparser.Ident{
+								Name: "SessionCreatedAt",
+							},
+							RightExpr: &sqlparser.FunctionExpr{
+								Name: &sqlparser.Ident{
+									Name: "toDateTime",
+								},
+								Params: &sqlparser.ParamExprList{
+									Items: &sqlparser.ColumnExprList{
+										Items: []sqlparser.Expr{&sqlparser.NumberLiteral{
+											Literal: strconv.FormatInt(params.DateRange.EndDate.Unix(), 10),
+										}},
+									},
+								},
+							},
+							Operation: "<=",
+						},
+						Operation: "AND",
+					},
+					Operation: "AND",
+				},
+			},
+			GroupBy: &sqlparser.GroupByClause{
+				Expr: &sqlparser.Ident{
+					Name: "SessionID",
+				},
+			},
+		}
+
+		join := &sqlparser.JoinExpr{
+			Left: query.From.Expr,
+			Right: &sqlparser.JoinExpr{
+				Left: &sqlparser.ParamExprList{
+					Items: &sqlparser.ColumnExprList{
+						Items: []sqlparser.Expr{attributeSelect},
+					},
+				},
+				Modifiers: []string{"INNER", "JOIN"},
+				Constraints: &sqlparser.OnClause{
+					On: &sqlparser.ColumnExprList{
+						Items: []sqlparser.Expr{
+							&sqlparser.BinaryOperation{
+								LeftExpr: &sqlparser.Ident{
+									Name: "ID",
+								},
+								RightExpr: &sqlparser.Ident{
+									Name: "SessionID",
+								},
+								Operation: "=",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		query.From.Expr = join
 	}
 }
 
@@ -745,7 +879,7 @@ func GetSessionsQueryImpl(admin *model.Admin, params modelInputs.QueryInput, pro
 	}
 
 	attributeFields := getAttributeFields(SessionsJoinedTableConfig, listener.GetFilters())
-	addAttributes(SessionsJoinedTableConfig, attributeFields, []int{projectId}, params, sb, false)
+	addAttributes(SessionsJoinedTableConfig, attributeFields, []int{projectId}, params, sb)
 
 	if useRandomSample {
 		sbOuter := sqlbuilder.NewSelectBuilder()

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -9641,8 +9641,8 @@ func (r *queryResolver) Metrics(ctx context.Context, productType modelInputs.Pro
 		if err != nil {
 			return nil, err
 		}
-		if len(tables) != 1 {
-			return nil, e.Errorf("Expected query to reference 1 table, found %d", len(tables))
+		if len(tables) > 1 {
+			return nil, e.Errorf("Expected query to reference at most 1 table, found %d", len(tables))
 		}
 		table := tables[0]
 		switch table {
@@ -9656,6 +9656,8 @@ func (r *queryResolver) Metrics(ctx context.Context, productType modelInputs.Pro
 			productType = modelInputs.ProductTypeTraces
 		case "events":
 			productType = modelInputs.ProductTypeEvents
+		case "metrics":
+			productType = modelInputs.ProductTypeMetrics
 		default:
 			return nil, e.Errorf("Unknown table %s", table)
 		}

--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -282,7 +282,7 @@ export const GraphingEditor: React.FC = () => {
 			title: metricViewTitle || tempMetricViewTitle,
 			type: viewType,
 			expressions: expressions,
-			sql: editor === Editor.SqlEditor ? sql : null,
+			sql: editor === Editor.SqlEditor ? sqlInternal : null,
 		}
 
 		if (isEdit) {

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -1284,7 +1284,13 @@ const Graph = ({
 
 	let xAxisMetric = GROUPS_KEY
 	if (sql) {
-		if (sql.includes(TIME_INTERVAL_MACRO)) {
+		const isBucketed =
+			results?.find(
+				(r) =>
+					r.metrics?.buckets.find((b) => b.bucket_value !== null) !==
+					undefined,
+			) !== undefined
+		if (isBucketed) {
 			xAxisMetric = TIMESTAMP_KEY
 		}
 	} else if (bucketByKey !== undefined) {


### PR DESCRIPTION
## Summary
- instead of transforming the input into a sqlbuilder select query, keep it in parsed form
- this allows more flexible types of input query (e.g. CTEs, union queries, nested selects)
- identify parts querying the main product tables and apply default filters to those only
- add other filters to the parsed form before transforming back into a string
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally for multiple resource types, complex queries
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
