### PR TITLE
Fix competitor URLs in sitemap

### DIFF
--- a/highlight.io/app/api/sitemap/route.ts
+++ b/highlight.io/app/api/sitemap/route.ts
@@ -54,7 +54,7 @@ async function generateXML(): Promise<string> {
 	)
 
 	const competitorPages = Object.keys(COMPETITORS).map(
-		(competitorSlug: string) => competitorSlug,
+		(competitorSlug: string) => `compare/${competitorSlug}`,
 	)
 
 	const staticPagePaths = process.env.staticPages?.split(', ') || []


### PR DESCRIPTION
## Summary

I noticed in our Google Search Console that a bunch of links weren't working for competitor pages. I think we forgot to update the sitemap URLs after changing the structure of them.

## How did you test this change?

Hit http://localhost:4000/sitemap.xml to verify the changes.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A