### PR TITLE
fix alert graph loop, graphs with time range and no rows

### DIFF
--- a/frontend/src/pages/Alerts/AlertGraph/index.tsx
+++ b/frontend/src/pages/Alerts/AlertGraph/index.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@highlight-run/ui/components'
-import React from 'react'
+import React, { useMemo } from 'react'
 import { ReferenceArea, ReferenceLine } from 'recharts'
 
 import {
@@ -66,6 +66,10 @@ export const AlertGraph: React.FC<Props> = ({
 
 	const viewConfig = sessionsProduct ? BAR_CONFIG : LINE_CONFIG
 
+	const expressions = useMemo(() => {
+		return [{ aggregator: functionType, column: functionColumn }]
+	}, [functionColumn, functionType])
+
 	return (
 		<Box cssClass={style.graphWrapper} shadow="small">
 			<Box
@@ -110,9 +114,7 @@ export const AlertGraph: React.FC<Props> = ({
 						thresholdType,
 						thresholdValue,
 					}}
-					expressions={[
-						{ aggregator: functionType, column: functionColumn },
-					]}
+					expressions={expressions}
 				>
 					{!sessionsProduct &&
 						thresholdType === ThresholdType.Constant && (


### PR DESCRIPTION
## Summary
- non-memoized `expressions` was causing graph to be redrawn repeatedly and lagging / crashing the UI
- no data (e.g. an alert that did not trigger in the shown time period) was displaying as unix zero time
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- should refactor useEffect in `Graph` to prevent non-memoized arguments from doing this in the future
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
