### PR TITLE
update configuration of highlight sdk on landing page

### DIFF
--- a/.changeset/shiny-hats-hope.md
+++ b/.changeset/shiny-hats-hope.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+record highlight session id on client-side metrics

--- a/.changeset/strong-rules-destroy.md
+++ b/.changeset/strong-rules-destroy.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/next': patch
+---
+
+proxy otlp requests via the backend when nextjs proxying is set up

--- a/backend/otel/metrics.go
+++ b/backend/otel/metrics.go
@@ -2,12 +2,13 @@ package otel
 
 import (
 	"context"
+	"time"
+
 	"github.com/highlight-run/highlight/backend/clickhouse"
 	"github.com/highlight/highlight/sdk/highlight-go"
 	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	"time"
 )
 
 type DataPoint interface {
@@ -24,7 +25,7 @@ func (dp *NumberDataPoint) ExtractAttributes() map[string]any {
 }
 
 func (dp *NumberDataPoint) ToMetricRow(ctx context.Context, retentionDays uint8, metricType pmetric.MetricType, fields *extractedFields) clickhouse.MetricRow {
-	ex := extractExemplars(dp.Exemplars())
+	ex := extractExemplars(dp.Exemplars(), fields)
 	m := clickhouse.MetricSumRow{
 		MetricBaseRow: clickhouse.MetricBaseRow{
 			ProjectId:                uint32(fields.projectIDInt),
@@ -64,7 +65,7 @@ func (dp *HistogramDataPoint) ExtractAttributes() map[string]any {
 }
 
 func (dp *HistogramDataPoint) ToMetricRow(ctx context.Context, retentionDays uint8, metricType pmetric.MetricType, fields *extractedFields) clickhouse.MetricRow {
-	ex := extractExemplars(dp.Exemplars())
+	ex := extractExemplars(dp.Exemplars(), fields)
 	m := clickhouse.MetricHistogramRow{
 		MetricBaseRow: clickhouse.MetricBaseRow{
 			ProjectId:                uint32(fields.projectIDInt),
@@ -188,7 +189,7 @@ type exemplars struct {
 	SecureSessionIDs []string
 }
 
-func extractExemplars(exSlice pmetric.ExemplarSlice) *exemplars {
+func extractExemplars(exSlice pmetric.ExemplarSlice, fields *extractedFields) *exemplars {
 	ex := exemplars{
 		Attributes:       make([]map[string]string, exSlice.Len()),
 		Timestamps:       make([]time.Time, exSlice.Len()),
@@ -236,6 +237,10 @@ func extractExemplars(exSlice pmetric.ExemplarSlice) *exemplars {
 		ex.SpanIDs = append(ex.SpanIDs, e.SpanID().String())
 		ex.TraceIDs = append(ex.TraceIDs, e.TraceID().String())
 		ex.SecureSessionIDs = append(ex.SecureSessionIDs, sessionID)
+	}
+	// since the session id is queried as an exemplar, store it from the parsed attributes
+	if fields.sessionID != "" {
+		ex.SecureSessionIDs = append(ex.SecureSessionIDs, fields.sessionID)
 	}
 	return &ex
 }

--- a/backend/otel/metrics.go
+++ b/backend/otel/metrics.go
@@ -240,6 +240,11 @@ func extractExemplars(exSlice pmetric.ExemplarSlice, fields *extractedFields) *e
 	}
 	// since the session id is queried as an exemplar, store it from the parsed attributes
 	if fields.sessionID != "" {
+		ex.Attributes = append(ex.Attributes, map[string]string{})
+		ex.Timestamps = append(ex.Timestamps, time.Time{})
+		ex.Values = append(ex.Values, 0)
+		ex.SpanIDs = append(ex.SpanIDs, "")
+		ex.TraceIDs = append(ex.TraceIDs, "")
 		ex.SecureSessionIDs = append(ex.SecureSessionIDs, fields.sessionID)
 	}
 	return &ex

--- a/highlight.io/components/QuickstartContent/server/dotnet/dot-net-4.tsx
+++ b/highlight.io/components/QuickstartContent/server/dotnet/dot-net-4.tsx
@@ -18,7 +18,7 @@ export const DotNet4OTLPReorganizedContent: QuickStartContent = {
 		{
 			title: 'Set up your highlight.io browser SDK.',
 			content: `The installation differs from the normal [frontend getting started guide](${siteUrl(
-				'/docs/getting-started/frontend/other',
+				'/docs/getting-started/client-sdk/other',
 			)}) in the configuration of the .NET trace propagation. 
 			The TraceParentContext value is set based on the server trace context so that
 			client side tracing can carry the existing trace ID and session context.

--- a/highlight.io/components/QuickstartContent/server/dotnet/dot-net.tsx
+++ b/highlight.io/components/QuickstartContent/server/dotnet/dot-net.tsx
@@ -18,7 +18,7 @@ export const DotNetOTLPReorganizedContent: QuickStartContent = {
 		{
 			title: 'Set up your highlight.io browser SDK.',
 			content: `The installation differs from the normal [frontend getting started guide](${siteUrl(
-				'/docs/getting-started/frontend/other',
+				'/docs/getting-started/client-sdk/other',
 			)}) in the configuration of the .NET trace propagation. 
 			The _traceParentContext value is set based on the server trace context so that
 			client side tracing can carry the existing trace ID and session context.

--- a/highlight.io/components/QuickstartContent/traces/dotnet/dot-net-4.tsx
+++ b/highlight.io/components/QuickstartContent/traces/dotnet/dot-net-4.tsx
@@ -13,7 +13,7 @@ export const DotNet4OTLPTracingContent: QuickStartContent = {
 		{
 			title: 'Set up your highlight.io browser SDK.',
 			content: `The installation differs from the normal [frontend getting started guide](${siteUrl(
-				'/docs/getting-started/frontend/other',
+				'/docs/getting-started/client-sdk/other',
 			)}) in the configuration of the .NET trace propagation. 
 			The TraceParentContext value is set based on the server trace context so that
 			client side tracing can carry the existing trace ID and session context.

--- a/highlight.io/components/QuickstartContent/traces/dotnet/dot-net.tsx
+++ b/highlight.io/components/QuickstartContent/traces/dotnet/dot-net.tsx
@@ -13,7 +13,7 @@ export const DotNetOTLPTracingContent: QuickStartContent = {
 		{
 			title: 'Set up your highlight.io browser SDK.',
 			content: `The installation differs from the normal [frontend getting started guide](${siteUrl(
-				'/docs/getting-started/frontend/other',
+				'/docs/getting-started/client-sdk/other',
 			)}) in the configuration of the .NET trace propagation. 
 			The _traceParentContext value is set based on the server trace context so that
 			client side tracing can carry the existing trace ID and session context.

--- a/highlight.io/instrumentation.ts
+++ b/highlight.io/instrumentation.ts
@@ -5,6 +5,6 @@ export async function register() {
 
 	registerHighlight({
 		projectID: '4d7k1xeo',
-		serviceName: 'highlight.io-next-backend',
+		serviceName: 'highlightio-nextjs-backend',
 	})
 }

--- a/highlight.io/pages/_app.tsx
+++ b/highlight.io/pages/_app.tsx
@@ -12,7 +12,10 @@ import Head from 'next/head'
 import Analytics from '../components/Analytics'
 import { Meta } from '../components/common/Head/Meta'
 import MetaImage from '../public/images/meta-image.jpg'
-import { ErrorBoundary as HighlightErrorBoundary } from '@highlight-run/next/client'
+import {
+	ErrorBoundary as HighlightErrorBoundary,
+	HighlightInit,
+} from '@highlight-run/next/client'
 
 Router.events.on('routeChangeStart', nProgress.start)
 Router.events.on('routeChangeError', nProgress.done)
@@ -24,19 +27,18 @@ Router.events.on('routeChangeComplete', () => {
 	nProgress.done()
 })
 
-H.init('4d7k1xeo', {
-	inlineStylesheet: true,
-	inlineImages: true,
-	networkRecording: {
-		enabled: true,
-		recordHeadersAndBody: true,
-	},
-	tracingOrigins: true,
-})
-
 function MyApp({ Component, pageProps }: AppProps) {
 	return (
 		<HighlightErrorBoundary showDialog>
+			<HighlightInit
+				projectId={'4d7k1xeo'}
+				serviceName="highlightio-nextjs-frontend"
+				tracingOrigins
+				networkRecording={{
+					enabled: true,
+					recordHeadersAndBody: true,
+				}}
+			/>
 			<Head>
 				<link
 					rel="preconnect"

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -1178,6 +1178,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			...metric.tags?.reduce((a, b) => ({ ...a, [b.name]: b.value }), {}),
 			group: metric.group,
 			category: metric.category,
+			'highlight.session_id': this.sessionData.sessionSecureID,
 		})
 	}
 
@@ -1194,6 +1195,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			...metric.tags?.reduce((a, b) => ({ ...a, [b.name]: b.value }), {}),
 			group: metric.group,
 			category: metric.category,
+			'highlight.session_id': this.sessionData.sessionSecureID,
 		})
 	}
 
@@ -1214,6 +1216,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			...metric.tags?.reduce((a, b) => ({ ...a, [b.name]: b.value }), {}),
 			group: metric.group,
 			category: metric.category,
+			'highlight.session_id': this.sessionData.sessionSecureID,
 		})
 	}
 
@@ -1230,6 +1233,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			...metric.tags?.reduce((a, b) => ({ ...a, [b.name]: b.value }), {}),
 			group: metric.group,
 			category: metric.category,
+			'highlight.session_id': this.sessionData.sessionSecureID,
 		})
 	}
 

--- a/sdk/highlight-next/src/next-client.tsx
+++ b/sdk/highlight-next/src/next-client.tsx
@@ -31,6 +31,7 @@ export function HighlightInit({
 				highlightInitOptions = {
 					...highlightOptions,
 					backendUrl: '/highlight-events',
+					otlpEndpoint: '/',
 				}
 			}
 

--- a/sdk/highlight-next/src/next-client.tsx
+++ b/sdk/highlight-next/src/next-client.tsx
@@ -31,7 +31,7 @@ export function HighlightInit({
 				highlightInitOptions = {
 					...highlightOptions,
 					backendUrl: '/highlight-events',
-					otlpEndpoint: '/',
+					otlpEndpoint: window.location.origin,
 				}
 			}
 

--- a/sdk/highlight-next/src/util/with-highlight-config.test.ts
+++ b/sdk/highlight-next/src/util/with-highlight-config.test.ts
@@ -8,6 +8,18 @@ describe('withHighlightConfig', () => {
 			destination: 'https://pub.highlight.io',
 			source: '/highlight-events',
 		},
+		{
+			destination: 'https://otel.highlight.io/v1/traces',
+			source: '/v1/traces',
+		},
+		{
+			destination: 'https://otel.highlight.io/v1/metrics',
+			source: '/v1/metrics',
+		},
+		{
+			destination: 'https://otel.highlight.io/v1/logs',
+			source: '/v1/logs',
+		},
 	]
 
 	it('creates new rewrites if none exist', async () => {

--- a/sdk/highlight-next/src/util/with-highlight-config.ts
+++ b/sdk/highlight-next/src/util/with-highlight-config.ts
@@ -163,7 +163,7 @@ const getHighlightConfig = async (
 					re.push(sourcemapRewrite)
 				}
 				if (defaultOpts.configureHighlightProxy) {
-					re.concat(...highlightRewrites)
+					re = re.concat(...highlightRewrites)
 				}
 				return re
 			} else {

--- a/sdk/highlight-next/src/util/with-highlight-config.ts
+++ b/sdk/highlight-next/src/util/with-highlight-config.ts
@@ -138,10 +138,24 @@ const getHighlightConfig = async (
 				destination: '/404',
 			}
 
-			const highlightRewrite = {
-				source: '/highlight-events',
-				destination: 'https://pub.highlight.io',
-			}
+			const highlightRewrites = [
+				{
+					source: '/highlight-events',
+					destination: 'https://pub.highlight.io',
+				},
+				{
+					source: '/v1/traces',
+					destination: 'https://otel.highlight.io/v1/traces',
+				},
+				{
+					source: '/v1/metrics',
+					destination: 'https://otel.highlight.io/v1/metrics',
+				},
+				{
+					source: '/v1/logs',
+					destination: 'https://otel.highlight.io/v1/logs',
+				},
+			]
 
 			if (!re || Array.isArray(re)) {
 				re = re ?? []
@@ -149,7 +163,7 @@ const getHighlightConfig = async (
 					re.push(sourcemapRewrite)
 				}
 				if (defaultOpts.configureHighlightProxy) {
-					re.push(highlightRewrite)
+					re.concat(...highlightRewrites)
 				}
 				return re
 			} else {
@@ -158,7 +172,7 @@ const getHighlightConfig = async (
 						? (re.beforeFiles ?? []).concat(sourcemapRewrite)
 						: re.beforeFiles,
 					afterFiles: defaultOpts.configureHighlightProxy
-						? (re.afterFiles ?? []).concat(highlightRewrite)
+						? (re.afterFiles ?? []).concat(...highlightRewrites)
 						: re.afterFiles,
 					fallback: re.fallback,
 				}


### PR DESCRIPTION
## Summary

Use the `<HighlightInit>` component and turn off features that may affect site performance.
Updates the `@highlight-run/next` SDK to proxy frontend OpenTelemetry requests.

## How did you test this change?

new session captured https://app.highlight.io/demo/sessions/lIM6TmDQUWE6ardqPfan5JR5LiWQ

vercel preview

proxying tested for otlp endpoints
<img width="730" alt="Screenshot 2025-02-05 at 18 38 44" src="https://github.com/user-attachments/assets/9c09cff2-8213-4a30-b121-ef22983c8376" />


## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
