### PR TITLE
avoid recording proxied highlight next.js requests

### DIFF
--- a/.changeset/curly-tables-mate.md
+++ b/.changeset/curly-tables-mate.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': minor
+---
+
+turn off firstload network recording in favor of opentelemetry instrumentation

--- a/.changeset/lovely-tips-speak.md
+++ b/.changeset/lovely-tips-speak.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+check trace header injection separately from body capture check

--- a/.changeset/rich-roses-breathe.md
+++ b/.changeset/rich-roses-breathe.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/next': patch
+---
+
+avoid recording proxied highlight next.js requests

--- a/highlight.io/next.config.js
+++ b/highlight.io/next.config.js
@@ -3,15 +3,25 @@ const getStaticPages = require('./scripts/get-static-pages')
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-	webpack: (config, { isServer }) => {
+	webpack: (config, { isServer, dev }) => {
 		config.resolve.fallback = {
 			...config.resolve.fallback, // if you miss it, all the other options in fallback, specified
 			// by next.js will be dropped. Doesn't make much sense, but how it is
 			fs: false, // the solution
 		}
 		// configure server-side sourcemaps
-		if (isServer) {
-			config.devtool = 'source-map'
+		if (!dev) {
+			if (isServer) {
+				config.devtool = 'source-map'
+			} else {
+				// process dependencies' sourcemaps
+				config.module.rules.push({
+					test: /\.(js|ts)x?$/,
+					loader: 'source-map-loader',
+					exclude: /node_modules/,
+					enforce: 'pre',
+				})
+			}
 		}
 		return config
 	},

--- a/highlight.io/next.config.js
+++ b/highlight.io/next.config.js
@@ -13,14 +13,6 @@ const nextConfig = {
 		if (!dev) {
 			if (isServer) {
 				config.devtool = 'source-map'
-			} else {
-				// process dependencies' sourcemaps
-				config.module.rules.push({
-					test: /\.(js|ts)x?$/,
-					loader: 'source-map-loader',
-					exclude: /node_modules/,
-					enforce: 'pre',
-				})
 			}
 		}
 		return config

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -299,7 +299,12 @@ export class Highlight {
 			new FirstLoadListeners({
 				...this.options,
 				// network recording handled by otel instrumentation, not firstload
-				disableNetworkRecording: true,
+				networkRecording: {
+					...(typeof client_options.networkRecording === 'object'
+						? client_options.networkRecording
+						: {}),
+					recordHeadersAndBody: false,
+				},
 			})
 		try {
 			// throws if parent is cross-origin
@@ -347,7 +352,12 @@ export class Highlight {
 		this._firstLoadListeners = new FirstLoadListeners({
 			...this.options,
 			// network recording handled by otel instrumentation, not firstload
-			disableNetworkRecording: true,
+			networkRecording: {
+				...(typeof client_options.networkRecording === 'object'
+					? client_options.networkRecording
+					: {}),
+				recordHeadersAndBody: false,
+			},
 		})
 		await this.initialize()
 		if (user_identifier && user_object) {

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -295,7 +295,12 @@ export class Highlight {
 		this._hasPreviouslyInitialized = false
 		// Old firstLoad versions (Feb 2022) do not pass in FirstLoadListeners, so we have to fallback to creating it
 		this._firstLoadListeners =
-			firstLoadListeners || new FirstLoadListeners(this.options)
+			firstLoadListeners ||
+			new FirstLoadListeners({
+				...this.options,
+				// network recording handled by otel instrumentation, not firstload
+				disableNetworkRecording: true,
+			})
 		try {
 			// throws if parent is cross-origin
 			if (window.parent.document) {
@@ -339,7 +344,11 @@ export class Highlight {
 		this.sessionData.sessionStartTime = Date.now()
 		this.options.sessionSecureID = this.sessionData.sessionSecureID
 		this.stopRecording()
-		this._firstLoadListeners = new FirstLoadListeners(this.options)
+		this._firstLoadListeners = new FirstLoadListeners({
+			...this.options,
+			// network recording handled by otel instrumentation, not firstload
+			disableNetworkRecording: true,
+		})
 		await this.initialize()
 		if (user_identifier && user_object) {
 			this.identify(user_identifier, user_object)

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -295,17 +295,7 @@ export class Highlight {
 		this._hasPreviouslyInitialized = false
 		// Old firstLoad versions (Feb 2022) do not pass in FirstLoadListeners, so we have to fallback to creating it
 		this._firstLoadListeners =
-			firstLoadListeners ||
-			new FirstLoadListeners({
-				...this.options,
-				// network recording handled by otel instrumentation, not firstload
-				networkRecording: {
-					...(typeof this.options.networkRecording === 'object'
-						? this.options.networkRecording
-						: {}),
-					recordHeadersAndBody: false,
-				},
-			})
+			firstLoadListeners || new FirstLoadListeners(this.options)
 		try {
 			// throws if parent is cross-origin
 			if (window.parent.document) {
@@ -349,16 +339,7 @@ export class Highlight {
 		this.sessionData.sessionStartTime = Date.now()
 		this.options.sessionSecureID = this.sessionData.sessionSecureID
 		this.stopRecording()
-		this._firstLoadListeners = new FirstLoadListeners({
-			...this.options,
-			// network recording handled by otel instrumentation, not firstload
-			networkRecording: {
-				...(typeof this.options.networkRecording === 'object'
-					? this.options.networkRecording
-					: {}),
-				recordHeadersAndBody: false,
-			},
-		})
+		this._firstLoadListeners = new FirstLoadListeners(this.options)
 		await this.initialize()
 		if (user_identifier && user_object) {
 			this.identify(user_identifier, user_object)

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -300,8 +300,8 @@ export class Highlight {
 				...this.options,
 				// network recording handled by otel instrumentation, not firstload
 				networkRecording: {
-					...(typeof client_options.networkRecording === 'object'
-						? client_options.networkRecording
+					...(typeof this.options.networkRecording === 'object'
+						? this.options.networkRecording
 						: {}),
 					recordHeadersAndBody: false,
 				},
@@ -353,8 +353,8 @@ export class Highlight {
 			...this.options,
 			// network recording handled by otel instrumentation, not firstload
 			networkRecording: {
-				...(typeof client_options.networkRecording === 'object'
-					? client_options.networkRecording
+				...(typeof this.options.networkRecording === 'object'
+					? this.options.networkRecording
 					: {}),
 				recordHeadersAndBody: false,
 			},

--- a/sdk/client/src/listeners/first-load-listeners.tsx
+++ b/sdk/client/src/listeners/first-load-listeners.tsx
@@ -156,9 +156,14 @@ export class FirstLoadListeners {
 		const _backendUrl =
 			options?.backendUrl ||
 			import.meta.env.REACT_APP_PUBLIC_GRAPH_URI ||
-			'https://pub.highlight.run'
+			'https://pub.highlight.io'
 		const otlpEndpoint = options.otlpEndpoint || 'https://otel.highlight.io'
-		sThis.highlightEndpoints = [_backendUrl, otlpEndpoint]
+		sThis.highlightEndpoints = [
+			_backendUrl,
+			`${otlpEndpoint}/v1/traces`,
+			`${otlpEndpoint}/v1/logs`,
+			`${otlpEndpoint}/v1/metrics`,
+		]
 
 		sThis.xhrNetworkContents = []
 		sThis.fetchNetworkContents = []

--- a/sdk/client/src/listeners/network-listener/utils/utils.test.ts
+++ b/sdk/client/src/listeners/network-listener/utils/utils.test.ts
@@ -214,14 +214,14 @@ describe('shouldNetworkRequestBeRecorded', () => {
 		).toBe(true)
 	})
 
-	it('does not record highlight endpoints when tracingOrigins is empty', () => {
+	it('records highlight endpoints when tracingOrigins is empty', () => {
 		expect(
 			shouldNetworkRequestBeRecorded(
 				'https://otel.highlight.io/v1/traces',
 				[],
 				[],
 			),
-		).toBe(false)
+		).toBe(true)
 	})
 
 	it('records highlight endpoints when tracingOrigins regex matches', () => {
@@ -254,13 +254,13 @@ describe('shouldNetworkRequestBeRecorded', () => {
 		).toBe(false)
 	})
 
-	it('records highlight endpoints even when they are passed in as an argument if in tracingOrigins', () => {
+	it('does not highlight endpoints even when they are passed in as an argument if in tracingOrigins', () => {
 		expect(
 			shouldNetworkRequestBeRecorded(
 				'https://otel.highlight.io/v1/traces',
 				['otel.highlight.io'],
 				[/.*highlight\.io/],
 			),
-		).toBe(true)
+		).toBe(false)
 	})
 })

--- a/sdk/client/src/listeners/network-listener/utils/utils.ts
+++ b/sdk/client/src/listeners/network-listener/utils/utils.ts
@@ -258,6 +258,13 @@ const isHighlightNetworkResourceFilter = (
 		) ||
 	name.toLocaleLowerCase().includes('pub.highlight.io') ||
 	name.toLocaleLowerCase().includes('otel.highlight.io') ||
+	// avoid recording requests to next.js highlight proxy
+	name
+		.toLocaleLowerCase()
+		.includes(`${window.location.origin}/highlight-events`) ||
+	name.toLocaleLowerCase().includes(`${window.location.origin}/v1/traces`) ||
+	name.toLocaleLowerCase().includes(`${window.location.origin}/v1/logs`) ||
+	name.toLocaleLowerCase().includes(`${window.location.origin}/v1/metrics`) ||
 	highlightEndpoints.some((backendUrl) =>
 		name.toLocaleLowerCase().includes(backendUrl),
 	)

--- a/sdk/client/src/listeners/network-listener/utils/utils.ts
+++ b/sdk/client/src/listeners/network-listener/utils/utils.ts
@@ -262,10 +262,7 @@ export const shouldNetworkRequestBeRecorded = (
 	highlightEndpoints: string[],
 	tracingOrigins?: boolean | (string | RegExp)[],
 ) => {
-	return (
-		!isHighlightNetworkResourceFilter(url, highlightEndpoints) &&
-		shouldNetworkRequestBeTraced(url, tracingOrigins ?? [], [])
-	)
+	return !isHighlightNetworkResourceFilter(url, highlightEndpoints)
 }
 
 // Determines whether we want to attach the x-highlight-request header to the

--- a/sdk/client/src/listeners/network-listener/utils/utils.ts
+++ b/sdk/client/src/listeners/network-listener/utils/utils.ts
@@ -265,8 +265,13 @@ const isHighlightNetworkResourceFilter = (
 	name.toLocaleLowerCase().includes(`${window.location.origin}/v1/traces`) ||
 	name.toLocaleLowerCase().includes(`${window.location.origin}/v1/logs`) ||
 	name.toLocaleLowerCase().includes(`${window.location.origin}/v1/metrics`) ||
-	highlightEndpoints.some((backendUrl) =>
-		name.toLocaleLowerCase().includes(backendUrl),
+	highlightEndpoints.some(
+		(backendUrl) =>
+			// only count backend urls that are full paths
+			backendUrl.startsWith('http') &&
+			// ignore top level origin which is used for otlp proxying
+			backendUrl !== window.location.origin &&
+			name.toLocaleLowerCase().includes(backendUrl),
 	)
 
 // Determines whether we store the network request and show it in the session

--- a/sdk/client/src/listeners/network-listener/utils/utils.ts
+++ b/sdk/client/src/listeners/network-listener/utils/utils.ts
@@ -262,18 +262,10 @@ export const shouldNetworkRequestBeRecorded = (
 	highlightEndpoints: string[],
 	tracingOrigins?: boolean | (string | RegExp)[],
 ) => {
-	const is = isHighlightNetworkResourceFilter(url, highlightEndpoints)
-	const should = shouldNetworkRequestBeTraced(url, tracingOrigins ?? [], [])
-	const result = !is && should
-	console.log('vadim', {
-		is,
-		should,
-		result,
-		url,
-		highlightEndpoints,
-		tracingOrigins,
-	})
-	return result
+	return (
+		!isHighlightNetworkResourceFilter(url, highlightEndpoints) &&
+		shouldNetworkRequestBeTraced(url, tracingOrigins ?? [], [])
+	)
 }
 
 // Determines whether we want to attach the x-highlight-request header to the

--- a/sdk/client/src/listeners/network-listener/utils/utils.ts
+++ b/sdk/client/src/listeners/network-listener/utils/utils.ts
@@ -251,27 +251,8 @@ const isHighlightNetworkResourceFilter = (
 	name: string,
 	highlightEndpoints: string[],
 ) =>
-	name
-		.toLocaleLowerCase()
-		.includes(
-			import.meta.env.REACT_APP_PUBLIC_GRAPH_URI ?? 'pub.highlight.io',
-		) ||
-	name.toLocaleLowerCase().includes('pub.highlight.io') ||
-	name.toLocaleLowerCase().includes('otel.highlight.io') ||
-	// avoid recording requests to next.js highlight proxy
-	name
-		.toLocaleLowerCase()
-		.includes(`${window.location.origin}/highlight-events`) ||
-	name.toLocaleLowerCase().includes(`${window.location.origin}/v1/traces`) ||
-	name.toLocaleLowerCase().includes(`${window.location.origin}/v1/logs`) ||
-	name.toLocaleLowerCase().includes(`${window.location.origin}/v1/metrics`) ||
-	highlightEndpoints.some(
-		(backendUrl) =>
-			// only count backend urls that are full paths
-			backendUrl.startsWith('http') &&
-			// ignore top level origin which is used for otlp proxying
-			backendUrl !== window.location.origin &&
-			name.toLocaleLowerCase().includes(backendUrl),
+	highlightEndpoints.some((backendUrl) =>
+		name.toLocaleLowerCase().includes(backendUrl),
 	)
 
 // Determines whether we store the network request and show it in the session
@@ -281,10 +262,18 @@ export const shouldNetworkRequestBeRecorded = (
 	highlightEndpoints: string[],
 	tracingOrigins?: boolean | (string | RegExp)[],
 ) => {
-	return (
-		!isHighlightNetworkResourceFilter(url, highlightEndpoints) ||
-		shouldNetworkRequestBeTraced(url, tracingOrigins ?? [], [])
-	)
+	const is = isHighlightNetworkResourceFilter(url, highlightEndpoints)
+	const should = shouldNetworkRequestBeTraced(url, tracingOrigins ?? [], [])
+	const result = !is && should
+	console.log('vadim', {
+		is,
+		should,
+		result,
+		url,
+		highlightEndpoints,
+		tracingOrigins,
+	})
+	return result
 }
 
 // Determines whether we want to attach the x-highlight-request header to the

--- a/sdk/client/src/otel/index.ts
+++ b/sdk/client/src/otel/index.ts
@@ -312,8 +312,8 @@ class CustomTraceContextPropagator extends W3CTraceContextPropagator {
 
 			const shouldTrace = shouldNetworkRequestBeTraced(
 				url,
-				this.highlightEndpoints,
-				this.tracingOrigins,
+				this.tracingOrigins ?? [],
+				this.urlBlocklist,
 			)
 			if (!shouldTrace) {
 				return // return early to prevent headers from being injected

--- a/sdk/client/src/otel/index.ts
+++ b/sdk/client/src/otel/index.ts
@@ -72,7 +72,7 @@ export const setupBrowserTracing = (config: BrowserTracingConfig) => {
 	const backendUrl =
 		config.backendUrl ||
 		import.meta.env.REACT_APP_PUBLIC_GRAPH_URI ||
-		'https://pub.highlight.run'
+		'https://pub.highlight.io'
 
 	const urlBlocklist = [
 		...(config.networkRecordingOptions?.urlBlocklist ?? []),
@@ -274,7 +274,12 @@ class CustomTraceContextPropagator extends W3CTraceContextPropagator {
 	constructor(config: CustomTraceContextPropagatorConfig) {
 		super()
 
-		this.highlightEndpoints = [config.backendUrl, config.otlpEndpoint]
+		this.highlightEndpoints = [
+			config.backendUrl,
+			`${config.otlpEndpoint}/v1/traces`,
+			`${config.otlpEndpoint}/v1/logs`,
+			`${config.otlpEndpoint}/v1/metrics`,
+		]
 		this.tracingOrigins = config.tracingOrigins
 		this.urlBlocklist = config.urlBlocklist
 	}

--- a/sdk/client/src/otel/index.ts
+++ b/sdk/client/src/otel/index.ts
@@ -28,7 +28,10 @@ import {
 	DEFAULT_URL_BLOCKLIST,
 	sanitizeHeaders,
 } from '../listeners/network-listener/utils/network-sanitizer'
-import { shouldNetworkRequestBeRecorded } from '../listeners/network-listener/utils/utils'
+import {
+	shouldNetworkRequestBeRecorded,
+	shouldNetworkRequestBeTraced,
+} from '../listeners/network-listener/utils/utils'
 import {
 	BrowserXHR,
 	getBodyThatShouldBeRecorded,
@@ -305,6 +308,14 @@ class CustomTraceContextPropagator extends W3CTraceContextPropagator {
 
 			if (!shouldRecord) {
 				span.setAttribute(RECORD_ATTRIBUTE, false) // used later to avoid additional processing
+			}
+
+			const shouldTrace = shouldNetworkRequestBeTraced(
+				url,
+				this.highlightEndpoints,
+				this.tracingOrigins,
+			)
+			if (!shouldTrace) {
 				return // return early to prevent headers from being injected
 			}
 		}

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -124,6 +124,8 @@ const H: HighlightPublicInterface = {
 					getTracer: otelGetTracer,
 				}) => {
 					setupBrowserTracing({
+						backendUrl:
+							options?.backendUrl ?? 'https://pub.highlight.io',
 						otlpEndpoint:
 							options?.otlpEndpoint ??
 							'https://otel.highlight.io',
@@ -160,16 +162,7 @@ const H: HighlightPublicInterface = {
 				appVersion: options?.version,
 				sessionSecureID,
 			}
-			first_load_listeners = new FirstLoadListeners({
-				...client_options,
-				// network recording handled by otel instrumentation, not firstload
-				networkRecording: {
-					...(typeof client_options.networkRecording === 'object'
-						? client_options.networkRecording
-						: {}),
-					recordHeadersAndBody: false,
-				},
-			})
+			first_load_listeners = new FirstLoadListeners(client_options)
 			if (!options?.manualStart) {
 				// Start some of the listeners before client is loaded, then hand the
 				// listeners over for client to manage

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -163,7 +163,12 @@ const H: HighlightPublicInterface = {
 			first_load_listeners = new FirstLoadListeners({
 				...client_options,
 				// network recording handled by otel instrumentation, not firstload
-				disableNetworkRecording: true,
+				networkRecording: {
+					...(typeof client_options.networkRecording === 'object'
+						? client_options.networkRecording
+						: {}),
+					recordHeadersAndBody: false,
+				},
 			})
 			if (!options?.manualStart) {
 				// Start some of the listeners before client is loaded, then hand the

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -160,7 +160,11 @@ const H: HighlightPublicInterface = {
 				appVersion: options?.version,
 				sessionSecureID,
 			}
-			first_load_listeners = new FirstLoadListeners(client_options)
+			first_load_listeners = new FirstLoadListeners({
+				...client_options,
+				// network recording handled by otel instrumentation, not firstload
+				disableNetworkRecording: true,
+			})
 			if (!options?.manualStart) {
 				// Start some of the listeners before client is loaded, then hand the
 				// listeners over for client to manage


### PR DESCRIPTION
## Summary

The `@highlight-run/next` SDK proxied
`/highlight-events`, `/v1/traces`,  `/v1/logs`, and  `/v1/metrics` endpoints would be recorded
by the highlight network request recording because they were referring to the hostname of the
page by the proxying. This would result in main loop blocking from large payload serialization.

## How did you test this change?

vercel preview

captured session with correct data
https://app.highlight.io/demo/sessions/hWfL4lYZhAeasJoVCP5KD9uJjduo

## Are there any deployment considerations?

changeset

Fixes HIG-5147

## Does this work require review from our design team?

no