### PR TITLE
add basic ability to download logs

### DIFF
--- a/frontend/src/pages/Graphing/hooks/exportGraph.ts
+++ b/frontend/src/pages/Graphing/hooks/exportGraph.ts
@@ -98,7 +98,10 @@ export const exportGraph = async (
 					return col
 						? m.isAfter(moment().subtract(10, 'year'))
 							? m.format('MM/DD/YYYY HH:mm:ss')
-							: col.toString().replaceAll(/[,;\t]/gi, '|')
+							: col
+									.toString()
+									.replaceAll(/[,;\t]/gi, '|')
+									.replaceAll(/\s+/gi, ' ')
 						: ''
 				})
 				.join(','),

--- a/frontend/src/pages/LogsPage/LogsCount/LogsCount.tsx
+++ b/frontend/src/pages/LogsPage/LogsCount/LogsCount.tsx
@@ -1,4 +1,10 @@
-import { Box, Stack, Text } from '@highlight-run/ui/components'
+import {
+	Box,
+	IconSolidDownload,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
+import { vars } from '@highlight-run/ui/vars'
 import { formatDate } from '@pages/LogsPage/utils'
 import { formatNumber } from '@util/numbers'
 import moment from 'moment'
@@ -12,12 +18,14 @@ const LogsCount = ({
 	presetSelected,
 	totalCount,
 	loading,
+	onDownload,
 }: {
 	startDate: Date
 	endDate: Date
 	presetSelected: boolean
 	totalCount: number | undefined
 	loading: boolean
+	onDownload?: () => void
 }) => {
 	const dateLabel = useMemo(() => {
 		if (presetSelected) {
@@ -50,6 +58,16 @@ const LogsCount = ({
 							{totalCount !== 1 ? 's' : ''}
 						</Text>
 					</Box>
+					{onDownload !== undefined ? (
+						<IconSolidDownload
+							size={12}
+							style={{
+								color: vars.theme.static.content.weak,
+								cursor: 'pointer',
+							}}
+							onClick={onDownload}
+						/>
+					) : null}
 					<Box br="dividerWeak" style={{ height: 20 }} />
 					<Text size="xSmall" color="weak">
 						{dateLabel}

--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -52,6 +52,7 @@ import {
 } from '@/pages/LogsPage/LogsTable/CustomColumns/columns'
 import { useApplicationContext } from '@/routers/AppRouter/context/ApplicationContext'
 import analytics from '@/util/analytics'
+import { exportLogs } from '@pages/LogsPage/utils'
 
 const LogsPage = () => {
 	const { log_cursor } = useParams<{
@@ -297,6 +298,7 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 						presetSelected={!!searchTimeContext.selectedPreset}
 						totalCount={totalCount}
 						loading={histogramLoading}
+						onDownload={() => exportLogs(logEdges)}
 					/>
 					<LogsHistogram
 						startDate={searchTimeContext.startDate}

--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -298,7 +298,9 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 						presetSelected={!!searchTimeContext.selectedPreset}
 						totalCount={totalCount}
 						loading={histogramLoading}
-						onDownload={() => exportLogs(logEdges)}
+						onDownload={
+							loading ? undefined : () => exportLogs(logEdges)
+						}
 					/>
 					<LogsHistogram
 						startDate={searchTimeContext.startDate}

--- a/frontend/src/pages/LogsPage/utils.ts
+++ b/frontend/src/pages/LogsPage/utils.ts
@@ -3,6 +3,8 @@ import moment from 'moment'
 import { TIME_FORMAT } from '@/components/Search/SearchForm/constants'
 import { DEFAULT_OPERATOR } from '@/components/Search/SearchForm/utils'
 import { ReservedLogKey, Session } from '@/graph/generated/schemas'
+import { exportFile, processRows } from '@util/session/report'
+import { LogEdgeWithResources } from '@pages/LogsPage/useGetLogs'
 
 export const formatDate = (date: Date) => {
 	return moment(date).format('M/D/YY h:mm:ss A')
@@ -37,4 +39,25 @@ export const buildSessionParams = ({
 				.add(5, 'minutes'),
 		},
 	}
+}
+
+export const exportLogs = async (edges: LogEdgeWithResources[]) => {
+	const csvContent = processRows(
+		edges.map((e) => ({ cursor: e.cursor, ...e.node })),
+	)
+		.map((rowArray) =>
+			rowArray
+				.map((col) => {
+					const m = moment(Number(col), 'X', true)
+					return col
+						? m.isAfter(moment().subtract(10, 'year'))
+							? m.format('MM/DD/YYYY HH:mm:ss')
+							: col.toString().replaceAll(/[,;\t]/gi, '|')
+						: ''
+				})
+				.join(','),
+		)
+		.join('\r\n')
+
+	await exportFile(`logs.csv`, csvContent)
 }

--- a/frontend/src/pages/LogsPage/utils.ts
+++ b/frontend/src/pages/LogsPage/utils.ts
@@ -43,7 +43,10 @@ export const buildSessionParams = ({
 
 export const exportLogs = async (edges: LogEdgeWithResources[]) => {
 	const csvContent = processRows(
-		edges.map((e) => ({ cursor: e.cursor, ...e.node })),
+		edges.map((e) => {
+			const { logAttributes, ...rest } = e.node
+			return { ...rest, ...logAttributes }
+		}),
 	)
 		.map((rowArray) =>
 			rowArray
@@ -52,7 +55,10 @@ export const exportLogs = async (edges: LogEdgeWithResources[]) => {
 					return col
 						? m.isAfter(moment().subtract(10, 'year'))
 							? m.format('MM/DD/YYYY HH:mm:ss')
-							: col.toString().replaceAll(/[,;\t]/gi, '|')
+							: col
+									.toString()
+									.replaceAll(/[,;\t]/gi, '|')
+									.replaceAll(/\s+/gi, ' ')
 						: ''
 				})
 				.join(','),

--- a/frontend/src/util/session/report.ts
+++ b/frontend/src/util/session/report.ts
@@ -50,11 +50,15 @@ export const processRows = <
 			Object.entries(keys)
 				.filter(([k]) => !ignoreKeys.has(k as keyof T))
 				.sort(([, idx1], [_, idx2]) => idx1 - idx2)
-				.map(([k]) =>
-					Object.hasOwn(data, k)
+				.map(([k]) => {
+					const value = Object.hasOwn(data, k)
 						? data[k as keyof T]
-						: data['' as keyof T],
-				),
+						: data['' as keyof T]
+					if (typeof value === 'object') {
+						return JSON.stringify(value)
+					}
+					return value
+				}),
 		)
 	}
 	return rows

--- a/frontend/src/util/session/report.ts
+++ b/frontend/src/util/session/report.ts
@@ -7,6 +7,7 @@ import {
 import { Maybe, Session, SessionsReportRow } from '@graph/schemas'
 import { useProjectId } from '@hooks/useProjectId'
 import moment from 'moment/moment'
+import analytics from '@util/analytics'
 
 export const processRows = <
 	T extends { __typename?: Maybe<string>; user_properties?: Maybe<string> },
@@ -110,6 +111,8 @@ const getSessionRows = (sessions: Session[]) => {
 }
 
 export const exportFile = async (name: string, content: string) => {
+	analytics.track('exportFile', { name, size: content.length })
+
 	const blob = new Blob([content], { type: 'text/csv' })
 	const link = document.createElement('a')
 	link.setAttribute('href', window.URL.createObjectURL(blob))

--- a/frontend/src/util/session/report.ts
+++ b/frontend/src/util/session/report.ts
@@ -227,7 +227,10 @@ export const useGenerateSessionsReportCSV = () => {
 					rowArray
 						.map((col) =>
 							col
-								? col.toString().replaceAll(/[,;\t]/gi, '|')
+								? col
+										.toString()
+										.replaceAll(/[,;\t]/gi, '|')
+										.replaceAll(/\s+/gi, ' ')
 								: '',
 						)
 						.join(','),


### PR DESCRIPTION
## Summary

Adds a new download button to the logs count display that allows downloading the current loaded logs as a CSV.
<img width="335" alt="Screenshot 2025-02-10 at 22 52 04" src="https://github.com/user-attachments/assets/41f13e8a-253e-49ff-b356-d88a46264768" />

## How did you test this change?

[reflame preview](https://preview.highlight.io/1/sessions?%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201JKSNK581E7JYEWMEFXWYFYJW%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22sup-184-download-filtered-logs-as-json%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D)

## Are there any deployment considerations?

currently only logs; will add for traces if there is a customer use-case

## Does this work require review from our design team?

yes @julian-highlight 
