### PR TITLE
Vadim/fix dotnet sdk propagation

### DIFF
--- a/sdk/highlight-dotnet/Highlight.ASPCore.csproj
+++ b/sdk/highlight-dotnet/Highlight.ASPCore.csproj
@@ -9,9 +9,9 @@
         <Nullable>enable</Nullable>
 
         <OutputType>library</OutputType>
-        <Version>0.2.14</Version>
-        <AssemblyVersion>0.2.14</AssemblyVersion>
-        <FileVersion>0.2.14</FileVersion>
+        <Version>0.2.15</Version>
+        <AssemblyVersion>0.2.15</AssemblyVersion>
+        <FileVersion>0.2.15</FileVersion>
         <Deterministic>true</Deterministic>
         <LangVersion>latest</LangVersion>
         <Company>highlight.io</Company>

--- a/sdk/highlight-dotnet/OpenTelemetry.cs
+++ b/sdk/highlight-dotnet/OpenTelemetry.cs
@@ -10,305 +10,282 @@ using Serilog.Events;
 using Serilog.Sinks.OpenTelemetry;
 using System.Diagnostics;
 
-namespace Serilog
-{
-    public static class HighlightSerilogExtensions
+namespace Serilog {
+public static class HighlightSerilogExtensions {
+    public static LoggerConfiguration HighlightOpenTelemetry(this LoggerSinkConfiguration loggerConfiguration,
+        Action<Highlight.OpenTelemetry.Config> configure)
     {
-        public static LoggerConfiguration HighlightOpenTelemetry(this LoggerSinkConfiguration loggerConfiguration,
-            Action<Highlight.OpenTelemetry.Config> configure)
-        {
-            Highlight.OpenTelemetry.Config config = new()
-            {
-                ProjectId = "",
-                ServiceName = ""
-            };
-            configure(config);
-            return loggerConfiguration.OpenTelemetry(options =>
-            {
-                options.Protocol = Highlight.OpenTelemetry.Protocol;
-                options.Endpoint = config.OtlpEndpoint.ToString();
-                options.ResourceAttributes = Highlight.OpenTelemetry.GetResourceAttributes();
-            });
-        }
-
-        public static LoggerConfiguration WithHighlight(this LoggerEnrichmentConfiguration loggerConfiguration)
-        {
-            return loggerConfiguration.With(new Highlight.LogEnricher());
-        }
-    }
-}
-
-namespace Microsoft.Extensions.DependencyInjection
-{
-    public static class HighlightCollectionExtensions
-    {
-        public static IServiceCollection AddHighlightInstrumentation(this IServiceCollection services,
-            Action<Highlight.OpenTelemetry.Config> configure)
-        {
-            if (configure == null)
-                throw new ArgumentNullException(nameof(configure));
-            Highlight.OpenTelemetry.InstrumentServices(services, configure);
-            return services;
-        }
-
-        public static ILoggingBuilder AddHighlightInstrumentation(this ILoggingBuilder logging,
-            Action<Highlight.OpenTelemetry.Config> configure)
-        {
-            if (configure == null)
-                throw new ArgumentNullException(nameof(configure));
-            Highlight.OpenTelemetry.InstrumentLogging(logging, configure);
-            return logging;
-        }
-    }
-}
-
-
-namespace Highlight
-{
-using global::OpenTelemetry.Context.Propagation;
-
-public class TraceProcessor : BaseProcessor<Activity>
-    {
-        public override void OnStart(Activity data)
-        {
-            var ctx = OpenTelemetry.GetHighlightContext();
-            foreach (var entry in ctx)
-            {
-                data.SetTag(entry.Key, entry.Value);
-            }
-
-            base.OnStart(data);
-        }
-    }
-
-    public class LogProcessor : BaseProcessor<LogRecord>
-    {
-        public override void OnStart(LogRecord data)
-        {
-            var ctx = OpenTelemetry.GetHighlightContext();
-            var attributes = ctx.Select(entry => new KeyValuePair<string, object?>(entry.Key, entry.Value)).ToList();
-            if (data.Attributes != null)
-            {
-                attributes = attributes.Concat(data.Attributes).ToList();
-            }
-
-            data.Attributes = attributes;
-            base.OnStart(data);
-        }
-    }
-
-    public class LogEnricher : ILogEventEnricher
-    {
-        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory pf)
-        {
-            var ctx = OpenTelemetry.GetHighlightContext();
-            foreach (var entry in ctx)
-            {
-                logEvent.AddOrUpdateProperty(pf.CreateProperty(entry.Key, entry.Value));
-            }
-        }
-    }
-
-
-    public static class OpenTelemetry
-    {
-        public const OtlpProtocol Protocol = OtlpProtocol.Grpc;
-        public const OtlpExportProtocol ExportProtocol = OtlpExportProtocol.Grpc;
-        public const string HighlightHeader = "x-highlight-request";
-
-        public class Config
-        {
-            public string ProjectId = "";
-            public string ServiceName = "";
-            public Uri OtlpEndpoint = new("https://otel.highlight.io:4317");
-
-            public Dictionary<string, object> ResourceAttributes = [];
-        };
-
-        public static Dictionary<string, object> GetResourceAttributes()
-        {
-            return _config.ResourceAttributes.Concat(new Dictionary<string, object>
-            {
-                ["highlight.project_id"] = _config.ProjectId,
-                ["service.name"] = _config.ServiceName,
-                ["telemetry.distro.name"] = "Highlight.ASPCore",
-                ["telemetry.distro.version"] = "0.2.15",
-            }).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-        }
-
-        static Config _config = new()
+        Highlight.OpenTelemetry.Config config = new()
         {
             ProjectId = "",
-            ServiceName = "default-service-name"
+            ServiceName = ""
         };
+        configure(config);
+        return loggerConfiguration.OpenTelemetry(options => {
+            options.Protocol = Highlight.OpenTelemetry.Protocol;
+            options.Endpoint = config.OtlpEndpoint.ToString();
+            options.ResourceAttributes = Highlight.OpenTelemetry.GetResourceAttributes();
+        });
+    }
 
-        static readonly Random Random = new();
-        static readonly TextMapPropagator _propagator = new TraceContextPropagator();
+    public static LoggerConfiguration WithHighlight(this LoggerEnrichmentConfiguration loggerConfiguration)
+    {
+        return loggerConfiguration.With(new Highlight.LogEnricher());
+    }
+}
+}
 
-        public static Dictionary<string, string?> GetHighlightContext()
+namespace Microsoft.Extensions.DependencyInjection {
+public static class HighlightCollectionExtensions {
+    public static IServiceCollection AddHighlightInstrumentation(this IServiceCollection services,
+        Action<Highlight.OpenTelemetry.Config> configure)
+    {
+        if (configure == null)
+            throw new ArgumentNullException(nameof(configure));
+
+        Highlight.OpenTelemetry.InstrumentServices(services, configure);
+        return services;
+    }
+
+    public static ILoggingBuilder AddHighlightInstrumentation(this ILoggingBuilder logging,
+        Action<Highlight.OpenTelemetry.Config> configure)
+    {
+        if (configure == null)
+            throw new ArgumentNullException(nameof(configure));
+
+        Highlight.OpenTelemetry.InstrumentLogging(logging, configure);
+        return logging;
+    }
+}
+}
+
+
+namespace Highlight {
+
+public class TraceProcessor : BaseProcessor<Activity> {
+    public override void OnStart(Activity data)
+    {
+        var ctx = OpenTelemetry.GetHighlightContext();
+        foreach (var entry in ctx)
         {
-            var ctx = new Dictionary<string, string?>
-            {
-                { "highlight.project_id", _config.ProjectId },
-                { "service.name", _config.ServiceName },
-            };
-
-            var headerValue = Baggage.GetBaggage(HighlightHeader);
-            if (headerValue == null) return ctx;
-
-            string?[] parts = headerValue.Split("/");
-            if (parts.Length < 2) return ctx;
-
-            ctx["highlight.session_id"] = parts[0];
-            ctx["highlight.trace_id"] = parts[1];
-            return ctx;
+            data.SetTag(entry.Key, entry.Value);
         }
 
-        public static Config GetConfig()
+        base.OnStart(data);
+    }
+}
+
+public class LogProcessor : BaseProcessor<LogRecord> {
+    public override void OnStart(LogRecord data)
+    {
+        var ctx = OpenTelemetry.GetHighlightContext();
+        var attributes = ctx.Select(entry => new KeyValuePair<string, object?>(entry.Key, entry.Value)).ToList();
+        if (data.Attributes != null)
         {
-            return _config;
+            attributes = attributes.Concat(data.Attributes).ToList();
         }
 
-        private static void EnrichWithHttpRequest(Activity activity, HttpRequest httpRequest)
+        data.Attributes = attributes;
+        base.OnStart(data);
+    }
+}
+
+public class LogEnricher : ILogEventEnricher {
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory pf)
+    {
+        var ctx = OpenTelemetry.GetHighlightContext();
+        foreach (var entry in ctx)
         {
-            activity.SetTag("http.client_ip", httpRequest.HttpContext.Connection.RemoteIpAddress?.ToString());
-            activity.SetTag("http.flavor", httpRequest.HttpContext.Request.Protocol);
-            activity.SetTag("http.host", httpRequest.Host);
-            activity.SetTag("http.method", httpRequest.Method);
-            activity.SetTag("http.request_content_length", httpRequest.ContentLength);
-            activity.SetTag("http.route", httpRequest.RouteValues["action"]);
-            activity.SetTag("http.scheme", httpRequest.Scheme);
-            activity.SetTag("http.server_name", httpRequest.HttpContext.Request.Host.Host);
-            activity.SetTag("http.url", httpRequest.Path);
-            activity.SetTag("http.user_agent", httpRequest.Headers["User-Agent"]);
-
-            for (var i = 0; i < httpRequest.Headers.Count; i++)
-            {
-                var header = httpRequest.Headers.ElementAt(i);
-                activity.SetTag($"http.request.header.{header.Key}", header.Value);
-            }
-
-            var (sessionId, requestId) = ExtractContext(httpRequest);
-            activity.SetTag("highlight.session_id", sessionId);
-            activity.SetTag("highlight.trace_id", requestId);
-            Baggage.SetBaggage([
-                new KeyValuePair<string, string?>(HighlightHeader, $"{sessionId}/{requestId}")
-            ]);
-            
-            var parentContext = _propagator.Extract(new PropagationContext(activity.Context, Baggage.Current), httpRequest.Headers, (headers, key) => headers[key]);
-            Baggage.Current = parentContext.Baggage;
-        }
-
-        private static void EnrichWithHttpResponse(Activity activity, HttpResponse httpResponse)
-        {
-            activity.SetTag("http.status_code", httpResponse.StatusCode);
-            activity.SetTag("http.response_content_length", httpResponse.ContentLength);
-
-            for (var i = 0; i < httpResponse.Headers.Count; i++)
-            {
-                var header = httpResponse.Headers.ElementAt(i);
-                activity.SetTag($"http.response.header.{header.Key}", header.Value);
-            }
-            
-            _propagator.Inject(new PropagationContext(activity.Context, Baggage.Current), httpResponse.Headers, (headers, key, value) => {
-                headers[key] = value;
-            });
-        }
-
-        private static (string, string) ExtractContext(HttpRequest httpRequest)
-        {
-            var headerValues = httpRequest.Headers[HighlightHeader];
-            if (headerValues is [not null, ..])
-            {
-                var parts = headerValues[0]?.Split("/");
-                if (parts?.Length >= 2)
-                {
-                    return (parts[0], parts[1]);
-                }
-            }
-
-            var sessionId = httpRequest.Cookies["sessionID"] ?? new string(Enumerable
-                .Repeat("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", 28)
-                .Select(s => s[Random.Next(s.Length)]).ToArray());
-
-            var sessionDataKey = $"sessionData_{sessionId}";
-            var start = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-            var sessionData = httpRequest.Cookies[sessionDataKey] ??
-                              $"{{\"sessionSecureID\":\"{sessionId}\",\"projectID\":\"{_config.ProjectId}\",\"payloadID\":1,\"sessionStartTime\":{start},\"lastPushTime\":{start}}}";
-
-            var opts = new CookieOptions
-            {
-                Expires = DateTimeOffset.Now.AddMinutes(15)
-            };
-            httpRequest.HttpContext.Response.Cookies.Append("sessionID", sessionId, opts);
-            httpRequest.HttpContext.Response.Cookies.Append(sessionDataKey, sessionData, opts);
-            return (sessionId, "");
-        }
-
-        public static void InstrumentServices(IServiceCollection services, Action<Config> configure)
-        {
-            configure(_config);
-            services.AddOpenTelemetry()
-                .WithTracing(tracing => tracing
-                    .SetSampler(new AlwaysOnSampler())
-                    .SetResourceBuilder(ResourceBuilder.CreateDefault().AddAttributes(GetResourceAttributes()).AddService(_config.ServiceName))
-                    .AddHttpClientInstrumentation()
-                    .AddGrpcClientInstrumentation()
-                    .AddSqlClientInstrumentation(option =>
-                    {
-                        option.SetDbStatementForText = true;
-                    })
-                    .AddQuartzInstrumentation()
-                    .AddWcfInstrumentation()
-                    .AddAspNetCoreInstrumentation(options =>
-                    {
-                        options.RecordException = true;
-                        options.EnrichWithHttpRequest = EnrichWithHttpRequest;
-                        options.EnrichWithHttpResponse = EnrichWithHttpResponse;
-                    })
-                    .AddSource([_config.ServiceName, "Microsoft.Azure.Functions.Worker"])
-                    .AddProcessor(new TraceProcessor())
-                    .AddOtlpExporter(options =>
-                    {
-                        options.Endpoint = _config.OtlpEndpoint;
-                        options.Protocol = ExportProtocol;
-                        options.BatchExportProcessorOptions.MaxExportBatchSize = 10000;
-                        options.BatchExportProcessorOptions.MaxQueueSize = 10000;
-                        options.BatchExportProcessorOptions.ScheduledDelayMilliseconds = 1000;
-                    }))
-                .WithMetrics(metrics => metrics
-                    .SetResourceBuilder(ResourceBuilder.CreateDefault().AddAttributes(GetResourceAttributes()).AddService(_config.ServiceName))
-                    .AddMeter(_config.ServiceName)
-                    .AddHttpClientInstrumentation()
-                    .AddRuntimeInstrumentation()
-                    .AddProcessInstrumentation()
-                    .AddAspNetCoreInstrumentation()
-                    .AddReader(new PeriodicExportingMetricReader(new OtlpMetricExporter(new OtlpExporterOptions
-                    {
-                        Endpoint = _config.OtlpEndpoint,
-                        Protocol = ExportProtocol
-                    }))));
-        }
-
-        public static void InstrumentLogging(ILoggingBuilder logging, Action<Config> configure)
-        {
-            configure(_config);
-            logging.AddOpenTelemetry(options =>
-            {
-                options
-                    .SetResourceBuilder(ResourceBuilder.CreateDefault().AddAttributes(GetResourceAttributes()))
-                    .AddProcessor(new LogProcessor())
-                    .AddOtlpExporter(exporterOptions =>
-                    {
-                        exporterOptions.Endpoint = _config.OtlpEndpoint;
-                        exporterOptions.Protocol = ExportProtocol;
-                        exporterOptions.BatchExportProcessorOptions.MaxExportBatchSize = 10000;
-                        exporterOptions.BatchExportProcessorOptions.MaxQueueSize = 10000;
-                        exporterOptions.BatchExportProcessorOptions.ScheduledDelayMilliseconds = 1000;
-                    });
-                options.IncludeScopes = true;
-                options.IncludeFormattedMessage = true;
-            });
+            logEvent.AddOrUpdateProperty(pf.CreateProperty(entry.Key, entry.Value));
         }
     }
+}
+
+
+public static class OpenTelemetry {
+    public const OtlpProtocol Protocol = OtlpProtocol.Grpc;
+    public const OtlpExportProtocol ExportProtocol = OtlpExportProtocol.Grpc;
+    public const string HighlightHeader = "x-highlight-request";
+
+    public class Config {
+        public string ProjectId = "";
+        public string ServiceName = "";
+        public Uri OtlpEndpoint = new("https://otel.highlight.io:4317");
+
+        public Dictionary<string, object> ResourceAttributes = [];
+    };
+
+    public static Dictionary<string, object> GetResourceAttributes()
+    {
+        return _config.ResourceAttributes.Concat(new Dictionary<string, object>
+        {
+            ["highlight.project_id"] = _config.ProjectId,
+            ["service.name"] = _config.ServiceName,
+            ["telemetry.distro.name"] = "Highlight.ASPCore",
+            ["telemetry.distro.version"] = "0.2.15",
+        }).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+    }
+
+    static Config _config = new()
+    {
+        ProjectId = "",
+        ServiceName = "default-service-name"
+    };
+
+    static readonly Random Random = new();
+
+    public static Dictionary<string, string?> GetHighlightContext()
+    {
+        var ctx = new Dictionary<string, string?>
+        {
+            {
+                "highlight.project_id", _config.ProjectId
+            },
+            {
+                "service.name", _config.ServiceName
+            },
+        };
+
+        var headerValue = Baggage.Current.GetBaggage(HighlightHeader);
+        if (headerValue == null) return ctx;
+
+        string?[] parts = headerValue.Split("/");
+        if (parts.Length < 2) return ctx;
+
+        ctx["highlight.session_id"] = parts[0];
+        // rely on `traceparent` w3c parent context propagation instead of highlight.trace_id
+        return ctx;
+    }
+
+    public static Config GetConfig()
+    {
+        return _config;
+    }
+
+    private static void EnrichWithHttpRequest(Activity activity, HttpRequest httpRequest)
+    {
+        activity.SetTag("http.client_ip", httpRequest.HttpContext.Connection.RemoteIpAddress?.ToString());
+        activity.SetTag("http.flavor", httpRequest.HttpContext.Request.Protocol);
+        activity.SetTag("http.host", httpRequest.Host);
+        activity.SetTag("http.method", httpRequest.Method);
+        activity.SetTag("http.request_content_length", httpRequest.ContentLength);
+        activity.SetTag("http.route", httpRequest.RouteValues["action"]);
+        activity.SetTag("http.scheme", httpRequest.Scheme);
+        activity.SetTag("http.server_name", httpRequest.HttpContext.Request.Host.Host);
+        activity.SetTag("http.url", httpRequest.Path);
+        activity.SetTag("http.user_agent", httpRequest.Headers["User-Agent"]);
+
+        for (var i = 0; i < httpRequest.Headers.Count; i++)
+        {
+            var header = httpRequest.Headers.ElementAt(i);
+            activity.SetTag($"http.request.header.{header.Key}", header.Value);
+        }
+
+        var (sessionId, requestId) = ExtractContext(httpRequest);
+        activity.SetTag("highlight.session_id", sessionId);
+        // rely on `traceparent` w3c parent context propagation instead of highlight.trace_id
+        Baggage.Current.SetBaggage(new KeyValuePair<string, string?>(HighlightHeader, $"{sessionId}/{requestId}"));
+    }
+
+    private static void EnrichWithHttpResponse(Activity activity, HttpResponse httpResponse)
+    {
+        activity.SetTag("http.status_code", httpResponse.StatusCode);
+        activity.SetTag("http.response_content_length", httpResponse.ContentLength);
+
+        for (var i = 0; i < httpResponse.Headers.Count; i++)
+        {
+            var header = httpResponse.Headers.ElementAt(i);
+            activity.SetTag($"http.response.header.{header.Key}", header.Value);
+        }
+    }
+
+    private static (string, string) ExtractContext(HttpRequest httpRequest)
+    {
+        var headerValues = httpRequest.Headers[HighlightHeader];
+        if (headerValues is [not null, ..])
+        {
+            var parts = headerValues[0]?.Split("/");
+            if (parts?.Length >= 2)
+            {
+                return (parts[0], parts[1]);
+            }
+        }
+
+        var sessionId = httpRequest.Cookies["sessionID"] ?? new string(Enumerable
+            .Repeat("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", 28)
+            .Select(s => s[Random.Next(s.Length)]).ToArray());
+
+        var sessionDataKey = $"sessionData_{sessionId}";
+        var start = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var sessionData = httpRequest.Cookies[sessionDataKey] ??
+                          $"{{\"sessionSecureID\":\"{sessionId}\",\"projectID\":\"{_config.ProjectId}\",\"payloadID\":1,\"sessionStartTime\":{start},\"lastPushTime\":{start}}}";
+
+        var opts = new CookieOptions
+        {
+            Expires = DateTimeOffset.Now.AddMinutes(15)
+        };
+        httpRequest.HttpContext.Response.Cookies.Append("sessionID", sessionId, opts);
+        httpRequest.HttpContext.Response.Cookies.Append(sessionDataKey, sessionData, opts);
+        return (sessionId, "");
+    }
+
+    public static void InstrumentServices(IServiceCollection services, Action<Config> configure)
+    {
+        configure(_config);
+        services.AddOpenTelemetry()
+            .WithTracing(tracing => tracing
+                .SetSampler(new AlwaysOnSampler())
+                .SetResourceBuilder(ResourceBuilder.CreateDefault().AddAttributes(GetResourceAttributes()).AddService(_config.ServiceName))
+                .AddHttpClientInstrumentation()
+                .AddGrpcClientInstrumentation()
+                .AddSqlClientInstrumentation(option => { option.SetDbStatementForText = true; })
+                .AddQuartzInstrumentation()
+                .AddWcfInstrumentation()
+                .AddAspNetCoreInstrumentation(options => {
+                    options.RecordException = true;
+                    options.EnrichWithHttpRequest = EnrichWithHttpRequest;
+                    options.EnrichWithHttpResponse = EnrichWithHttpResponse;
+                })
+                .AddSource([_config.ServiceName, "Microsoft.Azure.Functions.Worker"])
+                .AddProcessor(new TraceProcessor())
+                .AddOtlpExporter(options => {
+                    options.Endpoint = _config.OtlpEndpoint;
+                    options.Protocol = ExportProtocol;
+                    options.BatchExportProcessorOptions.MaxExportBatchSize = 10000;
+                    options.BatchExportProcessorOptions.MaxQueueSize = 10000;
+                    options.BatchExportProcessorOptions.ScheduledDelayMilliseconds = 1000;
+                }))
+            .WithMetrics(metrics => metrics
+                .SetResourceBuilder(ResourceBuilder.CreateDefault().AddAttributes(GetResourceAttributes()).AddService(_config.ServiceName))
+                .AddMeter(_config.ServiceName)
+                .AddHttpClientInstrumentation()
+                .AddRuntimeInstrumentation()
+                .AddProcessInstrumentation()
+                .AddAspNetCoreInstrumentation()
+                .AddReader(new PeriodicExportingMetricReader(new OtlpMetricExporter(new OtlpExporterOptions
+                {
+                    Endpoint = _config.OtlpEndpoint,
+                    Protocol = ExportProtocol
+                }))));
+    }
+
+    public static void InstrumentLogging(ILoggingBuilder logging, Action<Config> configure)
+    {
+        configure(_config);
+        logging.AddOpenTelemetry(options => {
+            options
+                .SetResourceBuilder(ResourceBuilder.CreateDefault().AddAttributes(GetResourceAttributes()))
+                .AddProcessor(new LogProcessor())
+                .AddOtlpExporter(exporterOptions => {
+                    exporterOptions.Endpoint = _config.OtlpEndpoint;
+                    exporterOptions.Protocol = ExportProtocol;
+                    exporterOptions.BatchExportProcessorOptions.MaxExportBatchSize = 10000;
+                    exporterOptions.BatchExportProcessorOptions.MaxQueueSize = 10000;
+                    exporterOptions.BatchExportProcessorOptions.ScheduledDelayMilliseconds = 1000;
+                });
+            options.IncludeScopes = true;
+            options.IncludeFormattedMessage = true;
+        });
+    }
+}
 }

--- a/sdk/highlight-dotnet4/Highlight.ASP4.csproj
+++ b/sdk/highlight-dotnet4/Highlight.ASP4.csproj
@@ -19,10 +19,10 @@
     </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>0.2.8</Version>
-    <PackageVersion>0.2.8</PackageVersion>
-    <AssemblyVersion>0.2.8</AssemblyVersion>
-    <FileVersion>0.2.8</FileVersion>
+    <Version>0.2.9</Version>
+    <PackageVersion>0.2.9</PackageVersion>
+    <AssemblyVersion>0.2.9</AssemblyVersion>
+    <FileVersion>0.2.9</FileVersion>
     <Company>highlight.io</Company>
     <Authors>Vadim Korolik</Authors>
     <Product>highlight.io</Product>

--- a/sdk/highlight-dotnet4/OpenTelemetry.cs
+++ b/sdk/highlight-dotnet4/OpenTelemetry.cs
@@ -98,7 +98,7 @@ public static class OpenTelemetry {
             ["highlight.project_id"] = Cfg.ProjectId,
             ["service.name"] = Cfg.ServiceName,
             ["telemetry.distro.name"] = "Highlight.ASP4",
-            ["telemetry.distro.version"] = "0.2.8",
+            ["telemetry.distro.version"] = "0.2.9",
         };
     }
 
@@ -129,7 +129,7 @@ public static class OpenTelemetry {
         if (parts.Length < 2) return ctx;
 
         ctx["highlight.session_id"] = parts[0];
-        ctx["highlight.trace_id"] = parts[1];
+        // rely on `traceparent` w3c parent context propagation instead of highlight.trace_id
         return ctx;
     }
 
@@ -160,7 +160,7 @@ public static class OpenTelemetry {
 
         var (sessionId, requestId) = ExtractContext(httpRequest);
         activity.SetTag("highlight.session_id", sessionId);
-        activity.SetTag("highlight.trace_id", requestId);
+        // rely on `traceparent` w3c parent context propagation instead of highlight.trace_id
         Baggage.SetBaggage(new[]
         {
             new KeyValuePair<string, string>(HighlightHeader, $"{sessionId}/{requestId}")


### PR DESCRIPTION
## Summary

Ensure that we use W3C `traceparent` context propagation for trace_id propagation
to connect frontned spans with backend spans correctly.

## How did you test this change?

```bash
curl -H 'traceparent: 00-0869d59c8b979d76dce187c6b846261d-aa672b2c57356794-01' -H 'x-highlight-request: FH8Opd0clu4lJTv8DJL38IhwJvP0/FcehmvwpKu' http://127.0.0.1:5249/api/traces
```

<img width="1417" alt="Screenshot 2025-02-13 at 11 06 48" src="https://github.com/user-attachments/assets/325ed056-b38b-40e5-b6db-9ad6f44e71ac" />

## Are there any deployment considerations?

new versions

## Does this work require review from our design team?

no
