### PR TITLE
turn off session cookie storage by default

### DIFF
--- a/.changeset/clean-balloons-pump.md
+++ b/.changeset/clean-balloons-pump.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': minor
+---
+
+turn off session cookie storage by default

--- a/highlight.io/components/QuickstartContent/backend/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/backend/shared-snippets.tsx
@@ -8,6 +8,8 @@ export const frontendInstallSnippet: QuickStartStep = {
 		{
 			text: `H.init("<YOUR_PROJECT_ID>", {
   tracingOrigins: ['localhost', 'example.myapp.com/backend'],
+  // Associate server-side rendering traces with the session via a cookie
+  sessionCookie: true,
   networkRecording: {
     enabled: true,
     recordHeadersAndBody: true,

--- a/highlight.io/components/QuickstartContent/traces/dotnet/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/traces/dotnet/shared-snippets.tsx
@@ -5,6 +5,8 @@ export const setupFrontendSnippet: string = `<script src="https://unpkg.com/high
         H.init('<YOUR_PROJECT_ID>', {
             serviceName: 'highlight-dot-net-frontend',
             tracingOrigins: true,
+			// Associate server-side rendering traces with the session via a cookie
+            sessionCookie: true,
             networkRecording: {
                 enabled: true,
                 recordHeadersAndBody: true,

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -141,7 +141,7 @@ export type HighlightClassOptions = {
 	sessionShortcut?: SessionShortcutOptions
 	sessionSecureID: string // Introduced in firstLoad 3.0.1
 	storageMode?: 'sessionStorage' | 'localStorage'
-	skipCookieSessionDataLoad?: true
+	sessionCookie?: true
 	sendMode?: 'webworker' | 'local'
 	otlpEndpoint?: HighlightOptions['otlpEndpoint']
 	otel?: HighlightOptions['otel']
@@ -236,7 +236,7 @@ export class Highlight {
 			)
 			setStorageMode(options.storageMode)
 		}
-		setCookieWriteEnabled(!options?.skipCookieSessionDataLoad)
+		setCookieWriteEnabled(!!options?.sessionCookie)
 
 		this._worker =
 			new HighlightClientWorker() as HighlightClientRequestWorker

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -247,11 +247,11 @@ export declare type HighlightOptions = {
 	 */
 	storageMode?: 'sessionStorage' | 'localStorage'
 	/**
-	 * Set `skipCookieSessionDataLoad` to bypass retrieval
-	 * of session context from server side cookies, which otherwise
-	 * would continue a session started server side.
+	 * By default, session data is stored in the `sessionStorage` of the browser.
+	 * Set to `true` to store session data in a cookie instead.
+	 * This can help with compliance for cookie-consent regulation.
 	 */
-	skipCookieSessionDataLoad?: true
+	sessionCookie?: true
 	/**
 	 * By default, data is serialized and send by the Web Worker. Set to `local` to force
 	 * sending from the main js thread. Only use `local` for custom environments where Web Workers

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -97,7 +97,7 @@ const H: HighlightPublicInterface = {
 				return
 			}
 
-			if (!options?.skipCookieSessionDataLoad) {
+			if (options?.sessionCookie) {
 				loadCookieSessionData()
 			} else {
 				setCookieWriteEnabled(false)


### PR DESCRIPTION
## Summary

Replace the `skipCookieSessionDataLoad` setting with an opt-in version (`sessionCookie: true`)
to default to not using the session cookie. While the cookie technique is useful to associate
server-side rendering context with the frontend session replay which starts after the trace,
the cookies cause HTTP request bloat when multiple navigations occur since they are not cleared.

Recommend the setting be used only when needed (for .NET Blazer apps, for instance).

## How did you test this change?

CI

## Are there any deployment considerations?

changeset included

## Does this work require review from our design team?

no
