### PR TITLE
Add RSS feed for blog

### DIFF
--- a/highlight.io/app/api/rss/route.ts
+++ b/highlight.io/app/api/rss/route.ts
@@ -1,0 +1,173 @@
+import { promises as fsp } from 'fs'
+import { getBlogPaths } from '../../../shared/blog'
+import fm from 'front-matter'
+import { withAppRouterHighlight } from '../../../highlight.app.config'
+import path from 'path'
+
+async function generateRSSXML(): Promise<string> {
+	const githubBlogPosts = await getBlogPaths(fsp, '')
+	const blogPosts = await Promise.all(
+		githubBlogPosts.map(async (page) => {
+			const content = await fsp.readFile(
+				path.join(
+					process.cwd(),
+					'../blog-content',
+					page.simple_path + '.md',
+				),
+				'utf-8',
+			)
+
+			/**
+			 * Example:
+			 *
+			 *     title: 'Maximizing Our Machines: Worker Pools At Highlight',
+			 *     createdAt: 2022-08-04T12:00:00.000Z,
+			 *     readingTime: 3,
+			 *     authorFirstName: 'Cameron',
+			 *     authorLastName: 'Brill',
+			 *     authorTitle: 'Software Engineer',
+			 *     authorTwitter: 'https://twitter.com/c00brill',
+			 *     authorLinkedIn: 'https://www.linkedin.com/in/cameronbrill/',
+			 *     authorGithub: 'https://github.com/cameronbrill',
+			 *     authorWebsite: 'https://www.cameronbrill.me/',
+			 *     authorPFP: 'https://www.highlight.io/_next/image?url=https%3A%2F%2Fmedia.graphassets.com%2FHj9YMnNCSUGwgR7KF3Cd&w=3840&q=75',
+			 *     image: 'https://www.highlight.io/_next/image?url=https%3A%2F%2Fmedia.graphassets.com%2FXmbzglNdRhezMtFLt9TL&w=3840&q=75',
+			 *     tags: 'Engineering',
+			 *     metaTitle: 'How-To: Use Worker Pools To Scale Customer Requests Fast'
+			 */
+			const { attributes, body } = fm<{
+				date: string
+				authorFirstName: string
+				authorLastName: string
+				authorTitle: string
+				authorTwitter: string
+				authorLinkedIn: string
+				authorGithub: string
+				authorWebsite: string
+				authorPFP: string
+				title: string
+				description: string
+				image: string
+				tags: string
+			}>(content)
+
+			return {
+				date: attributes.date,
+				author:
+					attributes.authorFirstName +
+					' ' +
+					attributes.authorLastName,
+				title: attributes.title,
+				description: attributes.description,
+				image: attributes.image,
+				content: body,
+				tags: attributes.tags.split(','),
+				path: page.simple_path.split('/').pop()?.replace('.md', ''),
+			}
+		}),
+	)
+
+	const safeURL = (url: string) => {
+		if (!url) return ''
+
+		// Basic XML character escaping
+		const escapeChars = (str: string) =>
+			str
+				.replace(/&/g, '&amp;')
+				.replace(/'/g, '&apos;')
+				.replace(/"/g, '&quot;')
+
+		try {
+			let finalUrl = url
+
+			// Handle relative URLs first
+			if (url.startsWith('/')) {
+				finalUrl = `${process.env.WEBSITE_URL ?? 'https://www.highlight.io'}${url}`
+			}
+
+			// Parse URL only once
+			const urlObj = new URL(finalUrl)
+
+			// Handle different URL types
+			if (urlObj.pathname.includes('_next/image')) {
+				const originalUrl = urlObj.searchParams.get('url')
+				if (originalUrl) {
+					return escapeChars(decodeURIComponent(originalUrl))
+				}
+			}
+
+			if (urlObj.hostname.includes('graphassets.com')) {
+				urlObj.search = ''
+			}
+
+			return escapeChars(urlObj.toString())
+		} catch {
+			// For unparseable URLs, just escape the original
+			if (url.startsWith('/')) {
+				return escapeChars(
+					`${process.env.WEBSITE_URL ?? 'https://www.highlight.io'}${url}`,
+				)
+			}
+			return escapeChars(url)
+		}
+	}
+
+	const items = blogPosts
+		.map((post) => {
+			const date = new Date(post.date)
+			const pubDate = !isNaN(date.getTime())
+				? date.toUTCString()
+				: new Date().toUTCString()
+
+			const escapeXML = (str: string) => {
+				if (!str) return ''
+				return str
+					.replace(/&/g, '&amp;')
+					.replace(/</g, '&lt;')
+					.replace(/>/g, '&gt;')
+					.replace(/"/g, '&quot;')
+					.replace(/'/g, '&apos;')
+					.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')
+			}
+
+			const baseURL =
+				process.env.WEBSITE_URL ?? 'https://www.highlight.io'
+			const link = safeURL(`${baseURL}/blog/${post.path}`)
+			const imageUrl = post.image ? safeURL(post.image) : ''
+
+			const categories = post.tags
+				? post.tags
+						.map(
+							(tag) =>
+								`<category>${escapeXML(tag.trim())}</category>`,
+						)
+						.join('')
+				: ''
+
+			const authorEmail = post.author
+				? `${escapeXML(post.author.replace(/\s+/g, '.').toLowerCase())}@highlight.io`
+				: 'team@highlight.io'
+
+			return `<item><title><![CDATA[${post.title || ''}]]></title><link>${link}</link><guid isPermaLink="true">${link}</guid><pubDate>${pubDate}</pubDate><description><![CDATA[${post.description || ''}]]></description><author>${authorEmail} (${post.author || 'Highlight.io Team'})</author>${categories}${imageUrl ? `<enclosure url="${imageUrl}" length="0" type="image/jpeg"/>` : ''}</item>`
+		})
+		.join('')
+
+	const baseURL = process.env.WEBSITE_URL ?? 'https://www.highlight.io'
+	const rssURL = safeURL(`${baseURL}/blog/rss.xml`)
+	const blogURL = safeURL(`${baseURL}/blog`)
+
+	return `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel><title>Highlight.io Blog</title><link>${blogURL}</link><atom:link href="${rssURL}" rel="self" type="application/rss+xml"/><description>The latest updates from Highlight.io</description><language>en-US</language>${items}</channel></rss>`
+}
+
+export const maxDuration = 300
+export const dynamic = 'force-dynamic'
+
+export const GET = withAppRouterHighlight(async function GET() {
+	return new Response(await generateRSSXML(), {
+		headers: {
+			'Content-Type': 'text/xml',
+			'Cache-control': 'stale-while-revalidate, s-maxage=3600',
+		},
+		status: 200,
+	})
+})

--- a/highlight.io/app/api/rss/route.ts
+++ b/highlight.io/app/api/rss/route.ts
@@ -139,7 +139,7 @@ const safeURL = (url: string) => {
 			}
 		}
 
-		if (urlObj.hostname.includes('graphassets.com')) {
+		if (urlObj.hostname === 'media.graphassets.com') {
 			urlObj.search = ''
 		}
 

--- a/highlight.io/components/Blog/BlogPage.tsx
+++ b/highlight.io/components/Blog/BlogPage.tsx
@@ -13,6 +13,7 @@ import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { HiOutlineSearch } from 'react-icons/hi'
 import { PostAuthor } from './Author'
+import Head from 'next/head'
 
 // https://usehooks-ts.com/react-hook/use-debounce
 function useDebounce<T>(value: T, delay?: number): T {
@@ -57,6 +58,14 @@ const BlogPage = ({
 
 	return (
 		<>
+			<Head>
+				<link
+					rel="alternate"
+					type="application/rss+xml"
+					title="Highlight.io Blog RSS Feed"
+					href="/blog/rss.xml"
+				/>
+			</Head>
 			<Navbar />
 			<main>
 				<div className="flex flex-row w-full gap-8 my-20 desktop:max-w-[1100px] mx-auto items-start px-6">

--- a/highlight.io/next.config.js
+++ b/highlight.io/next.config.js
@@ -129,6 +129,10 @@ const nextConfig = {
 				source: '/sitemap.xml',
 				destination: '/api/sitemap',
 			},
+			{
+				source: '/blog/rss.xml',
+				destination: '/api/rss',
+			},
 		]
 	},
 }

--- a/highlight.io/package.json
+++ b/highlight.io/package.json
@@ -27,6 +27,7 @@
 		"docs-content": "workspace:*",
 		"embla-carousel-react": "^7.0.5",
 		"framer-motion": "^8.5.2",
+		"front-matter": "^4.0.2",
 		"fuse.js": "^6.6.2",
 		"graphql": "^16.8.1",
 		"graphql-request": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -40092,6 +40092,7 @@ __metadata:
     eslint: "npm:^9.18.0"
     eslint-config-next: "npm:^15.1.4"
     framer-motion: "npm:^8.5.2"
+    front-matter: "npm:^4.0.2"
     fuse.js: "npm:^6.6.2"
     graphql: "npm:^16.8.1"
     graphql-request: "npm:^6.1.0"


### PR DESCRIPTION
## Summary

Adds an RSS feed for the Highlight.io blog.

## How did you test this change?

Local + PR preview click test. I ran the XML through an RSS validator as well.

* PR Preview RSS Feed: https://highlight-landing-lko6eysa0-highlight-run.vercel.app/blog/rss.xml
* PR Preview Blog: https://highlight-landing-lko6eysa0-highlight-run.vercel.app/blog

## Are there any deployment considerations?

N/A - should only be adding a new route that nobody is hitting yet. Will verify behavior by importing posts into dev.to once this is live.

## Does this work require review from our design team?

N/A