### PR TITLE
support SQL alerts

### DIFF
--- a/backend/jobs/metric-alerts/metric-alerts.go
+++ b/backend/jobs/metric-alerts/metric-alerts.go
@@ -93,7 +93,10 @@ func processMetricAlert(ctx context.Context, DB *gorm.DB, MailClient *sendgrid.C
 		thresholdWindow = time.Duration(*alert.ThresholdWindow) * time.Second
 	}
 
-	saveMetricState := alert.ProductType != modelInputs.ProductTypeErrors && alert.ProductType != modelInputs.ProductTypeSessions && alert.ProductType != modelInputs.ProductTypeEvents
+	saveMetricState := alert.Sql == nil &&
+		alert.ProductType != modelInputs.ProductTypeErrors &&
+		alert.ProductType != modelInputs.ProductTypeSessions &&
+		alert.ProductType != modelInputs.ProductTypeEvents
 
 	endDate := curDate
 	startDate := curDate.Add(-1 * thresholdWindow)
@@ -206,6 +209,7 @@ func processMetricAlert(ctx context.Context, DB *gorm.DB, MailClient *sendgrid.C
 			Aggregator: alert.FunctionType,
 			Column:     column,
 		}},
+		Sql: alert.Sql,
 	})
 	if err != nil {
 		return err

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1932,6 +1932,7 @@ type Alert struct {
 	ThresholdCooldown  *int
 	ThresholdType      modelInputs.ThresholdType
 	ThresholdCondition modelInputs.ThresholdCondition
+	Sql                *string
 }
 
 type AlertDestination struct {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -148,6 +148,7 @@ type ComplexityRoot struct {
 		ProductType        func(childComplexity int) int
 		ProjectID          func(childComplexity int) int
 		Query              func(childComplexity int) int
+		Sql                func(childComplexity int) int
 		ThresholdCondition func(childComplexity int) int
 		ThresholdCooldown  func(childComplexity int) int
 		ThresholdType      func(childComplexity int) int
@@ -896,7 +897,7 @@ type ComplexityRoot struct {
 		ChangeAdminRole                       func(childComplexity int, workspaceID int, adminID int, newRole string) int
 		ChangeProjectMembership               func(childComplexity int, workspaceID int, adminID int, projectIds []int) int
 		CreateAdmin                           func(childComplexity int) int
-		CreateAlert                           func(childComplexity int, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, defaultArg *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int, thresholdType *model.ThresholdType, thresholdCondition *model.ThresholdCondition, destinations []*model.AlertDestinationInput) int
+		CreateAlert                           func(childComplexity int, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, defaultArg *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int, thresholdType *model.ThresholdType, thresholdCondition *model.ThresholdCondition, destinations []*model.AlertDestinationInput, sql *string) int
 		CreateCloudflareProxy                 func(childComplexity int, workspaceID int, proxySubdomain string) int
 		CreateErrorComment                    func(childComplexity int, projectID int, errorGroupSecureID string, text string, textForEmail string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, errorURL string, authorName string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
 		CreateErrorCommentForExistingIssue    func(childComplexity int, projectID int, errorGroupSecureID string, text string, textForEmail string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, errorURL string, authorName string, issueURL string, issueTitle string, issueID string, integrations []*model.IntegrationType) int
@@ -956,7 +957,7 @@ type ComplexityRoot struct {
 		TestErrorEnhancement                  func(childComplexity int, errorObjectID int, githubRepoPath string, githubPrefix *string, buildPrefix *string, saveError *bool) int
 		UpdateAdminAboutYouDetails            func(childComplexity int, adminDetails model.AdminAboutYouDetails) int
 		UpdateAdminAndCreateWorkspace         func(childComplexity int, adminAndWorkspaceDetails model.AdminAndWorkspaceDetails) int
-		UpdateAlert                           func(childComplexity int, projectID int, alertID int, name *string, productType *model.ProductType, functionType *model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int, thresholdType *model.ThresholdType, thresholdCondition *model.ThresholdCondition, destinations []*model.AlertDestinationInput) int
+		UpdateAlert                           func(childComplexity int, projectID int, alertID int, name *string, productType *model.ProductType, functionType *model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int, thresholdType *model.ThresholdType, thresholdCondition *model.ThresholdCondition, destinations []*model.AlertDestinationInput, sql *string) int
 		UpdateAlertDisabled                   func(childComplexity int, projectID int, alertID int, disabled bool) int
 		UpdateAllowMeterOverage               func(childComplexity int, workspaceID int, allowMeterOverage bool) int
 		UpdateAllowedEmailOrigins             func(childComplexity int, workspaceID int, allowedAutoJoinEmailOrigins string) int
@@ -1884,8 +1885,8 @@ type MutationResolver interface {
 	SyncSlackIntegration(ctx context.Context, projectID int) (*model.SlackSyncResponse, error)
 	CreateMetricMonitor(ctx context.Context, projectID int, name string, aggregator model.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
 	UpdateMetricMonitor(ctx context.Context, metricMonitorID int, projectID int, name *string, aggregator *model.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, disabled *bool, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
-	CreateAlert(ctx context.Context, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, defaultArg *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int, thresholdType *model.ThresholdType, thresholdCondition *model.ThresholdCondition, destinations []*model.AlertDestinationInput) (*model1.Alert, error)
-	UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *model.ProductType, functionType *model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int, thresholdType *model.ThresholdType, thresholdCondition *model.ThresholdCondition, destinations []*model.AlertDestinationInput) (*model1.Alert, error)
+	CreateAlert(ctx context.Context, projectID int, name string, productType model.ProductType, functionType model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, defaultArg *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int, thresholdType *model.ThresholdType, thresholdCondition *model.ThresholdCondition, destinations []*model.AlertDestinationInput, sql *string) (*model1.Alert, error)
+	UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *model.ProductType, functionType *model.MetricAggregator, functionColumn *string, query *string, groupByKey *string, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int, thresholdType *model.ThresholdType, thresholdCondition *model.ThresholdCondition, destinations []*model.AlertDestinationInput, sql *string) (*model1.Alert, error)
 	UpdateAlertDisabled(ctx context.Context, projectID int, alertID int, disabled bool) (bool, error)
 	DeleteAlert(ctx context.Context, projectID int, alertID int) (bool, error)
 	UpdateErrorAlert(ctx context.Context, projectID int, name *string, errorAlertID int, countThreshold *int, thresholdWindow *int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, query string, regexGroups []*string, frequency *int, disabled *bool) (*model1.ErrorAlert, error)
@@ -2589,6 +2590,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Alert.Query(childComplexity), true
+
+	case "Alert.sql":
+		if e.complexity.Alert.Sql == nil {
+			break
+		}
+
+		return e.complexity.Alert.Sql(childComplexity), true
 
 	case "Alert.threshold_condition":
 		if e.complexity.Alert.ThresholdCondition == nil {
@@ -6055,7 +6063,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.CreateAlert(childComplexity, args["project_id"].(int), args["name"].(string), args["product_type"].(model.ProductType), args["function_type"].(model.MetricAggregator), args["function_column"].(*string), args["query"].(*string), args["group_by_key"].(*string), args["default"].(*bool), args["threshold_value"].(*float64), args["threshold_window"].(*int), args["threshold_cooldown"].(*int), args["threshold_type"].(*model.ThresholdType), args["threshold_condition"].(*model.ThresholdCondition), args["destinations"].([]*model.AlertDestinationInput)), true
+		return e.complexity.Mutation.CreateAlert(childComplexity, args["project_id"].(int), args["name"].(string), args["product_type"].(model.ProductType), args["function_type"].(model.MetricAggregator), args["function_column"].(*string), args["query"].(*string), args["group_by_key"].(*string), args["default"].(*bool), args["threshold_value"].(*float64), args["threshold_window"].(*int), args["threshold_cooldown"].(*int), args["threshold_type"].(*model.ThresholdType), args["threshold_condition"].(*model.ThresholdCondition), args["destinations"].([]*model.AlertDestinationInput), args["sql"].(*string)), true
 
 	case "Mutation.createCloudflareProxy":
 		if e.complexity.Mutation.CreateCloudflareProxy == nil {
@@ -6775,7 +6783,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.UpdateAlert(childComplexity, args["project_id"].(int), args["alert_id"].(int), args["name"].(*string), args["product_type"].(*model.ProductType), args["function_type"].(*model.MetricAggregator), args["function_column"].(*string), args["query"].(*string), args["group_by_key"].(*string), args["threshold_value"].(*float64), args["threshold_window"].(*int), args["threshold_cooldown"].(*int), args["threshold_type"].(*model.ThresholdType), args["threshold_condition"].(*model.ThresholdCondition), args["destinations"].([]*model.AlertDestinationInput)), true
+		return e.complexity.Mutation.UpdateAlert(childComplexity, args["project_id"].(int), args["alert_id"].(int), args["name"].(*string), args["product_type"].(*model.ProductType), args["function_type"].(*model.MetricAggregator), args["function_column"].(*string), args["query"].(*string), args["group_by_key"].(*string), args["threshold_value"].(*float64), args["threshold_window"].(*int), args["threshold_cooldown"].(*int), args["threshold_type"].(*model.ThresholdType), args["threshold_condition"].(*model.ThresholdCondition), args["destinations"].([]*model.AlertDestinationInput), args["sql"].(*string)), true
 
 	case "Mutation.updateAlertDisabled":
 		if e.complexity.Mutation.UpdateAlertDisabled == nil {
@@ -13825,6 +13833,7 @@ type Alert {
 	threshold_cooldown: Int
 	threshold_type: ThresholdType
 	threshold_condition: ThresholdCondition
+	sql: String
 }
 
 type AlertStateChange {
@@ -15086,6 +15095,7 @@ type Mutation {
 		threshold_type: ThresholdType
 		threshold_condition: ThresholdCondition
 		destinations: [AlertDestinationInput!]!
+		sql: String
 	): Alert
 	updateAlert(
 		project_id: ID!
@@ -15102,6 +15112,7 @@ type Mutation {
 		threshold_type: ThresholdType
 		threshold_condition: ThresholdCondition
 		destinations: [AlertDestinationInput!]
+		sql: String
 	): Alert
 	updateAlertDisabled(
 		project_id: ID!
@@ -15533,6 +15544,15 @@ func (ec *executionContext) field_Mutation_createAlert_args(ctx context.Context,
 		}
 	}
 	args["destinations"] = arg13
+	var arg14 *string
+	if tmp, ok := rawArgs["sql"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sql"))
+		arg14, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["sql"] = arg14
 	return args, nil
 }
 
@@ -18284,6 +18304,15 @@ func (ec *executionContext) field_Mutation_updateAlert_args(ctx context.Context,
 		}
 	}
 	args["destinations"] = arg13
+	var arg14 *string
+	if tmp, ok := rawArgs["sql"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sql"))
+		arg14, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["sql"] = arg14
 	return args, nil
 }
 
@@ -26540,6 +26569,47 @@ func (ec *executionContext) fieldContext_Alert_threshold_condition(ctx context.C
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type ThresholdCondition does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Alert_sql(ctx context.Context, field graphql.CollectedField, obj *model1.Alert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Alert_sql(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Sql, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Alert_sql(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Alert",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -51628,7 +51698,7 @@ func (ec *executionContext) _Mutation_createAlert(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["product_type"].(model.ProductType), fc.Args["function_type"].(model.MetricAggregator), fc.Args["function_column"].(*string), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["default"].(*bool), fc.Args["threshold_value"].(*float64), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int), fc.Args["threshold_type"].(*model.ThresholdType), fc.Args["threshold_condition"].(*model.ThresholdCondition), fc.Args["destinations"].([]*model.AlertDestinationInput))
+		return ec.resolvers.Mutation().CreateAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["product_type"].(model.ProductType), fc.Args["function_type"].(model.MetricAggregator), fc.Args["function_column"].(*string), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["default"].(*bool), fc.Args["threshold_value"].(*float64), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int), fc.Args["threshold_type"].(*model.ThresholdType), fc.Args["threshold_condition"].(*model.ThresholdCondition), fc.Args["destinations"].([]*model.AlertDestinationInput), fc.Args["sql"].(*string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -51686,6 +51756,8 @@ func (ec *executionContext) fieldContext_Mutation_createAlert(ctx context.Contex
 				return ec.fieldContext_Alert_threshold_type(ctx, field)
 			case "threshold_condition":
 				return ec.fieldContext_Alert_threshold_condition(ctx, field)
+			case "sql":
+				return ec.fieldContext_Alert_sql(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Alert", field.Name)
 		},
@@ -51718,7 +51790,7 @@ func (ec *executionContext) _Mutation_updateAlert(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().UpdateAlert(rctx, fc.Args["project_id"].(int), fc.Args["alert_id"].(int), fc.Args["name"].(*string), fc.Args["product_type"].(*model.ProductType), fc.Args["function_type"].(*model.MetricAggregator), fc.Args["function_column"].(*string), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["threshold_value"].(*float64), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int), fc.Args["threshold_type"].(*model.ThresholdType), fc.Args["threshold_condition"].(*model.ThresholdCondition), fc.Args["destinations"].([]*model.AlertDestinationInput))
+		return ec.resolvers.Mutation().UpdateAlert(rctx, fc.Args["project_id"].(int), fc.Args["alert_id"].(int), fc.Args["name"].(*string), fc.Args["product_type"].(*model.ProductType), fc.Args["function_type"].(*model.MetricAggregator), fc.Args["function_column"].(*string), fc.Args["query"].(*string), fc.Args["group_by_key"].(*string), fc.Args["threshold_value"].(*float64), fc.Args["threshold_window"].(*int), fc.Args["threshold_cooldown"].(*int), fc.Args["threshold_type"].(*model.ThresholdType), fc.Args["threshold_condition"].(*model.ThresholdCondition), fc.Args["destinations"].([]*model.AlertDestinationInput), fc.Args["sql"].(*string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -51776,6 +51848,8 @@ func (ec *executionContext) fieldContext_Mutation_updateAlert(ctx context.Contex
 				return ec.fieldContext_Alert_threshold_type(ctx, field)
 			case "threshold_condition":
 				return ec.fieldContext_Alert_threshold_condition(ctx, field)
+			case "sql":
+				return ec.fieldContext_Alert_sql(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Alert", field.Name)
 		},
@@ -60998,6 +61072,8 @@ func (ec *executionContext) fieldContext_Query_alerts(ctx context.Context, field
 				return ec.fieldContext_Alert_threshold_type(ctx, field)
 			case "threshold_condition":
 				return ec.fieldContext_Alert_threshold_condition(ctx, field)
+			case "sql":
+				return ec.fieldContext_Alert_sql(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Alert", field.Name)
 		},
@@ -61091,6 +61167,8 @@ func (ec *executionContext) fieldContext_Query_alert(ctx context.Context, field 
 				return ec.fieldContext_Alert_threshold_type(ctx, field)
 			case "threshold_condition":
 				return ec.fieldContext_Alert_threshold_condition(ctx, field)
+			case "sql":
+				return ec.fieldContext_Alert_sql(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Alert", field.Name)
 		},
@@ -88916,6 +88994,8 @@ func (ec *executionContext) _Alert(ctx context.Context, sel ast.SelectionSet, ob
 			out.Values[i] = ec._Alert_threshold_type(ctx, field, obj)
 		case "threshold_condition":
 			out.Values[i] = ec._Alert_threshold_condition(ctx, field, obj)
+		case "sql":
+			out.Values[i] = ec._Alert_sql(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1757,6 +1757,7 @@ type Alert {
 	threshold_cooldown: Int
 	threshold_type: ThresholdType
 	threshold_condition: ThresholdCondition
+	sql: String
 }
 
 type AlertStateChange {
@@ -3018,6 +3019,7 @@ type Mutation {
 		threshold_type: ThresholdType
 		threshold_condition: ThresholdCondition
 		destinations: [AlertDestinationInput!]!
+		sql: String
 	): Alert
 	updateAlert(
 		project_id: ID!
@@ -3034,6 +3036,7 @@ type Mutation {
 		threshold_type: ThresholdType
 		threshold_condition: ThresholdCondition
 		destinations: [AlertDestinationInput!]
+		sql: String
 	): Alert
 	updateAlertDisabled(
 		project_id: ID!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3405,7 +3405,7 @@ func (r *mutationResolver) UpdateMetricMonitor(ctx context.Context, metricMonito
 }
 
 // CreateAlert is the resolver for the createAlert field.
-func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name string, productType modelInputs.ProductType, functionType modelInputs.MetricAggregator, functionColumn *string, query *string, groupByKey *string, defaultArg *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int, thresholdType *modelInputs.ThresholdType, thresholdCondition *modelInputs.ThresholdCondition, destinations []*modelInputs.AlertDestinationInput) (*model.Alert, error) {
+func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name string, productType modelInputs.ProductType, functionType modelInputs.MetricAggregator, functionColumn *string, query *string, groupByKey *string, defaultArg *bool, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int, thresholdType *modelInputs.ThresholdType, thresholdCondition *modelInputs.ThresholdCondition, destinations []*modelInputs.AlertDestinationInput, sql *string) (*model.Alert, error) {
 	project, err := r.isUserInProject(ctx, projectID)
 	admin, _ := r.getCurrentAdmin(ctx)
 	if err != nil {
@@ -3443,6 +3443,7 @@ func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name 
 		ThresholdType:      thresholdTypeDeref,
 		ThresholdCondition: thresholdConditionDeref,
 		LastAdminToEditID:  admin.ID,
+		Sql:                sql,
 	}
 
 	createdAlert := &model.Alert{}
@@ -3481,7 +3482,7 @@ func (r *mutationResolver) CreateAlert(ctx context.Context, projectID int, name 
 }
 
 // UpdateAlert is the resolver for the updateAlert field.
-func (r *mutationResolver) UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *modelInputs.ProductType, functionType *modelInputs.MetricAggregator, functionColumn *string, query *string, groupByKey *string, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int, thresholdType *modelInputs.ThresholdType, thresholdCondition *modelInputs.ThresholdCondition, destinations []*modelInputs.AlertDestinationInput) (*model.Alert, error) {
+func (r *mutationResolver) UpdateAlert(ctx context.Context, projectID int, alertID int, name *string, productType *modelInputs.ProductType, functionType *modelInputs.MetricAggregator, functionColumn *string, query *string, groupByKey *string, thresholdValue *float64, thresholdWindow *int, thresholdCooldown *int, thresholdType *modelInputs.ThresholdType, thresholdCondition *modelInputs.ThresholdCondition, destinations []*modelInputs.AlertDestinationInput, sql *string) (*model.Alert, error) {
 	project, err := r.isUserInProject(ctx, projectID)
 	admin, _ := r.getCurrentAdmin(ctx)
 	if err != nil {
@@ -3502,6 +3503,7 @@ func (r *mutationResolver) UpdateAlert(ctx context.Context, projectID int, alert
 		"ThresholdCooldown":  thresholdCooldown,
 		"ThresholdType":      thresholdType,
 		"ThresholdCondition": thresholdCondition,
+		"Sql":                sql,
 	}
 
 	alert := &model.Alert{}

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6720,6 +6720,7 @@ body {
 }
 ._1s4anja6 {
   overflow: hidden;
+  height: 30px;
 }
 ._1a4jm560 {
   height: 40px;

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6738,39 +6738,36 @@ body {
   z-index: 0;
 }
 ._1a4jm564 {
-  width: 320px;
-}
-._1a4jm565 {
   margin-bottom: 4px;
 }
-._1a4jm566 {
+._1a4jm565 {
   border: var(--_1pyqka9j) solid 1px;
   width: 100%;
 }
-._1a4jm567 {
+._1a4jm566 {
   height: 28px;
 }
-._1a4jm568 {
+._1a4jm567 {
   display: grid;
   width: 100%;
   height: 100%;
   padding: 8px 28px;
 }
-._1a4jm566 > div {
+._1a4jm565 > div {
   width: 100%;
 }
 @media (width <= 850px) {
-  ._1a4jm568 {
+  ._1a4jm567 {
     grid-template-columns: 1fr;
   }
 }
 @media (850px < width <= 1250px) {
-  ._1a4jm568 {
+  ._1a4jm567 {
     grid-template-columns: 1fr 1fr;
   }
 }
 @media (1250px < width) {
-  ._1a4jm568 {
+  ._1a4jm567 {
     grid-template-columns: 1fr 1fr 1fr;
   }
 }
@@ -6798,10 +6795,6 @@ body {
 ._7o1fd83 {
   max-width: 280px;
 }
-._11j364l0 {
-  width: 720px;
-  height: 360px;
-}
 ._1b4bur70 {
   height: 40px;
 }
@@ -6809,10 +6802,10 @@ body {
   height: calc(100% - 40px);
 }
 ._1b4bur72 {
-  width: 100%;
+  flex-grow: 1;
 }
 ._1b4bur73 {
-  width: 320px;
+  width: 100%;
 }
 ._1b4bur74 {
   margin-bottom: 4px;
@@ -6830,6 +6823,145 @@ body {
   margin: auto;
   z-index: 1;
   background-color: #ffffff;
+}
+._1b4bur79 {
+  background-color: var(--_1pyqka90);
+  border-bottom-left-radius: 6px;
+  border-bottom-right-radius: 6px;
+}
+._1b4bur7a {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  border-bottom: var(--_1pyqka9j) solid 1px;
+  padding: 6px;
+}
+._1b4bur7b {
+  width: fit-content;
+}
+._1b4bur7c {
+  border: var(--_1pyqka9j) solid 1px;
+  border-radius: 6px;
+}
+._1yiubn60 {
+  width: 100%;
+}
+._1yiubn60 .cm-focused {
+  outline: initial;
+}
+._1yiubn60 .cm-tooltip {
+  max-width: 400px;
+  border-radius: 6px;
+  background-color: var(--_1pyqka91);
+  border: var(--_1pyqka9j) solid 1px;
+  overflow: hidden;
+}
+._1yiubn60 .cm-diagnosticText {
+  color: #383a42;
+}
+._1yiubn60 .cm-tooltip-autocomplete ul li {
+  font-family:
+    Consolas,
+    Monaco,
+    "Andale Mono",
+    "Ubuntu Mono",
+    monospace;
+  color: #383a42;
+}
+._1yiubn60 .cm-tooltip-autocomplete ul li[aria-selected] {
+  background-color: var(--_1pyqka91x);
+  color: #383a42;
+}
+._1yiubn60 .cm-completionIcon {
+  display: none;
+}
+._1axi0ww0 {
+  cursor: col-resize;
+  position: absolute;
+  left: -2px;
+  top: 0;
+  bottom: 0;
+  transition: background-color 0.3s;
+  width: 4px;
+  z-index: 1000;
+}
+._1axi0ww0:hover {
+  background-color: var(--_1pyqka91m);
+}
+._1axi0ww0:focus {
+  background-color: var(--_1pyqka91m);
+}
+.gw96js0 {
+  height: 40px;
+}
+.gw96js1 {
+  height: calc(100% - 40px);
+}
+.gw96js2 {
+  flex-grow: 1;
+}
+.gw96js3 {
+  z-index: 0;
+}
+.gw96js4 {
+  margin-bottom: 4px;
+}
+.gw96js5 {
+  height: 28px;
+}
+.gw96js6 {
+  width: 860px;
+  height: 540px;
+  margin: auto;
+  z-index: 1;
+  background-color: #ffffff;
+}
+.gw96js7 {
+  width: 100%;
+}
+.gw96js8 {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  border-bottom: var(--_1pyqka9j) solid 1px;
+  padding: 6px;
+}
+.gw96js9 {
+  width: fit-content;
+}
+.gw96jsa {
+  border: var(--_1pyqka9j) solid 1px;
+  border-radius: 6px;
+}
+.gw96jsb {
+  background-color: var(--_1pyqka90);
+  border-bottom-left-radius: 6px;
+  border-bottom-right-radius: 6px;
+}
+.k0as8h0 {
+  width: 100%;
+}
+.uok1x60 {
+  display: grid;
+  width: 100%;
+  height: 100%;
+  grid-template-columns: 1fr 1fr 1fr;
+}
+.uok1x61 {
+  width: 100%;
+  height: 120px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: none;
+}
+.uok1x61:hover {
+  border: 1px solid var(--_1pyqka9j);
+}
+.uok1x62 {
+  color: var(--_1pyqka9b);
+}
+.uok1x63 {
+  color: var(--_1pyqka9d);
 }
 ._1vb6x0p0 {
   text-decoration: none;
@@ -8121,126 +8253,6 @@ body {
   max-width: 400px;
   padding-bottom: 32px;
   padding-top: 32px;
-}
-.gw96js0 {
-  height: 40px;
-}
-.gw96js1 {
-  height: calc(100% - 40px);
-}
-.gw96js2 {
-  flex-grow: 1;
-}
-.gw96js3 {
-  z-index: 0;
-}
-.gw96js4 {
-  margin-bottom: 4px;
-}
-.gw96js5 {
-  height: 28px;
-}
-.gw96js6 {
-  width: 860px;
-  height: 540px;
-  margin: auto;
-  z-index: 1;
-  background-color: #ffffff;
-}
-.gw96js7 {
-  width: 100%;
-}
-.gw96js8 {
-  display: flex;
-  justify-content: space-between;
-  width: 100%;
-  border-bottom: var(--_1pyqka9j) solid 1px;
-  padding: 6px;
-}
-.gw96js9 {
-  width: fit-content;
-}
-.gw96jsa {
-  border: var(--_1pyqka9j) solid 1px;
-  border-radius: 6px;
-}
-.gw96jsb {
-  background-color: var(--_1pyqka90);
-  border-bottom-left-radius: 6px;
-  border-bottom-right-radius: 6px;
-}
-.k0as8h0 {
-  width: 100%;
-}
-.uok1x60 {
-  display: grid;
-  width: 100%;
-  height: 100%;
-  grid-template-columns: 1fr 1fr 1fr;
-}
-.uok1x61 {
-  width: 100%;
-  height: 120px;
-  border-radius: 4px;
-  cursor: pointer;
-  border: none;
-}
-.uok1x61:hover {
-  border: 1px solid var(--_1pyqka9j);
-}
-.uok1x62 {
-  color: var(--_1pyqka9b);
-}
-.uok1x63 {
-  color: var(--_1pyqka9d);
-}
-._1axi0ww0 {
-  cursor: col-resize;
-  position: absolute;
-  left: -2px;
-  top: 0;
-  bottom: 0;
-  transition: background-color 0.3s;
-  width: 4px;
-  z-index: 1000;
-}
-._1axi0ww0:hover {
-  background-color: var(--_1pyqka91m);
-}
-._1axi0ww0:focus {
-  background-color: var(--_1pyqka91m);
-}
-._1yiubn60 {
-  width: 100%;
-}
-._1yiubn60 .cm-focused {
-  outline: initial;
-}
-._1yiubn60 .cm-tooltip {
-  max-width: 400px;
-  border-radius: 6px;
-  background-color: var(--_1pyqka91);
-  border: var(--_1pyqka9j) solid 1px;
-  overflow: hidden;
-}
-._1yiubn60 .cm-diagnosticText {
-  color: #383a42;
-}
-._1yiubn60 .cm-tooltip-autocomplete ul li {
-  font-family:
-    Consolas,
-    Monaco,
-    "Andale Mono",
-    "Ubuntu Mono",
-    monospace;
-  color: #383a42;
-}
-._1yiubn60 .cm-tooltip-autocomplete ul li[aria-selected] {
-  background-color: var(--_1pyqka91x);
-  color: #383a42;
-}
-._1yiubn60 .cm-completionIcon {
-  display: none;
 }
 ._1n2x7d50 {
   width: 100%;

--- a/frontend/src/__generated/ve/pages/Alerts/AlertForm/styles.css.js
+++ b/frontend/src/__generated/ve/pages/Alerts/AlertForm/styles.css.js
@@ -1,21 +1,29 @@
 // src/pages/Alerts/AlertForm/styles.css.ts
 var editGraphHeader = "_1b4bur70";
 var editGraphPanel = "_1b4bur71";
-var editGraphSidebar = "_1b4bur73";
+var editGraphPreview = "_1b4bur72";
+var editorHeader = "_1b4bur7a";
 var editorLabel = "_1b4bur74";
+var editorSection = "_1b4bur7c";
+var editorSelect = "_1b4bur7b";
 var graphBackground = "_1b4bur77";
 var graphContainer = "_1b4bur78";
 var input = "_1b4bur75";
 var previewWindow = "_1b4bur76";
-var tagSwitch = "_1b4bur72";
+var sqlEditorWrapper = "_1b4bur79";
+var tagSwitch = "_1b4bur73";
 export {
   editGraphHeader,
   editGraphPanel,
-  editGraphSidebar,
+  editGraphPreview,
+  editorHeader,
   editorLabel,
+  editorSection,
+  editorSelect,
   graphBackground,
   graphContainer,
   input,
   previewWindow,
+  sqlEditorWrapper,
   tagSwitch
 };

--- a/frontend/src/__generated/ve/pages/Graphing/Dashboard.css.js
+++ b/frontend/src/__generated/ve/pages/Graphing/Dashboard.css.js
@@ -1,17 +1,15 @@
 // src/pages/Graphing/Dashboard.css.ts
 var dashboardContent = "_1a4jm561";
 var editGraphHeader = "_1a4jm560";
-var editGraphSidebar = "_1a4jm564";
-var editorLabel = "_1a4jm565";
+var editorLabel = "_1a4jm564";
 var graphBackground = "_1a4jm563";
-var graphGrid = "_1a4jm568";
+var graphGrid = "_1a4jm567";
 var headerDivider = "_1a4jm562";
-var input = "_1a4jm567";
-var menuButton = "_1a4jm566";
+var input = "_1a4jm566";
+var menuButton = "_1a4jm565";
 export {
   dashboardContent,
   editGraphHeader,
-  editGraphSidebar,
   editorLabel,
   graphBackground,
   graphGrid,

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -3316,6 +3316,7 @@ export const CreateAlertDocument = gql`
 		$threshold_type: ThresholdType
 		$threshold_condition: ThresholdCondition
 		$destinations: [AlertDestinationInput!]!
+		$sql: String
 	) {
 		createAlert(
 			project_id: $project_id
@@ -3332,6 +3333,7 @@ export const CreateAlertDocument = gql`
 			threshold_type: $threshold_type
 			threshold_condition: $threshold_condition
 			destinations: $destinations
+			sql: $sql
 		) {
 			id
 			name
@@ -3371,6 +3373,7 @@ export type CreateAlertMutationFn = Apollo.MutationFunction<
  *      threshold_type: // value for 'threshold_type'
  *      threshold_condition: // value for 'threshold_condition'
  *      destinations: // value for 'destinations'
+ *      sql: // value for 'sql'
  *   },
  * });
  */
@@ -3410,6 +3413,7 @@ export const UpdateAlertDocument = gql`
 		$threshold_type: ThresholdType
 		$threshold_condition: ThresholdCondition
 		$destinations: [AlertDestinationInput!]
+		$sql: String
 	) {
 		updateAlert(
 			project_id: $project_id
@@ -3426,6 +3430,7 @@ export const UpdateAlertDocument = gql`
 			threshold_type: $threshold_type
 			threshold_condition: $threshold_condition
 			destinations: $destinations
+			sql: $sql
 		) {
 			id
 			name
@@ -3465,6 +3470,7 @@ export type UpdateAlertMutationFn = Apollo.MutationFunction<
  *      threshold_type: // value for 'threshold_type'
  *      threshold_condition: // value for 'threshold_condition'
  *      destinations: // value for 'destinations'
+ *      sql: // value for 'sql'
  *   },
  * });
  */
@@ -12401,6 +12407,7 @@ export const GetAlertsPagePayloadDocument = gql`
 				type_id
 				type_name
 			}
+			sql
 		}
 	}
 	${DiscordChannelFragmentFragmentDoc}
@@ -12481,6 +12488,7 @@ export const GetAlertDocument = gql`
 				type_id
 				type_name
 			}
+			sql
 		}
 	}
 `

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -976,6 +976,7 @@ export type CreateAlertMutationVariables = Types.Exact<{
 	destinations:
 		| Array<Types.AlertDestinationInput>
 		| Types.AlertDestinationInput
+	sql?: Types.Maybe<Types.Scalars['String']>
 }>
 
 export type CreateAlertMutation = { __typename?: 'Mutation' } & {
@@ -1004,6 +1005,7 @@ export type UpdateAlertMutationVariables = Types.Exact<{
 	destinations?: Types.Maybe<
 		Array<Types.AlertDestinationInput> | Types.AlertDestinationInput
 	>
+	sql?: Types.Maybe<Types.Scalars['String']>
 }>
 
 export type UpdateAlertMutation = { __typename?: 'Mutation' } & {
@@ -4309,7 +4311,12 @@ export type GetAlertsPagePayloadQuery = { __typename?: 'Query' } & {
 		Types.Maybe<
 			{ __typename?: 'Alert' } & Pick<
 				Types.Alert,
-				'id' | 'updated_at' | 'name' | 'product_type' | 'disabled'
+				| 'id'
+				| 'updated_at'
+				| 'name'
+				| 'product_type'
+				| 'disabled'
+				| 'sql'
 			> & {
 					destinations: Array<
 						Types.Maybe<
@@ -4350,6 +4357,7 @@ export type GetAlertQuery = { __typename?: 'Query' } & {
 		| 'threshold_cooldown'
 		| 'threshold_type'
 		| 'threshold_condition'
+		| 'sql'
 	> & {
 			destinations: Array<
 				Types.Maybe<

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -142,6 +142,7 @@ export type Alert = {
 	product_type: ProductType
 	project_id: Scalars['ID']
 	query?: Maybe<Scalars['String']>
+	sql?: Maybe<Scalars['String']>
 	threshold_condition?: Maybe<ThresholdCondition>
 	threshold_cooldown?: Maybe<Scalars['Int']>
 	threshold_type?: Maybe<ThresholdType>
@@ -1387,6 +1388,7 @@ export type MutationCreateAlertArgs = {
 	product_type: ProductType
 	project_id: Scalars['ID']
 	query?: InputMaybe<Scalars['String']>
+	sql?: InputMaybe<Scalars['String']>
 	threshold_condition?: InputMaybe<ThresholdCondition>
 	threshold_cooldown?: InputMaybe<Scalars['Int']>
 	threshold_type?: InputMaybe<ThresholdType>
@@ -1829,6 +1831,7 @@ export type MutationUpdateAlertArgs = {
 	product_type?: InputMaybe<ProductType>
 	project_id: Scalars['ID']
 	query?: InputMaybe<Scalars['String']>
+	sql?: InputMaybe<Scalars['String']>
 	threshold_condition?: InputMaybe<ThresholdCondition>
 	threshold_cooldown?: InputMaybe<Scalars['Int']>
 	threshold_type?: InputMaybe<ThresholdType>

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -911,6 +911,7 @@ mutation CreateAlert(
 	$threshold_type: ThresholdType
 	$threshold_condition: ThresholdCondition
 	$destinations: [AlertDestinationInput!]!
+	$sql: String
 ) {
 	createAlert(
 		project_id: $project_id
@@ -927,6 +928,7 @@ mutation CreateAlert(
 		threshold_type: $threshold_type
 		threshold_condition: $threshold_condition
 		destinations: $destinations
+		sql: $sql
 	) {
 		id
 		name
@@ -949,6 +951,7 @@ mutation UpdateAlert(
 	$threshold_type: ThresholdType
 	$threshold_condition: ThresholdCondition
 	$destinations: [AlertDestinationInput!]
+	$sql: String
 ) {
 	updateAlert(
 		project_id: $project_id
@@ -965,6 +968,7 @@ mutation UpdateAlert(
 		threshold_type: $threshold_type
 		threshold_condition: $threshold_condition
 		destinations: $destinations
+		sql: $sql
 	) {
 		id
 		name

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1908,6 +1908,7 @@ query GetAlertsPagePayload($project_id: ID!) {
 			type_id
 			type_name
 		}
+		sql
 	}
 }
 
@@ -1935,6 +1936,7 @@ query GetAlert($id: ID!) {
 			type_id
 			type_name
 		}
+		sql
 	}
 }
 

--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -1,7 +1,7 @@
-import { Button } from '@components/Button'
 import { toast } from '@components/Toaster'
 import {
 	Box,
+	Button,
 	Callout,
 	DateRangePicker,
 	DEFAULT_TIME_PRESETS,
@@ -45,7 +45,12 @@ import {
 } from '@/pages/Alerts/constants'
 import { DestinationInput } from '@/pages/Alerts/DestinationInput'
 import { Combobox } from '@/pages/Graphing/Combobox'
-import { FUNCTION_TYPES, PRODUCT_OPTIONS } from '@/pages/Graphing/constants'
+import {
+	Editor,
+	EDITOR_OPTIONS,
+	FUNCTION_TYPES,
+	PRODUCT_OPTIONS,
+} from '@/pages/Graphing/constants'
 import { HeaderDivider } from '@/pages/Graphing/Dashboard'
 import { LabeledRow } from '@/pages/Graphing/LabeledRow'
 import { OptionDropdown } from '@/pages/Graphing/OptionDropdown'
@@ -56,6 +61,9 @@ import { useGraphData } from '@pages/Graphing/hooks/useGraphData'
 import { AlertGraph } from '../AlertGraph'
 import * as style from './styles.css'
 import { useGraphTime } from '@/pages/Graphing/hooks/useGraphTime'
+import { DEFAULT_SQL, SqlEditor } from '@/pages/Graphing/components/SqlEditor'
+import { Panel } from '@/pages/Graphing/components/Panel'
+import { GraphBackgroundWrapper } from '@/pages/Graphing/GraphingEditor'
 
 const SidebarSection = (props: PropsWithChildren) => {
 	return (
@@ -119,6 +127,8 @@ type AlertSettings = {
 	thresholdWindow: number
 	thresholdCooldown: number
 	destinations: AlertDestinationInput[]
+	editor: Editor
+	sql: string
 }
 
 const ALERT_PRODUCT_INFO = {
@@ -171,6 +181,14 @@ export const AlertForm: React.FC = () => {
 			? (JSON.parse(atob(settingsParam)) as AlertSettings)
 			: undefined,
 	)
+
+	const [editor, setEditor] = useState(
+		initialSettings?.editor ?? Editor.QueryBuilder,
+	)
+	const [sqlInternal, setSqlInternal] = useState(
+		initialSettings?.sql ?? DEFAULT_SQL,
+	)
+	const [sql, setSql] = useState(sqlInternal)
 
 	const [alertName, setAlertName] = useState(initialSettings?.alertName ?? '')
 	const [productType, setProductType] = useState(
@@ -314,6 +332,8 @@ export const AlertForm: React.FC = () => {
 		thresholdWindow,
 		thresholdCooldown,
 		destinations,
+		editor,
+		sql,
 	}
 
 	const settingsEncoded = btoa(JSON.stringify(settings))
@@ -528,7 +548,6 @@ export const AlertForm: React.FC = () => {
 										? redirectToAlert()
 										: redirectToAlerts()
 								}
-								trackingId="AlertCancel"
 							>
 								Cancel
 							</Button>
@@ -538,17 +557,12 @@ export const AlertForm: React.FC = () => {
 									size="small"
 									emphasis="low"
 									onClick={onDelete}
-									trackingId="AlertDelete"
 								>
 									Delete alert
 								</Button>
 							)}
 
-							<Button
-								disabled={disableSave}
-								onClick={onSave}
-								trackingId="AlertSave"
-							>
+							<Button disabled={disableSave} onClick={onSave}>
 								Save&nbsp;
 							</Button>
 						</Box>
@@ -561,19 +575,11 @@ export const AlertForm: React.FC = () => {
 					>
 						<Box
 							display="flex"
-							position="relative"
-							height="full"
-							cssClass={style.previewWindow}
+							flexDirection="column"
+							justifyContent="space-between"
+							cssClass={style.editGraphPreview}
 						>
-							<Box
-								position="absolute"
-								width="full"
-								height="full"
-								cssClass={style.graphBackground}
-							>
-								<EditorBackground />
-							</Box>
-							<Box cssClass={style.graphContainer}>
+							<GraphBackgroundWrapper>
 								<AlertGraph
 									alertName={alertName}
 									query={query}
@@ -590,18 +596,16 @@ export const AlertForm: React.FC = () => {
 									startDate={startDate}
 									endDate={endDate}
 									updateSearchTime={updateSearchTime}
+									sql={
+										editor === Editor.SqlEditor
+											? sql
+											: undefined
+									}
 								/>
-							</Box>
+							</GraphBackgroundWrapper>
 						</Box>
-						<Box
-							display="flex"
-							borderLeft="dividerWeak"
-							height="full"
-							cssClass={style.editGraphSidebar}
-							overflowY="auto"
-							overflowX="hidden"
-						>
-							<Form className={style.editGraphSidebar}>
+						<Panel>
+							<Form>
 								<SidebarSection>
 									<LabeledRow
 										label="Alert title"
@@ -620,231 +624,251 @@ export const AlertForm: React.FC = () => {
 									</LabeledRow>
 								</SidebarSection>
 								<Divider className="m-0" />
-								<SidebarSection>
-									<LabeledRow
-										label="Source"
-										name="source"
-										tooltip="The resource being queried, one of the five highlight.io resources."
-									>
-										<OptionDropdown
-											options={PRODUCT_OPTIONS}
-											selection={productType}
-											setSelection={handleProductChange}
-										/>
-									</LabeledRow>
-									{!isAnomaly &&
-										ALERT_PRODUCT_INFO[productType] && (
-											<Callout
-												title={`${productType} alerts`}
-											>
-												<Box pb="8">
-													<Text>
-														{
-															ALERT_PRODUCT_INFO[
-																productType
-															]
-														}
-													</Text>
-												</Box>
-											</Callout>
-										)}
-								</SidebarSection>
-								<Divider className="m-0" />
-								<SidebarSection>
-									{productType === ProductType.Events ? (
-										<EventSelection
-											initialQuery={query}
-											setQuery={setQuery}
-											startDate={startDate}
-											endDate={endDate}
-										/>
-									) : (
-										<LabeledRow
-											label="Filters"
-											name="query"
-											tooltip="The search query used to filter which data points are included before aggregating."
-										>
-											<Box
-												border="divider"
-												width="full"
-												borderRadius="6"
-											>
-												<SearchContext
-													initialQuery={query}
-													onSubmit={setQuery}
-												>
-													<Search
-														startDate={
-															new Date(startDate)
-														}
-														endDate={
-															new Date(endDate)
-														}
-														productType={
-															productType
-														}
-														hideIcon
-													/>
-												</SearchContext>
-											</Box>
-										</LabeledRow>
-									)}
-								</SidebarSection>
-								{(isAnomaly ||
-									(!isSessionAlert && !isErrorAlert)) && (
-									<>
-										<Box px="12">
-											<Divider className="m-0" />
-										</Box>
-										<SidebarSection>
-											<LabeledRow
-												label="Function"
-												name="function"
-												tooltip="Determines how data points are aggregated. If the function requires a numeric field as input, one can be chosen."
-											>
-												<OptionDropdown
-													key={functionType}
-													options={FUNCTION_TYPES}
-													selection={functionType}
-													setSelection={
-														setFunctionType
-													}
-												/>
-												<Combobox
-													key={fetchedFunctionColumn}
-													selection={
-														fetchedFunctionColumn
-													}
-													setSelection={
-														setFunctionColumn
-													}
-													searchConfig={
-														searchOptionsConfig
-													}
-													disabled={
-														functionType ===
-														MetricAggregator.Count
-													}
-													onlyNumericKeys={
-														functionType !==
-														MetricAggregator.CountDistinct
-													}
-												/>
-											</LabeledRow>
-											<LabeledRow
-												label="Group by"
-												name="groupBy"
-												enabled={groupByEnabled}
-												setEnabled={setGroupByEnabled}
-												tooltip="A categorical field for grouping results into separate series."
-											>
-												<Combobox
-													selection={groupByKey}
-													setSelection={setGroupByKey}
-													searchConfig={
-														searchOptionsConfig
-													}
-												/>
-											</LabeledRow>
-										</SidebarSection>
-									</>
-								)}
-								<>
-									<Divider className="m-0" />
-									<SidebarSection>
-										<LabeledRow
-											label="Alert threshold type"
-											name="alertType"
-										>
-											<OptionDropdown<ThresholdType>
-												options={THRESHOLD_TYPE_OPTIONS}
-												selection={thresholdType}
-												setSelection={setThresholdType}
+								<Box cssClass={style.editorSection}>
+									<Box cssClass={style.editorHeader}>
+										<Box cssClass={style.editorSelect}>
+											<OptionDropdown<Editor>
+												options={EDITOR_OPTIONS}
+												selection={settings.editor}
+												setSelection={setEditor}
 											/>
-										</LabeledRow>
-										{(isAnomaly || !isSessionAlert) && (
-											<>
+										</Box>
+										{settings.editor ===
+											Editor.SqlEditor && (
+											<Button
+												disabled={sqlInternal === sql}
+												onClick={() => {
+													setSql(sqlInternal)
+												}}
+											>
+												Update query
+											</Button>
+										)}
+									</Box>
+									{settings.editor === Editor.SqlEditor && (
+										<Box cssClass={style.sqlEditorWrapper}>
+											<SqlEditor
+												value={sqlInternal}
+												setValue={setSqlInternal}
+												startDate={startDate}
+												endDate={endDate}
+											/>
+										</Box>
+									)}
+									{settings.editor ===
+										Editor.QueryBuilder && (
+										<>
+											<SidebarSection>
 												<LabeledRow
-													label="Alert conditions"
-													name="alertConditions"
+													label="Source"
+													name="source"
+													tooltip="The resource being queried, one of the five highlight.io resources."
 												>
-													<OptionDropdown<ThresholdCondition>
-														options={getThresholdConditionOptions(
-															thresholdType,
-														)}
-														selection={
-															thresholdCondition
+													<OptionDropdown
+														options={
+															PRODUCT_OPTIONS
 														}
+														selection={productType}
 														setSelection={
-															setThresholdCondition
+															handleProductChange
 														}
 													/>
 												</LabeledRow>
-												<Stack direction="row" gap="12">
-													{isAnomaly && (
+												{!isAnomaly &&
+													ALERT_PRODUCT_INFO[
+														productType
+													] && (
+														<Callout
+															title={`${productType} alerts`}
+														>
+															<Box pb="8">
+																<Text>
+																	{
+																		ALERT_PRODUCT_INFO[
+																			productType
+																		]
+																	}
+																</Text>
+															</Box>
+														</Callout>
+													)}
+											</SidebarSection>
+											<Divider className="m-0" />
+											<SidebarSection>
+												{productType ===
+												ProductType.Events ? (
+													<EventSelection
+														initialQuery={query}
+														setQuery={setQuery}
+														startDate={startDate}
+														endDate={endDate}
+													/>
+												) : (
+													<LabeledRow
+														label="Filters"
+														name="query"
+														tooltip="The search query used to filter which data points are included before aggregating."
+													>
+														<Box
+															border="divider"
+															width="full"
+															borderRadius="6"
+														>
+															<SearchContext
+																initialQuery={
+																	query
+																}
+																onSubmit={
+																	setQuery
+																}
+															>
+																<Search
+																	startDate={
+																		new Date(
+																			startDate,
+																		)
+																	}
+																	endDate={
+																		new Date(
+																			endDate,
+																		)
+																	}
+																	productType={
+																		productType
+																	}
+																	hideIcon
+																/>
+															</SearchContext>
+														</Box>
+													</LabeledRow>
+												)}
+											</SidebarSection>
+											{(isAnomaly ||
+												(!isSessionAlert &&
+													!isErrorAlert)) && (
+												<>
+													<Box px="12">
+														<Divider className="m-0" />
+													</Box>
+													<SidebarSection>
 														<LabeledRow
-															label="Alert threshold"
-															name="thresholdValue"
+															label="Function"
+															name="function"
+															tooltip="Determines how data points are aggregated. If the function requires a numeric field as input, one can be chosen."
 														>
 															<OptionDropdown
+																key={
+																	functionType
+																}
 																options={
-																	CONFIDENCE_OPTIONS
+																	FUNCTION_TYPES
 																}
-																selection={String(
-																	thresholdValue,
-																)}
-																setSelection={(
-																	option,
-																) => {
-																	setThresholdValue(
-																		Number(
-																			option,
-																		),
-																	)
-																}}
+																selection={
+																	functionType
+																}
+																setSelection={
+																	setFunctionType
+																}
+															/>
+															<Combobox
+																key={
+																	fetchedFunctionColumn
+																}
+																selection={
+																	fetchedFunctionColumn
+																}
+																setSelection={
+																	setFunctionColumn
+																}
+																searchConfig={
+																	searchOptionsConfig
+																}
+																disabled={
+																	functionType ===
+																	MetricAggregator.Count
+																}
+																onlyNumericKeys={
+																	functionType !==
+																	MetricAggregator.CountDistinct
+																}
 															/>
 														</LabeledRow>
-													)}
-													{!isAnomaly && (
 														<LabeledRow
-															label="Alert threshold"
-															name="thresholdValue"
+															label="Group by"
+															name="groupBy"
+															enabled={
+																groupByEnabled
+															}
+															setEnabled={
+																setGroupByEnabled
+															}
+															tooltip="A categorical field for grouping results into separate series."
 														>
-															<Input
-																name="thresholdValue"
-																type="number"
-																value={
-																	thresholdValue
+															<Combobox
+																selection={
+																	groupByKey
 																}
-																onChange={(
-																	e,
-																) => {
-																	setThresholdValue(
-																		Number(
-																			e
-																				.target
-																				.value,
-																		),
-																	)
-																}}
+																setSelection={
+																	setGroupByKey
+																}
+																searchConfig={
+																	searchOptionsConfig
+																}
 															/>
 														</LabeledRow>
+													</SidebarSection>
+												</>
+											)}
+										</>
+									)}
+								</Box>
+								<Divider className="m-0" />
+								<SidebarSection>
+									<LabeledRow
+										label="Alert threshold type"
+										name="alertType"
+									>
+										<OptionDropdown<ThresholdType>
+											options={THRESHOLD_TYPE_OPTIONS}
+											selection={thresholdType}
+											setSelection={setThresholdType}
+										/>
+									</LabeledRow>
+									{(isAnomaly || !isSessionAlert) && (
+										<>
+											<LabeledRow
+												label="Alert conditions"
+												name="alertConditions"
+											>
+												<OptionDropdown<ThresholdCondition>
+													options={getThresholdConditionOptions(
+														thresholdType,
 													)}
+													selection={
+														thresholdCondition
+													}
+													setSelection={
+														setThresholdCondition
+													}
+												/>
+											</LabeledRow>
+											<Stack direction="row" gap="12">
+												{isAnomaly && (
 													<LabeledRow
-														label="Alert window"
-														name="thresholdWindow"
+														label="Alert threshold"
+														name="thresholdValue"
 													>
 														<OptionDropdown
 															options={
-																FREQUENCY_OPTIONS
+																CONFIDENCE_OPTIONS
 															}
 															selection={String(
-																thresholdWindow,
+																thresholdValue,
 															)}
 															setSelection={(
 																option,
 															) => {
-																setThresholdWindow(
+																setThresholdValue(
 																	Number(
 																		option,
 																	),
@@ -852,31 +876,69 @@ export const AlertForm: React.FC = () => {
 															}}
 														/>
 													</LabeledRow>
-												</Stack>
+												)}
+												{!isAnomaly && (
+													<LabeledRow
+														label="Alert threshold"
+														name="thresholdValue"
+													>
+														<Input
+															name="thresholdValue"
+															type="number"
+															value={
+																thresholdValue
+															}
+															onChange={(e) => {
+																setThresholdValue(
+																	Number(
+																		e.target
+																			.value,
+																	),
+																)
+															}}
+														/>
+													</LabeledRow>
+												)}
 												<LabeledRow
-													label="Cooldown"
-													name="thresholdCooldown"
+													label="Alert window"
+													name="thresholdWindow"
 												>
 													<OptionDropdown
 														options={
 															FREQUENCY_OPTIONS
 														}
 														selection={String(
-															thresholdCooldown,
+															thresholdWindow,
 														)}
 														setSelection={(
 															option,
 														) => {
-															setThresholdCooldown(
+															setThresholdWindow(
 																Number(option),
 															)
 														}}
 													/>
 												</LabeledRow>
-											</>
-										)}
-									</SidebarSection>
-								</>
+											</Stack>
+											<LabeledRow
+												label="Cooldown"
+												name="thresholdCooldown"
+											>
+												<OptionDropdown
+													options={FREQUENCY_OPTIONS}
+													selection={String(
+														thresholdCooldown,
+													)}
+													setSelection={(option) => {
+														setThresholdCooldown(
+															Number(option),
+														)
+													}}
+												/>
+											</LabeledRow>
+										</>
+									)}
+								</SidebarSection>
 								<Divider className="m-0" />
 								<SidebarSection>
 									<DestinationInput
@@ -887,7 +949,7 @@ export const AlertForm: React.FC = () => {
 									/>
 								</SidebarSection>
 							</Form>
-						</Box>
+						</Panel>
 					</Box>
 				</Box>
 			</Box>

--- a/frontend/src/pages/Alerts/AlertForm/styles.css.ts
+++ b/frontend/src/pages/Alerts/AlertForm/styles.css.ts
@@ -9,12 +9,12 @@ export const editGraphPanel = style({
 	height: 'calc(100% - 40px)',
 })
 
-export const tagSwitch = style({
-	width: '100%',
+export const editGraphPreview = style({
+	flexGrow: 1,
 })
 
-export const editGraphSidebar = style({
-	width: 320,
+export const tagSwitch = style({
+	width: '100%',
 })
 
 export const editorLabel = style({
@@ -37,4 +37,27 @@ export const graphContainer = style({
 	margin: 'auto',
 	zIndex: 1,
 	backgroundColor: vars.color.white,
+})
+
+export const sqlEditorWrapper = style({
+	backgroundColor: vars.theme.static.surface.nested,
+	borderBottomLeftRadius: vars.borderRadius[6],
+	borderBottomRightRadius: vars.borderRadius[6],
+})
+
+export const editorHeader = style({
+	display: 'flex',
+	justifyContent: 'space-between',
+	width: '100%',
+	borderBottom: vars.border.divider,
+	padding: '6px',
+})
+
+export const editorSelect = style({
+	width: 'fit-content',
+})
+
+export const editorSection = style({
+	border: vars.border.divider,
+	borderRadius: vars.borderRadius[6],
 })

--- a/frontend/src/pages/Alerts/AlertGraph/styles.css.ts
+++ b/frontend/src/pages/Alerts/AlertGraph/styles.css.ts
@@ -1,6 +1,10 @@
+import { vars } from '@highlight-run/ui/vars'
 import { style } from '@vanilla-extract/css'
 
 export const graphWrapper = style({
-	width: 720,
-	height: 360,
+	width: 860,
+	height: 540,
+	margin: 'auto',
+	zIndex: 1,
+	backgroundColor: vars.color.white,
 })

--- a/frontend/src/pages/Alerts/AlertPage/index.tsx
+++ b/frontend/src/pages/Alerts/AlertPage/index.tsx
@@ -315,6 +315,7 @@ export const AlertPage: React.FC = () => {
 									data.alert.threshold_condition ??
 									ThresholdCondition.Above
 								}
+								sql={data.alert.sql ?? undefined}
 							/>
 						</Box>
 						<Box height="full" width="full">

--- a/frontend/src/pages/Graphing/Dashboard.css.ts
+++ b/frontend/src/pages/Graphing/Dashboard.css.ts
@@ -21,10 +21,6 @@ export const graphBackground = style({
 	zIndex: 0,
 })
 
-export const editGraphSidebar = style({
-	width: 320,
-})
-
 export const editorLabel = style({
 	marginBottom: 4,
 })

--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -785,7 +785,9 @@ export const GraphingEditor: React.FC = () => {
 							<Button
 								emphasis="low"
 								kind="secondary"
-								onClick={redirectToDashboard}
+								onClick={() => {
+									navigate(-1)
+								}}
 							>
 								Cancel
 							</Button>

--- a/frontend/src/pages/Graphing/components/DashboardCard.tsx
+++ b/frontend/src/pages/Graphing/components/DashboardCard.tsx
@@ -5,6 +5,7 @@ import {
 	Box,
 	Button,
 	IconSolidArrowsExpand,
+	IconSolidBell,
 	IconSolidCursorClick,
 	IconSolidDocumentDownload,
 	IconSolidDotsHorizontal,
@@ -24,6 +25,7 @@ export const DashboardCard = ({
 	onClone,
 	onDelete,
 	onDownload,
+	onCreateAlert,
 	onExpand,
 	onEdit,
 	children,
@@ -32,6 +34,7 @@ export const DashboardCard = ({
 	onClone?: () => void
 	onDelete?: () => void
 	onDownload?: () => void
+	onCreateAlert?: () => void
 	onExpand?: () => void
 	onEdit?: () => void
 }>) => {
@@ -138,6 +141,23 @@ export const DashboardCard = ({
 												>
 													<IconSolidDocumentDownload />
 													Download CSV
+												</Box>
+											</Menu.Item>
+										)}
+										{onCreateAlert && (
+											<Menu.Item
+												onClick={(e) => {
+													e.stopPropagation()
+													onCreateAlert()
+												}}
+											>
+												<Box
+													display="flex"
+													alignItems="center"
+													gap="4"
+												>
+													<IconSolidBell />
+													Create alert
 												</Box>
 											</Menu.Item>
 										)}

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -181,6 +181,7 @@ export interface InnerChartProps<TConfig> {
 	loading?: boolean
 	viewConfig: TConfig
 	disabled?: boolean
+	thresholdSettings?: ThresholdSettings
 	setTimeRange?: SetTimeRange
 	loadExemplars?: LoadExemplars
 }
@@ -1524,7 +1525,7 @@ const Graph = ({
 						viewConfig={viewConfig}
 						spotlight={spotlight}
 						setTimeRange={setTimeRange}
-						loadExemplars={loadExemplars}
+						loadExemplars={sql ? undefined : loadExemplars}
 						minYAxisMax={axisLimit}
 						maxYAxisMin={axisLimit}
 						showGrid
@@ -1542,7 +1543,7 @@ const Graph = ({
 						viewConfig={viewConfig}
 						spotlight={spotlight}
 						setTimeRange={setTimeRange}
-						loadExemplars={loadExemplars}
+						loadExemplars={sql ? undefined : loadExemplars}
 						showGrid
 					>
 						{children}
@@ -1558,7 +1559,7 @@ const Graph = ({
 							viewConfig={FUNNEL_BAR_CONFIG}
 							spotlight={spotlight}
 							setTimeRange={setTimeRange}
-							loadExemplars={loadExemplars}
+							loadExemplars={sql ? undefined : loadExemplars}
 							showGrid
 						>
 							{children}
@@ -1572,7 +1573,7 @@ const Graph = ({
 							viewConfig={FUNNEL_LINE_CONFIG}
 							spotlight={spotlight}
 							setTimeRange={setTimeRange}
-							loadExemplars={loadExemplars}
+							loadExemplars={sql ? undefined : loadExemplars}
 							showGrid
 						>
 							{children}
@@ -1599,8 +1600,9 @@ const Graph = ({
 						xAxisMetric={xAxisMetric}
 						viewConfig={viewConfig}
 						disabled={disabled}
-						loadExemplars={loadExemplars}
+						loadExemplars={sql ? undefined : loadExemplars}
 						visualizationId={id}
+						thresholdSettings={thresholdSettings}
 					/>
 				)
 				break

--- a/frontend/src/pages/Graphing/components/SqlEditor.tsx
+++ b/frontend/src/pages/Graphing/components/SqlEditor.tsx
@@ -53,11 +53,19 @@ const functionTemplates = [
 
 export const DEFAULT_SQL = [
 	`SELECT`,
-	`    $time_interval('1 hour'),`,
-	`    concat('level: ', level),`,
-	`    count()`,
+	`  $time_interval('1 hour'),`,
+	`  concat('level: ', level),`,
+	`  count()`,
 	`FROM logs`,
 	`GROUP BY 1, 2`,
+].join('\n')
+
+export const DEFAULT_ALERT_SQL = [
+	`SELECT`,
+	`  concat('level: ', level),`,
+	`  count()`,
+	`FROM logs`,
+	`GROUP BY 1`,
 ].join('\n')
 
 export const SqlEditor: React.FC<Props> = ({

--- a/frontend/src/pages/Graphing/components/Table.css.ts
+++ b/frontend/src/pages/Graphing/components/Table.css.ts
@@ -29,4 +29,5 @@ export const firstCell = style({
 
 export const tableRow = style({
 	overflow: 'hidden',
+	height: '30px',
 })


### PR DESCRIPTION
## Summary
- add sql support for alerts
  - runs user's query across all data within the alert's interval
  - shows a table instead of graph since this is not a time series, just the current interval
  - disables anomaly detection
- update styling for alert settings page to match graphing settings (draggable sidebar, query editor, etc)
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally, ensured alerts were firing
![Screenshot 2025-02-20 at 6 12 01 PM](https://github.com/user-attachments/assets/7ffe53b0-094b-4361-95e2-7ac2bd94f487)

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, can think about adding more time series features in future for monitoring (is pretty hard in the general case though)
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- @julian-highlight fyi
<!--
 Request review from julian-highlight / our design team 
-->
