### PR TITLE
fix worker.session.initialize.count metric cardinality

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -339,14 +339,10 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 		if task.InitializeSession == nil {
 			break
 		}
-		s, err := w.PublicResolver.InitializeSessionImpl(ctx, task.InitializeSession)
-		tags := []attribute.KeyValue{
+		_, err := w.PublicResolver.InitializeSessionImpl(ctx, task.InitializeSession)
+		hmetric.Incr(ctx, "worker.session.initialize.count", []attribute.KeyValue{
 			attribute.Bool("success", err == nil),
-		}
-		if s != nil {
-			tags = append(tags, attribute.Int("project_id", s.ProjectID))
-		}
-		hmetric.Incr(ctx, "worker.session.initialize.count", tags, 1)
+		}, 1)
 		if err != nil {
 			log.WithContext(ctx).WithError(err).WithField("type", task.Type).WithField("key", string(task.KafkaMessage.Key)).Error("failed to process task")
 			return err

--- a/docker/collector.Dockerfile
+++ b/docker/collector.Dockerfile
@@ -14,7 +14,6 @@ FROM ${OTEL_COLLECTOR_IMAGE_NAME} AS collector
 
 COPY ./backend/localhostssl/server.crt /server.crt
 COPY ./backend/localhostssl/server.key /server.key
-COPY ./backend/localhostssl/server.pem /server.pem
 
 COPY --from=collector-build /collector.yml /etc/otel-collector-config.yaml
 CMD ["--config=/etc/otel-collector-config.yaml"]

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -103,8 +103,8 @@ services:
         extra_hosts:
             - 'host.docker.internal:host-gateway'
         volumes:
-            - ../backend/localhostssl/server.crt /server.crt
-            - ../backend/localhostssl/server.key /server.key
+            - ../backend/localhostssl/server.crt:/server.crt
+            - ../backend/localhostssl/server.key:/server.key
         ports:
             - '0.0.0.0:24224:24224'
             - '0.0.0.0:34302:34302'

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -102,6 +102,9 @@ services:
         container_name: collector
         extra_hosts:
             - 'host.docker.internal:host-gateway'
+        volumes:
+            - ../backend/localhostssl/server.crt /server.crt
+            - ../backend/localhostssl/server.key /server.key
         ports:
             - '0.0.0.0:24224:24224'
             - '0.0.0.0:34302:34302'


### PR DESCRIPTION
## Summary

* Addresses cardinality of worker session processing metric
* Mounts SSL certificate into the docker deploy opentelemetry collector

## How did you test this change?

CI

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no