### PR TITLE
fix stripe payment method check

### DIFF
--- a/backend/pricing/pricing.go
+++ b/backend/pricing/pricing.go
@@ -1313,8 +1313,11 @@ func (w *Worker) GetBillingIssue(ctx context.Context, workspace *model.Workspace
 	for _, paymentMethod := range i.PaymentMethodList().Data {
 		paymentMethods += 1
 		if paymentMethod.Card != nil && paymentMethod.Card.Checks != nil {
-			if paymentMethod.Card.Checks.CVCCheck == stripe.PaymentMethodCardChecksCVCCheckFail {
-				log.WithContext(ctx).WithField("customer", customer.ID).Info("stripe cvc check failed")
+			if paymentMethod.Card.Checks.CVCCheck == stripe.PaymentMethodCardChecksCVCCheckFail && paymentMethod.Card.Checks.AddressPostalCodeCheck == stripe.PaymentMethodCardChecksAddressPostalCodeCheckFail {
+				log.WithContext(ctx).
+					WithField("customer", customer.ID).
+					WithField("checks", *paymentMethod.Card.Checks).
+					Info("stripe cvc+zip check failed")
 				failures += 1
 			}
 		}


### PR DESCRIPTION
## Summary

Stripe payment method check would be too strict in validating the CVC 
(some mastercard customers may fail the check even with a valid payment method).

<img width="335" alt="Screenshot 2025-02-26 at 12 07 31" src="https://github.com/user-attachments/assets/d2762fff-b8b3-40ae-9458-0ed4c183591e" />

## How did you test this change?

checking behavior in production

## Are there any deployment considerations?

clear `cannot show billing banner` for affected customer

## Does this work require review from our design team?

no
