### PR TITLE
setup trace context propagation through kafka

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -387,8 +387,13 @@ func (p *Queue) Submit(ctx context.Context, partitionKey string, messages ...Ret
 
 func (p *Queue) Receive(ctx context.Context) (context.Context, RetryableMessage) {
 	start := time.Now()
+
 	rxCtx, cancel := context.WithTimeout(ctx, KafkaOperationTimeout)
 	defer cancel()
+
+	// clear timeout to return a context with no deadline
+	ctx = context.WithoutCancel(ctx)
+
 	m, err := p.kafkaC.FetchMessage(rxCtx)
 	if err != nil {
 		if err.Error() != "context deadline exceeded" {

--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -5,6 +5,9 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/highlight-run/highlight/backend/env"
 	"github.com/highlight-run/highlight/backend/util"
 	"github.com/highlight/highlight/sdk/highlight-go"
@@ -15,9 +18,8 @@ import (
 	"github.com/segmentio/kafka-go/sasl"
 	"github.com/segmentio/kafka-go/sasl/scram"
 	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"strings"
-	"time"
 )
 
 // KafkaOperationTimeout The timeout for all kafka send/receive operations.
@@ -60,7 +62,7 @@ type Queue struct {
 
 type MessageQueue interface {
 	Stop(context.Context)
-	Receive(context.Context) RetryableMessage
+	Receive(context.Context) (context.Context, RetryableMessage)
 	Submit(context.Context, string, ...RetryableMessage) error
 	LogStats()
 }
@@ -113,6 +115,29 @@ func getLogger(mode, topic string, level log.Level) kafka.LoggerFunc {
 		return lg.Errorf
 	}
 	return lg.Debugf
+}
+
+type KafkaCarrier struct {
+	Headers []kafka.Header
+}
+
+func (c *KafkaCarrier) Get(key string) string {
+	for _, header := range c.Headers {
+		if header.Key == key {
+			return string(header.Value)
+		}
+	}
+	return ""
+}
+
+func (c *KafkaCarrier) Set(key, value string) {
+	c.Headers = append(c.Headers, kafka.Header{Key: key, Value: []byte(value)})
+}
+
+func (c *KafkaCarrier) Keys() []string {
+	return lo.Map(c.Headers, func(header kafka.Header, _ int) string {
+		return header.Key
+	})
 }
 
 func New(ctx context.Context, topic string, mode Mode, configOverride *ConfigOverride) *Queue {
@@ -326,6 +351,10 @@ func (p *Queue) Submit(ctx context.Context, partitionKey string, messages ...Ret
 		partitionKey = util.GenerateRandomString(32)
 	}
 
+	carrier := KafkaCarrier{}
+	propagator := otel.GetTextMapPropagator()
+	propagator.Inject(ctx, &carrier)
+
 	var kMessages []kafka.Message
 	for _, msg := range messages {
 		msg.SetMaxRetries(TaskRetries)
@@ -338,8 +367,9 @@ func (p *Queue) Submit(ctx context.Context, partitionKey string, messages ...Ret
 			log.WithContext(ctx).WithField("topic", p.Topic).WithField("partitionKey", partitionKey).WithField("msgBytes", len(msgBytes)).Warn("large kafka message")
 		}
 		kMessages = append(kMessages, kafka.Message{
-			Key:   []byte(partitionKey),
-			Value: msgBytes,
+			Key:     []byte(partitionKey),
+			Value:   msgBytes,
+			Headers: carrier.Headers,
 		})
 		hmetric.Incr(ctx, p.metricPrefix()+"produce.count", nil, 1)
 	}
@@ -355,26 +385,31 @@ func (p *Queue) Submit(ctx context.Context, partitionKey string, messages ...Ret
 	return nil
 }
 
-func (p *Queue) Receive(ctx context.Context) (msg RetryableMessage) {
+func (p *Queue) Receive(ctx context.Context) (context.Context, RetryableMessage) {
 	start := time.Now()
-	ctx, cancel := context.WithTimeout(ctx, KafkaOperationTimeout)
+	rxCtx, cancel := context.WithTimeout(ctx, KafkaOperationTimeout)
 	defer cancel()
-	m, err := p.kafkaC.FetchMessage(ctx)
+	m, err := p.kafkaC.FetchMessage(rxCtx)
 	if err != nil {
 		if err.Error() != "context deadline exceeded" {
 			log.WithContext(ctx).Error(errors.Wrap(err, "failed to receive message"))
 		}
-		return nil
+		return ctx, nil
 	}
-	msg, err = p.deserializeMessage(m.Value)
+
+	carrier := KafkaCarrier{Headers: m.Headers}
+	propagator := otel.GetTextMapPropagator()
+	ctx = propagator.Extract(ctx, &carrier)
+
+	msg, err := p.deserializeMessage(m.Value)
 	if err != nil {
 		log.WithContext(ctx).WithField("topic", p.Topic).WithField("partition", m.Partition).WithField("msgBytes", len(m.Value)).Error(errors.Wrap(err, "failed to deserialize message"))
-		return nil
+		return ctx, nil
 	}
 	msg.SetKafkaMessage(&m)
 	hmetric.Incr(ctx, p.metricPrefix()+"consume.count", nil, 1)
 	hmetric.Histogram(ctx, p.metricPrefix()+"receive.sec", time.Since(start).Seconds(), nil, 1)
-	return
+	return ctx, msg
 }
 
 func (p *Queue) Rewind(ctx context.Context, dur time.Duration) error {

--- a/backend/kafka-queue/kafkaqueue_test.go
+++ b/backend/kafka-queue/kafkaqueue_test.go
@@ -104,7 +104,7 @@ func TestQueue_Submit(t *testing.T) {
 					break
 				}
 
-				msg := reader.Receive(ctx)
+				ctx, msg := reader.Receive(ctx)
 				if msg == nil {
 					log.WithContext(ctx).WithField("map", sids).Warn("expected to get a message")
 					errors++

--- a/backend/kafka-queue/types.go
+++ b/backend/kafka-queue/types.go
@@ -413,8 +413,8 @@ func (k *MockMessageQueue) Stop(context.Context) {
 
 }
 
-func (k *MockMessageQueue) Receive(context.Context) RetryableMessage {
-	return nil
+func (k *MockMessageQueue) Receive(context.Context) (context.Context, RetryableMessage) {
+	return context.TODO(), nil
 }
 
 func (k *MockMessageQueue) Submit(context.Context, string, ...RetryableMessage) error {

--- a/backend/otel/otel_test.go
+++ b/backend/otel/otel_test.go
@@ -5,6 +5,10 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
 	"github.com/golang/snappy"
 	"github.com/highlight-run/highlight/backend/env"
 	"github.com/highlight/highlight/sdk/highlight-go"
@@ -12,9 +16,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 	"gorm.io/gorm"
-	"net/http"
-	"os"
-	"testing"
 
 	"github.com/highlight-run/highlight/backend/clickhouse"
 	"github.com/highlight-run/highlight/backend/integrations"
@@ -42,7 +43,9 @@ type MockKafkaProducer struct {
 
 func (m *MockKafkaProducer) Stop(_ context.Context) {}
 
-func (m *MockKafkaProducer) Receive(_ context.Context) kafkaqueue.RetryableMessage { return nil }
+func (m *MockKafkaProducer) Receive(_ context.Context) (context.Context, kafkaqueue.RetryableMessage) {
+	return context.TODO(), nil
+}
 
 func (m *MockKafkaProducer) Submit(_ context.Context, _ string, messages ...kafkaqueue.RetryableMessage) error {
 	m.messages = append(m.messages, messages...)

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -69,7 +69,7 @@ func (k *KafkaWorker) ProcessMessages() {
 			defer s.Finish(err)
 
 			s1, _ := util.StartSpanFromContext(ctx, "worker.kafka.receiveMessage")
-			task := k.KafkaQueue.Receive(ctx)
+			ctx, task := k.KafkaQueue.Receive(ctx)
 			s1.Finish()
 
 			if task == nil {
@@ -698,7 +698,7 @@ func (k *KafkaBatchWorker) ProcessMessages() {
 			// and restarting the receive call
 			receiveCtx, receiveCancel := context.WithTimeout(ctx, k.BatchedFlushTimeout)
 			defer receiveCancel()
-			task := k.KafkaQueue.Receive(receiveCtx)
+			ctx, task := k.KafkaQueue.Receive(receiveCtx)
 			s1.Finish()
 
 			if task != nil {


### PR DESCRIPTION
## Summary

Propagate the trace context via the kafka message headers in our backend.
Helps with debugging kafka processing and demoing the distributed tracing.

## How did you test this change?

![image](https://github.com/user-attachments/assets/cd2e3a62-0de5-4425-ad11-14c302bb6bc9)

## Are there any deployment considerations?

will monitor number of spans created in prod in case this affects sampling

## Does this work require review from our design team?

no
