### PR TITLE
Snooze error alerts

### DIFF
--- a/backend/clickhouse/migrations/000144_add_error_groups_snoozed_until.down.sql
+++ b/backend/clickhouse/migrations/000144_add_error_groups_snoozed_until.down.sql
@@ -1,0 +1,2 @@
+alter table error_groups
+    drop column SnoozedUntil; 

--- a/backend/clickhouse/migrations/000144_add_error_groups_snoozed_until.up.sql
+++ b/backend/clickhouse/migrations/000144_add_error_groups_snoozed_until.up.sql
@@ -1,0 +1,2 @@
+alter table error_groups
+    add column SnoozedUntil DateTime64(6);

--- a/backend/clickhouse/migrations/000145_reacreate_errors_joined_vw.up.sql
+++ b/backend/clickhouse/migrations/000145_reacreate_errors_joined_vw.up.sql
@@ -1,0 +1,10 @@
+DROP VIEW IF EXISTS errors_joined_vw;
+CREATE VIEW IF NOT EXISTS errors_joined_vw AS
+SELECT ProjectID as ProjectId,
+    *
+FROM error_objects eo FINAL
+    INNER JOIN (
+        SELECT *
+        FROM error_groups FINAL
+    ) eg ON eg.ID = eo.ErrorGroupID
+    AND eg.ProjectID = eo.ProjectID;

--- a/backend/clickhouse/migrations/000145_recreate_errors_joined_vw.down.sql
+++ b/backend/clickhouse/migrations/000145_recreate_errors_joined_vw.down.sql
@@ -1,0 +1,10 @@
+DROP VIEW IF EXISTS errors_joined_vw;
+CREATE VIEW IF NOT EXISTS errors_joined_vw AS
+SELECT ProjectID as ProjectId,
+    *
+FROM error_objects eo FINAL
+    INNER JOIN (
+        SELECT *
+        FROM error_groups FINAL
+    ) eg ON eg.ID = eo.ErrorGroupID
+    AND eg.ProjectID = eo.ProjectID;

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -13162,6 +13162,7 @@ enum ReservedErrorObjectKey {
 enum ReservedErrorGroupKey {
 	event
 	secure_id
+	snoozed_until
 	status
 	tag
 	type
@@ -13180,6 +13181,7 @@ enum ReservedErrorsJoinedKey {
 	secure_session_id
 	service_name
 	service_version
+	snoozed_until
 	timestamp
 	trace_id
 	visited_url

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -2134,16 +2134,18 @@ func (e ProductType) MarshalGQL(w io.Writer) {
 type ReservedErrorGroupKey string
 
 const (
-	ReservedErrorGroupKeyEvent    ReservedErrorGroupKey = "event"
-	ReservedErrorGroupKeySecureID ReservedErrorGroupKey = "secure_id"
-	ReservedErrorGroupKeyStatus   ReservedErrorGroupKey = "status"
-	ReservedErrorGroupKeyTag      ReservedErrorGroupKey = "tag"
-	ReservedErrorGroupKeyType     ReservedErrorGroupKey = "type"
+	ReservedErrorGroupKeyEvent        ReservedErrorGroupKey = "event"
+	ReservedErrorGroupKeySecureID     ReservedErrorGroupKey = "secure_id"
+	ReservedErrorGroupKeySnoozedUntil ReservedErrorGroupKey = "snoozed_until"
+	ReservedErrorGroupKeyStatus       ReservedErrorGroupKey = "status"
+	ReservedErrorGroupKeyTag          ReservedErrorGroupKey = "tag"
+	ReservedErrorGroupKeyType         ReservedErrorGroupKey = "type"
 )
 
 var AllReservedErrorGroupKey = []ReservedErrorGroupKey{
 	ReservedErrorGroupKeyEvent,
 	ReservedErrorGroupKeySecureID,
+	ReservedErrorGroupKeySnoozedUntil,
 	ReservedErrorGroupKeyStatus,
 	ReservedErrorGroupKeyTag,
 	ReservedErrorGroupKeyType,
@@ -2151,7 +2153,7 @@ var AllReservedErrorGroupKey = []ReservedErrorGroupKey{
 
 func (e ReservedErrorGroupKey) IsValid() bool {
 	switch e {
-	case ReservedErrorGroupKeyEvent, ReservedErrorGroupKeySecureID, ReservedErrorGroupKeyStatus, ReservedErrorGroupKeyTag, ReservedErrorGroupKeyType:
+	case ReservedErrorGroupKeyEvent, ReservedErrorGroupKeySecureID, ReservedErrorGroupKeySnoozedUntil, ReservedErrorGroupKeyStatus, ReservedErrorGroupKeyTag, ReservedErrorGroupKeyType:
 		return true
 	}
 	return false
@@ -2250,6 +2252,7 @@ const (
 	ReservedErrorsJoinedKeySecureSessionID ReservedErrorsJoinedKey = "secure_session_id"
 	ReservedErrorsJoinedKeyServiceName     ReservedErrorsJoinedKey = "service_name"
 	ReservedErrorsJoinedKeyServiceVersion  ReservedErrorsJoinedKey = "service_version"
+	ReservedErrorsJoinedKeySnoozedUntil    ReservedErrorsJoinedKey = "snoozed_until"
 	ReservedErrorsJoinedKeyTimestamp       ReservedErrorsJoinedKey = "timestamp"
 	ReservedErrorsJoinedKeyTraceID         ReservedErrorsJoinedKey = "trace_id"
 	ReservedErrorsJoinedKeyVisitedURL      ReservedErrorsJoinedKey = "visited_url"
@@ -2271,6 +2274,7 @@ var AllReservedErrorsJoinedKey = []ReservedErrorsJoinedKey{
 	ReservedErrorsJoinedKeySecureSessionID,
 	ReservedErrorsJoinedKeyServiceName,
 	ReservedErrorsJoinedKeyServiceVersion,
+	ReservedErrorsJoinedKeySnoozedUntil,
 	ReservedErrorsJoinedKeyTimestamp,
 	ReservedErrorsJoinedKeyTraceID,
 	ReservedErrorsJoinedKeyVisitedURL,
@@ -2283,7 +2287,7 @@ var AllReservedErrorsJoinedKey = []ReservedErrorsJoinedKey{
 
 func (e ReservedErrorsJoinedKey) IsValid() bool {
 	switch e {
-	case ReservedErrorsJoinedKeyID, ReservedErrorsJoinedKeyBrowser, ReservedErrorsJoinedKeyClientID, ReservedErrorsJoinedKeyEnvironment, ReservedErrorsJoinedKeyHasSession, ReservedErrorsJoinedKeyOsName, ReservedErrorsJoinedKeySecureSessionID, ReservedErrorsJoinedKeyServiceName, ReservedErrorsJoinedKeyServiceVersion, ReservedErrorsJoinedKeyTimestamp, ReservedErrorsJoinedKeyTraceID, ReservedErrorsJoinedKeyVisitedURL, ReservedErrorsJoinedKeyEvent, ReservedErrorsJoinedKeySecureID, ReservedErrorsJoinedKeyStatus, ReservedErrorsJoinedKeyTag, ReservedErrorsJoinedKeyType:
+	case ReservedErrorsJoinedKeyID, ReservedErrorsJoinedKeyBrowser, ReservedErrorsJoinedKeyClientID, ReservedErrorsJoinedKeyEnvironment, ReservedErrorsJoinedKeyHasSession, ReservedErrorsJoinedKeyOsName, ReservedErrorsJoinedKeySecureSessionID, ReservedErrorsJoinedKeyServiceName, ReservedErrorsJoinedKeyServiceVersion, ReservedErrorsJoinedKeySnoozedUntil, ReservedErrorsJoinedKeyTimestamp, ReservedErrorsJoinedKeyTraceID, ReservedErrorsJoinedKeyVisitedURL, ReservedErrorsJoinedKeyEvent, ReservedErrorsJoinedKeySecureID, ReservedErrorsJoinedKeyStatus, ReservedErrorsJoinedKeyTag, ReservedErrorsJoinedKeyType:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1086,6 +1086,7 @@ enum ReservedErrorObjectKey {
 enum ReservedErrorGroupKey {
 	event
 	secure_id
+	snoozed_until
 	status
 	tag
 	type
@@ -1104,6 +1105,7 @@ enum ReservedErrorsJoinedKey {
 	secure_session_id
 	service_name
 	service_version
+	snoozed_until
 	timestamp
 	trace_id
 	visited_url

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -3190,6 +3190,7 @@ export type ReferrerTablePayload = {
 export enum ReservedErrorGroupKey {
 	Event = 'event',
 	SecureId = 'secure_id',
+	SnoozedUntil = 'snoozed_until',
 	Status = 'status',
 	Tag = 'tag',
 	Type = 'type',
@@ -3223,6 +3224,7 @@ export enum ReservedErrorsJoinedKey {
 	SecureSessionId = 'secure_session_id',
 	ServiceName = 'service_name',
 	ServiceVersion = 'service_version',
+	SnoozedUntil = 'snoozed_until',
 	Status = 'status',
 	Tag = 'tag',
 	Timestamp = 'timestamp',


### PR DESCRIPTION
## Summary
Snoozed errors are still alerting

<img width="789" alt="Screenshot 2025-02-27 at 10 27 46 AM" src="https://github.com/user-attachments/assets/fec2bfd2-5ab3-46f2-ac15-c6efe5adcbc5" />

## How did you test this change?
1. Create an error alert that reports to Slack
2. Cause an error
- [ ] Alerted in slack
3. Snooze the error
4. Cause the error
- [ ] Not alerted in slack
5. After snooze expires
6. Cause the error
- [ ] Alerted in slack

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
