### PR TITLE
add default dashboards for AWS and frontend metrics

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -14266,7 +14266,7 @@ input VariableInput {
 }
 
 enum DashboardTemplateType {
-	Blank
+	None
 	FrontendMetrics
 	AWSMetrics
 }

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -14265,6 +14265,12 @@ input VariableInput {
 	field: String
 }
 
+enum DashboardTemplateType {
+	Blank
+	FrontendMetrics
+	AWSMetrics
+}
+
 input VisualizationInput {
 	id: ID
 	projectId: ID!
@@ -14272,6 +14278,7 @@ input VisualizationInput {
 	graphIds: [ID!]
 	timePreset: String
 	variables: [VariableInput!]
+	dashboardTemplateType: DashboardTemplateType
 }
 
 scalar Upload
@@ -88348,7 +88355,7 @@ func (ec *executionContext) unmarshalInputVisualizationInput(ctx context.Context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "projectId", "name", "graphIds", "timePreset", "variables"}
+	fieldsInOrder := [...]string{"id", "projectId", "name", "graphIds", "timePreset", "variables", "dashboardTemplateType"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -88397,6 +88404,13 @@ func (ec *executionContext) unmarshalInputVisualizationInput(ctx context.Context
 				return it, err
 			}
 			it.Variables = data
+		case "dashboardTemplateType":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dashboardTemplateType"))
+			data, err := ec.unmarshalODashboardTemplateType2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐDashboardTemplateType(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DashboardTemplateType = data
 		}
 	}
 
@@ -110286,6 +110300,22 @@ func (ec *executionContext) marshalODashboardDefinition2ᚖgithubᚗcomᚋhighli
 		return graphql.Null
 	}
 	return ec._DashboardDefinition(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalODashboardTemplateType2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐDashboardTemplateType(ctx context.Context, v interface{}) (*model.DashboardTemplateType, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var res = new(model.DashboardTemplateType)
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalODashboardTemplateType2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐDashboardTemplateType(ctx context.Context, sel ast.SelectionSet, v *model.DashboardTemplateType) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
 }
 
 func (ec *executionContext) unmarshalODateRangeRequiredInput2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐDateRangeRequiredInput(ctx context.Context, v interface{}) (*model.DateRangeRequiredInput, error) {

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -1304,20 +1304,20 @@ func (e DashboardChartType) MarshalGQL(w io.Writer) {
 type DashboardTemplateType string
 
 const (
-	DashboardTemplateTypeBlank           DashboardTemplateType = "Blank"
+	DashboardTemplateTypeNone            DashboardTemplateType = "None"
 	DashboardTemplateTypeFrontendMetrics DashboardTemplateType = "FrontendMetrics"
 	DashboardTemplateTypeAWSMetrics      DashboardTemplateType = "AWSMetrics"
 )
 
 var AllDashboardTemplateType = []DashboardTemplateType{
-	DashboardTemplateTypeBlank,
+	DashboardTemplateTypeNone,
 	DashboardTemplateTypeFrontendMetrics,
 	DashboardTemplateTypeAWSMetrics,
 }
 
 func (e DashboardTemplateType) IsValid() bool {
 	switch e {
-	case DashboardTemplateTypeBlank, DashboardTemplateTypeFrontendMetrics, DashboardTemplateTypeAWSMetrics:
+	case DashboardTemplateTypeNone, DashboardTemplateTypeFrontendMetrics, DashboardTemplateTypeAWSMetrics:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -1129,12 +1129,13 @@ type VercelProjectMappingInput struct {
 }
 
 type VisualizationInput struct {
-	ID         *int             `json:"id,omitempty"`
-	ProjectID  int              `json:"projectId"`
-	Name       *string          `json:"name,omitempty"`
-	GraphIds   []int            `json:"graphIds,omitempty"`
-	TimePreset *string          `json:"timePreset,omitempty"`
-	Variables  []*VariableInput `json:"variables,omitempty"`
+	ID                    *int                   `json:"id,omitempty"`
+	ProjectID             int                    `json:"projectId"`
+	Name                  *string                `json:"name,omitempty"`
+	GraphIds              []int                  `json:"graphIds,omitempty"`
+	TimePreset            *string                `json:"timePreset,omitempty"`
+	Variables             []*VariableInput       `json:"variables,omitempty"`
+	DashboardTemplateType *DashboardTemplateType `json:"dashboardTemplateType,omitempty"`
 }
 
 type WebSocketEvent struct {
@@ -1297,6 +1298,49 @@ func (e *DashboardChartType) UnmarshalGQL(v interface{}) error {
 }
 
 func (e DashboardChartType) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type DashboardTemplateType string
+
+const (
+	DashboardTemplateTypeBlank           DashboardTemplateType = "Blank"
+	DashboardTemplateTypeFrontendMetrics DashboardTemplateType = "FrontendMetrics"
+	DashboardTemplateTypeAWSMetrics      DashboardTemplateType = "AWSMetrics"
+)
+
+var AllDashboardTemplateType = []DashboardTemplateType{
+	DashboardTemplateTypeBlank,
+	DashboardTemplateTypeFrontendMetrics,
+	DashboardTemplateTypeAWSMetrics,
+}
+
+func (e DashboardTemplateType) IsValid() bool {
+	switch e {
+	case DashboardTemplateTypeBlank, DashboardTemplateTypeFrontendMetrics, DashboardTemplateTypeAWSMetrics:
+		return true
+	}
+	return false
+}
+
+func (e DashboardTemplateType) String() string {
+	return string(e)
+}
+
+func (e *DashboardTemplateType) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = DashboardTemplateType(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid DashboardTemplateType", str)
+	}
+	return nil
+}
+
+func (e DashboardTemplateType) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -2189,6 +2189,12 @@ input VariableInput {
 	field: String
 }
 
+enum DashboardTemplateType {
+	None
+	FrontendMetrics
+	AWSMetrics
+}
+
 input VisualizationInput {
 	id: ID
 	projectId: ID!
@@ -2196,6 +2202,7 @@ input VisualizationInput {
 	graphIds: [ID!]
 	timePreset: String
 	variables: [VariableInput!]
+	dashboardTemplateType: DashboardTemplateType
 }
 
 scalar Upload

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -4814,6 +4814,14 @@ func (r *mutationResolver) UpsertVisualization(ctx context.Context, visualizatio
 		})
 	}
 
+	if visualization.DashboardTemplateType != nil {
+		if *visualization.DashboardTemplateType == modelInputs.DashboardTemplateTypeAWSMetrics {
+			return r.CreateAWSMetricsDashboard(ctx, &toSave)
+		} else if *visualization.DashboardTemplateType == modelInputs.DashboardTemplateTypeFrontendMetrics {
+			return r.CreateFrontendMetricsDashboard(ctx, &toSave)
+		}
+	}
+
 	if err := r.DB.WithContext(ctx).Save(&toSave).Error; err != nil {
 		return 0, err
 	}

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -438,6 +438,12 @@ export type DashboardPayload = {
 	value: Scalars['Float']
 }
 
+export enum DashboardTemplateType {
+	AwsMetrics = 'AWSMetrics',
+	FrontendMetrics = 'FrontendMetrics',
+	None = 'None',
+}
+
 export type DateHistogramBucketSize = {
 	calendar_interval: OpenSearchCalendarInterval
 	multiple: Scalars['Int']
@@ -4035,6 +4041,7 @@ export type Visualization = {
 }
 
 export type VisualizationInput = {
+	dashboardTemplateType?: InputMaybe<DashboardTemplateType>
 	graphIds?: InputMaybe<Array<Scalars['ID']>>
 	id?: InputMaybe<Scalars['ID']>
 	name?: InputMaybe<Scalars['String']>

--- a/frontend/src/pages/Graphing/components/CreateDashboardModal.tsx
+++ b/frontend/src/pages/Graphing/components/CreateDashboardModal.tsx
@@ -7,6 +7,13 @@ import { Box, Form, Stack } from '@highlight-run/ui/components'
 import React from 'react'
 
 import { useProjectId } from '@/hooks/useProjectId'
+import { DashboardTemplateType } from '@/graph/generated/schemas'
+
+const DASHBOARD_TEMPLATE_TYPES = [
+	{ name: 'Blank dashboard', value: DashboardTemplateType.None },
+	{ name: 'Frontend metrics', value: DashboardTemplateType.FrontendMetrics },
+	{ name: 'AWS metrics', value: DashboardTemplateType.AwsMetrics },
+]
 
 interface Props {
 	showModal: boolean
@@ -28,12 +35,13 @@ export const CreateDashboardModal: React.FC<Props> = ({
 		],
 	})
 
-	const onSubmit = (name: string) => {
+	const onSubmit = (name: string, type: DashboardTemplateType) => {
 		upsertViz({
 			variables: {
 				visualization: {
 					name,
 					projectId,
+					dashboardTemplateType: type,
 				},
 			},
 			onCompleted: (d) => {
@@ -64,20 +72,22 @@ export const CreateDashboardModal: React.FC<Props> = ({
 interface ModalProps {
 	loading: boolean
 	onHideModal: () => void
-	onSubmit: (name: string) => void
+	onSubmit: (name: string, type: DashboardTemplateType) => void
 }
 
 const InnerModal = ({ loading, onHideModal, onSubmit }: ModalProps) => {
 	const formStore = Form.useStore({
 		defaultValues: {
 			name: '',
+			type: DashboardTemplateType.None,
 		},
 	})
 
 	const handleSubmit = (e: { preventDefault: () => void }) => {
 		e.preventDefault()
 		const newName = formStore.getValue(formStore.names.name)
-		onSubmit(newName)
+		const newType = formStore.getValue(formStore.names.type)
+		onSubmit(newName, newType)
 	}
 
 	return (
@@ -86,13 +96,18 @@ const InnerModal = ({ loading, onHideModal, onSubmit }: ModalProps) => {
 				<Form onSubmit={handleSubmit} store={formStore}>
 					<Form.Input
 						name={formStore.names.name}
-						label="Dashboard name"
+						label="Title"
 						placeholder="Untitled dashboard"
-						type="name"
 						autoFocus
 						autoComplete="off"
 					/>
 					<Box borderTop="dividerWeak" my="12" width="full" />
+					<Form.Select
+						name={formStore.names.type}
+						label="Dashboard type"
+						autoComplete="off"
+						options={DASHBOARD_TEMPLATE_TYPES}
+					/>
 
 					<Box
 						display="flex"


### PR DESCRIPTION
## Summary
- when creating a dashboard, can select "AWS Metrics" or "Frontend Metrics"
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
