### PR TITLE
remove extra marshalling/unmarshalling in pushPayload

### DIFF
--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -821,18 +821,30 @@ func UnmarshallMouseInteractionEvent(data map[string]interface{}) (*MouseInterac
 	var source *EventSource
 	var mouseInteractions *MouseInteractions
 	if data["x"] != nil {
-		x = pointy.Float64(data["x"].(float64))
+		asFloat, ok := data["x"].(float64)
+		if ok {
+			x = pointy.Float64(asFloat)
+		}
 	}
 	if data["y"] != nil {
-		y = pointy.Float64(data["y"].(float64))
+		asFloat, ok := data["y"].(float64)
+		if ok {
+			y = pointy.Float64(asFloat)
+		}
 	}
 	if data["source"] != nil {
-		asEventSource := EventSource(data["source"].(float64))
-		source = &asEventSource
+		asFloat, ok := data["source"].(float64)
+		if ok {
+			asEventSource := EventSource(asFloat)
+			source = &asEventSource
+		}
 	}
 	if data["type"] != nil {
-		asMouseInteractions := MouseInteractions(data["type"].(float64))
-		mouseInteractions = &asMouseInteractions
+		asFloat, ok := data["type"].(float64)
+		if ok {
+			asMouseInteractions := MouseInteractions(asFloat)
+			mouseInteractions = &asMouseInteractions
+		}
 	}
 
 	aux := MouseInteractionEventData{

--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -190,6 +190,24 @@ type ReplayEvents struct {
 	Events []*ReplayEvent `json:"events"`
 }
 
+func (r *ReplayEvent) UnmarshalJSON(b []byte) error {
+	aux := struct {
+		Timestamp float64                `json:"timestamp"`
+		Type      EventType              `json:"type"`
+		Data      map[string]interface{} `json:"data"`
+		SID       float64                `json:"_sid"`
+	}{}
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return errors.Wrap(err, "error with custom unmarshal of events")
+	}
+	r.Data = aux.Data
+	r.Type = aux.Type
+	r.Timestamp = JavascriptToGolangTime(aux.Timestamp)
+	r.TimestampRaw = aux.Timestamp
+	r.SID = aux.SID
+	return nil
+}
+
 // MouseInteractionEventData represents the data field for click events from the following parent events
 type MouseInteractionEventData struct {
 	X      *float64           `json:"x"`

--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -221,8 +221,16 @@ func NewSnapshot(inputData map[string]interface{}, hostUrl *string) (*Snapshot, 
 	return s, nil
 }
 
-func (s *Snapshot) Encode() map[string]interface{} {
+func (s *Snapshot) GetData() map[string]interface{} {
 	return s.data
+}
+
+func (s *Snapshot) Encode() (json.RawMessage, error) {
+	b, err := json.Marshal(s.data)
+	if err != nil {
+		return nil, errors.Wrap(err, "error marshaling back to json")
+	}
+	return b, nil
 }
 
 // EscapeJavascript adds a guardrail to prevent javascript from being stored in the recording.

--- a/backend/event-parse/parse_test.go
+++ b/backend/event-parse/parse_test.go
@@ -22,18 +22,6 @@ import (
 var DB *gorm.DB
 var redisClient *redis.Client
 
-func teardown(t *testing.T) {
-	err := util.ClearTablesInDB(DB)
-	if err != nil {
-		t.Fatal(e.Wrap(err, "error clearing database"))
-	}
-
-	err = redisClient.FlushDB(context.TODO())
-	if err != nil {
-		t.Fatal(e.Wrap(err, "error clearing database"))
-	}
-}
-
 // Gets run once; M.run() calls the tests in this file.
 func TestMain(m *testing.M) {
 	dbName := "highlight_testing_db"
@@ -144,16 +132,6 @@ func TestEventsFromString(t *testing.T) {
 			t.Errorf("[%v]: \n%v", i, diff)
 		}
 	}
-}
-
-type fetcherMock struct{}
-
-func (u fetcherMock) fetchStylesheetData(href string, s *Snapshot) ([]byte, error) {
-	body := []byte("@font-face {\n\tfont-display: swap;\n\tfont-family: 'Inter';\n\tfont-style: normal;\n\tfont-weight: bold;\n\tsrc: local('Inter Bold'), local('InterBold'),\n\t\turl('font/Inter-Bold.woff2') format('woff2'), url(\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAE0lEQVQImWP4////f4bdu3f/BwAlfgctduB85QAAAABJRU5ErkJggg==\"), url(\"https://testing.psx-staging.energid.net/assets/fonts/roboto_medium_latin-ext.woff2\");\n}")
-	body = replaceRelativePaths(body, href)
-	body = append([]byte("/*highlight-inject*/\n"), body...)
-
-	return body, nil
 }
 
 func TestGetHostUrlFromEvents(t *testing.T) {

--- a/backend/event-parse/parse_test.go
+++ b/backend/event-parse/parse_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,7 +12,11 @@ import (
 
 	"github.com/aws/smithy-go/ptr"
 	"github.com/go-test/deep"
+	"github.com/highlight-run/highlight/backend/model"
+	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/redis"
+	"github.com/highlight-run/highlight/backend/storage"
+	"github.com/highlight-run/highlight/backend/store"
 	"github.com/highlight-run/highlight/backend/util"
 	"github.com/kylelemons/godebug/pretty"
 	e "github.com/pkg/errors"
@@ -21,6 +26,18 @@ import (
 
 var DB *gorm.DB
 var redisClient *redis.Client
+
+func teardown(t *testing.T) {
+	err := util.ClearTablesInDB(DB)
+	if err != nil {
+		t.Fatal(e.Wrap(err, "error clearing database"))
+	}
+
+	err = redisClient.FlushDB(context.TODO())
+	if err != nil {
+		t.Fatal(e.Wrap(err, "error clearing database"))
+	}
+}
 
 // Gets run once; M.run() calls the tests in this file.
 func TestMain(m *testing.M) {
@@ -130,6 +147,243 @@ func TestEventsFromString(t *testing.T) {
 		}
 		if diff := pretty.Compare(gotInterface, tt.wantInterface); diff != "" {
 			t.Errorf("[%v]: \n%v", i, diff)
+		}
+	}
+}
+
+type fetcherMock struct{}
+
+func (u fetcherMock) fetchStylesheetData(href string, s *Snapshot) ([]byte, error) {
+	body := []byte("@font-face {\n\tfont-display: swap;\n\tfont-family: 'Inter';\n\tfont-style: normal;\n\tfont-weight: bold;\n\tsrc: local('Inter Bold'), local('InterBold'),\n\t\turl('font/Inter-Bold.woff2') format('woff2'), url(\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAE0lEQVQImWP4////f4bdu3f/BwAlfgctduB85QAAAABJRU5ErkJggg==\"), url(\"https://testing.psx-staging.energid.net/assets/fonts/roboto_medium_latin-ext.woff2\");\n}")
+	body = replaceRelativePaths(body, href)
+	body = append([]byte("/*highlight-inject*/\n"), body...)
+
+	return body, nil
+}
+
+func TestInjectStyleSheets(t *testing.T) {
+	ProxyURL = "https://localhost:8082/public/cors"
+	// Get sample input of events and serialize.
+	fetch = fetcherMock{}
+	inputBytes, err := os.ReadFile("./sample-events/input.json")
+	if err != nil {
+		t.Fatalf("error reading: %v", err)
+	}
+
+	var data map[string]interface{}
+	err = json.Unmarshal(inputBytes, &data)
+	if err != nil {
+		t.Fatalf("error unmarshaling: %v", err)
+	}
+
+	snapshot, err := NewSnapshot(data, nil)
+	if err != nil {
+		t.Fatalf("error parsing: %v", err)
+	}
+
+	// Pass sample set to `injectStylesheets` and convert to interface.
+	err = snapshot.InjectStylesheets(context.TODO())
+	if err != nil {
+		t.Fatalf("error injecting: %v", err)
+	}
+
+	gotMsg, err := snapshot.Encode()
+	if err != nil {
+		t.Fatalf("error marshalling: %v", err)
+	}
+
+	var gotInterface interface{}
+	err = json.Unmarshal(gotMsg, &gotInterface)
+	if err != nil {
+		t.Fatalf("error getting interface: %v", err)
+	}
+
+	// Get wanted output of events and serialize.
+	wantBytes, err := os.ReadFile("./sample-events/output.json")
+	if err != nil {
+		t.Fatalf("error reading: %v", err)
+	}
+	var wantInterface interface{}
+	err = json.Unmarshal(wantBytes, &wantInterface)
+	if err != nil {
+		t.Fatalf("error getting interface: %v", err)
+	}
+
+	// Compare.
+	if diff := pretty.Compare(gotInterface, wantInterface); diff != "" {
+		t.Errorf("(-got +want)\n%s", diff)
+	}
+}
+
+func TestEscapeJavascript(t *testing.T) {
+	inputBytes, err := os.ReadFile("./sample-events/dom-with-scripts.json")
+	if err != nil {
+		t.Fatalf("error reading: %v", err)
+	}
+
+	var data map[string]interface{}
+	err = json.Unmarshal(inputBytes, &data)
+	if err != nil {
+		t.Fatalf("error unmarshaling: %v", err)
+	}
+
+	snapshot, err := NewSnapshot(data, nil)
+	if err != nil {
+		t.Fatalf("error parsing: %v", err)
+	}
+
+	err = snapshot.EscapeJavascript(context.TODO())
+	if err != nil {
+		t.Fatalf("error escaping: %v", err)
+	}
+
+	processed, err := snapshot.Encode()
+	if err != nil {
+		t.Fatalf("error marshalling: %v", err)
+	}
+
+	str := string(processed)
+	if strings.Contains(str, "attack") {
+		t.Errorf("attack substring not escaped %+v", str)
+	}
+}
+
+func TestSnapshot_ReplaceAssets(t *testing.T) {
+	defer teardown(t)
+	ctx := context.TODO()
+	inputBytes, err := os.ReadFile("./sample-events/input.json")
+	if err != nil {
+		t.Fatalf("error reading: %v", err)
+	}
+
+	var data map[string]interface{}
+	err = json.Unmarshal(inputBytes, &data)
+	if err != nil {
+		t.Fatalf("error unmarshaling: %v", err)
+	}
+
+	snapshot, err := NewSnapshot(data, nil)
+	if err != nil {
+		t.Fatalf("error parsing: %v", err)
+	}
+
+	var storageClient storage.Client
+	if storageClient, err = storage.NewFSClient(ctx, "https://test.highlight.io", "/tmp/test"); err != nil {
+		log.WithContext(ctx).Fatalf("error creating filesystem storage client: %v", err)
+	}
+	if err := snapshot.ReplaceAssets(ctx, 1, store.NewStore(DB, redis.NewClient(), nil, storageClient, nil, nil), modelInputs.RetentionPeriodThreeMonths); err != nil {
+		t.Fatalf("failed to replace assets %+v", err)
+	}
+
+	var assets []*model.SavedAsset
+	if err := DB.Model(&model.SavedAsset{}).Find(&assets).Error; err != nil {
+		t.Fatalf("failed to fetch assets %+v", err)
+	}
+
+	// broken asset "https://static.highlight.io/dev/test.mp4?AWSAccessKeyId=asdffdsa1234"
+	// should not be stored
+	// https://app.highlight.run/public.css is not found but redirects to https://app.highlight.run/index.html
+	assert.Equal(t, 4, len(assets))
+	for _, exp := range []string{
+		// check that we store <link> tags with an href
+		"https://unpkg.com/@highlight-run/rrweb@0.9.27/dist/index.css",
+		"https://static.highlight.io/dev/BigBuckBunny.mp4?AWSAccessKeyId=asdffdsa1234",
+		"https://static.highlight.io/v6.2.0/index.js",
+		"https://app.highlight.run/public.css",
+	} {
+		matched := false
+		for _, asset := range assets {
+			if asset.OriginalUrl == exp {
+				matched = true
+				break
+			}
+		}
+		assert.True(t, matched, "no asset matched %s", exp)
+	}
+
+	gotMsg, err := snapshot.Encode()
+	if err != nil {
+		t.Fatalf("error marshalling: %v", err)
+	}
+
+	var gotInterface struct {
+		Node struct {
+			ChildNodes []struct {
+				ChildNodes []struct {
+					ChildNodes []struct {
+						Id         int                    `json:"id"`
+						Attributes map[string]interface{} `json:"attributes"`
+					} `json:"childNodes"`
+				} `json:"childNodes"`
+			} `json:"childNodes"`
+		} `json:"node"`
+	}
+	err = json.Unmarshal(gotMsg, &gotInterface)
+	if err != nil {
+		t.Fatalf("error getting interface: %v", err)
+	}
+
+	assert.Equal(t, gotInterface.Node.ChildNodes[1].ChildNodes[0].ChildNodes[30].Id, 36)
+	assert.Equal(t, gotInterface.Node.ChildNodes[1].ChildNodes[0].ChildNodes[31].Id, 37)
+
+	assert.Nil(t, gotInterface.Node.ChildNodes[1].ChildNodes[0].ChildNodes[30].Attributes["rel"])
+	assert.Nil(t, gotInterface.Node.ChildNodes[1].ChildNodes[0].ChildNodes[31].Attributes["rel"])
+}
+func TestSnapshot_ReplaceAssets_Capacitor(t *testing.T) {
+	defer teardown(t)
+	ctx := context.TODO()
+
+	DB.Model(&model.ProjectAssetTransform{}).Create(&model.ProjectAssetTransform{
+		ProjectID:         33914,
+		SourceScheme:      "capacitor",
+		DestinationScheme: "https",
+		DestinationHost:   "app.priceworx.co.uk",
+	})
+
+	inputBytes, err := os.ReadFile("./sample-events/capacitor.json")
+	if err != nil {
+		t.Fatalf("error reading: %v", err)
+	}
+
+	var data map[string]interface{}
+	err = json.Unmarshal(inputBytes, &data)
+	if err != nil {
+		t.Fatalf("error unmarshaling: %v", err)
+	}
+
+	snapshot, err := NewSnapshot(data, nil)
+	if err != nil {
+		t.Fatalf("error parsing: %v", err)
+	}
+
+	var storageClient storage.Client
+	if storageClient, err = storage.NewFSClient(ctx, "https://test.highlight.io", "/tmp/test"); err != nil {
+		log.WithContext(ctx).Fatalf("error creating filesystem storage client: %v", err)
+	}
+	if err := snapshot.ReplaceAssets(ctx, 33914, store.NewStore(DB, redis.NewClient(), nil, storageClient, nil, nil), modelInputs.RetentionPeriodThreeMonths); err != nil {
+		t.Fatalf("failed to replace assets %+v", err)
+	}
+
+	var assets []*model.SavedAsset
+	if err := DB.Model(&model.SavedAsset{}).Find(&assets).Error; err != nil {
+		t.Fatalf("failed to fetch assets %+v", err)
+	}
+
+	assert.Equal(t, 21, len(assets))
+	for _, exp := range []string{
+		"capacitor://localhost/fonts/KFOmCnqEu92Fr1Mu4mxM.f1e2a767.woff",
+		"capacitor://localhost/icons/favicon-128x128.png",
+	} {
+		var savedAsset *model.SavedAsset
+		for _, asset := range assets {
+			if asset.OriginalUrl == exp {
+				savedAsset = asset
+				break
+			}
+		}
+		assert.NotNilf(t, savedAsset, "no asset matched %s", exp)
+		if savedAsset != nil {
+			assert.Falsef(t, strings.HasPrefix(savedAsset.HashVal, "Err"), "asset fetch errored %s", exp)
 		}
 	}
 }

--- a/backend/event-parse/parse_test.go
+++ b/backend/event-parse/parse_test.go
@@ -74,7 +74,7 @@ func TestEventsFromString(t *testing.T) {
 				{
 					Timestamp: time.Date(1970, time.Month(1), 1, 0, 0, 0, 0, time.UTC),
 					Type:      Meta,
-					Data:      map[string]interface{}{"test": 5},
+					Data:      map[string]interface{}{"test": 5.0},
 					SID:       1234,
 				},
 			}},

--- a/backend/main.go
+++ b/backend/main.go
@@ -202,13 +202,7 @@ func main() {
 		serviceName = string(handlerParsed)
 	}
 
-	var samplingMap = map[trace.SpanKind]float64{
-		trace.SpanKindUnspecified: 1.,
-		trace.SpanKindInternal:    1.,
-		trace.SpanKindConsumer:    1.,
-		trace.SpanKindServer:      1.,
-		trace.SpanKindClient:      1.,
-	}
+	var samplingMap = map[trace.SpanKind]float64{}
 	if env.IsProduction() {
 		samplingMap = map[trace.SpanKind]float64{
 			trace.SpanKindUnspecified: 1. / 1_000_000,

--- a/backend/main.go
+++ b/backend/main.go
@@ -202,7 +202,13 @@ func main() {
 		serviceName = string(handlerParsed)
 	}
 
-	var samplingMap = map[trace.SpanKind]float64{}
+	var samplingMap = map[trace.SpanKind]float64{
+		trace.SpanKindUnspecified: 1.,
+		trace.SpanKindInternal:    1.,
+		trace.SpanKindConsumer:    1.,
+		trace.SpanKindServer:      1.,
+		trace.SpanKindClient:      1.,
+	}
 	if env.IsProduction() {
 		samplingMap = map[trace.SpanKind]float64{
 			trace.SpanKindUnspecified: 1. / 1_000_000,

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2751,7 +2751,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 						}
 					}
 
-					event.Data = snapshot.Encode()
+					event.Data = snapshot.GetData()
 				}
 			}
 			eventLoopSpan.Finish()

--- a/backend/redis/cache.go
+++ b/backend/redis/cache.go
@@ -2,9 +2,10 @@ package redis
 
 import (
 	"context"
+	"time"
+
 	"github.com/go-redis/cache/v9"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 type Config struct {

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -614,17 +614,12 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 	if len(accumulator.EventsForTimelineIndicator) > 0 {
 		var eventsForTimelineIndicator []*model.TimelineIndicatorEvent
 		for _, customEvent := range accumulator.EventsForTimelineIndicator {
-			var parsedData model.JSONB
-			err = json.Unmarshal(customEvent.Data, &parsedData)
-			if err != nil {
-				return e.Wrap(err, "error unmarshalling event chunk")
-			}
 			eventsForTimelineIndicator = append(eventsForTimelineIndicator, &model.TimelineIndicatorEvent{
 				SessionSecureID: s.SecureID,
 				Timestamp:       customEvent.TimestampRaw,
 				SID:             customEvent.SID,
 				Type:            int(customEvent.Type),
-				Data:            parsedData,
+				Data:            customEvent.Data,
 			})
 		}
 


### PR DESCRIPTION
## Summary
- there are a few places in pushPayload that we marshal/unmarshal to transform between types; however this is expensive and circumvents the type system
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally to make sure sessions were being recorded correctly
- observed logs to check for 
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will monitor prod after deployment - able to revert and replay the sessions queue if issues
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
