### PR TITLE
Frontend trace killswitch

### DIFF
--- a/.changeset/early-timers-clean.md
+++ b/.changeset/early-timers-clean.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': minor
+---
+
+Add option to disable frontend tracing

--- a/blog-content/monitoring-browser-applications-with-opentelemetry.md
+++ b/blog-content/monitoring-browser-applications-with-opentelemetry.md
@@ -37,7 +37,14 @@ These insights allow developers to identify bottlenecks, track user interactions
 
 Highlight's JavaScript SDK offers built-in support for collecting OpenTelemetry data from client-side applications. This integration allows you to seamlessly incorporate OpenTelemetry tracing into your web applications.
 
-Highlight automatically collects most of the OpenTelemetry data you'll need by leveraging the auto instrumentations and doing some additional processing to make the data more useful in Highlight.
+Highlight automatically collects most of the OpenTelemetry data you'll need by leveraging the auto instrumentations and doing some additional processing to make the data more useful in Highlight. You can disable frontend traces by using the `disableOtelTracing` option as seen below
+
+```ts
+H.init({
+  // ...
+  disableOtelTracing: true
+})
+```
 
 ### Connecting Client and Server Traces
 

--- a/docs-content/getting-started/3_browser/7_replay-configuration/opentelemetry.md
+++ b/docs-content/getting-started/3_browser/7_replay-configuration/opentelemetry.md
@@ -7,18 +7,14 @@ updatedAt: 2024-08-23T22:55:19.000Z
 
 Highlight's JavaScript SDK offers built-in support for collecting OpenTelemetry data from client-side applications, allowing you to seamlessly integrate OpenTelemetry tracing into your web applications.
 
-## Enabling OpenTelemetry with Highlight
-
-To enable OpenTelemetry tracing in your application using Highlight's SDK, set the `enableOtelTracing` configuration option when initializing the SDK:
+Highlight automatically collects most of the OpenTelemetry data you'll need by leveraging the auto instrumentations and doing some additional processing to make the data more useful in Highlight. You can disable frontend traces by using the `disableOtelTracing` option as seen below
 
 ```ts
 H.init({
   // ...
-  enableOtelTracing: true
+  disableOtelTracing: true
 })
 ```
-
-This will automatically start collecting OTeL information using all the standard auto instrumentations, including:
 
 * **Document Load Performance:** Captures timing information related to the loading of the web page, including navigation start, DOM content loaded, and page load complete events.
 * **User Interactions:** Tracks user actions such as clicks, form submissions, and other interactions with the web page.

--- a/docs-content/sdk/client.md
+++ b/docs-content/sdk/client.md
@@ -111,6 +111,12 @@ slug: client
           <h5>inlineStylesheet <code>boolean</code> <code>optional</code></h5>
           <p>Specifies whether to inline CSS style tags into the recording. When not set, defaults to true which will inline stylesheets to make sure apps recorded from localhost or other non-public network endpoints can be replayed. Setting to false may help with CORS issues caused by fetching the stylesheet contents, as well as with performance issues caused by the inlining process.</p>
         </aside>
+        <aside className="parameter">
+          <h5>disableOtelTracing <code>boolean</code> <code>optional</code></h5>
+          <p>
+            Specifies whether the OpenTelemetry Browser instrumentation will be disabled for your project. Learn more in [Browser OpenTelemetry](../getting-started/3_client-sdk/7_replay-configuration/opentelemetry.md).
+          </p>
+        </aside>
       </article>
     </aside>
   </div>

--- a/docs-content/sdk/client.md
+++ b/docs-content/sdk/client.md
@@ -114,7 +114,7 @@ slug: client
         <aside className="parameter">
           <h5>disableOtelTracing <code>boolean</code> <code>optional</code></h5>
           <p>
-            Specifies whether the OpenTelemetry Browser instrumentation will be disabled for your project. Learn more in [Browser OpenTelemetry](../getting-started/3_client-sdk/7_replay-configuration/opentelemetry.md).
+            Specifies whether the OpenTelemetry Browser instrumentation will be disabled for your project. Learn more in [Browser OpenTelemetry](../getting-started/3_browser/7_replay-configuration/opentelemetry.md).
           </p>
         </aside>
       </article>

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -144,6 +144,7 @@ export type HighlightClassOptions = {
 	skipCookieSessionDataLoad?: true
 	sendMode?: 'webworker' | 'local'
 	otlpEndpoint?: HighlightOptions['otlpEndpoint']
+	disableOtelTracing?: HighlightOptions['disableOtelTracing']
 }
 
 /**

--- a/sdk/client/src/listeners/first-load-listeners.tsx
+++ b/sdk/client/src/listeners/first-load-listeners.tsx
@@ -138,6 +138,9 @@ export class FirstLoadListeners {
 				{ enablePromisePatch: this.enablePromisePatch },
 			),
 		)
+		if (!this.options.disableOtelTracing) {
+			this.listeners.push(shutdown)
+		}
 		this.listeners.push(shutdown)
 		FirstLoadListeners.setupNetworkListener(this, this.options)
 	}
@@ -271,6 +274,7 @@ export class FirstLoadListeners {
 					tracingOrigins: sThis.tracingOrigins,
 					urlBlocklist: sThis.urlBlocklist,
 					bodyKeysToRecord: sThis.networkBodyKeysToRecord,
+					otelDisabled: !!options.disableOtelTracing,
 				}),
 			)
 		}

--- a/sdk/client/src/listeners/network-listener/network-listener.ts
+++ b/sdk/client/src/listeners/network-listener/network-listener.ts
@@ -22,6 +22,7 @@ type NetworkListenerArguments = {
 	highlightEndpoints: string[]
 	tracingOrigins: boolean | (string | RegExp)[]
 	urlBlocklist: string[]
+	otelDisabled: boolean
 } & Pick<NetworkRecordingOptions, 'bodyKeysToRecord'>
 
 export const NetworkListener = ({
@@ -35,6 +36,7 @@ export const NetworkListener = ({
 	tracingOrigins,
 	urlBlocklist,
 	bodyKeysToRecord,
+	otelDisabled,
 }: NetworkListenerArguments) => {
 	const removeXHRListener = XHRListener(
 		xhrCallback,
@@ -43,6 +45,7 @@ export const NetworkListener = ({
 		urlBlocklist,
 		bodyKeysToRedact,
 		bodyKeysToRecord,
+		otelDisabled,
 	)
 	const removeFetchListener = FetchListener(
 		fetchCallback,
@@ -51,6 +54,7 @@ export const NetworkListener = ({
 		urlBlocklist,
 		bodyKeysToRedact,
 		bodyKeysToRecord,
+		otelDisabled,
 	)
 
 	const removeWebSocketListener = !disableWebSocketRecording

--- a/sdk/client/src/listeners/network-listener/utils/fetch-listener.ts
+++ b/sdk/client/src/listeners/network-listener/utils/fetch-listener.ts
@@ -29,6 +29,7 @@ export const FetchListener = (
 	urlBlocklist: string[],
 	bodyKeysToRedact: string[],
 	bodyKeysToRecord: string[] | undefined,
+	otelDisabled: boolean,
 ) => {
 	const originalFetch = window._fetchProxy
 
@@ -44,7 +45,8 @@ export const FetchListener = (
 			return originalFetch.call(this, input, init)
 		}
 
-		const [sessionSecureID, requestId] = createNetworkRequestId()
+		const [sessionSecureID, requestId] =
+			createNetworkRequestId(otelDisabled)
 		if (shouldNetworkRequestBeTraced(url, tracingOrigins, urlBlocklist)) {
 			init = init || {}
 			// Pre-existing headers could be one of three different formats; this reads all of them.

--- a/sdk/client/src/listeners/network-listener/utils/utils.ts
+++ b/sdk/client/src/listeners/network-listener/utils/utils.ts
@@ -311,9 +311,13 @@ function makeId(length: number) {
 	return result
 }
 
-export const createNetworkRequestId = () => {
+export const createNetworkRequestId = (disableOtelTracing: boolean) => {
 	// Long enough to avoid collisions, not long enough to be unguessable
 	const requestId = makeId(10)
+
+	if (disableOtelTracing) {
+		return [getNetworkSessionSecureID(), requestId]
+	}
 
 	const context = getActiveSpan()
 	const traceId = context?.spanContext().traceId

--- a/sdk/client/src/listeners/network-listener/utils/xhr-listener.ts
+++ b/sdk/client/src/listeners/network-listener/utils/xhr-listener.ts
@@ -29,6 +29,7 @@ export const XHRListener = (
 	urlBlocklist: string[],
 	bodyKeysToRedact: string[],
 	bodyKeysToRecord: string[] | undefined,
+	otelDisabled: boolean,
 ) => {
 	const XHR = XMLHttpRequest.prototype
 
@@ -78,7 +79,8 @@ export const XHRListener = (
 			return originalSend.apply(this, arguments)
 		}
 
-		const [sessionSecureID, requestId] = createNetworkRequestId()
+		const [sessionSecureID, requestId] =
+			createNetworkRequestId(otelDisabled)
 		if (
 			shouldNetworkRequestBeTraced(
 				this._url,

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -261,6 +261,10 @@ export declare type HighlightOptions = {
 	 * OTLP endpoint for OpenTelemetry tracing.
 	 */
 	otlpEndpoint?: string
+	/**
+	 * Specifies whether to disable OpenTelemetry tracing on the client.
+	 */
+	disableOtelTracing?: boolean
 }
 
 export declare interface HighlightPublicInterface {

--- a/sdk/firstload/src/index.test.tsx
+++ b/sdk/firstload/src/index.test.tsx
@@ -132,56 +132,104 @@ describe('should work outside of the browser in unit test', () => {
 	})
 
 	describe('startSpan', () => {
-		it('it returns the value of the callback', () =>
-			new Promise(async (done) => {
-				highlight.init(1)
-
-				let tracer: any
-				await vi.waitFor(() => {
-					tracer = otel.getTracer()
-					expect(tracer).toBeDefined()
+		describe('when otel is disabled', () => {
+			it('it returns the value of the callback', () => {
+				highlight.init(1, {
+					disableOtelTracing: true,
 				})
-
-				vi.spyOn(tracer, 'startActiveSpan')
 
 				const value = highlight.startSpan('test', () => 'test')
 				expect(value).toBe('test')
+			})
 
-				expect(tracer.startActiveSpan).toHaveBeenCalledWith(
-					'test',
-					expect.any(Function),
-				)
+			it('handles async callbacks', () => {
+				return new Promise(async (resolve) => {
+					highlight.init(1, {
+						disableOtelTracing: true,
+					})
 
-				done(true)
-			}))
+					const value = await highlight.startSpan(
+						'test',
+						async () => {
+							await sleep(10)
+							return 'testing'
+						},
+					)
+
+					expect(value).toBe('testing')
+					resolve(true)
+				})
+			})
+		})
+
+		describe('when otel is enabled', () => {
+			it('it returns the value of the callback', () =>
+				new Promise(async (done) => {
+					highlight.init(1)
+
+					let tracer: any
+					await vi.waitFor(() => {
+						tracer = otel.getTracer()
+						expect(tracer).toBeDefined()
+					})
+
+					vi.spyOn(tracer, 'startActiveSpan')
+
+					const value = highlight.startSpan('test', () => 'test')
+					expect(value).toBe('test')
+
+					expect(tracer.startActiveSpan).toHaveBeenCalledWith(
+						'test',
+						expect.any(Function),
+					)
+
+					done(true)
+				}))
+		})
 	})
 
 	describe('startManualSpan', () => {
-		it('it returns the value of the callback', () =>
-			new Promise(async (done) => {
-				highlight.init(1)
-
-				let tracer: any
-				await vi.waitFor(() => {
-					tracer = otel.getTracer()
-					expect(tracer).toBeDefined()
+		describe('when otel is disabled', () => {
+			it('it returns the value of the callback', () => {
+				highlight.init(1, {
+					disableOtelTracing: true,
 				})
-
-				vi.spyOn(tracer, 'startActiveSpan')
 
 				const value = highlight.startManualSpan('test', (span) => {
 					span.end()
 					return 'test'
 				})
 				expect(value).toBe('test')
+			})
+		})
 
-				expect(tracer.startActiveSpan).toHaveBeenCalledWith(
-					'test',
-					expect.any(Function),
-				)
+		describe('when otel is enabled', () => {
+			it('it returns the value of the callback', () =>
+				new Promise(async (done) => {
+					highlight.init(1)
 
-				done(true)
-			}))
+					let tracer: any
+					await vi.waitFor(() => {
+						tracer = otel.getTracer()
+						expect(tracer).toBeDefined()
+					})
+
+					vi.spyOn(tracer, 'startActiveSpan')
+
+					const value = highlight.startManualSpan('test', (span) => {
+						span.end()
+						return 'test'
+					})
+					expect(value).toBe('test')
+
+					expect(tracer.startActiveSpan).toHaveBeenCalledWith(
+						'test',
+						expect.any(Function),
+					)
+
+					done(true)
+				}))
+		})
 	})
 })
 

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -123,24 +123,27 @@ const H: HighlightPublicInterface = {
 					setupBrowserTracing,
 					getTracer: otelGetTracer,
 				}) => {
-					setupBrowserTracing({
-						backendUrl:
-							options?.backendUrl ?? 'https://pub.highlight.io',
-						otlpEndpoint:
-							options?.otlpEndpoint ??
-							'https://otel.highlight.io',
-						projectId: projectID,
-						sessionSecureId: sessionSecureID,
-						environment: options?.environment ?? 'production',
-						networkRecordingOptions:
-							typeof options?.networkRecording === 'object'
-								? options.networkRecording
-								: undefined,
-						tracingOrigins: options?.tracingOrigins,
-						serviceName:
-							options?.serviceName ?? 'highlight-browser',
-					})
-					getTracer = otelGetTracer
+					if (!options?.disableOtelTracing) {
+						setupBrowserTracing({
+							backendUrl:
+								options?.backendUrl ??
+								'https://pub.highlight.io',
+							otlpEndpoint:
+								options?.otlpEndpoint ??
+								'https://otel.highlight.io',
+							projectId: projectID,
+							sessionSecureId: sessionSecureID,
+							environment: options?.environment ?? 'production',
+							networkRecordingOptions:
+								typeof options?.networkRecording === 'object'
+									? options.networkRecording
+									: undefined,
+							tracingOrigins: options?.tracingOrigins,
+							serviceName:
+								options?.serviceName ?? 'highlight-browser',
+						})
+						getTracer = otelGetTracer
+					}
 
 					highlight_obj = new Highlight(
 						client_options,

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -116,7 +116,9 @@ const H: HighlightPublicInterface = {
 			init_called = true
 
 			initializeFetchListener()
-			initializeWebSocketListener()
+			initializeWebSocketListener({
+				disableOtel: !!options?.disableOtelTracing,
+			})
 			import('@highlight-run/client/src').then(
 				async ({
 					Highlight,
@@ -150,7 +152,9 @@ const H: HighlightPublicInterface = {
 						first_load_listeners,
 					)
 					initializeFetchListener()
-					initializeWebSocketListener()
+					initializeWebSocketListener({
+						disableOtel: !!options?.disableOtelTracing,
+					})
 					if (!options?.manualStart) {
 						await highlight_obj.initialize()
 					}
@@ -610,7 +614,9 @@ if (typeof window !== 'undefined') {
 
 listenToChromeExtensionMessage()
 initializeFetchListener()
-initializeWebSocketListener()
+initializeWebSocketListener({
+	disableOtel: !!H.options?.disableOtelTracing,
+})
 
 // Helpers only for testing
 const __testing = {

--- a/sdk/firstload/src/listeners/web-socket/index.ts
+++ b/sdk/firstload/src/listeners/web-socket/index.ts
@@ -5,7 +5,11 @@ declare var window: HighlightWebSocketWindow
 
 const placeholderCallback = () => null
 
-export const initializeWebSocketListener = () => {
+export const initializeWebSocketListener = ({
+	disableOtel,
+}: {
+	disableOtel: boolean
+}) => {
 	if (typeof window !== 'undefined') {
 		// avoid initializing fetch listener more than once.
 		if (typeof window._highlightWebSocketRequestCallback !== 'undefined') {
@@ -20,7 +24,7 @@ export const initializeWebSocketListener = () => {
 				target,
 				args: [url: string, protocols?: string | string[]],
 			) {
-				const [, socketId] = createNetworkRequestId()
+				const [, socketId] = createNetworkRequestId(disableOtel)
 				const webSocket = new target(...args)
 
 				const openHandler = (event: Event) => {


### PR DESCRIPTION
## Summary
Adds an option to disable browser OTel changes, using the removed changes from https://github.com/highlight/highlight/pull/9598 as a guide.

## How did you test this change?
1. Start a session
2. View traces
- [ ] mousemove events in traces
3. Set `disableOtelTracing: true` in the Highlight initialization
4. Start a new session
5. View traces
- [ ] no mousemove events in traces

## Are there any deployment considerations?
Bump minor version

## Does this work require review from our design team?
N/A