### PR TITLE
Debug enable business dashboards

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -94,7 +94,7 @@ func (r *allWorkspaceSettingsResolver) EnableBusinessDashboards(ctx context.Cont
 	}
 
 	log.WithContext(ctx).WithField("workspace_id", obj.WorkspaceID).Infof("limited dashboards: current dashboard count %d", numDashboards)
-	return numDashboards < 2, nil
+	return numDashboards <= 2, nil
 }
 
 // EnableBusinessProjects is the resolver for the enable_business_projects field.

--- a/frontend/src/components/Billing/EnterpriseFeatureButton.tsx
+++ b/frontend/src/components/Billing/EnterpriseFeatureButton.tsx
@@ -18,7 +18,7 @@ const FEATURE_DESCRIPTIONS = {
 	'More than 1 project': 'create more than 1 project to segment your data.',
 	'More than 15 team members':
 		'allow manually inviting more than 15 team members.',
-	'More than 2 dashboards': 'allow creating more than 2 dashboards.',
+	'More than 3 dashboards': 'allow creating more than 3 dashboards.',
 	'Ingestion Limits': 'control data ingestion filters.',
 	'Ingestion Sampling': 'control data ingestion rates and sample data.',
 	'Custom Data Retention':

--- a/frontend/src/pages/Graphing/DashboardOverview.tsx
+++ b/frontend/src/pages/Graphing/DashboardOverview.tsx
@@ -173,7 +173,7 @@ export const DashboardOverview: React.FC = () => {
 										</Text>
 										<EnterpriseFeatureButton
 											setting="enable_business_dashboards"
-											name="More than 2 dashboards"
+											name="More than 3 dashboards"
 											fn={async () => {
 												setShowModal(true)
 											}}


### PR DESCRIPTION
## Summary
Bug reported that they cannot create a dashboard despite only having 1 dashboard - DB confirms only 1 dashboard

- add logging
- remove unnecessary queries
- update wording on frontend to say "3 dashboards" as per the backend and [pricing page](https://www.highlight.io/pricing)

## How did you test this change?
1. Create a new workspace
2. Try to create a new dashboard
- [ ] Successfully create dashboard
3. Try to create a new dashboard
- [ ] Successfully create dashboard
4. Try to create another dashboard
- [ ] Cannot create dashboard
- [ ] Receive update plan with "More than 3 dashboards are not available on your current plan."

## Are there any deployment considerations?
Remove unnecessary logs after debug

## Does this work require review from our design team?
N/A
