### PR TITLE
increase ingest sampling rate to 50%

### DIFF
--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -37,7 +37,7 @@ func (r *mutationResolver) InitializeSession(ctx context.Context, sessionSecureI
 	if err != nil {
 		log.WithContext(ctx).Errorf("An unsupported verboseID was used: %s, %s", organizationVerboseID, clientConfig)
 	} else {
-		if (projectID == 127101 || projectID == 127102) && !isIngestedBySample(ctx, sessionSecureID, 0.1) {
+		if (projectID == 127101 || projectID == 127102) && !isIngestedBySample(ctx, sessionSecureID, 0.5) {
 			return nil, e.New("Session excluded by ingest filter")
 		}
 

--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -37,7 +37,7 @@ func (r *mutationResolver) InitializeSession(ctx context.Context, sessionSecureI
 	if err != nil {
 		log.WithContext(ctx).Errorf("An unsupported verboseID was used: %s, %s", organizationVerboseID, clientConfig)
 	} else {
-		if (projectID == 127101 || projectID == 127102) && isIngestedBySample(ctx, sessionSecureID, 0.1) {
+		if (projectID == 127101 || projectID == 127102) && !isIngestedBySample(ctx, sessionSecureID, 0.1) {
 			return nil, e.New("Session excluded by ingest filter")
 		}
 


### PR DESCRIPTION
## Summary
- increase ingest sampling rate to 50%
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will monitor production traffic
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- 10% sampling is still in effect for pushPayload processing. Increase ingest rate first, then increase processing sampling if all looks good
- no, can revert if issues
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
