### PR TITLE
Bump version

### DIFF
--- a/.changeset/early-timers-clean.md
+++ b/.changeset/early-timers-clean.md
@@ -1,5 +1,0 @@
----
-'highlight.run': minor
----
-
-Add option to disable frontend tracing

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -1,5 +1,11 @@
 # highlight.run
 
+## 9.12.0
+
+### Minor Changes
+
+-   6a3b836: Add option to disable frontend tracing
+
 ## 9.11.1
 
 ### Patch Changes

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "9.11.1",
+	"version": "9.12.0",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "9.11.1"
+export default "9.12.0"

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "9.12.0"
+export default "9.11.1"

--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @highlight-run/next
 
+## 7.9.1
+
+### Patch Changes
+
+-   Updated dependencies [6a3b836]
+    -   highlight.run@9.12.0
+    -   @highlight-run/node@3.12.0
+    -   @highlight-run/react@13.0.0
+
 ## 7.9.0
 
 ### Minor Changes

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "7.9.0",
+	"version": "7.9.1",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-react/CHANGELOG.md
+++ b/sdk/highlight-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @highlight-run/react
 
+## 13.0.0
+
+### Patch Changes
+
+-   Updated dependencies [6a3b836]
+    -   highlight.run@9.12.0
+
 ## 12.1.0
 
 ### Minor Changes

--- a/sdk/highlight-react/package.json
+++ b/sdk/highlight-react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/react",
-	"version": "12.1.0",
+	"version": "13.0.0",
 	"description": "The official Highlight SDK for React",
 	"license": "Apache-2.0",
 	"peerDependencies": {

--- a/sdk/highlight-remix/CHANGELOG.md
+++ b/sdk/highlight-remix/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @highlight-run/remix
 
+## 2.0.85
+
+### Patch Changes
+
+-   Updated dependencies [6a3b836]
+    -   highlight.run@9.12.0
+    -   @highlight-run/node@3.12.0
+    -   @highlight-run/react@13.0.0
+
 ## 2.0.84
 
 ### Patch Changes

--- a/sdk/highlight-remix/package.json
+++ b/sdk/highlight-remix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/remix",
-	"version": "2.0.84",
+	"version": "2.0.85",
 	"description": "Client for interfacing with Highlight in Remix",
 	"packageManager": "yarn@4.0.2",
 	"author": "",


### PR DESCRIPTION
## Summary
`Publish npm packages` is failing - left out bumping the version using this PR as a guide: https://github.com/highlight/highlight/pull/9598

## How did you test this change?
N/A

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
