### PR TITLE
avoid project-token refresh breaking auth

### DIFF
--- a/frontend/src/routers/ProjectRouter/ProjectRouter.tsx
+++ b/frontend/src/routers/ProjectRouter/ProjectRouter.tsx
@@ -72,23 +72,21 @@ export const ProjectRouter = () => {
 	}, [projectId, setLocalStorageProjectId])
 
 	useEffect(() => {
-		let intervalId: NodeJS.Timeout
+		const fetchToken = async () => {
+			if (!projectId) return
+			const token = await auth.currentUser?.getIdToken()
+			if (!token) return
+			await fetch(`${PRIVATE_GRAPH_URI}/project-token/${projectId}`, {
+				credentials: 'include',
+				headers: {
+					token: token ?? '',
+				},
+			})
+		}
 
-		auth.currentUser?.getIdToken().then((t) => {
-			const fetchToken = () => {
-				fetch(`${PRIVATE_GRAPH_URI}/project-token/${projectId}`, {
-					credentials: 'include',
-					headers: {
-						token: t,
-					},
-				})
-			}
-			if (projectId) {
-				// Fetch a new token now and every 30 mins
-				fetchToken()
-			}
-			intervalId = setInterval(fetchToken, 30 * 60 * 1000)
-		})
+		// Fetch a new token now and every 30 mins
+		fetchToken()
+		const intervalId = setInterval(fetchToken, 30 * 60 * 1000)
 		return () => {
 			clearInterval(intervalId)
 		}


### PR DESCRIPTION
## Summary

* Periodic `/project-token` requests would break auth by forcing a logout due to using an old login token
* Use the user `name` claim for OAuth SSO

## How did you test this change?

preview, deploying to prod

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
