### PR TITLE
push payload perf

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/go-redsync/redsync/v4 v4.12.1
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible
 	github.com/go-test/deep v1.1.0
+	github.com/goccy/go-json v0.10.5
 	github.com/gofiber/fiber/v2 v2.52.5
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang-jwt/jwt/v4 v4.5.1
@@ -130,7 +131,6 @@ require (
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/go-github/v60 v60.0.0 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -130,7 +130,7 @@ require (
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/goccy/go-json v0.10.3 // indirect
+	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/go-github/v60 v60.0.0 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -227,6 +227,8 @@ github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncV
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-json v0.10.3 h1:KZ5WoDbxAIgm2HNbYckL0se1fHD6rz5j4ywS6ebzDqA=
 github.com/goccy/go-json v0.10.3/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
+github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofiber/fiber/v2 v2.52.5 h1:tWoP1MJQjGEe4GB5TUGOi7P2E0ZMMRx5ZTG4rT+yGMo=
 github.com/gofiber/fiber/v2 v2.52.5/go.mod h1:KEOE+cXMhXG0zHc9d8+E38hoX+ZN7bhOtgeF2oT6jrQ=

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -225,8 +225,6 @@ github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3a
 github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
 github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
-github.com/goccy/go-json v0.10.3 h1:KZ5WoDbxAIgm2HNbYckL0se1fHD6rz5j4ywS6ebzDqA=
-github.com/goccy/go-json v0.10.3/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -4,7 +4,6 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -19,6 +18,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"github.com/PaesslerAG/jsonpath"
 	"github.com/aws/smithy-go/ptr"
@@ -2589,7 +2590,7 @@ type PushPayloadChunk struct {
 }
 
 func (r *Resolver) ProcessCompressedPayload(ctx context.Context, sessionSecureID string, payloadID int, data string) error {
-	querySessionSpan, _ := util.StartSpanFromContext(ctx, "public-graph.pushPayload.decompress")
+	querySessionSpan, sCtx := util.StartSpanFromContext(ctx, "public-graph.pushPayload.decompress")
 
 	reader, err := gzip.NewReader(base64.NewDecoder(base64.StdEncoding, strings.NewReader(data)))
 	if err != nil {
@@ -2611,7 +2612,7 @@ func (r *Resolver) ProcessCompressedPayload(ctx context.Context, sessionSecureID
 
 	querySessionSpan.Finish()
 
-	return r.ProcessPayload(ctx, sessionSecureID, payload.Events, payload.Messages, payload.Resources, payload.WebSocketEvents, payload.Errors, ptr.ToBool(payload.IsBeacon), ptr.ToBool(payload.HasSessionUnloaded), payload.HighlightLogs, pointy.Int(payloadID))
+	return r.ProcessPayload(sCtx, sessionSecureID, payload.Events, payload.Messages, payload.Resources, payload.WebSocketEvents, payload.Errors, ptr.ToBool(payload.IsBeacon), ptr.ToBool(payload.HasSessionUnloaded), payload.HighlightLogs, pointy.Int(payloadID))
 }
 
 func TransformEvents(evs []*publicModel.ReplayEventInput) (*parse.ReplayEvents, error) {

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2655,10 +2655,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 		util.Tag("numberOfErrors", len(errors)),
 		util.Tag("numberOfEvents", len(events.Events)),
 	}
-	// sample-in 1/1000 of ProcessPayload calls
-	if env.IsProduction() && isIngestedBySample(ctx, "", 1./1000) {
-		opts = append(opts, util.WithSpanKind(trace.SpanKindServer))
-	}
+
 	span, ctx := util.StartSpanFromContext(ctx, "public-graph.pushPayload", opts...)
 	defer span.Finish()
 

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2655,8 +2655,8 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 		util.Tag("numberOfErrors", len(errors)),
 		util.Tag("numberOfEvents", len(events.Events)),
 	}
-	// sample-in payload with many events
-	if len(events.Events) > 1_000 {
+	// sample-in 1/1000 of ProcessPayload calls
+	if env.IsProduction() && isIngestedBySample(ctx, "", 1./1000) {
 		opts = append(opts, util.WithSpanKind(trace.SpanKindServer))
 	}
 	span, ctx := util.StartSpanFromContext(ctx, "public-graph.pushPayload", opts...)

--- a/backend/public-graph/graph/sampling.go
+++ b/backend/public-graph/graph/sampling.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
+	"regexp"
+	"time"
+
 	"github.com/aws/smithy-go/ptr"
 	"github.com/google/uuid"
 	"github.com/highlight-run/highlight/backend/clickhouse"
@@ -15,9 +19,6 @@ import (
 	e "github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/attribute"
-	"hash/fnv"
-	"regexp"
-	"time"
 )
 
 func (r *Resolver) IsMetricIngested(ctx context.Context, metric clickhouse.MetricRow) bool {
@@ -309,7 +310,7 @@ func (r *Resolver) isItemIngestedBySample(ctx context.Context, product privateMo
 		}
 		return 1.
 	}()
-	ingested := isIngestedBySample(ctx, key, rate)
+	ingested := IsIngestedBySample(ctx, key, rate)
 	return ingested
 }
 
@@ -389,7 +390,7 @@ func (r *Resolver) isItemIngestedByFilter(ctx context.Context, product privateMo
 	return !excluded
 }
 
-func isIngestedBySample(ctx context.Context, key string, rate float64) bool {
+func IsIngestedBySample(ctx context.Context, key string, rate float64) bool {
 	if rate >= 1 {
 		return true
 	}

--- a/backend/public-graph/graph/sampling_test.go
+++ b/backend/public-graph/graph/sampling_test.go
@@ -2,6 +2,10 @@ package graph
 
 import (
 	"context"
+	"math"
+	"testing"
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/highlight-run/highlight/backend/model"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
@@ -10,15 +14,12 @@ import (
 	"github.com/highlight-run/highlight/backend/store"
 	"github.com/openlyinc/pointy"
 	"github.com/stretchr/testify/assert"
-	"math"
-	"testing"
-	"time"
 )
 
 func Benchmark_isIngestedBySample(b *testing.B) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		isIngestedBySample(ctx, "", 0.5)
+		IsIngestedBySample(ctx, "", 0.5)
 	}
 	if b.N > 1 {
 		assert.Less(b, b.Elapsed()/time.Duration(b.N), time.Millisecond, "benchmarked fn is too slow")
@@ -30,7 +31,7 @@ func Test_isIngestedBySample_FindRare(t *testing.T) {
 	var rare []string
 	for i := 0; i < 10*100_000; i++ {
 		key := uuid.New().String()
-		ingested := isIngestedBySample(ctx, key, 1./100_000)
+		ingested := IsIngestedBySample(ctx, key, 1./100_000)
 		if ingested {
 			t.Logf("ingested key %s", key)
 			rare = append(rare, key)
@@ -46,7 +47,7 @@ func Fuzz_isIngestedBySample(f *testing.F) {
 	f.Add("hello, world!", 1.)
 	f.Add("", 0.)
 	f.Fuzz(func(t *testing.T, key string, rate float64) {
-		isIngestedBySample(ctx, key, rate)
+		IsIngestedBySample(ctx, key, rate)
 	})
 }
 
@@ -56,9 +57,9 @@ func Fuzz_isIngestedByExtremeSamples(f *testing.F) {
 	f.Add("key")
 	f.Add("hello, world!")
 	f.Fuzz(func(t *testing.T, key string) {
-		ingested := isIngestedBySample(ctx, key, 0)
+		ingested := IsIngestedBySample(ctx, key, 0)
 		assert.False(t, ingested)
-		ingested = isIngestedBySample(ctx, key, 1)
+		ingested = IsIngestedBySample(ctx, key, 1)
 		assert.True(t, ingested)
 	})
 }
@@ -69,7 +70,7 @@ func Test_isIngestedBySample(t *testing.T) {
 	for rate := 0.; rate < 1.; rate += 0.1 {
 		ingested := 0
 		for i := 0; i < N; i++ {
-			if isIngestedBySample(ctx, "", rate) {
+			if IsIngestedBySample(ctx, "", rate) {
 				ingested += 1
 			}
 		}


### PR DESCRIPTION
## Summary
- in production, the `public-graph.pushPayload.parseEvents.remarshalEvents` span is 30%-40% of the total processPayload time for larger messages
- this change switches every `resolver.go` json.Marshal / Unmarshal call to use an alternate library
- change sampling logic to sample in 1/1000 of processPayload messages to ingest more processPayload spans and avoid overrepresenting larger messages
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran locally, saw an improvement in the remarshal spans
![Screenshot 2025-03-17 at 2 08 48 PM](https://github.com/user-attachments/assets/0b06c145-8b36-4ed7-b380-5aec5760811c)

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, can revert if issues 
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
