### PR TITLE
remove type assertions around tracer on shutdown

### DIFF
--- a/.changeset/cyan-peaches-float.md
+++ b/.changeset/cyan-peaches-float.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+remove type assertions around tracer on shutdown

--- a/sdk/client/src/otel/index.ts
+++ b/sdk/client/src/otel/index.ts
@@ -371,10 +371,10 @@ class CustomTraceContextPropagator extends W3CTraceContextPropagator {
 export const BROWSER_TRACER_NAME = 'highlight-browser'
 export const BROWSER_METER_NAME = BROWSER_TRACER_NAME
 export const getTracer = () => {
-	return providers.tracerProvider!.getTracer(BROWSER_TRACER_NAME)
+	return providers.tracerProvider?.getTracer(BROWSER_TRACER_NAME)
 }
 export const getMeter = () => {
-	return providers.meterProvider!.getMeter(BROWSER_METER_NAME)
+	return providers.meterProvider?.getMeter(BROWSER_METER_NAME)
 }
 
 export const getActiveSpan = () => {
@@ -386,10 +386,18 @@ export const getActiveSpanContext = () => {
 }
 
 export const shutdown = async () => {
-	await providers.tracerProvider!.forceFlush()
-	await providers.tracerProvider!.shutdown()
-	await providers.meterProvider!.forceFlush()
-	await providers.meterProvider!.shutdown()
+	if (providers.tracerProvider) {
+		await providers.tracerProvider.forceFlush()
+		await providers.tracerProvider.shutdown()
+	} else {
+		console.warn('OTEL shutdown called without initialized tracerProvider.')
+	}
+	if (providers.meterProvider) {
+		await providers.meterProvider.forceFlush()
+		await providers.meterProvider.shutdown()
+	} else {
+		console.warn('OTEL shutdown called without initialized meterProvider.')
+	}
 }
 
 const getSpanName = (

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -74,7 +74,7 @@ let highlight_obj: Highlight
 let first_load_listeners: FirstLoadListeners
 let init_called = false
 type Callback = (span?: Span) => any
-let getTracer: () => Tracer
+let getTracer: () => Tracer | undefined
 const H: HighlightPublicInterface = {
 	options: undefined,
 	init: (projectID?: string | number, options?: HighlightOptions) => {


### PR DESCRIPTION
## Summary

Tracer provider was not typechecked when `shutdown()` was called,
causing a potential SDK crash when shutdown was called before the otel instrumentation was set up.

## How did you test this change?

CI

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no