### PR TITLE
only update columns which have changed, fix span kind

### DIFF
--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -92,7 +92,9 @@ func (k *KafkaWorker) ProcessMessages() {
 			s.SetAttribute("partitionKey", string(task.GetKafkaMessage().Key))
 			k.log(ctx, task, "received message")
 
-			s2, sCtx := util.StartSpanFromContext(ctx, "worker.kafka.processMessage")
+			// When the propagated span is extracted from the Kafka message, it is a non-recording span.
+			// Set the SpanKind here again.
+			s2, sCtx := util.StartSpanFromContext(ctx, "worker.kafka.processMessage", util.WithSpanKind(spanKind))
 			for i := 0; i <= task.GetMaxRetries(); i++ {
 				k.log(ctx, task, "starting processing ", i)
 				start := time.Now()


### PR DESCRIPTION
## Summary
- updating the session metadata is the single most expensive DB operation:
![Screenshot 2025-03-18 at 6 02 34 PM](https://github.com/user-attachments/assets/e040de16-6fff-4d2e-b6e5-75f51c3fcee4)
- only update the columns which need updating to avoid unnecessary writes to multiple indexes
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally to make sure sessions were being recorded properly, processed + live mode
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, also able to revert and replay the queue if major issues
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
