### PR TITLE
improve error handling when oauth token is expired

### DIFF
--- a/backend/private-graph/graph/auth_client.go
+++ b/backend/private-graph/graph/auth_client.go
@@ -474,7 +474,7 @@ func (c *OAuthAuthClient) updateContextWithAuthenticatedUser(ctx context.Context
 	prov, err := c.getOIDCProvider(req)
 	if err != nil {
 		log.WithContext(req.Context()).WithError(err).Error("error getting oidc provider")
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		return ctx, e.New("error getting oidc provider")
 	}
 
 	verifier := prov.Verifier(&oidc.Config{ClientID: clientID})
@@ -482,7 +482,7 @@ func (c *OAuthAuthClient) updateContextWithAuthenticatedUser(ctx context.Context
 	if err != nil {
 		log.WithContext(ctx).WithField("token", token).WithError(err).Info("invalid user token")
 		c.handleLogout(w, req)
-		return ctx, nil
+		return ctx, e.New("invalid user token")
 	}
 
 	// Extract claims
@@ -490,7 +490,7 @@ func (c *OAuthAuthClient) updateContextWithAuthenticatedUser(ctx context.Context
 	if err := idToken.Claims(&claims); err != nil {
 		log.WithContext(ctx).WithField("token", token).WithError(err).Info("invalid user claim")
 		c.handleLogout(w, req)
-		return ctx, nil
+		return ctx, e.New("invalid user claim")
 	}
 
 	// check that the oidc email domain matches allowed domains

--- a/backend/private-graph/graph/middleware.go
+++ b/backend/private-graph/graph/middleware.go
@@ -119,7 +119,7 @@ func PrivateMiddleware(next http.Handler) http.Handler {
 		if token != "" {
 			ctx, err = AuthClient.updateContextWithAuthenticatedUser(ctx, w, r, token)
 			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
+				http.Error(w, err.Error(), http.StatusUnauthorized)
 				return
 			}
 		} else if apiKey := r.Header.Get("ApiKey"); apiKey != "" {


### PR DESCRIPTION
## Summary

The frontend expects a 401 when the login expires to retrigger a login.
Make sure expected auth errors return 401 to avoid the frontend getting stuck in a loading loop.

## How did you test this change?

local deploy with SSO setup

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
