### PR TITLE
use aliases to override group/series/bucket behavior

### DIFF
--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -592,7 +592,8 @@ const getCustomTooltip =
 										label={
 											isValid
 												? getTickFormatter(
-														seriesInfo?.column ??
+														seriesInfo?.column ||
+															seriesInfo?.aggregator ||
 															'',
 													)(p.value)
 												: ''

--- a/frontend/src/pages/Graphing/components/Table.tsx
+++ b/frontend/src/pages/Graphing/components/Table.tsx
@@ -289,7 +289,7 @@ const MetricTableRow = ({
 				}
 
 				if (value !== '') {
-					value = getTickFormatter(s.column)(value)
+					value = getTickFormatter(s.column || s.aggregator)(value)
 				}
 
 				const groups = GROUPS_KEY in row ? row[GROUPS_KEY] : s.groups


### PR DESCRIPTION
## Summary
- user wants to create table with a timestamp series; right now we automatically bucket by timestamp
- this allows series/group behavior to be overridden by aliasing the column to "x_series" or "x_group"
![Screenshot 2025-03-24 at 1 57 43 PM](https://github.com/user-attachments/assets/9b7d7e57-0e2a-4bad-8ae9-239f97dd9617)

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
