### PR TITLE
fix local sendmode in highlight.run sdk

### DIFF
--- a/.changeset/clean-balloons-pump.md
+++ b/.changeset/clean-balloons-pump.md
@@ -1,5 +1,0 @@
----
-'highlight.run': minor
----
-
-turn off session cookie storage by default

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -34,6 +34,7 @@
 		"@rrweb/web-extension",
 		"@highlight-run/ui",
 		"angular.io-example",
+		"aws-lambda",
 		"cloudflare-worker",
 		"emails",
 		"e2e-express",

--- a/.changeset/rude-ghosts-unite.md
+++ b/.changeset/rude-ghosts-unite.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+fix local sendmode not incrementing payload id

--- a/.changeset/rude-ghosts-unite.md
+++ b/.changeset/rude-ghosts-unite.md
@@ -1,5 +1,0 @@
----
-'highlight.run': patch
----
-
-fix local sendmode not incrementing payload id

--- a/.changeset/tough-wolves-explain.md
+++ b/.changeset/tough-wolves-explain.md
@@ -1,5 +1,0 @@
----
-'@highlight-run/node': patch
----
-
-ensure @highlight-run/node serverless handlers flush trace

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -101,6 +101,7 @@ jobs:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Publish npm packages
+              if: github.ref == 'refs/heads/main'
               id: changesets-publish
               uses: changesets/action@v1
               with:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -101,7 +101,6 @@ jobs:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Publish npm packages
-              if: github.ref == 'refs/heads/main'
               id: changesets-publish
               uses: changesets/action@v1
               with:

--- a/e2e/aws-lambda/package.json
+++ b/e2e/aws-lambda/package.json
@@ -4,7 +4,7 @@
 	"version": "0.0.1",
 	"private": true,
 	"dependencies": {
-		"@highlight-run/node": "3.12.1"
+		"@highlight-run/node": "latest"
 	},
 	"scripts": {
 		"build": "sam build",

--- a/e2e/aws-lambda/package.json
+++ b/e2e/aws-lambda/package.json
@@ -4,7 +4,7 @@
 	"version": "0.0.1",
 	"private": true,
 	"dependencies": {
-		"@highlight-run/node": "3.12.0"
+		"@highlight-run/node": "3.12.1"
 	},
 	"scripts": {
 		"build": "sam build",

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -1445,6 +1445,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 				errors,
 				is_beacon: false,
 				has_session_unloaded: this.hasSessionUnloaded,
+				highlight_logs: highlightLogs || undefined,
 			})
 		} else {
 			this._worker.postMessage({

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -1435,7 +1435,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 		if (sendFn) {
 			await sendFn({
 				session_secure_id: this.sessionData.sessionSecureID,
-				payload_id: this.sessionData.payloadID.toString(),
+				payload_id: (this.sessionData.payloadID++).toString(),
 				events: { events } as ReplayEventsInput,
 				messages: stringify({ messages: messages }),
 				resources: JSON.stringify({ resources: resources }),

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -1,5 +1,15 @@
 # highlight.run
 
+## 9.15.0
+
+### Minor Changes
+
+-   06d109a: turn off session cookie storage by default
+
+### Patch Changes
+
+-   0acb4c2: fix local sendmode not incrementing payload id
+
 ## 9.14.0
 
 ### Minor Changes

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "9.14.0",
+	"version": "9.15.0",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "9.14.0"
+export default "9.15.0"

--- a/sdk/highlight-apollo/CHANGELOG.md
+++ b/sdk/highlight-apollo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @highlight-run/apollo
 
+## 3.4.28
+
+### Patch Changes
+
+-   Updated dependencies [f54bce0]
+    -   @highlight-run/node@3.12.1
+
 ## 3.4.27
 
 ### Patch Changes

--- a/sdk/highlight-apollo/package.json
+++ b/sdk/highlight-apollo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/apollo",
-	"version": "3.4.27",
+	"version": "3.4.28",
 	"license": "Apache-2.0",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-hono/CHANGELOG.md
+++ b/sdk/highlight-hono/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @highlight-run/hono
 
+## 1.0.4
+
+### Patch Changes
+
+-   Updated dependencies [f54bce0]
+    -   @highlight-run/node@3.12.1
+
 ## 1.0.3
 
 ### Patch Changes

--- a/sdk/highlight-hono/package.json
+++ b/sdk/highlight-hono/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/hono",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "Highlight.io SDK for Hono applications",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/sdk/highlight-nest/CHANGELOG.md
+++ b/sdk/highlight-nest/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @highlight-run/nest
 
+## 3.6.13
+
+### Patch Changes
+
+-   Updated dependencies [f54bce0]
+    -   @highlight-run/node@3.12.1
+
 ## 3.6.12
 
 ### Patch Changes

--- a/sdk/highlight-nest/package.json
+++ b/sdk/highlight-nest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/nest",
-	"version": "3.6.12",
+	"version": "3.6.13",
 	"description": "Client for interfacing with Highlight in nestjs",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @highlight-run/next
 
+## 7.9.5
+
+### Patch Changes
+
+-   Updated dependencies [06d109a]
+-   Updated dependencies [0acb4c2]
+-   Updated dependencies [f54bce0]
+    -   highlight.run@9.15.0
+    -   @highlight-run/node@3.12.1
+    -   @highlight-run/react@16.0.0
+
 ## 7.9.4
 
 ### Patch Changes

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "7.9.4",
+	"version": "7.9.5",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-node/CHANGELOG.md
+++ b/sdk/highlight-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @highlight-run/node
 
+## 3.12.1
+
+### Patch Changes
+
+-   f54bce0: ensure @highlight-run/node serverless handlers flush trace
+
 ## 3.12.0
 
 ### Minor Changes

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/node",
-	"version": "3.12.0",
+	"version": "3.12.1",
 	"license": "Apache-2.0",
 	"scripts": {
 		"typegen": "tsc -d --emitDeclarationOnly",

--- a/sdk/highlight-react/CHANGELOG.md
+++ b/sdk/highlight-react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @highlight-run/react
 
+## 16.0.0
+
+### Patch Changes
+
+-   Updated dependencies [06d109a]
+-   Updated dependencies [0acb4c2]
+    -   highlight.run@9.15.0
+
 ## 15.0.0
 
 ### Patch Changes

--- a/sdk/highlight-react/package.json
+++ b/sdk/highlight-react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/react",
-	"version": "15.0.0",
+	"version": "16.0.0",
 	"description": "The official Highlight SDK for React",
 	"license": "Apache-2.0",
 	"peerDependencies": {

--- a/sdk/highlight-remix/CHANGELOG.md
+++ b/sdk/highlight-remix/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @highlight-run/remix
 
+## 2.0.88
+
+### Patch Changes
+
+-   Updated dependencies [06d109a]
+-   Updated dependencies [0acb4c2]
+-   Updated dependencies [f54bce0]
+    -   highlight.run@9.15.0
+    -   @highlight-run/node@3.12.1
+    -   @highlight-run/react@16.0.0
+
 ## 2.0.87
 
 ### Patch Changes

--- a/sdk/highlight-remix/package.json
+++ b/sdk/highlight-remix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/remix",
-	"version": "2.0.87",
+	"version": "2.0.88",
 	"description": "Client for interfacing with Highlight in Remix",
 	"packageManager": "yarn@4.0.2",
 	"author": "",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10486,7 +10486,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@highlight-run/node@npm:3.12.0, @highlight-run/node@workspace: *, @highlight-run/node@workspace:*, @highlight-run/node@workspace:sdk/highlight-node":
+"@highlight-run/node@npm:latest":
+  version: 3.12.0
+  resolution: "@highlight-run/node@npm:3.12.0"
+  dependencies:
+    "@prisma/instrumentation": "npm:>=5.0.0"
+    require-in-the-middle: "npm:^7.4.0"
+  checksum: 10/091efceeb8cb9807e4e9da55ffdccb9343c951f2c1caf4a4b5a5ccaf4d9076f2f76d085fef7fa8e67e4ff5f67de1c870ce822eacc58121f7c0ead6d34c85a738
+  languageName: node
+  linkType: hard
+
+"@highlight-run/node@workspace: *, @highlight-run/node@workspace:*, @highlight-run/node@workspace:sdk/highlight-node":
   version: 0.0.0-use.local
   resolution: "@highlight-run/node@workspace:sdk/highlight-node"
   dependencies:
@@ -28097,7 +28107,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aws-lambda@workspace:e2e/aws-lambda"
   dependencies:
-    "@highlight-run/node": "npm:3.12.0"
+    "@highlight-run/node": "npm:latest"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Make sure that the `sendMode: 'local'` setting correctly increments `payloadId` with each submission.

## How did you test this change?

before

payload 1
<img width="949" alt="Screenshot 2025-03-25 at 10 34 36" src="https://github.com/user-attachments/assets/01a5173a-3e93-48ab-b688-92393d850650" />

payload 2
<img width="956" alt="Screenshot 2025-03-25 at 10 34 59" src="https://github.com/user-attachments/assets/11c81a1f-3bab-4d70-a493-05be9da8e46e" />

after
<img width="1106" alt="Screenshot 2025-03-25 at 10 43 50" src="https://github.com/user-attachments/assets/fbd40879-0640-4a0a-b4b9-aec171a81016" />

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
