### PR TITLE
fix issue where fields were written unnecessarily

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2796,7 +2796,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			}
 
 			if !lastUserInteractionTimestamp.IsZero() {
-				if err := r.DB.WithContext(ctx).Model(&sessionObj).Updates(&model.Session{
+				if err := r.DB.WithContext(ctx).Model(&model.Session{Model: model.Model{ID: sessionID}}).Updates(&model.Session{
 					LastUserInteractionTime: lastUserInteractionTimestamp,
 				}).Error; err != nil {
 					return e.Wrap(err, "error updating LastUserInteractionTime")


### PR DESCRIPTION
## Summary
- because sessionObj.Fields was populated, this was causing unnecessary writes to `session_fields` and `fields`
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- debug logging locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
