### PR TITLE
Trace left panel

### DIFF
--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -647,6 +647,10 @@ func (client *Client) TracesKeyValues(ctx context.Context, projectID int, keyNam
 	return KeyValuesAggregated(ctx, client, TraceKeyValuesTable, projectID, keyName, startDate, endDate, query, limit, nil)
 }
 
+func (client *Client) TracesKeyValueSuggestions(ctx context.Context, projectID int, startDate time.Time, endDate time.Time, keys []string) ([]*modelInputs.KeyValueSuggestion, error) {
+	return KeyValueSuggestionsAggregated(ctx, client, TraceKeysTable, TraceKeyValuesTable, projectID, startDate, endDate, keys)
+}
+
 func TraceMatchesQuery(trace *TraceRow, filters listener.Filters) bool {
 	return matchesQuery(trace, TracesTableConfig, filters, listener.OperatorAnd)
 }

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -9726,6 +9726,8 @@ func (r *queryResolver) KeyValuesSuggestions(ctx context.Context, productType mo
 	switch productType {
 	case modelInputs.ProductTypeLogs:
 		return r.ClickhouseClient.LogsKeyValueSuggestions(ctx, project.ID, dateRange.StartDate, dateRange.EndDate, keys)
+	case modelInputs.ProductTypeTraces:
+		return r.ClickhouseClient.TracesKeyValueSuggestions(ctx, project.ID, dateRange.StartDate, dateRange.EndDate, keys)
 	default:
 		return nil, e.Errorf("product type not supported %s", productType)
 	}

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6108,7 +6108,7 @@ body {
   font-weight: 500 !important;
   max-width: calc(100% - 24px);
   padding-bottom: 12px;
-  padding-right: 14px;
+  padding-right: 10px;
   padding-top: 12px;
   pointer-events: none;
   position: absolute;

--- a/frontend/src/components/Search/LeftPanel/KeyFilter.tsx
+++ b/frontend/src/components/Search/LeftPanel/KeyFilter.tsx
@@ -5,7 +5,10 @@ import {
 	IconSolidCheckCircle,
 	IconSolidCheveronRight,
 	ComboboxSelect,
+	Tag,
 	Text,
+	Tooltip,
+	IconSolidInformationCircle,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
 import { useEffect, useMemo, useState } from 'react'
@@ -106,6 +109,20 @@ export const KeyFilter: React.FC<Props> = ({
 				>
 					Attributes
 				</Button>
+				<Tooltip
+					trigger={
+						<Tag
+							kind="secondary"
+							size="medium"
+							shape="basic"
+							emphasis="low"
+							iconRight={<IconSolidInformationCircle />}
+						/>
+					}
+				>
+					Manage the saved attributes for quick access and
+					recommendations to be used.
+				</Tooltip>
 			</Stack>
 			{expanded && (
 				<Stack gap="8" pl="8">

--- a/frontend/src/components/Search/LeftPanel/constants.ts
+++ b/frontend/src/components/Search/LeftPanel/constants.ts
@@ -8,11 +8,20 @@ const STANDARD_LOG_FILTERS = [
 	'source',
 ]
 
+const STANDARD_TRACE_FILTERS = [
+	'service_name',
+	'service_version',
+	'environment',
+	'span_name',
+	'span_kind',
+	'metric_name',
+]
+
 export const STANDARD_FILTERS: Record<ProductType, string[]> = {
 	[ProductType.Sessions]: [],
 	[ProductType.Errors]: [],
 	[ProductType.Logs]: STANDARD_LOG_FILTERS,
-	[ProductType.Traces]: [],
+	[ProductType.Traces]: STANDARD_TRACE_FILTERS,
 	[ProductType.Metrics]: [],
 	[ProductType.Events]: [],
 }

--- a/frontend/src/components/Search/SearchForm/SearchForm.css.ts
+++ b/frontend/src/components/Search/SearchForm/SearchForm.css.ts
@@ -60,7 +60,7 @@ export const comboboxTagsContainer = style([
 		fontWeight: '500 !important',
 		maxWidth: 'calc(100% - 24px)',
 		paddingBottom: 12,
-		paddingRight: 14,
+		paddingRight: 10,
 		paddingTop: 12,
 		pointerEvents: 'none',
 		position: 'absolute',

--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -58,6 +58,8 @@ import { LeftPanel } from '@/components/Search/LeftPanel'
 import { ControlsBar } from '@/components/Search/LeftPanel/ControlsBar'
 import { useLeftPanel } from '@/components/Search/LeftPanel/useLeftPanel'
 
+const MIN_DATE = presetStartDate(DEFAULT_TIME_PRESETS[5])
+
 const LogsPage = () => {
 	const { log_cursor } = useParams<{
 		log_cursor: string
@@ -297,7 +299,7 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 						hideDatePicker
 						onDatesChange={() => {}}
 						presets={[]}
-						minDate={presetStartDate(DEFAULT_TIME_PRESETS[5])}
+						minDate={MIN_DATE}
 						timeMode={timeMode}
 					/>
 					<Box
@@ -322,9 +324,7 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 									searchTimeContext.updateSearchTime
 								}
 								presets={DEFAULT_TIME_PRESETS}
-								minDate={presetStartDate(
-									DEFAULT_TIME_PRESETS[5],
-								)}
+								minDate={MIN_DATE}
 								selectedPreset={
 									searchTimeContext.selectedPreset
 								}


### PR DESCRIPTION
## Summary
Add the left panel to trace search

![Screenshot 2025-03-26 at 10 46 41 AM](https://github.com/user-attachments/assets/8f20a58c-7c51-43d4-afbd-d6ed0f02a872)

## How did you test this change?
1. Load the traces search
2. Expand the controls
- [ ] Standard filters are displayed
- [ ] Search by adding filters
- [ ] Search by removing filters
- [ ] Add filters manually
- [ ] Reorder filters
- [ ] Save new filters
- [ ] Reload page and filters are maintained

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
