### PR TITLE
Improve funnel option dropdown

### DIFF
--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -48,7 +48,7 @@ import { Combobox } from '@/pages/Graphing/Combobox'
 import {
 	Editor,
 	EDITOR_OPTIONS,
-	FUNCTION_TYPES,
+	FUNCTION_TYPE_OPTIONS,
 	PRODUCT_OPTIONS,
 } from '@/pages/Graphing/constants'
 import { HeaderDivider } from '@/pages/Graphing/Dashboard'
@@ -645,7 +645,7 @@ export const AlertForm: React.FC = () => {
 									<Box cssClass={style.editorSection}>
 										<Box cssClass={style.editorHeader}>
 											<Box cssClass={style.editorSelect}>
-												<OptionDropdown<Editor>
+												<OptionDropdown
 													options={EDITOR_OPTIONS}
 													selection={settings.editor}
 													setSelection={setEditor}
@@ -788,7 +788,7 @@ export const AlertForm: React.FC = () => {
 																		functionType
 																	}
 																	options={
-																		FUNCTION_TYPES
+																		FUNCTION_TYPE_OPTIONS
 																	}
 																	selection={
 																		functionType

--- a/frontend/src/pages/Alerts/constants.ts
+++ b/frontend/src/pages/Alerts/constants.ts
@@ -1,15 +1,24 @@
 import { ThresholdCondition, ThresholdType } from '@/graph/generated/schemas'
 
 export const THRESHOLD_CONDITION_OPTIONS = [
-	ThresholdCondition.Above,
-	ThresholdCondition.Below,
-	ThresholdCondition.Outside,
+	{
+		name: ThresholdCondition.Above,
+		value: ThresholdCondition.Above,
+	},
+	{
+		name: ThresholdCondition.Below,
+		value: ThresholdCondition.Below,
+	},
+	{
+		name: ThresholdCondition.Outside,
+		value: ThresholdCondition.Outside,
+	},
 ]
 
 export const getThresholdConditionOptions = (thresholdType: ThresholdType) => {
 	if (thresholdType === ThresholdType.Constant) {
 		return THRESHOLD_CONDITION_OPTIONS.filter(
-			(o) => o !== ThresholdCondition.Outside,
+			(o) => o.value !== ThresholdCondition.Outside,
 		)
 	}
 
@@ -17,6 +26,12 @@ export const getThresholdConditionOptions = (thresholdType: ThresholdType) => {
 }
 
 export const THRESHOLD_TYPE_OPTIONS = [
-	ThresholdType.Constant,
-	ThresholdType.Anomaly,
+	{
+		name: ThresholdType.Constant,
+		value: ThresholdType.Constant,
+	},
+	{
+		name: ThresholdType.Anomaly,
+		value: ThresholdType.Anomaly,
+	},
 ]

--- a/frontend/src/pages/Graphing/EventSelection/ClickFilters.tsx
+++ b/frontend/src/pages/Graphing/EventSelection/ClickFilters.tsx
@@ -30,10 +30,19 @@ enum ClickTypeFilter {
 	ClickSelector = 'clickSelector',
 }
 
-const CLICK_TYPES: ClickType[] = [
-	ClickType.Text,
-	ClickType.Target,
-	ClickType.Selector,
+const CLICK_TYPE_OPTIONS = [
+	{
+		value: ClickType.Text,
+		name: ClickType.Text,
+	},
+	{
+		value: ClickType.Target,
+		name: ClickType.Target,
+	},
+	{
+		value: ClickType.Selector,
+		name: ClickType.Selector,
+	},
 ]
 
 const CLICK_TYPE_TO_FILTER = {
@@ -164,7 +173,7 @@ export const ClickFilters: React.FC<Props> = ({
 			<Box display="flex" flexDirection="row" gap="4">
 				<LabeledRow label="Click type" name="clickType">
 					<OptionDropdown
-						options={CLICK_TYPES}
+						options={CLICK_TYPE_OPTIONS}
 						selection={clickType}
 						setSelection={setClickType}
 					/>

--- a/frontend/src/pages/Graphing/EventSelection/NavigateFilters.tsx
+++ b/frontend/src/pages/Graphing/EventSelection/NavigateFilters.tsx
@@ -32,11 +32,23 @@ enum NavigateTypeFilter {
 	ExitPage = 'exit_page',
 }
 
-const NAVIGATE_TYPES: NavigateType[] = [
-	NavigateType.Visited,
-	NavigateType.Reloaded,
-	NavigateType.LandingPage,
-	NavigateType.ExitPage,
+const NAVIGATE_TYPE_OPTIONS = [
+	{
+		name: NavigateType.Visited,
+		value: NavigateType.Visited,
+	},
+	{
+		name: NavigateType.Reloaded,
+		value: NavigateType.Reloaded,
+	},
+	{
+		name: NavigateType.LandingPage,
+		value: NavigateType.LandingPage,
+	},
+	{
+		name: NavigateType.ExitPage,
+		value: NavigateType.ExitPage,
+	},
 ]
 
 const NAVIGATE_TYPE_TO_FILTER = {
@@ -171,7 +183,7 @@ export const NavigateFilters: React.FC<Props> = ({
 			<Box display="flex" flexDirection="row" gap="4">
 				<LabeledRow label="Navigate type" name="navigateType">
 					<OptionDropdown
-						options={NAVIGATE_TYPES}
+						options={NAVIGATE_TYPE_OPTIONS}
 						selection={navigateType}
 						setSelection={setNavigateType}
 					/>

--- a/frontend/src/pages/Graphing/EventSelection/index.tsx
+++ b/frontend/src/pages/Graphing/EventSelection/index.tsx
@@ -16,6 +16,11 @@ const EVENT_TYPES: EventType[] = [
 	EventType.Navigate,
 ]
 
+const EVENT_TYPE_OPTIONS = EVENT_TYPES.map((type) => ({
+	name: type,
+	value: type,
+}))
+
 type Props = {
 	initialQuery: string
 	setQuery: (query: string) => void
@@ -150,7 +155,7 @@ export const EventSelection: React.FC<Props> = ({
 		<Box width="full" display="flex" flexDirection="column" gap="12" p="0">
 			<LabeledRow label="Event type" name="eventType">
 				<OptionDropdown
-					options={EVENT_TYPES}
+					options={EVENT_TYPE_OPTIONS}
 					selection={eventDetails.type}
 					setSelection={(type: EventType) =>
 						setEventDetails((e) => ({ ...e, type }))

--- a/frontend/src/pages/Graphing/GraphingEditor/FormPanel/GroupBySection.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor/FormPanel/GroupBySection.tsx
@@ -6,7 +6,10 @@ import { LabeledRow } from '@/pages/Graphing/LabeledRow'
 import { OptionDropdown } from '@/pages/Graphing/OptionDropdown'
 import { useGraphingEditorContext } from '@/pages/Graphing/GraphingEditor/GraphingEditorContext'
 import { Combobox } from '@/pages/Graphing/Combobox'
-import { FUNCTION_TYPES, MAX_LIMIT_SIZE } from '@pages/Graphing/constants'
+import {
+	FUNCTION_TYPE_OPTIONS,
+	MAX_LIMIT_SIZE,
+} from '@pages/Graphing/constants'
 import { SidebarSection } from '@/pages/Graphing/GraphingEditor/FormPanel/SidebarSection'
 
 import * as style from '../GraphingEditor.css'
@@ -85,7 +88,7 @@ export const GroupBySection: React.FC<Props> = ({
 						tooltip="The function used to determine which groups are included."
 					>
 						<OptionDropdown
-							options={FUNCTION_TYPES}
+							options={FUNCTION_TYPE_OPTIONS}
 							selection={settings.limitFunctionType}
 							setSelection={setLimitFunctionType}
 							disabled={isPreview}

--- a/frontend/src/pages/Graphing/GraphingEditor/FormPanel/QueryBuilder.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor/FormPanel/QueryBuilder.tsx
@@ -17,7 +17,10 @@ import { EventSteps } from '@pages/Graphing/EventSelection/EventSteps'
 import { EventSelection } from '@pages/Graphing/EventSelection'
 import { useGraphingEditorContext } from '@/pages/Graphing/GraphingEditor/GraphingEditorContext'
 import { Combobox } from '@/pages/Graphing/Combobox'
-import { FUNCTION_TYPES, PRODUCT_OPTIONS } from '@pages/Graphing/constants'
+import {
+	FUNCTION_TYPE_OPTIONS,
+	PRODUCT_OPTIONS,
+} from '@pages/Graphing/constants'
 
 type Props = {
 	isPreview: boolean
@@ -148,7 +151,7 @@ export const QueryBuilder: React.FC<Props> = ({
 							key={`${e.aggregator}:${e.column}:${i}`}
 						>
 							<OptionDropdown
-								options={FUNCTION_TYPES}
+								options={FUNCTION_TYPE_OPTIONS}
 								selection={e.aggregator}
 								setSelection={handleFunctionTypeChange(i)}
 								disabled={

--- a/frontend/src/pages/Graphing/OptionDropdown/index.tsx
+++ b/frontend/src/pages/Graphing/OptionDropdown/index.tsx
@@ -1,13 +1,14 @@
 import {
 	Box,
+	IconSolidInformationCircle,
 	Select,
 	SelectOption,
 	Stack,
+	Tag,
 	Text,
+	Tooltip,
 } from '@highlight-run/ui/components'
-import React, { useMemo } from 'react'
-
-type Options<T> = T[] | SelectOption[]
+import { useMemo } from 'react'
 
 export const OptionDropdown = <T extends string>({
 	options,
@@ -15,7 +16,7 @@ export const OptionDropdown = <T extends string>({
 	setSelection,
 	disabled,
 }: {
-	options: Options<T>
+	options: SelectOption[]
 	selection: T
 	setSelection: (option: T) => void
 	disabled?: boolean
@@ -36,7 +37,6 @@ export const OptionDropdown = <T extends string>({
 						</Text>
 					)
 				}}
-				options={options}
 				onValueChange={(v: SelectOption) => {
 					const newSelection = v.value as T
 					if (newSelection !== selection) {
@@ -44,32 +44,63 @@ export const OptionDropdown = <T extends string>({
 					}
 				}}
 				disabled={disabled}
-			/>
+			>
+				{options.map((option) => (
+					<Select.Option
+						key={option.value}
+						value={String(option.value)}
+					>
+						<Stack
+							direction="row"
+							justifyContent="space-between"
+							width="full"
+							align="center"
+							color="secondaryContentOnEnabled"
+						>
+							<Stack direction="row" gap="6" align="center">
+								{option.icon}
+								<Text>{option.name}</Text>
+							</Stack>
+							{option.info && (
+								<Tooltip
+									trigger={
+										<Tag
+											kind="secondary"
+											size="medium"
+											shape="basic"
+											emphasis="low"
+											iconRight={
+												<IconSolidInformationCircle />
+											}
+										/>
+									}
+								>
+									{option.info}
+								</Tooltip>
+							)}
+						</Stack>
+					</Select.Option>
+				))}
+			</Select>
 		</Box>
 	)
 }
 
-const SelectValue = <T extends string>({
+const SelectValue = ({
 	options,
 	value,
 }: {
-	options: Options<T>
-	value: T
+	options: SelectOption[]
+	value: string
 }) => {
 	const selectedOption = useMemo(() => {
-		if (typeof options === 'string') {
-			return value
-		}
-
 		return (
-			(options as SelectOption[]).find((opt) => opt.value === value) ||
-			value
+			(options as SelectOption[]).find((opt) => opt.value === value) || {
+				name: value,
+				value: value,
+			}
 		)
 	}, [options, value])
-
-	if (typeof selectedOption === 'string') {
-		return value
-	}
 
 	return (
 		<>

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -93,6 +93,7 @@ export const VIEW_OPTIONS = [
 		value: 'Funnel chart',
 		name: 'Funnel chart',
 		icon: <IconSolidLocationMarker size={16} key="funnel chart" />,
+		info: 'This chart is only supported for events.',
 	},
 	{
 		value: 'Table',

--- a/frontend/src/pages/Graphing/components/VariablesModal.tsx
+++ b/frontend/src/pages/Graphing/components/VariablesModal.tsx
@@ -18,7 +18,7 @@ import { useProjectId } from '@/hooks/useProjectId'
 import { SuggestionType, Variable } from '@/graph/generated/schemas'
 import { useGraphingVariables } from '@/pages/Graphing/hooks/useGraphingVariables'
 import { OptionDropdown } from '@/pages/Graphing/OptionDropdown'
-import { SUGGESTION_TYPES } from '@/pages/Graphing/constants'
+import { SUGGESTION_TYPE_OPTIONS } from '@/pages/Graphing/constants'
 import { Combobox, ValueCombobox } from '@/pages/Graphing/Combobox'
 
 import * as style from './VariablesModal.css'
@@ -230,7 +230,7 @@ const InnerModal = ({
 									</Table.Cell>
 									<Table.Cell>
 										<OptionDropdown<SuggestionType>
-											options={SUGGESTION_TYPES}
+											options={SUGGESTION_TYPE_OPTIONS}
 											selection={variable.suggestionType}
 											setSelection={(suggestionType) => {
 												setVariable(

--- a/frontend/src/pages/Graphing/constants.tsx
+++ b/frontend/src/pages/Graphing/constants.tsx
@@ -123,10 +123,24 @@ export const FUNCTION_TYPES: MetricAggregator[] = [
 	...NUMERIC_FUNCTION_TYPES,
 ]
 
-export const SUGGESTION_TYPES: SuggestionType[] = [
-	SuggestionType.Value,
-	SuggestionType.Key,
-	SuggestionType.None,
+export const FUNCTION_TYPE_OPTIONS = FUNCTION_TYPES.map((type) => ({
+	value: type,
+	name: type,
+}))
+
+export const SUGGESTION_TYPE_OPTIONS = [
+	{
+		value: SuggestionType.Value,
+		name: SuggestionType.Value,
+	},
+	{
+		value: SuggestionType.Key,
+		name: SuggestionType.Key,
+	},
+	{
+		value: SuggestionType.None,
+		name: SuggestionType.None,
+	},
 ]
 
 export const GRAPHING_FIELD_DOCS_LINK =


### PR DESCRIPTION
## Summary
Improve the view type option dropdown to:
- show icons
- add a info tooltip for funnels

![Screenshot 2025-03-26 at 6 01 14 PM](https://github.com/user-attachments/assets/132208b7-f8d2-4389-b29d-6aa7858c1612)

## How did you test this change?
1. Create a new graph
2. Expand the "View type" option dropdown
- [ ] Icons are displayed in dropdown
- [ ] Info tooltip for funnels
- [ ] Able to select an option

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A