### PR TITLE
add e2e python to node kafka example

### DIFF
--- a/e2e/python/highlight_kafka/README.md
+++ b/e2e/python/highlight_kafka/README.md
@@ -1,0 +1,1 @@
+# highlight_kafka

--- a/e2e/python/highlight_kafka/kafka.mjs
+++ b/e2e/python/highlight_kafka/kafka.mjs
@@ -1,0 +1,77 @@
+import { Kafka } from 'kafkajs'
+import { trace, context, propagation } from '@opentelemetry/api'
+import { H } from '@highlight-run/node'
+
+// Set up OpenTelemetry using Highlight SDK
+H.init({
+	projectID: '<YOUR_PROJECT_ID>',
+	serviceName: 'kafka-consumer',
+	serviceVersion: 'git-sha',
+	environment: 'e2e-test',
+})
+
+const tracer = trace.getTracer('kafka-consumer')
+
+// Kafka consumer configuration
+const kafka = new Kafka({
+	clientId: 'highlight-kafka-consumer',
+	brokers: ['localhost:9092'],
+})
+
+const consumer = kafka.consumer({ groupId: 'highlight-consumer-group' })
+
+async function run() {
+	// Connect to the Kafka broker
+	await consumer.connect()
+
+	// Subscribe to the topic
+	await consumer.subscribe({ topic: 'dev', fromBeginning: true })
+
+	// Start consuming messages
+	await consumer.run({
+		eachMessage: async ({ topic, partition, message }) => {
+			// Extract the trace context from message headers
+			const carrier = {}
+			if (message.headers) {
+				Object.entries(message.headers).forEach(([key, value]) => {
+					if (value) {
+						carrier[key] = value.toString()
+					}
+				})
+			}
+
+			console.log('message', carrier)
+			await H.runWithHeaders('kafka.consume', carrier, async (span) => {
+				span.setAttribute('kafka.topic', topic)
+				span.setAttribute('kafka.partition', partition)
+				span.setAttribute(
+					'kafka.key',
+					message.key ? message.key.toString() : '',
+				)
+
+				console.log({
+					topic,
+					partition,
+					key: message.key ? message.key.toString() : null,
+					value: message.value ? message.value.toString() : null,
+					headers: message.headers,
+				})
+
+				// Simulate some processing time
+				await new Promise((resolve) => setTimeout(resolve, 100))
+			})
+		},
+	})
+}
+
+run().catch(console.error)
+
+// Handle graceful shutdown
+const shutdown = async () => {
+	await consumer.disconnect()
+	await provider.shutdown()
+	process.exit(0)
+}
+
+process.on('SIGTERM', shutdown)
+process.on('SIGINT', shutdown)

--- a/e2e/python/highlight_kafka/kafka.py
+++ b/e2e/python/highlight_kafka/kafka.py
@@ -1,0 +1,42 @@
+from confluent_kafka import Producer
+from opentelemetry.propagate import inject
+import highlight_io
+
+H = highlight_io.H(
+    "<YOUR_PROJECT_ID>",
+    instrument_logging=True,
+    service_name="kafka-producer",
+)
+
+# Define configuration for the Kafka producer
+conf = {
+    "bootstrap.servers": "localhost:9092",  # Kafka broker address
+}
+topic = "dev"
+
+
+def delivery_callback(*args, **kwargs):
+    print("delivery callback", args, kwargs)
+
+
+def main():
+    # Create the Producer instance
+    producer = Producer(conf)
+
+    for k, v in {"key": "value"}.items():
+        with H.trace("kafka.produce"):
+            headers = {"x-example-header": "value"}
+            inject(headers)
+            print("headers", headers)
+            producer.produce(
+                topic, key=k, value=v, headers=headers, on_delivery=delivery_callback
+            )
+            producer.poll(5000)
+            producer.flush()
+
+    producer.flush()
+
+
+if __name__ == "__main__":
+    main()
+    H.flush()

--- a/e2e/python/highlight_kafka/package.json
+++ b/e2e/python/highlight_kafka/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "highlight_kafka",
+	"packageManager": "yarn@4.6.0",
+	"dependencies": {
+		"@highlight-run/node": "workspace:*",
+		"kafkajs": "^2.2.4"
+	},
+	"scripts": {
+		"start": "node kafka.mjs"
+	}
+}

--- a/e2e/python/highlight_script/kafka.py
+++ b/e2e/python/highlight_script/kafka.py
@@ -1,0 +1,37 @@
+import logging
+import random
+import time
+
+import highlight_io
+
+H = highlight_io.H(
+    "1",
+    instrument_logging=True,
+    otlp_endpoint="http://localhost:4317",
+    service_name="manual",
+)
+
+
+@highlight_io.trace
+def my_cool_method():
+    logging.info("hello my_cool_method", {"customer": "unknown", "trace": "inside"})
+    time.sleep(random.randint(0, 10) / 1000)
+    logging.info("goodbye my_cool_method", {"customer": "unknown", "trace": "inside"})
+
+
+def main():
+    logging.info("hello main", {"customer": "world", "trace": "outside"})
+    with H.trace():
+        logging.info("hello handler", {"customer": "unknown"})
+        for idx in range(1000):
+            my_cool_method()
+            logging.info(f"hello {idx}")
+            time.sleep(0.001)
+            if random.randint(0, 100) == 1:
+                raise Exception(f"random error! {idx}")
+        logging.warning("made it outside the loop!")
+
+
+if __name__ == "__main__":
+    main()
+    H.flush()

--- a/e2e/python/poetry.lock
+++ b/e2e/python/poetry.lock
@@ -569,6 +569,65 @@ files = [
 ]
 
 [[package]]
+name = "confluent-kafka"
+version = "2.8.2"
+description = "Confluent's Python client for Apache Kafka"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "confluent_kafka-2.8.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2de2540246d01ec73f6ccbbe189106c97e828ff99d5803b4b629639d3fcf61bd"},
+    {file = "confluent_kafka-2.8.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8fa24b18a1dfa7afa22124a4c417c991d3a7e5639c968c5993724d0e6b55069e"},
+    {file = "confluent_kafka-2.8.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:fae2edce2e4f9b0455d60e1590421ea36e5a31562073663c39446feedf804f19"},
+    {file = "confluent_kafka-2.8.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:bf6cff008f407cb9c2eac6465c858402980af81355a94dc0070f6ac70b014aa5"},
+    {file = "confluent_kafka-2.8.2-cp310-cp310-win_amd64.whl", hash = "sha256:835594da79e09cb239a0d9434af556d8ca6bedb4d7efc1995adf085ca44aaca6"},
+    {file = "confluent_kafka-2.8.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:958be78c89e25f2506ef39ee0251c171b9cd3f771ad7687ab56165e8e32b7df1"},
+    {file = "confluent_kafka-2.8.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:38e0c4809670d9a6a3e268b82793db90fe408a569f7215266abd27b52b7ecf3d"},
+    {file = "confluent_kafka-2.8.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:882b67c076661be252dca962fe7f26c92e8da23b6607618e6512e462750e7f83"},
+    {file = "confluent_kafka-2.8.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:fd10d521873e7d2f64c7d1bc0ee1fc27434d7bc45e50e8a8abf7e8366e38002a"},
+    {file = "confluent_kafka-2.8.2-cp311-cp311-win_amd64.whl", hash = "sha256:1969bfb672a7c55d1bcacd54d3c2cf90f45dbef29a5934828d439cafded31dc9"},
+    {file = "confluent_kafka-2.8.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b632a230abee16b03bdfbb931eb6cdd05a3b9474066b5dcae01550a0faf7cbaf"},
+    {file = "confluent_kafka-2.8.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cd8f33fb94258b676c7c86520f572e2866405056bb31c3425d01fbe0a21f6883"},
+    {file = "confluent_kafka-2.8.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:2cb254a1d53af672cd0d9f3b34492cb5ca4dae829cecc48292afedd199312f06"},
+    {file = "confluent_kafka-2.8.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:9ca5a6ddd6401684d6e7237e11efb112087e4c4c4535503e07fc3385e52b2f16"},
+    {file = "confluent_kafka-2.8.2-cp312-cp312-win_amd64.whl", hash = "sha256:77eb22389c5d95a5d4b8a5713ee3f9ad084cbd19107eb80f51678f676fc3a27f"},
+    {file = "confluent_kafka-2.8.2-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:0974d544bf8b0f23cae70852e53a4e7fec1af7fc83222b302f3ce8855d3ff70b"},
+    {file = "confluent_kafka-2.8.2-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:8eb18f6908aa10cb1f410b429abcb0a62d0ca0daf4386ef3784022d0779d236e"},
+    {file = "confluent_kafka-2.8.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:9171a75ef2430eb04dea4b433de7ae20db063b7cea2318cb0e6394175a153f6f"},
+    {file = "confluent_kafka-2.8.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6ea4f733aaa2c6363adb8cd1cfeda16599642c472e479cea66c6b298325df0aa"},
+    {file = "confluent_kafka-2.8.2-cp313-cp313-win_amd64.whl", hash = "sha256:60c6b77179301366410b35bbd224099a43061c983047329b69ed594f86240e7a"},
+    {file = "confluent_kafka-2.8.2-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:1eaf441620918600bd8dcfb0e38f2102bf735938ba4d87b057bddacd1fa46262"},
+    {file = "confluent_kafka-2.8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ec6c0e72c2b8d8d19209a094ddbb87579973b096f7490229aff5c0a1603aef38"},
+    {file = "confluent_kafka-2.8.2-cp37-cp37m-manylinux_2_28_aarch64.whl", hash = "sha256:d78deb8a443dc4ba2ed21c4902da9b78fba469b7ceeac92f4e1db739a74b512e"},
+    {file = "confluent_kafka-2.8.2-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:5cf86372a660e29363c9165014227fd492923887efb3fea85373bb67cbd8a1a3"},
+    {file = "confluent_kafka-2.8.2-cp37-cp37m-win_amd64.whl", hash = "sha256:169788daf3f6a45e50df3e8ebce5beec5ecd1387edebac181291de5d92db58c5"},
+    {file = "confluent_kafka-2.8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:59411423ebb9804743f4b409b352af93c003bd2bd929890744e3c95f4c76d37a"},
+    {file = "confluent_kafka-2.8.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:696689124df8734f6f8ed2edf7d0036d66acdff2c3915078e66b73aebef6b333"},
+    {file = "confluent_kafka-2.8.2-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:5c5a7490c2c593d8fb84fb10ae95ec9ec631fb229c64e307247a3d1558b7f3e7"},
+    {file = "confluent_kafka-2.8.2-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:5093c3d2dde81ac1dccf5355bcab4f28c8c39f3501b18d910cbdc08cb0b2b946"},
+    {file = "confluent_kafka-2.8.2-cp38-cp38-win_amd64.whl", hash = "sha256:41f646f924a77e5d2dcc1d421d24130bf8e518f80043c5b740c1763bf5c79f25"},
+    {file = "confluent_kafka-2.8.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c1206376218e083a9a962c20fabb881b995b63e8ff55d2ee3408a7527de5584f"},
+    {file = "confluent_kafka-2.8.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b179d792c9ccecbb5d358db8bc16f01798f55ba3f0f281f6b2d698541489cd47"},
+    {file = "confluent_kafka-2.8.2-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:5e49281da59dbefc9ea0f41431e1604a629076ff9ad9cadf9258f4a57b12f968"},
+    {file = "confluent_kafka-2.8.2-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:356d0a27bf350da69fea80d982b777a6b87f91f4b2326b3c8b061e3a01bcdd60"},
+    {file = "confluent_kafka-2.8.2-cp39-cp39-win_amd64.whl", hash = "sha256:5b4471c7ced93407c2c8ee89d7735cbc387aaa3f68707201e7351ce03f59647c"},
+    {file = "confluent_kafka-2.8.2.tar.gz", hash = "sha256:e8cac2a00968c587d7e7a8fbb6b2d3c2eb0d342d42fdf1fdc36c10036b944bf3"},
+]
+
+[package.extras]
+all = ["attrs", "attrs", "authlib", "avro (>=1.11.1,<2)", "avro (>=1.11.1,<2)", "azure-identity", "azure-identity", "azure-keyvault-keys", "azure-keyvault-keys", "boto3", "boto3 (>=1.35)", "cachetools", "cachetools", "cel-python (>=0.1.5)", "cel-python (>=0.1.5)", "confluent-kafka", "fastapi", "fastavro (<1.8.0)", "fastavro (<1.8.0)", "fastavro (<2)", "fastavro (<2)", "flake8", "google-api-core", "google-api-core", "google-auth", "google-auth", "google-cloud-kms", "google-cloud-kms", "googleapis-common-protos", "googleapis-common-protos", "hkdf (==0.0.3)", "hkdf (==0.0.3)", "httpx", "httpx (>=0.26)", "hvac", "hvac", "jsonata-python", "jsonata-python", "jsonschema", "jsonschema", "opentelemetry-distro", "opentelemetry-exporter-otlp", "orjson", "protobuf", "protobuf", "psutil", "pydantic", "pyrsistent", "pyrsistent", "pytest", "pytest-timeout", "pytest_cov", "pyyaml (>=6.0.0)", "pyyaml (>=6.0.0)", "requests", "requests", "requests-mock", "respx", "six", "sphinx", "sphinx-rtd-theme", "tink", "tink", "urllib3 (<2)", "urllib3 (<3)", "uvicorn"]
+avro = ["attrs", "authlib", "avro (>=1.11.1,<2)", "cachetools", "fastavro (<1.8.0)", "fastavro (<2)", "httpx (>=0.26)", "requests"]
+dev = ["attrs", "attrs", "authlib", "avro (>=1.11.1,<2)", "avro (>=1.11.1,<2)", "azure-identity", "azure-identity", "azure-keyvault-keys", "azure-keyvault-keys", "boto3", "boto3 (>=1.35)", "cachetools", "cachetools", "cel-python (>=0.1.5)", "cel-python (>=0.1.5)", "confluent-kafka", "fastapi", "fastavro (<1.8.0)", "fastavro (<1.8.0)", "fastavro (<2)", "fastavro (<2)", "flake8", "google-api-core", "google-api-core", "google-auth", "google-auth", "google-cloud-kms", "google-cloud-kms", "googleapis-common-protos", "googleapis-common-protos", "hkdf (==0.0.3)", "hkdf (==0.0.3)", "httpx", "httpx (>=0.26)", "hvac", "hvac", "jsonata-python", "jsonata-python", "jsonschema", "jsonschema", "orjson", "protobuf", "protobuf", "pydantic", "pyrsistent", "pyrsistent", "pytest", "pytest-timeout", "pytest_cov", "pyyaml (>=6.0.0)", "pyyaml (>=6.0.0)", "requests", "requests", "requests-mock", "respx", "six", "sphinx", "sphinx-rtd-theme", "tink", "tink", "urllib3 (<2)", "urllib3 (<3)", "uvicorn"]
+docs = ["attrs", "authlib", "avro (>=1.11.1,<2)", "azure-identity", "azure-keyvault-keys", "boto3 (>=1.35)", "cachetools", "cel-python (>=0.1.5)", "fastavro (<1.8.0)", "fastavro (<2)", "google-api-core", "google-auth", "google-cloud-kms", "googleapis-common-protos", "hkdf (==0.0.3)", "httpx (>=0.26)", "hvac", "jsonata-python", "jsonschema", "protobuf", "pyrsistent", "pyyaml (>=6.0.0)", "requests", "sphinx", "sphinx-rtd-theme", "tink"]
+examples = ["attrs", "avro (>=1.11.1,<2)", "azure-identity", "azure-keyvault-keys", "boto3", "cachetools", "cel-python (>=0.1.5)", "confluent-kafka", "fastapi", "fastavro (<1.8.0)", "fastavro (<2)", "google-api-core", "google-auth", "google-cloud-kms", "googleapis-common-protos", "hkdf (==0.0.3)", "httpx", "hvac", "jsonata-python", "jsonschema", "protobuf", "pydantic", "pyrsistent", "pyyaml (>=6.0.0)", "requests", "six", "tink", "uvicorn"]
+json = ["attrs", "authlib", "cachetools", "httpx (>=0.26)", "jsonschema", "pyrsistent"]
+protobuf = ["attrs", "authlib", "cachetools", "googleapis-common-protos", "httpx (>=0.26)", "protobuf"]
+rules = ["attrs", "authlib", "azure-identity", "azure-keyvault-keys", "boto3 (>=1.35)", "cachetools", "cel-python (>=0.1.5)", "google-api-core", "google-auth", "google-cloud-kms", "hkdf (==0.0.3)", "httpx (>=0.26)", "hvac", "jsonata-python", "pyyaml (>=6.0.0)", "tink"]
+schema-registry = ["attrs", "authlib", "cachetools", "httpx (>=0.26)"]
+schemaregistry = ["attrs", "authlib", "cachetools", "httpx (>=0.26)"]
+soaktest = ["opentelemetry-distro", "opentelemetry-exporter-otlp", "psutil"]
+tests = ["attrs", "authlib", "avro (>=1.11.1,<2)", "azure-identity", "azure-keyvault-keys", "boto3 (>=1.35)", "cachetools", "cel-python (>=0.1.5)", "fastavro (<1.8.0)", "fastavro (<2)", "flake8", "google-api-core", "google-auth", "google-cloud-kms", "googleapis-common-protos", "hkdf (==0.0.3)", "httpx (>=0.26)", "hvac", "jsonata-python", "jsonschema", "orjson", "protobuf", "pyrsistent", "pytest", "pytest-timeout", "pytest_cov", "pyyaml (>=6.0.0)", "requests", "requests-mock", "respx", "tink", "urllib3 (<2)", "urllib3 (<3)"]
+
+[[package]]
 name = "coverage"
 version = "7.7.0"
 description = "Code coverage measurement for Python"
@@ -3850,4 +3909,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "983d3cb808c5d757c68121ce86e3765158c351a6f86b257c56d6256331309fd6"
+content-hash = "e8dd0fbb8cc0edb701a92ce74894bb71108670e5351d31ad836bd9ba0bd811a3"

--- a/e2e/python/pyproject.toml
+++ b/e2e/python/pyproject.toml
@@ -26,6 +26,7 @@ orjson = "3.9.15"
 uvicorn = {extras = ["standard"], version = "^0.29.0"}
 highlight-io = {path = "../../sdk/highlight-py", develop = true}
 urllib3 = "2.2.2"
+confluent-kafka = "^2.8.2"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.2"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 	"workspaces": [
 		"docs-content",
 		"e2e/*",
+		"e2e/python/highlight_kafka",
 		"packages/*",
 		"highlight.io",
 		"frontend",

--- a/yarn.lock
+++ b/yarn.lock
@@ -40302,6 +40302,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"highlight_kafka@workspace:e2e/python/highlight_kafka":
+  version: 0.0.0-use.local
+  resolution: "highlight_kafka@workspace:e2e/python/highlight_kafka"
+  dependencies:
+    "@highlight-run/node": "workspace:*"
+    kafkajs: "npm:^2.2.4"
+  languageName: unknown
+  linkType: soft
+
 "history@npm:4.10.1, history@npm:^4.9.0":
   version: 4.10.1
   resolution: "history@npm:4.10.1"
@@ -44358,6 +44367,13 @@ __metadata:
     jwa: "npm:^2.0.0"
     safe-buffer: "npm:^5.0.1"
   checksum: 10/1d15f4cdea376c6bd6a81002bd2cb0bf3d51d83da8f0727947b5ba3e10cf366721b8c0d099bf8c1eb99eb036e2c55e5fd5efd378ccff75a2b4e0bd10002348b9
+  languageName: node
+  linkType: hard
+
+"kafkajs@npm:^2.2.4":
+  version: 2.2.4
+  resolution: "kafkajs@npm:2.2.4"
+  checksum: 10/75eb0d221397085f90e51f8a2d752495c9fa9c1b3a1a6db610cd7074fa8c52777f295832fd0a7c49cded5e574337a09fafa8c3f7cf1caa38f4dc9aa20fcfb7df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds a new e2e example app that sets up a Python Kafka producer and a Node.js Kafka consumer,
demonstrating trace context propagation between the two services.

## How did you test this change?

![image](https://github.com/user-attachments/assets/d7a5515f-9fab-46e2-b094-ac93c7777b73)

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
