### PR TITLE
fix sso breaking when multiple domains are set up for the same client

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -112,6 +112,9 @@ jobs:
               working-directory: ./e2e/tests
               run: poetry install --all-extras
 
+            - name: Install Doppler CLI
+              uses: dopplerhq/cli-action@v3
+
             - name: Login to Docker Hub
               if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'
               uses: docker/login-action@v3
@@ -148,6 +151,10 @@ jobs:
                   ./start-infra.sh > /tmp/highlight.log 2>&1;
                   docker compose exec -e PSQL_HOST -e PSQL_USER -e PSQL_DB postgres bash -c 'psql -h $PSQL_HOST -U $PSQL_USER $PSQL_DB < /root/init.sql' >> /tmp/highlight.log 2>&1;
 
+                  # load in SSO configuration from doppler
+                  # adds sensitive SSO config to the local-running db so we should not dump db contents to the github action
+                  docker compose exec -e PSQL_HOST -e PSQL_USER -e PSQL_DB postgres psql -h $PSQL_HOST -U $PSQL_USER $PSQL_DB -c "$(doppler secrets get --plain SSO_SQL)" >> /tmp/highlight.log 2>&1;
+
                   # start highlight
                   ./run-enterprise.sh --no-pull >> /tmp/highlight.log 2>&1;
                   popd;
@@ -162,6 +169,9 @@ jobs:
                   export HIGHLIGHT_OAUTH_CLIENT_SECRET=def456
                   poetry run pytest -k "not cypress" .
                   popd
+
+                  # run cypress tests for sso
+                  yarn cy:run --spec "cypress/e2e/sso.cy.js";
 
                   # look for containers that crashed
                   num_crashed=$(docker ps -a -f status=exited | grep -E '\(' | grep -cvE '\(\d+\)' || true)
@@ -180,24 +190,3 @@ jobs:
               run: |
                   cd docker;
                   docker compose -f compose.yml -f compose.enterprise.yml logs;
-
-            - name: Dump databases on failure
-              if: failure()
-              run: |
-                  cd docker;
-                  mkdir backups
-
-                  docker compose exec postgres bash -c "mkdir /backups";
-                  docker compose exec postgres bash -c "pg_dump -h localhost -U postgres postgres > /backups/postgres.sql";
-                  docker compose exec postgres bash -c "cat /backups/postgres.sql" > ./backups/postgres.sql 2>&1;
-
-                  docker compose exec clickhouse bash -c "mkdir /backups && chmod -R 777 /backups";
-                  docker compose exec clickhouse clickhouse-client --host clickhouse --query "BACKUP DATABASE default TO File('/backups/clickhouse.zip')";
-                  docker compose exec clickhouse bash -c "cat /backups/clickhouse.zip" > ./backups/clickhouse.zip 2>&1;
-
-            - name: Save database artifacts
-              if: failure()
-              uses: actions/upload-artifact@v4
-              with:
-                  name: db-dump
-                  path: docker/backups/*

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -142,6 +142,7 @@ jobs:
                   export FRONTEND_IMAGE_NAME=ghcr.io/highlight/highlight-frontend:$IMAGE_TAG
                   export RELEASE=$IMAGE_TAG
                   export LICENSE_KEY
+                  export REACT_APP_AUTH_MODE=firebase
 
                   pushd docker;
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -146,8 +146,9 @@ jobs:
                   pushd docker;
 
                   # setup infra / db
+                  # update to firebase auth mode for sso test
+                  sed -i'' -e 's/password/firebase/g' .env
                   source ./env.sh --go-docker;
-                  export REACT_APP_AUTH_MODE=firebase
                   # ensure db migrated so we can insert the desired records
                   ./start-infra.sh > /tmp/highlight.log 2>&1;
                   docker compose exec -e PSQL_HOST -e PSQL_USER -e PSQL_DB postgres bash -c 'psql -h $PSQL_HOST -U $PSQL_USER $PSQL_DB < /root/init.sql' >> /tmp/highlight.log 2>&1;

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,9 @@ jobs:
               with:
                   submodules: recursive
 
+            - name: Install Doppler CLI
+              uses: dopplerhq/cli-action@v3
+
             - name: Login to Docker Hub
               uses: docker/login-action@v3
               with:
@@ -132,6 +135,7 @@ jobs:
 
             - name: Run docker enterprise
               env:
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
                   LICENSE_KEY: ${{ secrets.LICENSE_KEY }}
               run: |
                   IMAGE_TAG=$(echo ${{ github.ref_name }} | sed 's/\//-/g')-${{ github.sha }}
@@ -153,6 +157,7 @@ jobs:
                   ./start-infra.sh > /tmp/highlight.log 2>&1;
                   docker compose exec -e PSQL_HOST -e PSQL_USER -e PSQL_DB postgres bash -c 'psql -h $PSQL_HOST -U $PSQL_USER $PSQL_DB < /root/init.sql' >> /tmp/highlight.log 2>&1;
 
+                  doppler configure
                   # load in SSO configuration from doppler
                   # adds sensitive SSO config to the local-running db so we should not dump db contents to the github action
                   docker compose exec -e PSQL_HOST -e PSQL_USER -e PSQL_DB postgres psql -h $PSQL_HOST -U $PSQL_USER $PSQL_DB -c "$(doppler secrets get --plain SSO_SQL)" >> /tmp/highlight.log 2>&1;

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -142,12 +142,12 @@ jobs:
                   export FRONTEND_IMAGE_NAME=ghcr.io/highlight/highlight-frontend:$IMAGE_TAG
                   export RELEASE=$IMAGE_TAG
                   export LICENSE_KEY
-                  export REACT_APP_AUTH_MODE=firebase
 
                   pushd docker;
 
                   # setup infra / db
                   source ./env.sh --go-docker;
+                  export REACT_APP_AUTH_MODE=firebase
                   # ensure db migrated so we can insert the desired records
                   ./start-infra.sh > /tmp/highlight.log 2>&1;
                   docker compose exec -e PSQL_HOST -e PSQL_USER -e PSQL_DB postgres bash -c 'psql -h $PSQL_HOST -U $PSQL_USER $PSQL_DB < /root/init.sql' >> /tmp/highlight.log 2>&1;

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -97,7 +97,7 @@ jobs:
                   yarn dlx wait-on -l -s 3 http://127.0.0.1:3000/index.html http://127.0.0.1:8082/health;
 
                   # run cypress tests
-                  yarn cy:run;
+                  yarn cy:run --spec 'cypress/e2e/*.cy.js,!cypress/e2e/sso.cy.js';
 
                   # run python functional tests that ensure cypress session is correct
                   pushd ./e2e/tests

--- a/backend/private-graph/graph/auth_client.go
+++ b/backend/private-graph/graph/auth_client.go
@@ -47,7 +47,7 @@ type FirebaseAuthClient struct {
 	authClient *auth.Client
 }
 type OAuthClient struct {
-	domain       string
+	domains      []string
 	oidcProvider *oidc.Provider
 	oauthConfig  *oauth2.Config
 }
@@ -502,9 +502,9 @@ func (c *OAuthAuthClient) updateContextWithAuthenticatedUser(ctx context.Context
 	domain := parts[1]
 
 	var validated bool
-	var domains = lo.Map(lo.Values(c.oauthClients), func(item *OAuthClient, _ int) string {
-		return item.domain
-	})
+	var domains = lo.Flatten(lo.Map(lo.Values(c.oauthClients), func(item *OAuthClient, _ int) []string {
+		return item.domains
+	}))
 	for _, dom := range domains {
 		if dom == domain {
 			validated = true
@@ -644,10 +644,14 @@ func NewOAuthClient(ctx context.Context, store *store.Store) (*OAuthAuthClient, 
 			Scopes: []string{oidc.ScopeOpenID, "profile", "email"},
 		}
 
-		oauthClients[ssoClient.ClientID] = &OAuthClient{
-			domain:       ssoClient.Domain,
-			oidcProvider: provider,
-			oauthConfig:  &oauth2Config,
+		if _, ok := oauthClients[ssoClient.ClientID]; ok {
+			oauthClients[ssoClient.ClientID].domains = append(oauthClients[ssoClient.ClientID].domains, ssoClient.Domain)
+		} else {
+			oauthClients[ssoClient.ClientID] = &OAuthClient{
+				domains:      []string{ssoClient.Domain},
+				oidcProvider: provider,
+				oauthConfig:  &oauth2Config,
+			}
 		}
 	}
 

--- a/cypress/e2e/sso.cy.js
+++ b/cypress/e2e/sso.cy.js
@@ -2,7 +2,7 @@ describe('login spec', () => {
 	it('allows you to log in using SSO', () => {
 		cy.visit('/1/buttons').wait(5000)
 		cy.url().should('include', '/sign_in')
-		cy.get('[name="email"]').type('vadim@highlight.io').blur().wait(1000)
+		cy.get('[name="email"]').type('vadim@highlight.io').blur().wait(5000)
 		cy.get('[name="password"]').should('not.exist')
 		cy.get('button[type="submit"]').click()
 		// Verify redirect to Google SSO page
@@ -15,7 +15,7 @@ describe('login spec', () => {
 		cy.visit('/sign_in').url().should('include', '/sign_in') // Verify we're redirected to sign_in page
 
 		// Try again with different email domain
-		cy.get('[name="email"]').clear().type('vadim@highlight.run').blur().wait(1000)
+		cy.get('[name="email"]').clear().type('vadim@highlight.run').blur().wait(5000)
 		cy.get('[name="password"]').should('not.exist')
 		cy.get('button[type="submit"]').click()
 		// Verify redirect to Google SSO page

--- a/cypress/e2e/sso.cy.js
+++ b/cypress/e2e/sso.cy.js
@@ -1,0 +1,24 @@
+describe('login spec', () => {
+	it('allows you to log in using SSO', () => {
+		cy.visit('/1/buttons').wait(1000).url().should('include', '/sign_in')
+		cy.get('[name="email"]').type('vadim@highlight.io').blur()
+		cy.get('[name="password"]').should('not.exist')
+		cy.get('button[type="submit"]')
+			.click()
+			.wait(1000)
+			.url()
+			.should('include', 'accounts.google.com') // Verify redirect to Google SSO page
+
+		// Return to local buttons page after Google SSO
+		cy.go('back').wait(1000).url().should('include', '/sign_in') // Verify we're redirected to sign_in page
+
+		// Try again with different email domain
+		cy.get('[name="email"]').clear().type('vadim@highlight.run').blur()
+		cy.get('[name="password"]').should('not.exist')
+		cy.get('button[type="submit"]')
+			.click()
+			.wait(1000)
+			.url()
+			.should('include', 'accounts.google.com') // Verify redirect to Google SSO page
+	})
+})

--- a/cypress/e2e/sso.cy.js
+++ b/cypress/e2e/sso.cy.js
@@ -3,22 +3,24 @@ describe('login spec', () => {
 		cy.visit('/1/buttons').wait(1000).url().should('include', '/sign_in')
 		cy.get('[name="email"]').type('vadim@highlight.io').blur()
 		cy.get('[name="password"]').should('not.exist')
-		cy.get('button[type="submit"]')
-			.click()
-			.wait(1000)
-			.url()
-			.should('include', 'accounts.google.com') // Verify redirect to Google SSO page
+		cy.get('button[type="submit"]').click().wait(1000)
+		// Verify redirect to Google SSO page
+		cy.origin('accounts.google.com', () => {
+			// We're now in the Google domain context
+			cy.url().should('include', 'accounts.google.com')
+		})
 
 		// Return to local buttons page after Google SSO
-		cy.go('back').wait(1000).url().should('include', '/sign_in') // Verify we're redirected to sign_in page
+		cy.visit('/1/buttons').wait(1000).url().should('include', '/sign_in') // Verify we're redirected to sign_in page
 
 		// Try again with different email domain
 		cy.get('[name="email"]').clear().type('vadim@highlight.run').blur()
 		cy.get('[name="password"]').should('not.exist')
-		cy.get('button[type="submit"]')
-			.click()
-			.wait(1000)
-			.url()
-			.should('include', 'accounts.google.com') // Verify redirect to Google SSO page
+		cy.get('button[type="submit"]').click().wait(1000)
+		// Verify redirect to Google SSO page
+		cy.origin('accounts.google.com', () => {
+			// We're now in the Google domain context
+			cy.url().should('include', 'accounts.google.com')
+		})
 	})
 })

--- a/cypress/e2e/sso.cy.js
+++ b/cypress/e2e/sso.cy.js
@@ -1,9 +1,9 @@
 describe('login spec', () => {
 	it('allows you to log in using SSO', () => {
 		cy.visit('/1/buttons').wait(1000).url().should('include', '/sign_in')
-		cy.get('[name="email"]').type('vadim@highlight.io').blur()
+		cy.get('[name="email"]').type('vadim@highlight.io').blur().wait(1000)
 		cy.get('[name="password"]').should('not.exist')
-		cy.get('button[type="submit"]').click().wait(1000)
+		cy.get('button[type="submit"]').click().wait(5000)
 		// Verify redirect to Google SSO page
 		cy.origin('accounts.google.com', () => {
 			// We're now in the Google domain context
@@ -14,9 +14,13 @@ describe('login spec', () => {
 		cy.visit('/1/buttons').wait(1000).url().should('include', '/sign_in') // Verify we're redirected to sign_in page
 
 		// Try again with different email domain
-		cy.get('[name="email"]').clear().type('vadim@highlight.run').blur()
+		cy.get('[name="email"]')
+			.clear()
+			.type('vadim@highlight.run')
+			.blur()
+			.wait(1000)
 		cy.get('[name="password"]').should('not.exist')
-		cy.get('button[type="submit"]').click().wait(1000)
+		cy.get('button[type="submit"]').click().wait(5000)
 		// Verify redirect to Google SSO page
 		cy.origin('accounts.google.com', () => {
 			// We're now in the Google domain context

--- a/cypress/e2e/sso.cy.js
+++ b/cypress/e2e/sso.cy.js
@@ -15,7 +15,11 @@ describe('login spec', () => {
 		cy.visit('/sign_in').url().should('include', '/sign_in') // Verify we're redirected to sign_in page
 
 		// Try again with different email domain
-		cy.get('[name="email"]').clear().type('vadim@highlight.run').blur().wait(5000)
+		cy.get('[name="email"]')
+			.clear()
+			.type('vadim@highlight.run')
+			.blur()
+			.wait(5000)
 		cy.get('[name="password"]').should('not.exist')
 		cy.get('button[type="submit"]').click()
 		// Verify redirect to Google SSO page

--- a/cypress/e2e/sso.cy.js
+++ b/cypress/e2e/sso.cy.js
@@ -1,9 +1,10 @@
 describe('login spec', () => {
 	it('allows you to log in using SSO', () => {
-		cy.visit('/1/buttons').wait(1000).url().should('include', '/sign_in')
+		cy.visit('/1/buttons').wait(5000)
+		cy.url().should('include', '/sign_in')
 		cy.get('[name="email"]').type('vadim@highlight.io').blur().wait(1000)
 		cy.get('[name="password"]').should('not.exist')
-		cy.get('button[type="submit"]').click().wait(5000)
+		cy.get('button[type="submit"]').click()
 		// Verify redirect to Google SSO page
 		cy.origin('accounts.google.com', () => {
 			// We're now in the Google domain context
@@ -11,16 +12,12 @@ describe('login spec', () => {
 		})
 
 		// Return to local buttons page after Google SSO
-		cy.visit('/1/buttons').wait(1000).url().should('include', '/sign_in') // Verify we're redirected to sign_in page
+		cy.visit('/sign_in').url().should('include', '/sign_in') // Verify we're redirected to sign_in page
 
 		// Try again with different email domain
-		cy.get('[name="email"]')
-			.clear()
-			.type('vadim@highlight.run')
-			.blur()
-			.wait(1000)
+		cy.get('[name="email"]').clear().type('vadim@highlight.run').blur().wait(1000)
 		cy.get('[name="password"]').should('not.exist')
-		cy.get('button[type="submit"]').click().wait(5000)
+		cy.get('button[type="submit"]').click()
 		// Verify redirect to Google SSO page
 		cy.origin('accounts.google.com', () => {
 			// We're now in the Google domain context


### PR DESCRIPTION
## Summary

Since the same client can be configured for more than one domain, this causes
an issue with the `user email x@y.z does not match allowed domains` check because
one of the domains will be picked rather than all being scanned.

## How did you test this change?

new e2e cypress test validating SSO working
local testing

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no