### PR TITLE
Disable dev tools for public users

### DIFF
--- a/frontend/src/pages/Player/Toolbar/ToolbarControlBar/ToolbarControlBar.tsx
+++ b/frontend/src/pages/Player/Toolbar/ToolbarControlBar/ToolbarControlBar.tsx
@@ -338,7 +338,7 @@ export const ToolbarControlBar = () => {
 								/>
 							}
 							delayed
-							disabled={idisableDevTools}
+							disabled={disableDevTools}
 						>
 							<KeyboardShortcut
 								label="Dev tools"

--- a/frontend/src/pages/Player/Toolbar/ToolbarControlBar/ToolbarControlBar.tsx
+++ b/frontend/src/pages/Player/Toolbar/ToolbarControlBar/ToolbarControlBar.tsx
@@ -107,7 +107,7 @@ export const ToolbarControlBar = () => {
 	const disableControls =
 		state === ReplayerState.Loading || !canViewSession || !isPlayerReady
 	const showLiveToggle = session?.processed === false && !disableControls
-	const disableDevTools = disableControls || !isLoggedIn
+	const disableDevTools = disableControls || !isLoggedIn || isPlayerFullscreen
 
 	const [showSettings, setShowSettings] = useState(false)
 
@@ -333,14 +333,12 @@ export const ToolbarControlBar = () => {
 										setShowDevTools(!showDevTools)
 									}}
 									checked={showDevTools}
-									disabled={
-										isPlayerFullscreen || disableDevTools
-									}
+									disabled={disableDevTools}
 									iconLeft={<IconSolidTerminal size={14} />}
 								/>
 							}
 							delayed
-							disabled={isPlayerFullscreen || disableDevTools}
+							disabled={idisableDevTools}
 						>
 							<KeyboardShortcut
 								label="Dev tools"

--- a/frontend/src/pages/Player/Toolbar/ToolbarControlBar/ToolbarControlBar.tsx
+++ b/frontend/src/pages/Player/Toolbar/ToolbarControlBar/ToolbarControlBar.tsx
@@ -64,6 +64,7 @@ import { playerTimeToSessionAbsoluteTime } from '@util/session/utils'
 import { MillisToMinutesAndSeconds } from '@util/time'
 import clsx from 'clsx'
 import { useCallback, useState } from 'react'
+import { useAuthContext } from '@/authentication/AuthContext'
 
 import timelinePopoverStyle from '../TimelineIndicators/TimelinePopover/TimelinePopover.module.css'
 import style from './ToolbarControlBar.module.css'
@@ -71,6 +72,7 @@ import style from './ToolbarControlBar.module.css'
 const EventTypeToExclude: readonly string[] = []
 
 export const ToolbarControlBar = () => {
+	const { isLoggedIn } = useAuthContext()
 	const {
 		setTime,
 		time,
@@ -105,6 +107,7 @@ export const ToolbarControlBar = () => {
 	const disableControls =
 		state === ReplayerState.Loading || !canViewSession || !isPlayerReady
 	const showLiveToggle = session?.processed === false && !disableControls
+	const disableDevTools = disableControls || !isLoggedIn
 
 	const [showSettings, setShowSettings] = useState(false)
 
@@ -331,13 +334,13 @@ export const ToolbarControlBar = () => {
 									}}
 									checked={showDevTools}
 									disabled={
-										isPlayerFullscreen || disableControls
+										isPlayerFullscreen || disableDevTools
 									}
 									iconLeft={<IconSolidTerminal size={14} />}
 								/>
 							}
 							delayed
-							disabled={isPlayerFullscreen || disableControls}
+							disabled={isPlayerFullscreen || disableDevTools}
 						>
 							<KeyboardShortcut
 								label="Dev tools"
@@ -404,6 +407,7 @@ interface ControlSettingsProps {
 }
 const ControlSettings = ({ setShowSettingsPopover }: ControlSettingsProps) => {
 	const { projectId } = useProjectId()
+	const { isLoggedIn } = useAuthContext()
 	const [showSessionSettings, setShowSessionSettings] = useState(true)
 	const { currentWorkspace } = useApplicationContext()
 	const {
@@ -493,6 +497,7 @@ const ControlSettings = ({ setShowSettingsPopover }: ControlSettingsProps) => {
 			<button
 				className={style.settingsButton}
 				onClick={() => setShowDevTools(!showDevTools)}
+				disabled={!isLoggedIn}
 			>
 				<IconSolidTerminal />
 				<Text color="secondaryContentText">Dev tools</Text>
@@ -503,6 +508,7 @@ const ControlSettings = ({ setShowSettingsPopover }: ControlSettingsProps) => {
 				<Switch
 					trackingId="DevToolsMenuToggle"
 					checked={showDevTools}
+					disabled={!isLoggedIn}
 					onChange={(checked: boolean) => {
 						setShowDevTools(checked)
 					}}

--- a/frontend/src/pages/Player/utils/PlayerHooks.tsx
+++ b/frontend/src/pages/Player/utils/PlayerHooks.tsx
@@ -10,6 +10,7 @@ import usePlayerConfiguration, {
 import analytics from '@util/analytics'
 import { useEffect, useRef, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
+import { useAuthContext } from '@/authentication/AuthContext'
 
 import { ReplayerState, useReplayerContext } from '../ReplayerContext'
 
@@ -41,6 +42,7 @@ export const getNewTimeWithSkip = ({
 }
 
 export const usePlayerKeyboardShortcuts = () => {
+	const { isLoggedIn } = useAuthContext()
 	const { state, play, pause, time, replayer, sessionMetadata } =
 		useReplayerContext()
 	const { setIsPlayerFullscreen, setRightPanelView } = usePlayerUIContext()
@@ -265,6 +267,11 @@ export const usePlayerKeyboardShortcuts = () => {
 	useHotkeys(
 		'cmd+/, ctrl+/',
 		(e) => {
+			if (!isLoggedIn) {
+				toast.error('Must be logged in to view the dev tools.')
+				return
+			}
+
 			analytics.track('PlayerToggleDevToolsKeyboardShortcut')
 			moveFocusToDocument(e)
 


### PR DESCRIPTION
## Summary
The log and trace information is not accessible for logged out users, even if the session is public. Disable the dev tools for users that are not logged in.

## How did you test this change?
1. View a session while signed in and make the session public
- [ ] Able to toggle dev tools with button
- [ ] Able to tool dev tools in settings
- [ ] Able to toggle dev tools with shortcut
2. View the session in an incognito window while logged out
- [ ] Not able to toggle dev tools with button
- [ ] Not able to tool dev tools in settings
- [ ] Not able to toggle dev tools with shortcut

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A