### PR TITLE
support ISS SSO login initiation

### DIFF
--- a/backend/private-graph/graph/auth_client.go
+++ b/backend/private-graph/graph/auth_client.go
@@ -442,7 +442,6 @@ func (c *OAuthAuthClient) handleOAuth2Callback(w http.ResponseWriter, r *http.Re
 		queryParams.Add("scope", oidc.ScopeOpenID)
 		queryParams.Add("state", state)
 		queryParams.Add("nonce", nonce)
-		queryParams.Add("iss", provider)
 
 		u, err := url.Parse(client.oauthConfig.RedirectURL)
 		if err != nil {

--- a/backend/private-graph/graph/auth_client.go
+++ b/backend/private-graph/graph/auth_client.go
@@ -26,7 +26,6 @@ import (
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 	"net/http"
-	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -429,20 +428,7 @@ func (c *OAuthAuthClient) handleOAuth2Callback(w http.ResponseWriter, r *http.Re
 		}
 		c.setCallbackCookie(w, r, oauthClientIDCookieName, client.oauthConfig.ClientID)
 
-		u, err := url.Parse(client.oauthConfig.RedirectURL)
-		if err != nil {
-			log.WithContext(ctx).WithError(err).Error("failed to parse provider url")
-			http.Error(w, "failed to parse provider url", http.StatusBadRequest)
-			return
-		}
-
-		queryParams := url.Values{}
-		queryParams.Add("state", state)
-		u.RawQuery = queryParams.Encode()
-
-		redirect := u.String()
-		span.SetAttribute("redirect", redirect)
-		http.Redirect(w, r, redirect, http.StatusFound)
+		http.Redirect(w, r, client.oauthConfig.AuthCodeURL(state), http.StatusFound)
 		return
 	}
 


### PR DESCRIPTION
## Summary

Support a login flow initiated by the SSO provider such as Okta
which will request using the `iss` query string paramater.

In these cases, the oauth middleware will redirect back to the SSO provider
initiating the OAuth2 flow.

## How did you test this change?

deploying to prod w okta

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no