### PR TITLE
Fix error using context outside provider

### DIFF
--- a/frontend/src/components/RelatedResources/TracePanel.tsx
+++ b/frontend/src/components/RelatedResources/TracePanel.tsx
@@ -11,7 +11,8 @@ import {
 	useRelatedResource,
 } from '@/components/RelatedResources/hooks'
 import { useEffect, useState } from 'react'
-import { SearchContext } from '../Search/SearchContext'
+import { SearchContext, useSearchContext } from '../Search/SearchContext'
+import { FlameGraphSpan } from '@/pages/Traces/utils'
 
 export const TracePanel: React.FC<{ resource: RelatedTrace }> = () => {
 	const { highlightedSpan, loading, selectedSpan, traces } = useTrace()
@@ -49,11 +50,24 @@ export const TracePanel: React.FC<{ resource: RelatedTrace }> = () => {
 							</Text>
 							<Box bb="dividerWeak" mt="12" mb="8" />
 
-							{span && <TraceSpanAttributes span={span} />}
+							{span && <TraceAttributes span={span} />}
 						</Box>
 					</Box>
 				)}
 			</Box>
 		</SearchContext>
+	)
+}
+
+const TraceAttributes: React.FC<{ span: FlameGraphSpan }> = ({ span }) => {
+	const { onSubmit, queryParts, query } = useSearchContext()
+
+	return (
+		<TraceSpanAttributes
+			span={span}
+			query={query}
+			queryParts={queryParts}
+			onSubmitQuery={onSubmit}
+		/>
 	)
 }

--- a/frontend/src/pages/Traces/TraceSpanAttributes.tsx
+++ b/frontend/src/pages/Traces/TraceSpanAttributes.tsx
@@ -4,17 +4,23 @@ import { JsonViewerV2 } from '@/components/JsonViewer/JsonViewerV2'
 import { findMatchingAttributes } from '@/components/JsonViewer/utils'
 import { FlameGraphSpan, formatTraceAttributes } from '@/pages/Traces/utils'
 import analytics from '@/util/analytics'
-import { useSearchContext } from '@/components/Search/SearchContext'
+import { SearchExpression } from '@/components/Search/Parser/listener'
 
 type Props = {
 	span: FlameGraphSpan
 	query?: string
+	queryParts?: SearchExpression[]
+	onSubmitQuery?: (query: string) => void
 }
 
-export const TraceSpanAttributes: React.FC<Props> = ({ span }) => {
+export const TraceSpanAttributes: React.FC<Props> = ({
+	span,
+	query,
+	queryParts,
+	onSubmitQuery,
+}) => {
 	const attributes: { [key: string]: any } = { ...span }
 	const formattedSpan = formatTraceAttributes(attributes)
-	const { onSubmit, queryParts, query } = useSearchContext()
 
 	const matchedAttributes = useMemo(
 		() =>
@@ -32,7 +38,7 @@ export const TraceSpanAttributes: React.FC<Props> = ({ span }) => {
 			attribute={formattedSpan}
 			matchedAttributes={matchedAttributes}
 			query={query}
-			setQuery={onSubmit}
+			setQuery={onSubmitQuery}
 		/>
 	)
 }


### PR DESCRIPTION
## Summary

Fixes [an error](https://app.highlight.io/1/errors/1DytS4emiHuLuF2m1Pw6lSHHgETd/instances/510389460?search=false) we were seeing from trying to access a context outside its provider.

## How did you test this change?

Click tested locally with the following steps to repro the issue and ensure the fix worked as expected.

* [ ] View a session
* [ ] View a network request
* [ ] Open the Trace tab and ensure you can view the trace attributes
* [ ] View all traces
* [ ] Type in a search term
* [ ] View an individual trace and ensure
  * [ ] Syntax highlighting still works
  * [ ] You can click the icon next to an attribute to apply it as a filter

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A
