### PR TITLE
Bump reflame deps

### DIFF
--- a/.reflame.config.jsonc
+++ b/.reflame.config.jsonc
@@ -347,10 +347,10 @@
       ],
     },
     "highlight.run": {
-      "version": "9.4.2"
+      "version": "9.16.0"
     },
     "@highlight-run/react": {
-      "version": "6.0.2"
+      "version": "17.0.0"
     },
     "antd": {
       "entryPoints": [


### PR DESCRIPTION
## Summary

Reflame deploys on main were broken because we were depending on earlier versions of highlight libraries that lacked some of the expected changes.

This PR just bumps those libs to the latest available on NPM.

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

Clicked the [preview link](https://preview.highlight.io/?%7Er_preview=%7B%22action%22%3A%22start%22%2C%22variantId%22%3A%2201JTGWV01BM7ZXTHS2XJ5BZPZ2%22%2C%22region%22%3A%22ewr%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22bump-reflame-deps%5C%22%2C%5C%22forkSpecifier%5C%22%3A%5C%22lewisl9029%2Fhighlight%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D)

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
