### PR TITLE
Bug fixes and performance optimizations

### DIFF
--- a/frontend/src/pages/Player/PlayerHook/utils/usePlayerConfiguration.tsx
+++ b/frontend/src/pages/Player/PlayerHook/utils/usePlayerConfiguration.tsx
@@ -38,7 +38,7 @@ const usePlayerConfiguration = () => {
 
 	const [selectedDevToolsTab, setSelectedDevToolsTab] = useLocalStorage<Tab>(
 		'tabs-DevTools-active-tab',
-		Tab.Errors,
+		Tab.Console,
 	)
 
 	const [selectedRightPlayerPanelTab, setSelectedRightPlayerPanelTab] =

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -205,6 +205,7 @@ const DevToolsWindowV2: React.FC<
 							</Box>
 						) : (
 							<Tabs
+								selectedId={selectedDevToolsTab}
 								onChange={(id) => {
 									setSelectedDevToolsTab(id as Tab)
 									setQuery(
@@ -427,7 +428,10 @@ const DevToolsWindowV2: React.FC<
 										)}
 									</Stack>
 								</Tabs.List>
-								<Tabs.Panel id={Tab.Console}>
+								<Tabs.Panel
+									id={Tab.Console}
+									tabId={Tab.Console}
+								>
 									<ConsolePage
 										autoScroll={autoScroll}
 										filter={filter}
@@ -435,14 +439,17 @@ const DevToolsWindowV2: React.FC<
 										panelHeight={panelHeight}
 									/>
 								</Tabs.Panel>
-								<Tabs.Panel id={Tab.Errors}>
+								<Tabs.Panel id={Tab.Errors} tabId={Tab.Errors}>
 									<ErrorsPage
 										autoScroll={autoScroll}
 										filter={filter}
 										time={time}
 									/>
 								</Tabs.Panel>
-								<Tabs.Panel id={Tab.Network}>
+								<Tabs.Panel
+									id={Tab.Network}
+									tabId={Tab.Network}
+								>
 									<NetworkPage
 										autoScroll={autoScroll}
 										requestTypes={requestTypes}
@@ -451,7 +458,7 @@ const DevToolsWindowV2: React.FC<
 										time={time}
 									/>
 								</Tabs.Panel>
-								<Tabs.Panel id={Tab.Traces}>
+								<Tabs.Panel id={Tab.Traces} tabId={Tab.Traces}>
 									<TracesPage
 										autoScroll={autoScroll}
 										filter={filter}
@@ -462,6 +469,7 @@ const DevToolsWindowV2: React.FC<
 								<Tabs.Panel
 									id={Tab.Performance}
 									style={{ height: '100%' }}
+									tabId={Tab.Performance}
 								>
 									<PerformancePage />
 								</Tabs.Panel>

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/PerformancePage/PerformancePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/PerformancePage/PerformancePage.tsx
@@ -8,18 +8,31 @@ import { MetricAggregator, ProductType } from '@/graph/generated/schemas'
 import { useGraphData } from '@pages/Graphing/hooks/useGraphData'
 import { GraphContextProvider } from '@/pages/Graphing/context/GraphContext'
 
+type PerformanceGraphProps = {
+	metricName: string
+	title: string
+	sessionSecureId?: string
+	startTime: number
+	endTime: number
+}
+
 const PerformanceGraph = React.memo(
-	({ metricName, title }: { metricName: string; title: string }) => {
-		const { session, sessionMetadata } = useReplayerContext()
+	({
+		metricName,
+		title,
+		sessionSecureId,
+		startTime,
+		endTime,
+	}: PerformanceGraphProps) => {
 		const { project_id } = useParams<{ project_id: string }>()
 		return (
 			<Box width="full" height="full" p="16">
 				<Graph
 					projectId={project_id!}
 					productType={ProductType.Metrics}
-					query={`secure_session_id=${session?.secure_id} AND metric_name=${metricName}`}
-					startDate={new Date(sessionMetadata.startTime)}
-					endDate={new Date(sessionMetadata.endTime)}
+					query={`secure_session_id=${sessionSecureId} AND metric_name=${metricName}`}
+					startDate={new Date(startTime)}
+					endDate={new Date(endTime)}
 					groupByKeys={['metric_name']}
 					bucketByKey={TIMESTAMP_KEY}
 					bucketCount={60}
@@ -41,20 +54,37 @@ const PerformanceGraph = React.memo(
 	},
 )
 
-const PerformancePage = React.memo(() => {
+const PerformancePage = () => {
 	const graphContext = useGraphData()
+	const { session, sessionMetadata } = useReplayerContext()
+
+	const sessionProps = {
+		sessionSecureId: session?.secure_id,
+		startTime: sessionMetadata.startTime,
+		endTime: sessionMetadata.endTime,
+	}
+
 	return (
 		<GraphContextProvider value={graphContext}>
 			<Box width="full" height="full" display="flex">
 				<PerformanceGraph
 					metricName="usedJSHeapSize"
 					title="Browser Memory Usage"
+					{...sessionProps}
 				/>
-				<PerformanceGraph metricName="fps" title="Render FPS" />
-				<PerformanceGraph metricName="Jank" title="Render Jank" />
+				<PerformanceGraph
+					metricName="fps"
+					title="Render FPS"
+					{...sessionProps}
+				/>
+				<PerformanceGraph
+					metricName="Jank"
+					title="Render Jank"
+					{...sessionProps}
+				/>
 			</Box>
 		</GraphContextProvider>
 	)
-})
+}
 
 export default PerformancePage

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/helpers.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/helpers.ts
@@ -32,7 +32,7 @@ export const formatDatetime = (
 		case 'Date and Time':
 			return dt.format('M/D/YY h:mm A')
 		case 'Date and Time with Milliseconds':
-			return dt.format('M/D/YY h:mm:s A')
+			return dt.format('M/D/YY h:mm:ss A')
 		case 'Unix':
 			return dt.format('X')
 		case 'Unix With Milliseconds':

--- a/packages/ui/src/components/Tabs/Tabs.test.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.test.tsx
@@ -11,8 +11,12 @@ describe('Tabs', () => {
 					<Tabs.Tab id="1">Tab 1</Tabs.Tab>
 					<Tabs.Tab id="2">Tab 2</Tabs.Tab>
 				</Tabs.List>
-				<Tabs.Panel id="1">Panel 1</Tabs.Panel>
-				<Tabs.Panel id="2">Panel 2</Tabs.Panel>
+				<Tabs.Panel id="1" unmountOnHide={false}>
+					Panel 1
+				</Tabs.Panel>
+				<Tabs.Panel id="2" unmountOnHide={false}>
+					Panel 2
+				</Tabs.Panel>
 			</Tabs>,
 		)
 

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -169,11 +169,11 @@ const TabPanel: React.FC<TabPanelProps> = ({
 					flexGrow={1}
 					id={props.id}
 					overflowY={scrollable ? 'auto' : undefined}
-				>
-					{children}
-				</Stack>
+				/>
 			}
-		/>
+		>
+			{children}
+		</Ariakit.TabPanel>
 	)
 }
 


### PR DESCRIPTION
## Summary
Make the following bug fixes and optimizations:
- show milliseconds with 2 digits (i.e. 8 -> 08)
- memoize devtool performance graph appropriately
- hide tab children when not rendered
- pass in selected tab id into dev tools tabs to load when page reloads

## How did you test this change?
1. View a session
2. Swap Date format to include date and milliseconds
- [ ] All session dates shown with 2 digit milliseconds
3. Open the dev tools
- [ ] Correct tab and filters loaded
- [ ] No extraneous requests from other tabs
4. Swap to performance tab and play session
- [ ] No reloading of graphs

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
