### PR TITLE
Replayer performance optimizations

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -66,6 +66,7 @@ jobs:
                   COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
                   REF: ${{ github.ref }}
                   REPO: ${{ github.event.pull_request.head.repo.full_name }}
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
               run: |
                   export RUN_SESSION_SCREENSHOT_LAMBDA=false
                   if [[ "$REF" != "refs/heads/main" && "$REPO" == "highlight/highlight" ]]; then

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -66,7 +66,6 @@ jobs:
                   COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
                   REF: ${{ github.ref }}
                   REPO: ${{ github.event.pull_request.head.repo.full_name }}
-                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
               run: |
                   export RUN_SESSION_SCREENSHOT_LAMBDA=false
                   if [[ "$REF" != "refs/heads/main" && "$REPO" == "highlight/highlight" ]]; then

--- a/__generated/rr/rrweb/rr.js
+++ b/__generated/rr/rrweb/rr.js
@@ -14999,10 +14999,6 @@ var Timer = class {
     this.actions = this.actions.concat(actions);
   }
   replaceActions(actions) {
-    this.actions.length = 0;
-    this.actions.splice(0, 0, ...actions);
-  }
-  replaceActionsV2(actions) {
     const rafWasActive = this.raf === true;
     this.actions.length = 0;
     this.actions = [...actions];
@@ -15245,10 +15241,6 @@ function createPlayerService(context, { getCastFn, applyEventsSynchronously, emi
             REPLACE_EVENTS: {
               target: "playing",
               actions: ["replaceEvents"]
-            },
-            REPLACE_EVENTS_V2: {
-              target: "playing",
-              actions: ["replaceEventsV2"]
             }
           }
         },
@@ -15273,10 +15265,6 @@ function createPlayerService(context, { getCastFn, applyEventsSynchronously, emi
             REPLACE_EVENTS: {
               target: "paused",
               actions: ["replaceEvents"]
-            },
-            REPLACE_EVENTS_V2: {
-              target: "paused",
-              actions: ["replaceEventsV2"]
             }
           }
         },
@@ -15371,32 +15359,7 @@ function createPlayerService(context, { getCastFn, applyEventsSynchronously, emi
         }),
         /* Highlight Code Start */
         replaceEvents: o((ctx, machineEvent) => {
-          const { events: curEvents, timer, baselineTime } = ctx;
-          if (machineEvent.type === "REPLACE_EVENTS") {
-            const { events: newEvents } = machineEvent.payload;
-            curEvents.length = 0;
-            const actions = [];
-            for (const event of newEvents) {
-              addDelay(event, baselineTime);
-              curEvents.push(event);
-              if (event.timestamp >= timer.timeOffset + baselineTime) {
-                const castFn = getCastFn(event, false);
-                actions.push({
-                  doAction: () => {
-                    castFn();
-                  },
-                  delay: event.delay
-                });
-              }
-            }
-            if (timer.isActive()) {
-              timer.replaceActions(actions);
-            }
-          }
-          return { ...ctx, events: curEvents };
-        }),
-        replaceEventsV2: o((ctx, machineEvent) => {
-          if (machineEvent.type !== "REPLACE_EVENTS_V2") return ctx;
+          if (machineEvent.type !== "REPLACE_EVENTS") return ctx;
           const { events: curEvents, timer, baselineTime } = ctx;
           const { events: newEvents } = machineEvent.payload;
           if (newEvents.length === 0) return ctx;
@@ -15414,7 +15377,7 @@ function createPlayerService(context, { getCastFn, applyEventsSynchronously, emi
             }
           }
           if (timer.isActive()) {
-            timer.replaceActionsV2(actions);
+            timer.replaceActions(actions);
           }
           return { ...ctx, events: curEvents };
         }),
@@ -16551,15 +16514,6 @@ var Replayer = class {
       }
     }
     this.service.send({ type: "REPLACE_EVENTS", payload: { events } });
-  }
-  replaceEventsV2(events) {
-    for (const event of events) {
-      if (indicatesTouchDevice(event)) {
-        this.mouse.classList.add("touch-device");
-        break;
-      }
-    }
-    this.service.send({ type: "REPLACE_EVENTS_V2", payload: { events } });
   }
   enableInteract() {
     this.iframe.setAttribute("scrolling", "auto");

--- a/__generated/rr/rrweb/rr.js
+++ b/__generated/rr/rrweb/rr.js
@@ -15004,12 +15004,8 @@ var Timer = class {
   }
   replaceActionsV2(actions) {
     const rafWasActive = this.raf === true;
-    if (this.actions.length > actions.length * 2) {
-      this.actions = [...actions];
-    } else {
-      this.actions.length = 0;
-      this.actions.push(...actions);
-    }
+    this.actions.length = 0;
+    this.actions = [...actions];
     if (rafWasActive) {
       this.raf = requestAnimationFrame(this.rafCheck.bind(this));
     }

--- a/frontend/src/pages/Billing/UpdatePlanPage.tsx
+++ b/frontend/src/pages/Billing/UpdatePlanPage.tsx
@@ -35,7 +35,7 @@ import {
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
-import { loadStripe, Stripe } from '@stripe/stripe-js'
+import type { Stripe } from '@stripe/stripe-js'
 import { getPlanChangeEmail } from '@util/billing/billing'
 import { formatNumber, formatNumberWithDelimiters } from '@util/numbers'
 import { isOnPrem } from '@util/onPrem/onPremUtils'
@@ -152,14 +152,6 @@ export const getNextBillingDate = (
 	} else {
 		return moment().add(1, 'M').toDate()
 	}
-}
-
-export const getStripePromiseOrNull = () => {
-	const stripe_publishable_key = import.meta.env.REACT_APP_STRIPE_API_PK
-	if (stripe_publishable_key) {
-		return loadStripe(stripe_publishable_key)
-	}
-	return null
 }
 
 type ProductCardProps = {
@@ -603,8 +595,14 @@ const UpdatePlanPage = ({
 
 	useEffect(() => {
 		const loadStripeIfNeeded = () => {
-			const stripeInstance = getStripePromiseOrNull()
-			setStripePromise(stripeInstance)
+			const stripe_publishable_key = import.meta.env
+				.REACT_APP_STRIPE_API_PK
+
+			if (stripe_publishable_key) {
+				import('@stripe/stripe-js').then(({ loadStripe }) => {
+					setStripePromise(loadStripe(stripe_publishable_key))
+				})
+			}
 		}
 
 		loadStripeIfNeeded()
@@ -1633,7 +1631,7 @@ const FAQEntry = ({
 	faq: { question: string; answer: string }
 	bottomBorder?: boolean
 }) => {
-	const [expanded, setExpanded] = React.useState<boolean>(false)
+	const [expanded, setExpanded] = useState<boolean>(false)
 	return (
 		<Box
 			key={faq.question}
@@ -1753,11 +1751,11 @@ export const UpdatePlanModal: React.FC<{
 	currentPlanType: Exclude<PlanType, PlanType.Free>
 }> = ({ step, setStep, currentPlanType }) => {
 	const [selectedPlanType, setSelectedPlanType] =
-		React.useState<PlanType>(currentPlanType)
-	const [hasChanges, setHasChanges] = React.useState<boolean>(false)
+		useState<PlanType>(currentPlanType)
+	const [hasChanges, setHasChanges] = useState<boolean>(false)
 	const [showConfirmCloseModal, setShowConfirmCloseModal] =
-		React.useState<boolean>(false)
-	React.useEffect(() => {
+		useState<boolean>(false)
+	useEffect(() => {
 		if (step === null) {
 			setHasChanges(false)
 			setShowConfirmCloseModal(false)

--- a/frontend/src/pages/Buttons/Buttons.module.css
+++ b/frontend/src/pages/Buttons/Buttons.module.css
@@ -26,9 +26,3 @@
 	flex-direction: column;
 	width: 100%;
 }
-
-.sourcemapErrors {
-	margin: 20px auto;
-	max-width: 980px;
-	padding: 0 20px;
-}

--- a/frontend/src/pages/Buttons/Buttons.tsx
+++ b/frontend/src/pages/Buttons/Buttons.tsx
@@ -9,9 +9,8 @@ import {
 	useSendEmailSignupMutation,
 } from '@graph/hooks'
 import { SampleBuggyButton } from '@highlight-run/react'
-import { Box } from '@highlight-run/ui/components'
+import { Box, Table } from '@highlight-run/ui/components'
 import DO_NOT_USE_Canvas from '@pages/Buttons/Canvas'
-import { SourcemapErrorDetails } from '@pages/ErrorsV2/SourcemapErrorDetails/SourcemapErrorDetails'
 import { H } from 'highlight.run'
 import { useEffect, useState } from 'react'
 import { trace } from '@opentelemetry/api'
@@ -39,6 +38,7 @@ export const Buttons = () => {
 
 	const [hasError, setHasError] = useState(false)
 	const [showWebSocket, setShowWebSocket] = useState(false)
+	const [showLargeDOMTree, setShowLargeDOMTree] = useState(false)
 	const [email, setEmail] = useState('')
 	const [sendEmail, { loading }] = useSendEmailSignupMutation()
 	if (hasError) {
@@ -601,6 +601,55 @@ export const Buttons = () => {
 					>
 						Private Graph Request
 					</button>
+
+					<button
+						className={commonStyles.submitButton}
+						onClick={() => {
+							for (let i = 0; i < 200; i++) {
+								H.track('test', {
+									property: `value-${i}`,
+								})
+							}
+						}}
+					>
+						Create a ton of track events
+					</button>
+
+					<button
+						className={commonStyles.submitButton}
+						onClick={() => {
+							setShowLargeDOMTree(!showLargeDOMTree)
+						}}
+					>
+						Test large DOM tree
+					</button>
+					{showLargeDOMTree && (
+						<Table style={{ maxHeight: 500, overflowY: 'scroll' }}>
+							<Table.Head>
+								<Table.Header>Name</Table.Header>
+								<Table.Header>Value</Table.Header>
+							</Table.Head>
+							<Table.Body>
+								{Array.from({ length: 2000 }).map(
+									(_, index) => (
+										<Table.Row key={index}>
+											<Table.Cell>{`Cell ${index}`}</Table.Cell>
+											<Table.Cell>{`Cell ${index}`}</Table.Cell>
+											<Table.Cell>{`Cell ${index}`}</Table.Cell>
+											<Table.Cell>{`Cell ${index}`}</Table.Cell>
+											<Table.Cell>{`Cell ${index}`}</Table.Cell>
+											<Table.Cell>{`Cell ${index}`}</Table.Cell>
+											<Table.Cell>{`Cell ${index}`}</Table.Cell>
+											<Table.Cell>{`Cell ${index}`}</Table.Cell>
+											<Table.Cell>{`Cell ${index}`}</Table.Cell>
+											<Table.Cell>{`Cell ${index}`}</Table.Cell>
+											<Table.Cell>{`Cell ${index}`}</Table.Cell>
+										</Table.Row>
+									),
+								)}
+							</Table.Body>
+						</Table>
+					)}
 				</div>
 				<div>
 					<button
@@ -715,95 +764,7 @@ export const Buttons = () => {
 				</div>
 			</div>
 
-			<div className={styles.sourcemapErrors}>
-				<h2>Sourcemap Errors UI</h2>
-
-				<Box mb="24">
-					<h3>Sourcemap_File_Missing_In_S3_And_URL</h3>
-					<SourcemapErrorDetails
-						error={
-							Sourcemap_File_Missing_In_S3_And_URL.sourceMappingErrorMetadata
-						}
-					/>
-				</Box>
-
-				<Box mb="24">
-					<h3>Missing_Source_Map_File_In_S3</h3>
-					<SourcemapErrorDetails
-						error={
-							Missing_Source_Map_File_In_S3.sourceMappingErrorMetadata
-						}
-					/>
-				</Box>
-
-				<Box mb="24">
-					<h3>File_Name_Missing_From_Source_Path</h3>
-					<SourcemapErrorDetails
-						error={
-							File_Name_Missing_From_Source_Path.sourceMappingErrorMetadata
-						}
-					/>
-				</Box>
-
-				<Box mb="24">
-					<h3>Error_Parsing_Stack_Trace_File_Url</h3>
-					<SourcemapErrorDetails
-						error={
-							Error_Parsing_Stack_Trace_File_Url.sourceMappingErrorMetadata
-						}
-					/>
-				</Box>
-
-				<Box mb="24">
-					<h3>Minified_File_Missing_In_S3_And_URL</h3>
-					<SourcemapErrorDetails
-						error={
-							Minified_File_Missing_In_S3_And_URL.sourceMappingErrorMetadata
-						}
-					/>
-				</Box>
-
-				<Box mb="24">
-					<h3>Minified_File_Larger</h3>
-					<SourcemapErrorDetails
-						error={Minified_File_Larger.sourceMappingErrorMetadata}
-					/>
-				</Box>
-
-				<Box mb="24">
-					<h3>Source_Map_File_Larger</h3>
-					<SourcemapErrorDetails
-						error={
-							Source_Map_File_Larger.sourceMappingErrorMetadata
-						}
-					/>
-				</Box>
-
-				<Box mb="24">
-					<h3>Invalid_SourceMapURL</h3>
-					<SourcemapErrorDetails
-						error={Invalid_SourceMapURL.sourceMappingErrorMetadata}
-					/>
-				</Box>
-
-				<Box mb="24">
-					<h3>Sourcemap_Library_Couldnt_Parse</h3>
-					<SourcemapErrorDetails
-						error={
-							Sourcemap_Library_Couldnt_Parse.sourceMappingErrorMetadata
-						}
-					/>
-				</Box>
-
-				<Box mb="24">
-					<h3>Sourcemap_Library_Couldnt_Retrieve_Source</h3>
-					<SourcemapErrorDetails
-						error={
-							Sourcemap_Library_Couldnt_Retrieve_Source.sourceMappingErrorMetadata
-						}
-					/>
-				</Box>
-
+			<Box margin="auto" style={{ width: 1000 }}>
 				<Box mb="24">
 					<Box display="flex">
 						{[
@@ -855,7 +816,7 @@ export const Buttons = () => {
 						}}
 					></div>
 				</Box>
-			</div>
+			</Box>
 		</div>
 	)
 }
@@ -866,148 +827,5 @@ const BadComponent = () => (
 		{badVariableAccess}
 	</div>
 )
-
-const File_Name_Missing_From_Source_Path = {} as any
-
-const Error_Parsing_Stack_Trace_File_Url = {} as any
-
-const Minified_File_Missing_In_S3_And_URL = {
-	fileName:
-		'https://btloader.com/recovery?w=5170702742192128\u0026upapi=true',
-	lineNumber: 4,
-	functionName: '_s',
-	columnNumber: 221192,
-	error: 'error fetching file: https://btloader.com/recovery: status code not OK',
-	sourceMappingErrorMetadata: {
-		errorCode: 'Minified_File_Missing_In_S3_And_URL',
-		stackTraceFileURL: 'https://btloader.com/recovery',
-		sourcemapFetchStrategy: null,
-		sourceMapURL: null,
-		minifiedFetchStrategy: 'S3 and URL',
-		actualMinifiedFetchedPath: 'recovery',
-		minifiedLineNumber: null,
-		minifiedColumnNumber: null,
-		actualSourcemapFetchedPath: null,
-		sourcemapFileSize: null,
-		minifiedFileSize: null,
-		mappedLineNumber: null,
-		mappedColumnNumber: null,
-	},
-	lineContent: null,
-	linesBefore: null,
-	linesAfter: null,
-} as any
-
-const Minified_File_Larger = {} as any
-
-const Source_Map_File_Larger = {} as any
-
-const Invalid_SourceMapURL = {} as any
-
-const Sourcemap_Library_Couldnt_Parse = {
-	fileName: 'https://app.highlight.io/assets/index.e1f78689.js',
-	lineNumber: 57,
-	functionName: 'new yl',
-	columnNumber: 196,
-	error: "error parsing fetched source map: https://app.highlight.io/assets/index.e1f78689.js.map - \u003cnil\u003e, invalid character '\u003c' looking for beginning of value: invalid character '\u003c' looking for beginning of value",
-	sourceMappingErrorMetadata: {
-		errorCode: 'Sourcemap_Library_Couldnt_Parse',
-		stackTraceFileURL: 'https://app.highlight.io/assets/index.e1f78689.js',
-		sourcemapFetchStrategy: 'URL',
-		sourceMapURL: 'https://app.highlight.io/assets/index.e1f78689.js.map',
-		minifiedFetchStrategy: 'S3',
-		actualMinifiedFetchedPath: 'assets/index.e1f78689.js',
-		minifiedLineNumber: null,
-		minifiedColumnNumber: null,
-		actualSourcemapFetchedPath: 'assets/index.e1f78689.js.map',
-		sourcemapFileSize: null,
-		minifiedFileSize: 8676204,
-		mappedLineNumber: null,
-		mappedColumnNumber: null,
-	},
-	lineContent: null,
-	linesBefore: null,
-	linesAfter: null,
-} as any
-
-const Sourcemap_Library_Couldnt_Retrieve_Source = {
-	fileName: 'https://app.posthog.com/static/recorder.js?v=1.36.0',
-	lineNumber: 32,
-	functionName: 'console.error',
-	columnNumber: 9367,
-	error: 'error extracting true error info from source map: https://app.posthog.com/static/recorder.js.map',
-	sourceMappingErrorMetadata: {
-		errorCode: 'Sourcemap_Library_Couldnt_Retrieve_Source',
-		stackTraceFileURL: 'https://app.posthog.com/static/recorder.js',
-		sourcemapFetchStrategy: 'S3',
-		sourceMapURL: 'https://app.posthog.com/static/recorder.js.map',
-		minifiedFetchStrategy: 'S3',
-		actualMinifiedFetchedPath: 'static/recorder.js',
-		minifiedLineNumber: null,
-		minifiedColumnNumber: null,
-		actualSourcemapFetchedPath: 'static/recorder.js.map',
-		sourcemapFileSize: 251509,
-		minifiedFileSize: 62577,
-		mappedLineNumber: 32,
-		mappedColumnNumber: 9367,
-	},
-	lineContent: null,
-	linesBefore: null,
-	linesAfter: null,
-} as any
-
-const Sourcemap_File_Missing_In_S3_And_URL = {
-	fileName: 'https://widget.ybug.io/button/k2cyfzgsn9ha9xr2qsx0.js',
-	lineNumber: 1,
-	functionName: 'e.\u003ccomputed\u003e [as error]',
-	columnNumber: 6914,
-	error: 'error fetching source map file: https://widget.ybug.io/button/k2cyfzgsn9ha9xr2qsx0.js.map: status code not OK',
-	sourceMappingErrorMetadata: {
-		errorCode: 'Sourcemap_File_Missing_In_S3_And_URL',
-		stackTraceFileURL:
-			'https://widget.ybug.io/button/k2cyfzgsn9ha9xr2qsx0.js',
-		sourcemapFetchStrategy: 'S3 and URL',
-		sourceMapURL:
-			'https://widget.ybug.io/button/k2cyfzgsn9ha9xr2qsx0.js.map',
-		minifiedFetchStrategy: 'S3',
-		actualMinifiedFetchedPath: 'button/k2cyfzgsn9ha9xr2qsx0.js',
-		minifiedLineNumber: null,
-		minifiedColumnNumber: null,
-		actualSourcemapFetchedPath: 'button/k2cyfzgsn9ha9xr2qsx0.js.map',
-		sourcemapFileSize: null,
-		minifiedFileSize: 22040,
-		mappedLineNumber: null,
-		mappedColumnNumber: null,
-	},
-	lineContent: null,
-	linesBefore: null,
-	linesAfter: null,
-} as any
-
-const Missing_Source_Map_File_In_S3 = {
-	fileName: 'webpack-internal:///./pages/joinBeta.jsx',
-	lineNumber: 655,
-	functionName: 'eval',
-	columnNumber: 64,
-	error: 'error fetching file: webpack-internal:///./pages/joinBeta.jsx: error getting source file: Get "webpack-internal:///./pages/joinBeta.jsx": unsupported protocol scheme "webpack-internal"',
-	sourceMappingErrorMetadata: {
-		errorCode: 'Minified_File_Missing_In_S3_And_URL',
-		stackTraceFileURL: 'webpack-internal:///./pages/joinBeta.jsx',
-		sourcemapFetchStrategy: null,
-		sourceMapURL: null,
-		minifiedFetchStrategy: 'S3 and URL',
-		actualMinifiedFetchedPath: './pages/joinBeta.jsx',
-		minifiedLineNumber: null,
-		minifiedColumnNumber: null,
-		actualSourcemapFetchedPath: null,
-		sourcemapFileSize: null,
-		minifiedFileSize: null,
-		mappedLineNumber: null,
-		mappedColumnNumber: null,
-	},
-	lineContent: null,
-	linesBefore: null,
-	linesAfter: null,
-} as any
 
 export default Buttons

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -263,6 +263,8 @@ export const usePlayer = (
 			const chunksIndexesWithData = Array.from(chunkEvents.entries())
 				.filter(([, v]) => !!v.length)
 				.map(([k]) => k)
+
+			// TODO(o11y): Experiment with lowering max chunk count to see if it reduces memory usage
 			if (chunksIndexesWithData.length <= MAX_CHUNK_COUNT) {
 				return toRemove
 			}
@@ -455,6 +457,7 @@ export const usePlayer = (
 					state.sessionMetadata.startTime + startTime,
 				)
 				if (currentChunkIdx) {
+					// TODO(o11y): Confirm this is clearing everything out and reduces memory usage
 					toRemove.delete(currentChunkIdx)
 				}
 				log('PlayerHook.tsx:ensureChunksLoaded', 'getChunksToRemove', {
@@ -657,6 +660,7 @@ export const usePlayer = (
 		],
 	)
 
+	// TODO(o11y): Experiment with bumping the throttle time
 	const onFrame = useMemo(
 		() =>
 			_.throttle(

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -359,7 +359,7 @@ export const PlayerReducer = (
 		case PlayerActionType.addLiveEvents:
 			s.liveEventCount += 1
 			s.lastActiveTimestamp = action.lastActiveTimestamp
-			s.replayer?.replaceEvents(events)
+			s.replayer?.replaceEventsV2(events)
 			s.replayer?.play(events[events.length - 1].timestamp)
 			s.replayerState = ReplayerState.Playing
 			break
@@ -425,7 +425,9 @@ export const PlayerReducer = (
 		case PlayerActionType.updateEvents:
 			if (s.replayer) {
 				log('updateEvents', { events })
-				s.replayer.replaceEvents(events)
+				s.replayer.replaceEventsV2(
+					events.filter((e) => e.type !== EventType.Custom),
+				)
 			}
 			break
 		case PlayerActionType.updateViewport:
@@ -474,7 +476,9 @@ export const PlayerReducer = (
 				}
 			} else {
 				log('onChunksLoad', { events })
-				s.replayer.replaceEvents(events)
+				s.replayer.replaceEventsV2(
+					events.filter((e) => e.type !== EventType.Custom),
+				)
 			}
 			s = replayerAction(
 				PlayerActionType.onChunksLoad,

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -360,7 +360,7 @@ export const PlayerReducer = (
 		case PlayerActionType.addLiveEvents:
 			s.liveEventCount += 1
 			s.lastActiveTimestamp = action.lastActiveTimestamp
-			s.replayer?.replaceEventsV2(getNonCustomEvents(events))
+			s.replayer?.replaceEvents(getNonCustomEvents(events))
 			s.replayer?.play(events[events.length - 1].timestamp)
 			s.replayerState = ReplayerState.Playing
 			break
@@ -426,7 +426,7 @@ export const PlayerReducer = (
 		case PlayerActionType.updateEvents:
 			if (s.replayer) {
 				log('updateEvents', { events })
-				s.replayer.replaceEventsV2(getNonCustomEvents(events))
+				s.replayer.replaceEvents(getNonCustomEvents(events))
 			}
 			break
 		case PlayerActionType.updateViewport:
@@ -475,7 +475,7 @@ export const PlayerReducer = (
 				}
 			} else {
 				log('onChunksLoad', { events })
-				s.replayer.replaceEventsV2(getNonCustomEvents(events))
+				s.replayer.replaceEvents(getNonCustomEvents(events))
 			}
 			s = replayerAction(
 				PlayerActionType.onChunksLoad,

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -37,6 +37,7 @@ import {
 	getAllPerformanceEvents,
 	getAllUrlEvents,
 	getBrowserExtensionScriptURLs,
+	getNonCustomEvents,
 } from '@pages/Player/SessionLevelBar/utils/utils'
 import {
 	customEvent,
@@ -359,7 +360,7 @@ export const PlayerReducer = (
 		case PlayerActionType.addLiveEvents:
 			s.liveEventCount += 1
 			s.lastActiveTimestamp = action.lastActiveTimestamp
-			s.replayer?.replaceEventsV2(events)
+			s.replayer?.replaceEventsV2(getNonCustomEvents(events))
 			s.replayer?.play(events[events.length - 1].timestamp)
 			s.replayerState = ReplayerState.Playing
 			break
@@ -425,9 +426,7 @@ export const PlayerReducer = (
 		case PlayerActionType.updateEvents:
 			if (s.replayer) {
 				log('updateEvents', { events })
-				s.replayer.replaceEventsV2(
-					events.filter((e) => e.type !== EventType.Custom),
-				)
+				s.replayer.replaceEventsV2(getNonCustomEvents(events))
 			}
 			break
 		case PlayerActionType.updateViewport:
@@ -476,9 +475,7 @@ export const PlayerReducer = (
 				}
 			} else {
 				log('onChunksLoad', { events })
-				s.replayer.replaceEventsV2(
-					events.filter((e) => e.type !== EventType.Custom),
-				)
+				s.replayer.replaceEventsV2(getNonCustomEvents(events))
 			}
 			s = replayerAction(
 				PlayerActionType.onChunksLoad,

--- a/frontend/src/pages/Player/SessionLevelBar/utils/utils.ts
+++ b/frontend/src/pages/Player/SessionLevelBar/utils/utils.ts
@@ -1,4 +1,4 @@
-import { customEvent } from '@rrweb/types'
+import { customEvent, EventType } from '@rrweb/types'
 
 import {
 	HighlightEvent,
@@ -60,6 +60,10 @@ export const getAllUrlEvents = (events: HighlightEvent[]) => {
 	})
 
 	return urlEvents as customEvent<string>[]
+}
+
+export const getNonCustomEvents = (events: HighlightEvent[]) => {
+	return events.filter((event) => event.type !== EventType.Custom)
 }
 
 export const getBrowserExtensionScriptURLs = (events: HighlightEvent[]) => {

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -169,11 +169,11 @@ const TabPanel: React.FC<TabPanelProps> = ({
 					flexGrow={1}
 					id={props.id}
 					overflowY={scrollable ? 'auto' : undefined}
-				>
-					{children}
-				</Stack>
+				/>
 			}
-		/>
+		>
+			{children}
+		</Ariakit.TabPanel>
 	)
 }
 


### PR DESCRIPTION
## Summary

A few optimizations to the session replayer:

* Changes how rrweb replaces actions by completely replacing the array rather than using `splice` to reset it. This seems to fix an infinite loop we were seeing, though probably has some tradeoffs with creating a new array rather than reusing the existing.
* Filters out custom events before passing events to rrweb since those are only used on the timeline, not for replay.
* Adds some mechanisms for creating many track events at once and viewing very large DOM trees to test those scenarios in recording/replay.
* Prevents Stripe from loading when any page is rendered in our app and lazy loads it only when needed on the update plan page.

## How did you test this change?

Click tested locally and in the Reflame preview, which included the rrweb updates. Compared prod session viewing to the app preview for some sessions that had obvious playback issues.

## Are there any deployment considerations?

* Need to release https://github.com/highlight/rrweb/pull/122 and update rrweb in this PR before merging.
* Will need to follow up with customers to let them know replay should be better (see Jira ticket for details on who to contact).

## Does this work require review from our design team?

N/A
