### PR TITLE
fix(docs): Correct image path for InfluxDB architecture

### DIFF
--- a/docs-content/general/4_company/open-source/contributing/architecture.md
+++ b/docs-content/general/4_company/open-source/contributing/architecture.md
@@ -39,7 +39,7 @@ Here's the high level structure of the code that you'll want to start tinkering 
 
 ## InfluxDB Diagram
 
-![](/images/influx.png)
+![](/images/Influx.png)
 
 ## OpenTelemetry Diagram
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
Before :- 
<img src="https://github.com/user-attachments/assets/d031ec5d-2943-4083-be99-2eda447d70f1" alt="InfluxDB Diagram" width="500" />
After:-
<img src="https://github.com/user-attachments/assets/e615d2eb-9268-477f-8731-cac95f51470d" alt="InfluxDB Diagram" width="500" />
## Are there any deployment considerations?
NA

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
NA
<!--
 Request review from julian-highlight / our design team 
-->
