### PR TITLE
Fix invalid sdks

### DIFF
--- a/frontend/src/pages/Connect/ConnectPage/index.tsx
+++ b/frontend/src/pages/Connect/ConnectPage/index.tsx
@@ -55,13 +55,11 @@ export const ConnectPage = () => {
 	useEffect(() => analytics.page('Connect'), [])
 
 	const guide = useMemo(() => {
-		const guideLanguage = language
-		const guidePlatform = platform
-
 		// return selected platform if valid
-		if (guideLanguage && guidePlatform) {
-			const sdk = (quickStartContentReorganized as any)[guideLanguage]
-				?.sdks[guidePlatform] as QuickStartContent
+		if (language && platform) {
+			const sdk = (quickStartContentReorganized as any)[language]?.sdks[
+				platform
+			] as QuickStartContent
 			if (sdk) {
 				return sdk
 			}


### PR DESCRIPTION
## Summary
Some invalid sdk is causing the connect page to crash (likely `serverless_aws-lambda`). Find the first valid sdk to show on the page instead of crashing. Return a warning for invalid selected sdks.

https://github.com/user-attachments/assets/f01cc153-e6f8-4f59-ba45-16d57a5344b4

## How did you test this change?
1. Update platforms to start with an invalid sdk.
2. Load the connect page
- [ ] First invalid sdk is skipped
- [ ] A warning is sent for the sdk

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A