### PR TITLE
fix: replace downlinkMax to zero if it is infinity

### DIFF
--- a/sdk/highlight-run/src/client/listeners/network-listener/performance-listener.ts
+++ b/sdk/highlight-run/src/client/listeners/network-listener/performance-listener.ts
@@ -35,7 +35,7 @@ export const NetworkPerformanceListener = (
 		callback({
 			relativeTimestamp,
 			downlink: conn.downlink,
-			downlinkMax: conn.downlinkMax,
+			downlinkMax: conn.downlinkMax === Infinity ? 0 : conn.downlinkMax,
 			effectiveType: conn.effectiveType,
 			rtt: conn.rtt,
 			saveData: conn.saveData,


### PR DESCRIPTION
## Summary

I sat up Highlight within a React app and saw a lot of network errors for an invalid payload (status 400). It was already reported as an issue here: https://github.com/highlight/highlight/issues/10202.

**Route:** `POST https://otel.highlight.io/v1/metrics`
**Response payload:**
```json
{
    "code": 3,
    "message": "ReadUint64: unsupported value type, error found in #10 byte of ...|asDouble\":null}]}},{|..., bigger context ...|\",\"timeUnixNano\":\"1751821448078000000\",\"asDouble\":null}]}},{\"name\":\"rtt\",\"description\":\"\",\"unit\":\"\",|..."
}
```

The error didn't expose the key with invalid value, but looking into the payload, there was only one `null` value.

**Request payload:**
```json
{
    "name": "downlinkMax",
    "description": "",
    "unit": "",
    "gauge": {
        "dataPoints": [
            {
                "attributes": [
                    ...
                ],
                "startTimeUnixNano": "1751821694388000000",
                "timeUnixNano": "1751821695531000000",
                "asDouble": null // <-------------------
            }
        ]
    }
},
```

-----

Looking the code, it was fetching the data from `navigator.connection` and mine looks like this:

```javascript
NetworkInformation{
    downlink: 2.05
    downlinkMax: Infinity // <---- the problem is here
    effectiveType: "4g"
    onchange: null
    ontypechange: null
    rtt: 250
    saveData: false
    type: "unknown"
}
```

According to the NetworkInformation docs (https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/downlinkMax) the `downlinkMax` property is experimental.

And according to this other link https://wicg.github.io/netinfo/#underlying-connection-technology-0, when the `type` [of the connection technology] cannot be determined, `downlinkMax` is set to `Infinity`.

----

The code already has a validation for empty values collected by the `NetworkPerformanceListener`, checking for valid numbers: `value && typeof value === 'number'`.

`typeof Infinity` is in fact a `"number"`, but when encoded to json by `JSON.stringify`, it becomes `null`:

```javascript
JSON.stringify({ downlinkMax: navigator.connection.downlinkMax })
// > '{"downlinkMax":null}'
```

## How did you test this change?

Probably this error appeared to me for using chromium, since other browsers link chrome itself supports the feature.

So, to reproduce, test it with chromium: `'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36'`

## Are there any deployment considerations?

After reviewed, this change must be replicated to the other repo https://github.com/launchdarkly/observability-sdk.

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

No