### PR TITLE
use correct retention date for errors

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5186,7 +5186,7 @@ func (r *queryResolver) Session(ctx context.Context, secureID string) (*model.Se
 		return nil, err
 	}
 
-	retentionDate, err := r.GetProjectRetentionDate(s.ProjectID)
+	retentionDate, err := r.GetProjectSessionsRetentionDate(s.ProjectID)
 	if err != nil {
 		return nil, err
 	}
@@ -5459,7 +5459,7 @@ func (r *queryResolver) ErrorGroup(ctx context.Context, secureID string, useClic
 	if err != nil {
 		return nil, err
 	}
-	retentionDate, err := r.GetProjectRetentionDate(eg.ProjectID)
+	retentionDate, err := r.GetProjectErrorsRetentionDate(eg.ProjectID)
 	if err != nil {
 		return nil, err
 	}
@@ -5538,7 +5538,7 @@ func (r *queryResolver) ErrorInstance(ctx context.Context, errorGroupSecureID st
 		return nil, err
 	}
 
-	retentionDate, err := r.GetProjectRetentionDate(errorGroup.ProjectID)
+	retentionDate, err := r.GetProjectErrorsRetentionDate(errorGroup.ProjectID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- we're using the incorrect retention date when querying for errors, noticeable for a customer with sessions retention = 7 days and errors retention = 6 months
- patched from LD repo
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested in other branch, will validate customer issue after deploying 
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
