### PR TITLE
pin docker image versions

### DIFF
--- a/deploy/kafka-connect.Dockerfile
+++ b/deploy/kafka-connect.Dockerfile
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-kafka-connect:latest
+FROM confluentinc/cp-kafka-connect:7.2.15
 
 RUN curl "https://highlight-client-bundle.s3.us-east-2.amazonaws.com/assets/clickhouse-kafka-connect-v1.2.6-confluent.jar" --output /home/appuser/clickhouse-kafka-connect-v1.2.6.jar
 

--- a/deploy/opentelemetry-collector.Dockerfile
+++ b/deploy/opentelemetry-collector.Dockerfile
@@ -1,4 +1,4 @@
-FROM otel/opentelemetry-collector-contrib:latest
+FROM otel/opentelemetry-collector-contrib:0.130.1
 
 COPY ./otel-collector.yaml /etc/otel-collector-config.yaml
 


### PR DESCRIPTION
## Summary

Pin OpenTelemetry collector version to avoid 0.131 `snappy` collector breaking changes being deployed.

## How did you test this change?

CI (e2e job)

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
