### PR TITLE
Adding optional parameter to omit http response / request body when fetching trace information

### DIFF
--- a/backend/clickhouse/traces_test.go
+++ b/backend/clickhouse/traces_test.go
@@ -174,7 +174,7 @@ func TestReadTracesWithEnvironmentFilter(t *testing.T) {
 	payload, err := client.ReadTraces(ctx, 1, modelInputs.QueryInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "environment:production",
-	}, Pagination{})
+	}, Pagination{}, nil)
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 10)
 	if len(payload.Edges) > 0 {
@@ -184,7 +184,7 @@ func TestReadTracesWithEnvironmentFilter(t *testing.T) {
 	payload, err = client.ReadTraces(ctx, 1, modelInputs.QueryInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "environment:*dev*",
-	}, Pagination{})
+	}, Pagination{}, nil)
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 10)
 	if len(payload.Edges) > 0 {
@@ -194,7 +194,7 @@ func TestReadTracesWithEnvironmentFilter(t *testing.T) {
 	payload, err = client.ReadTraces(ctx, 1, modelInputs.QueryInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "environment:(production OR development)",
-	}, Pagination{})
+	}, Pagination{}, nil)
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 20)
 }
@@ -220,7 +220,7 @@ func TestReadTracesWithSorting(t *testing.T) {
 			Column:    "duration",
 			Direction: "DESC",
 		},
-	}, Pagination{})
+	}, Pagination{}, nil)
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 3)
 
@@ -235,7 +235,7 @@ func TestReadTracesWithSorting(t *testing.T) {
 			Column:    "host.name",
 			Direction: "DESC",
 		},
-	}, Pagination{})
+	}, Pagination{}, nil)
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 3)
 

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -1192,7 +1192,7 @@ type ComplexityRoot struct {
 		TimelineIndicatorEvents          func(childComplexity int, sessionSecureID string) int
 		TopUsers                         func(childComplexity int, projectID int, lookbackDays float64) int
 		Trace                            func(childComplexity int, projectID int, traceID string, timestamp time.Time, sessionSecureID *string) int
-		Traces                           func(childComplexity int, projectID int, params model.QueryInput, after *string, before *string, at *string, direction model.SortDirection, limit *int) int
+		Traces                           func(childComplexity int, projectID int, params model.QueryInput, after *string, before *string, at *string, direction model.SortDirection, limit *int, omitBody *bool) int
 		TracesIntegration                func(childComplexity int, projectID int) int
 		TracesKeyValues                  func(childComplexity int, projectID int, keyName string, dateRange model.DateRangeRequiredInput, query *string, count *int) int
 		TracesKeys                       func(childComplexity int, projectID int, dateRange model.DateRangeRequiredInput, query *string, typeArg *model.KeyType) int
@@ -2088,7 +2088,7 @@ type QueryResolver interface {
 	ErrorTags(ctx context.Context) ([]*model1.ErrorTag, error)
 	MatchErrorTag(ctx context.Context, query string) ([]*model.MatchedErrorTag, error)
 	Trace(ctx context.Context, projectID int, traceID string, timestamp time.Time, sessionSecureID *string) (*model.TracePayload, error)
-	Traces(ctx context.Context, projectID int, params model.QueryInput, after *string, before *string, at *string, direction model.SortDirection, limit *int) (*model.TraceConnection, error)
+	Traces(ctx context.Context, projectID int, params model.QueryInput, after *string, before *string, at *string, direction model.SortDirection, limit *int, omitBody *bool) (*model.TraceConnection, error)
 	TracesMetrics(ctx context.Context, projectID int, params model.QueryInput, sql *string, column *string, metricTypes []model.MetricAggregator, groupBy []string, bucketBy *string, bucketCount *int, bucketWindow *int, limit *int, limitAggregator *model.MetricAggregator, limitColumn *string, expressions []*model.MetricExpressionInput) (*model.MetricsBuckets, error)
 	TracesKeys(ctx context.Context, projectID int, dateRange model.DateRangeRequiredInput, query *string, typeArg *model.KeyType) ([]*model.QueryKey, error)
 	TracesKeyValues(ctx context.Context, projectID int, keyName string, dateRange model.DateRangeRequiredInput, query *string, count *int) ([]string, error)
@@ -9067,7 +9067,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Traces(childComplexity, args["project_id"].(int), args["params"].(model.QueryInput), args["after"].(*string), args["before"].(*string), args["at"].(*string), args["direction"].(model.SortDirection), args["limit"].(*int)), true
+		return e.complexity.Query.Traces(childComplexity, args["project_id"].(int), args["params"].(model.QueryInput), args["after"].(*string), args["before"].(*string), args["at"].(*string), args["direction"].(model.SortDirection), args["limit"].(*int), args["omitBody"].(*bool)), true
 
 	case "Query.tracesIntegration":
 		if e.complexity.Query.TracesIntegration == nil {
@@ -14707,6 +14707,7 @@ type Query {
 		at: String
 		direction: SortDirection!
 		limit: Int
+		omitBody: Boolean
 	): TraceConnection!
 	# deprecated - use ` + "`" + `metrics` + "`" + ` instead
 	traces_metrics(
@@ -23141,6 +23142,15 @@ func (ec *executionContext) field_Query_traces_args(ctx context.Context, rawArgs
 		}
 	}
 	args["limit"] = arg6
+	var arg7 *bool
+	if tmp, ok := rawArgs["omitBody"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("omitBody"))
+		arg7, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["omitBody"] = arg7
 	return args, nil
 }
 
@@ -66684,7 +66694,7 @@ func (ec *executionContext) _Query_traces(ctx context.Context, field graphql.Col
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Traces(rctx, fc.Args["project_id"].(int), fc.Args["params"].(model.QueryInput), fc.Args["after"].(*string), fc.Args["before"].(*string), fc.Args["at"].(*string), fc.Args["direction"].(model.SortDirection), fc.Args["limit"].(*int))
+		return ec.resolvers.Query().Traces(rctx, fc.Args["project_id"].(int), fc.Args["params"].(model.QueryInput), fc.Args["after"].(*string), fc.Args["before"].(*string), fc.Args["at"].(*string), fc.Args["direction"].(model.SortDirection), fc.Args["limit"].(*int), fc.Args["omitBody"].(*bool))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -2558,6 +2558,7 @@ type Query {
 		at: String
 		direction: SortDirection!
 		limit: Int
+		omitBody: Boolean
 	): TraceConnection!
 	# deprecated - use `metrics` instead
 	traces_metrics(

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -9389,7 +9389,7 @@ func (r *queryResolver) Trace(ctx context.Context, projectID int, traceID string
 }
 
 // Traces is the resolver for the traces field.
-func (r *queryResolver) Traces(ctx context.Context, projectID int, params modelInputs.QueryInput, after *string, before *string, at *string, direction modelInputs.SortDirection, limit *int) (*modelInputs.TraceConnection, error) {
+func (r *queryResolver) Traces(ctx context.Context, projectID int, params modelInputs.QueryInput, after *string, before *string, at *string, direction modelInputs.SortDirection, limit *int, omitBody *bool) (*modelInputs.TraceConnection, error) {
 	project, err := r.isUserInProjectOrDemoProject(ctx, projectID)
 	if err != nil {
 		return nil, err
@@ -9401,7 +9401,7 @@ func (r *queryResolver) Traces(ctx context.Context, projectID int, params modelI
 		At:        at,
 		Direction: direction,
 		Limit:     limit,
-	})
+	}, omitBody)
 }
 
 // TracesMetrics is the resolver for the traces_metrics field.

--- a/frontend/src/components/RelatedResources/RelatedResourceList.tsx
+++ b/frontend/src/components/RelatedResources/RelatedResourceList.tsx
@@ -107,6 +107,7 @@ export const RelatedResourceList: React.FC<{
 		sortColumn,
 		sortDirection,
 		skip: resource.type !== 'traces',
+		omitBody: true,
 	})
 
 	const {

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -14364,6 +14364,7 @@ export const GetTracesDocument = gql`
 		$at: String
 		$direction: SortDirection!
 		$limit: Int
+		$omitBody: Boolean
 	) {
 		traces(
 			project_id: $project_id
@@ -14373,6 +14374,7 @@ export const GetTracesDocument = gql`
 			at: $at
 			direction: $direction
 			limit: $limit
+			omitBody: $omitBody
 		) {
 			edges {
 				cursor
@@ -14431,6 +14433,7 @@ export const GetTracesDocument = gql`
  *      at: // value for 'at'
  *      direction: // value for 'direction'
  *      limit: // value for 'limit'
+ *      omitBody: // value for 'omitBody'
  *   },
  * });
  */

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4977,6 +4977,7 @@ export type GetTracesQueryVariables = Types.Exact<{
 	at?: Types.Maybe<Types.Scalars['String']>
 	direction: Types.SortDirection
 	limit?: Types.Maybe<Types.Scalars['Int']>
+	omitBody?: Types.Maybe<Types.Scalars['Boolean']>
 }>
 
 export type GetTracesQuery = { __typename?: 'Query' } & {

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -3035,6 +3035,7 @@ export type QueryTracesArgs = {
 	before?: InputMaybe<Scalars['String']>
 	direction: SortDirection
 	limit?: InputMaybe<Scalars['Int']>
+	omitBody?: InputMaybe<Scalars['Boolean']>
 	params: QueryInput
 	project_id: Scalars['ID']
 }

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2423,6 +2423,7 @@ query GetTraces(
 	$at: String
 	$direction: SortDirection!
 	$limit: Int
+	$omitBody: Boolean
 ) {
 	traces(
 		project_id: $project_id
@@ -2432,6 +2433,7 @@ query GetTraces(
 		at: $at
 		direction: $direction
 		limit: $limit
+		omitBody: $omitBody
 	) {
 		edges {
 			cursor

--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -192,6 +192,7 @@ export const useResources = (
 		skip: !session?.secure_id,
 		skipPolling: true,
 		limit: 1_000,
+		omitBody: true,
 	})
 
 	const [resources, setResources] = useState<NetworkResourceWithID[]>([])

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/TracesPage/TracesPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/TracesPage/TracesPage.tsx
@@ -45,6 +45,7 @@ export const TracesPage = ({
 		sortColumn: 'timestamp',
 		sortDirection: SortDirection.Asc,
 		limit: 1_000,
+		omitBody: true,
 	})
 
 	const fetchMoreWhenScrolled = useCallback(

--- a/frontend/src/pages/Traces/TracesPage.tsx
+++ b/frontend/src/pages/Traces/TracesPage.tsx
@@ -118,6 +118,7 @@ export const TracesPage: React.FC = () => {
 		skipPolling,
 		sortColumn: sortColumn || undefined,
 		sortDirection: sortDirection as SortDirection,
+		omitBody: true,
 	})
 
 	const [

--- a/frontend/src/pages/Traces/useGetTraces.ts
+++ b/frontend/src/pages/Traces/useGetTraces.ts
@@ -22,6 +22,7 @@ export const useGetTraces = ({
 	sortDirection = Types.SortDirection.Desc,
 	skip,
 	limit,
+	omitBody,
 }: {
 	query: string
 	projectId: string | undefined
@@ -33,6 +34,7 @@ export const useGetTraces = ({
 	sortDirection?: Types.SortDirection
 	skip?: boolean
 	limit?: number
+	omitBody?: boolean
 }) => {
 	const [loadingAfter, setLoadingAfter] = useState(false)
 
@@ -53,6 +55,7 @@ export const useGetTraces = ({
 					direction: sortDirection,
 				},
 			},
+			omitBody,
 		},
 		fetchPolicy: 'cache-and-network',
 		skip,
@@ -105,6 +108,7 @@ export const useGetTraces = ({
 				project_id: projectId!,
 				at: traceCursor,
 				direction: sortDirection,
+				omitBody,
 				params: {
 					query,
 					date_range: {
@@ -126,6 +130,7 @@ export const useGetTraces = ({
 				traceResultMetadata.endDate,
 				sortColumn,
 				sortDirection,
+				omitBody,
 			],
 		),
 		moreDataQuery,
@@ -141,7 +146,7 @@ export const useGetTraces = ({
 		debounce(
 			async (cursor: string) => {
 				await fetchMore({
-					variables: { after: cursor },
+					variables: { after: cursor, omitBody },
 					updateQuery: (prevResult, { fetchMoreResult }) => {
 						return {
 							traces: {
@@ -167,7 +172,7 @@ export const useGetTraces = ({
 			300,
 			{ leading: true, trailing: false },
 		),
-		[fetchMore],
+		[fetchMore, omitBody],
 	)
 
 	const fetchMoreForward = useCallback(async () => {


### PR DESCRIPTION
## Summary

https://launchdarkly.atlassian.net/browse/O11Y-389

This is a performance improvement. Most places that traces are fetched, the response / request body is not used, though it often is very large. This leads to the client fetching a lot more data than is actually needed.

## How did you test this change?

Tested with local front-end. No changes should be apparent to user other than increased performance. Additionally, added some new go tests to test the new parameter.

## Are there any deployment considerations?

Backend change needs to be deployed before frontend change can be deployed

## Does this work require review from our design team?

No
