### PR TITLE
Remove antd components from workspace/project settings

### DIFF
--- a/.changeset/brave-apples-shine.md
+++ b/.changeset/brave-apples-shine.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+refactor: replace antd components with @highlight-run/ui in workspace/project settings

--- a/frontend/src/pages/ErrorsV2/GitHubEnhancementSettings/GitHubEnhancementSettingsForm.tsx
+++ b/frontend/src/pages/ErrorsV2/GitHubEnhancementSettings/GitHubEnhancementSettingsForm.tsx
@@ -9,12 +9,12 @@ import {
 	IconSolidQuestionMarkCircle,
 	IconSolidTrash,
 	IconSolidXCircle,
+	Select,
 	Stack,
 	Text,
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import React, { useEffect, useMemo, useState } from 'react'
 
 import LoadingBox from '@/components/LoadingBox'
@@ -64,8 +64,7 @@ export const GitHubEnhancementSettingsForm: React.FC<
 	const githubOptions = useMemo(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
-				id: repo.key,
-				label: repo.name.split('/').pop(),
+				name: repo.name.split('/').pop() || repo.name,
 				value: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
@@ -219,9 +218,9 @@ export const GitHubEnhancementSettingsForm: React.FC<
 						<Box display="flex" alignItems="center" gap="8">
 							<Select
 								aria-label="GitHub repository"
-								className={styles.repoSelect}
+								filterable
 								placeholder="Search repos..."
-								onSelect={(repo: string) =>
+								onValueChange={(repo: string) =>
 									formStore.setValue(
 										formStore.names.githubRepo,
 										repo,
@@ -232,10 +231,6 @@ export const GitHubEnhancementSettingsForm: React.FC<
 									.pop()}
 								options={githubOptions}
 								disabled={disabled || testLoading}
-								notFoundContent={<span>No repos found</span>}
-								optionFilterProp="label"
-								filterOption
-								showSearch
 							/>
 							<ButtonIcon
 								kind="secondary"

--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -10,12 +10,12 @@ import {
 	IconSolidQuestionMarkCircle,
 	IconSolidTrash,
 	IconSolidX,
+	Select,
 	Text,
 	TextLink,
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -120,8 +120,7 @@ const GithubSettingsForm = ({
 	const githubOptions = useMemo(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
-				id: repo.key,
-				label: repo.name.split('/').pop(),
+				name: repo.name.split('/').pop() || repo.name,
 				value: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
@@ -153,9 +152,9 @@ const GithubSettingsForm = ({
 					<Box display="flex" alignItems="center" gap="8">
 						<Select
 							aria-label="GitHub repository"
-							className={styles.repoSelect}
+							filterable
 							placeholder="Search repos..."
-							onSelect={(repo: string) =>
+							onValueChange={(repo: string) =>
 								formStore.setValue(
 									formStore.names.githubRepo,
 									repo,
@@ -165,10 +164,6 @@ const GithubSettingsForm = ({
 								?.split('/')
 								.pop()}
 							options={githubOptions}
-							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
-							filterOption
-							showSearch
 						/>
 						<ButtonIcon
 							kind="secondary"

--- a/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.module.css
+++ b/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.module.css
@@ -13,3 +13,40 @@
 	display: flex;
 	height: 100%;
 }
+
+.input {
+	background: var(--color-white);
+	border: 1px solid var(--color-divider-weak);
+	border-radius: 6px;
+	color: var(--text-primary);
+	font-size: 13px;
+	height: 28px;
+	outline: none;
+	padding: 0 8px;
+	width: 100%;
+}
+
+.input:focus {
+	border-color: var(--color-purple-500);
+}
+
+.input:disabled {
+	cursor: not-allowed;
+	opacity: 0.6;
+}
+
+@keyframes spin {
+	from {
+		transform: rotate(0deg);
+	}
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+.loadingIcon {
+	animation: spin 1s linear infinite;
+	color: var(--text-primary-inverted);
+	height: 18px;
+	width: 18px;
+}

--- a/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx
+++ b/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx
@@ -1,5 +1,8 @@
-import Input from '@components/Input/Input'
-import { Tooltip } from '@highlight-run/ui/components'
+import { Button } from '@components/Button'
+import {
+	IconSolidLoading,
+	Tooltip,
+} from '@highlight-run/ui/components'
 import { toast } from '@components/Toaster'
 import { useEditProjectMutation, useEditWorkspaceMutation } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
@@ -7,8 +10,6 @@ import { useParams } from '@util/react-router/useParams'
 import React, { useState } from 'react'
 
 import commonStyles from '../../../Common.module.css'
-import Button from '../../../components/Button/Button/Button'
-import { CircularSpinner } from '../../../components/Loading/Loading'
 import styles from './FieldsForm.module.css'
 
 type Props = {
@@ -65,17 +66,20 @@ export const FieldsForm: React.FC<Props> = ({
 		}
 	}
 
+	const loading = editProjectLoading || editWorkspaceLoading
+
 	return (
 		<form onSubmit={onSubmit} key={project_id}>
 			<div className={styles.fieldRow}>
 				<label className={styles.fieldKey}>Name</label>
-				<Input
+				<input
 					name="name"
 					value={name}
 					onChange={(e) => {
 						setName(e.target.value)
 					}}
 					disabled={formDisabled}
+					className={styles.input}
 				/>
 			</div>
 			{isWorkspace ? null : (
@@ -83,7 +87,7 @@ export const FieldsForm: React.FC<Props> = ({
 					{' '}
 					<div className={styles.fieldRow}>
 						<label className={styles.fieldKey}>Billing Email</label>
-						<Input
+						<input
 							placeholder="Billing Email"
 							type="email"
 							name="email"
@@ -92,6 +96,7 @@ export const FieldsForm: React.FC<Props> = ({
 								setEmail(e.target.value)
 							}}
 							disabled={formDisabled}
+							className={styles.input}
 						/>
 					</div>
 				</>
@@ -104,17 +109,14 @@ export const FieldsForm: React.FC<Props> = ({
 							trackingId={`${
 								isWorkspace ? 'Workspace' : 'Project'
 							}Update`}
-							htmlType="submit"
-							type="primary"
+							type="submit"
+							kind="primary"
 							className={commonStyles.submitButton}
 							disabled={formDisabled}
 						>
-							{editProjectLoading || editWorkspaceLoading ? (
-								<CircularSpinner
-									style={{
-										fontSize: 18,
-										color: 'var(--text-primary-inverted)',
-									}}
+							{loading ? (
+								<IconSolidLoading
+									className={styles.loadingIcon}
 								/>
 							) : (
 								'Save changes'

--- a/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
@@ -1,7 +1,6 @@
-import Alert from '@components/Alert/Alert'
 import { FieldsBox } from '@components/FieldsBox/FieldsBox'
 import { AdminRole } from '@graph/schemas'
-import { Box } from '@highlight-run/ui/components'
+import { Box, Callout } from '@highlight-run/ui/components'
 import { AutoJoinForm } from '@pages/WorkspaceTeam/components/AutoJoinForm'
 import { Authorization } from '@util/authorization/authorization'
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
@@ -43,12 +42,14 @@ const WorkspaceSettings = () => {
 						<Authorization
 							allowedRoles={[AdminRole.Admin]}
 							forbiddenFallback={
-								<Alert
-									trackingId="AdminNoAccessToAutoJoinDomains"
-									type="info"
-									message="You don't have access to auto-access domains."
-									description={`You don't have permission to configure auto-access domains. Please contact a workspace admin to make changes.`}
-								/>
+								<Callout
+									kind="info"
+									title="You don't have access to auto-access domains."
+								>
+									You don't have permission to configure
+									auto-access domains. Please contact a
+									workspace admin to make changes.
+								</Callout>
 							}
 						>
 							<AutoJoinForm />

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.module.css
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.module.css
@@ -8,10 +8,9 @@
 	min-height: var(--size-xxLarge);
 }
 
-.select {
-	width: 100%;
-
-	&:global(.ant-select-disabled .ant-select-selector) {
-		background-color: var(--color-primary-background) !important;
-	}
+.checkbox {
+	accent-color: var(--color-purple-500);
+	cursor: pointer;
+	height: 16px;
+	width: 16px;
 }

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -1,14 +1,12 @@
 import { useAuthContext } from '@authentication/AuthContext'
 import { toast } from '@components/Toaster'
-import Tooltip from '@components/Tooltip/Tooltip'
 import {
 	useGetWorkspaceAdminsQuery,
 	useUpdateAllowedEmailOriginsMutation,
 } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
-import { Box, Select, Text } from '@highlight-run/ui/components'
+import { Box, Select, Text, Tooltip } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React, { useState } from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -61,8 +59,8 @@ export const AutoJoinForm: React.FC = () => {
 		}
 	}
 
-	const handleCheckboxChange = (event: CheckboxChangeEvent) => {
-		const checked = event.target.checked
+	const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const checked = e.target.checked
 		if (checked) {
 			onChangeMsg([adminsEmailDomain], 'Successfully enabled auto-join!')
 		} else {
@@ -79,29 +77,31 @@ export const AutoJoinForm: React.FC = () => {
 
 	return (
 		<Tooltip
-			title="Automatically share the workspace with all users on this domain."
-			align={{ offset: [0, 6] }}
-			mouseEnterDelay={0}
-		>
-			<div className={styles.container}>
-				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
-						checked={autoJoinDomains.length > 0}
-						onChange={handleCheckboxChange}
+			trigger={
+				<div className={styles.container}>
+					<Box display="flex" alignItems="center" gap="8" p="0" m="0">
+						<input
+							type="checkbox"
+							checked={autoJoinDomains.length > 0}
+							onChange={handleCheckboxChange}
+							className={styles.checkbox}
+						/>
+						<Text>Auto-approved email domains</Text>
+					</Box>
+					<Select
+						creatable
+						filterable
+						displayMode="tags"
+						loading={loading}
+						placeholder={`${adminsEmailDomain}, acme.corp, piedpiper.com`}
+						value={autoJoinDomains}
+						onValueChange={handleSelectChange}
+						options={adminDomains}
 					/>
-					<Text>Auto-approved email domains</Text>
-				</Box>
-				<Select
-					creatable
-					filterable
-					displayMode="tags"
-					loading={loading}
-					placeholder={`${adminsEmailDomain}, acme.corp, piedpiper.com`}
-					value={autoJoinDomains}
-					onValueChange={handleSelectChange}
-					options={adminDomains}
-				/>
-			</div>
+				</div>
+			}
+		>
+			Automatically share the workspace with all users on this domain.
 		</Tooltip>
 	)
 }


### PR DESCRIPTION
## Summary

Resolves #8635 — removes all `antd` and `@ant-design` dependencies from workspace and project settings pages, replacing them with `@highlight-run/ui` components and native HTML elements.

### Changes by file:

| File | antd Component Removed | Replacement |
|------|----------------------|-------------|
| `WorkspaceSettings.tsx` | `Alert` (via `@components/Alert`) | `Callout` from `@highlight-run/ui` |
| `FieldsForm.tsx` | `Input`, `Button`, `CircularSpinner` | Native `<input>`, UI `Button`, `IconSolidLoading` |
| `AutoJoinForm.tsx` | `Checkbox` from `antd/es/checkbox`, `Tooltip` wrapper | Native `<input type="checkbox">`, UI `Tooltip` |
| `GitHubSettingsModal.tsx` | `Select` from `antd` | `Select` from `@highlight-run/ui` |
| `GitHubEnhancementSettingsForm.tsx` | `Select` from `antd` | `Select` from `@highlight-run/ui` |

Also cleaned up antd-specific CSS selectors from `AutoJoinForm.module.css`.

### Why this PR vs existing ones:
- **Complete coverage**: All 5 files with antd references are updated (PR #10304 only covers 2, PR #10313 covers 1, PR #10306 covers 2)
- **Zero antd imports remaining** in these settings pages
- **Follows existing patterns**: Uses the same UI components already used elsewhere in the codebase

/claim #8635

## Test plan

- [ ] Verify WorkspaceSettings page renders with Callout instead of Alert
- [ ] Verify FieldsForm inputs work (name field, billing email, save button with loading state)
- [ ] Verify AutoJoinForm checkbox toggles auto-join and Tooltip shows on hover
- [ ] Verify GitHub repo Select works with search/filter in both GitHubSettingsModal and GitHubEnhancementSettingsForm
- [ ] Confirm no `antd` or `@ant-design` imports remain in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)