### PR TITLE
refactor: replace antd Select with ComboboxSelect in GitHubSettingsModal

### DIFF
--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -5,6 +5,7 @@ import ModalBody from '@components/ModalBody/ModalBody'
 import {
 	Box,
 	ButtonIcon,
+	ComboboxSelect,
 	Form,
 	IconSolidInformationCircle,
 	IconSolidQuestionMarkCircle,
@@ -15,7 +16,6 @@ import {
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -120,12 +120,11 @@ const GithubSettingsForm = ({
 	const githubOptions = useMemo(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
-				id: repo.key,
-				label: repo.name.split('/').pop(),
-				value: repo.repo_id.replace(
+				key: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
 				),
+				render: repo.name.split('/').pop(),
 			})),
 		[githubRepos],
 	)
@@ -151,24 +150,23 @@ const GithubSettingsForm = ({
 					name="githubRepo"
 				>
 					<Box display="flex" alignItems="center" gap="8">
-						<Select
-							aria-label="GitHub repository"
-							className={styles.repoSelect}
-							placeholder="Search repos..."
-							onSelect={(repo: string) =>
+						<ComboboxSelect
+							label="GitHub repository"
+							queryPlaceholder="Search repos..."
+							value={formState.values.githubRepo ?? undefined}
+							options={githubOptions}
+							onChange={(repo: string) =>
 								formStore.setValue(
 									formStore.names.githubRepo,
 									repo,
 								)
 							}
-							value={formState.values.githubRepo
-								?.split('/')
-								.pop()}
-							options={githubOptions}
-							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
-							filterOption
-							showSearch
+							emptyStateRender={
+								<Text size="xSmall" color="n9">
+									No repos found
+								</Text>
+							}
+							wrapperCssClass={styles.repoSelect}
 						/>
 						<ButtonIcon
 							kind="secondary"


### PR DESCRIPTION
## Summary

Part of #8635 — removes the last `antd` dependency from project settings pages.

### Changes
- Replace `antd` `Select` with `@highlight-run/ui` `ComboboxSelect` in `GitHubSettingsModal.tsx`
- Maintains search/filter functionality via ComboboxSelect built-in search
- Uses existing highlight-run/ui components consistently
- Single file, minimal change (1 file, -17/+15 lines)

## How did you test this change?

Verified the component API mapping:
- `showSearch` + `filterOption` → ComboboxSelect has built-in search
- `onSelect` → `onChange`
- `notFoundContent` → `emptyStateRender`
- `options` format updated from `{id, label, value}` to `{key, render}`

## Are there any deployment considerations?

No. Frontend-only, single component swap.

/claim #8635