### PR TITLE
refactor: replace antd Divider and TooltipPlacement with native components

### DIFF
--- a/.changeset/remove-antd-components.md
+++ b/.changeset/remove-antd-components.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/frontend': patch
+---
+
+Replace antd Divider, Progress, Checkbox, and TooltipPlacement with native components

--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -13,7 +13,6 @@ import {
 	Tag,
 	Text,
 } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
 import React, { PropsWithChildren, useEffect, useMemo, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { useNavigate, useSearchParams } from 'react-router-dom'
@@ -640,7 +639,7 @@ export const AlertForm: React.FC = () => {
 										/>
 									</LabeledRow>
 								</SidebarSection>
-								<Divider className="m-0" />
+								<Box borderTop="dividerWeak" />
 								<SidebarSection>
 									<Box cssClass={style.editorSection}>
 										<Box cssClass={style.editorHeader}>
@@ -718,7 +717,7 @@ export const AlertForm: React.FC = () => {
 															</Callout>
 														)}
 												</SidebarSection>
-												<Divider className="m-0" />
+												<Box borderTop="dividerWeak" />
 												<SidebarSection>
 													{productType ===
 													ProductType.Events ? (
@@ -775,7 +774,7 @@ export const AlertForm: React.FC = () => {
 														!isErrorAlert)) && (
 													<>
 														<Box px="12">
-															<Divider className="m-0" />
+															<Box borderTop="dividerWeak" />
 														</Box>
 														<SidebarSection>
 															<LabeledRow
@@ -850,7 +849,7 @@ export const AlertForm: React.FC = () => {
 										)}
 									</Box>
 								</SidebarSection>
-								<Divider className="m-0" />
+								<Box borderTop="dividerWeak" />
 								<SidebarSection>
 									<LabeledRow
 										label="Alert threshold type"
@@ -970,7 +969,7 @@ export const AlertForm: React.FC = () => {
 										</>
 									)}
 								</SidebarSection>
-								<Divider className="m-0" />
+								<Box borderTop="dividerWeak" />
 								<SidebarSection>
 									<DestinationInput
 										initialDestinations={

--- a/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorDistributions.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorDistributions.tsx
@@ -8,7 +8,6 @@ import {
 } from '@graph/schemas'
 import { colors } from '@highlight-run/ui/colors'
 import { Badge, Box, Stack, Text } from '@highlight-run/ui/components'
-import { Progress } from 'antd'
 import React, { useEffect, useState } from 'react'
 
 type Props = {
@@ -151,14 +150,9 @@ const Buckets: React.FC<
 								</Text>
 							</Box>
 						</Box>
-						<Progress
-							percent={Math.floor(bucket.percent * 100)}
-							showInfo={false}
-							strokeColor={colors.n8}
-							trailColor={colors.n4}
-							strokeWidth={4}
-							status="normal"
-						/>
+						<Box style={{ width: '100%', height: 4, backgroundColor: colors.n4, borderRadius: 2 }}>
+							<Box style={{ width: `${Math.floor(bucket.percent * 100)}%`, height: '100%', backgroundColor: colors.n8, borderRadius: 2 }} />
+						</Box>
 					</Box>
 				)
 			})}

--- a/frontend/src/pages/ErrorsV2/GitHubEnhancementSettings/GitHubEnhancementSettingsForm.tsx
+++ b/frontend/src/pages/ErrorsV2/GitHubEnhancementSettings/GitHubEnhancementSettingsForm.tsx
@@ -12,9 +12,9 @@ import {
 	Stack,
 	Text,
 	Tooltip,
+	ComboboxSelect,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import React, { useEffect, useMemo, useState } from 'react'
 
 import LoadingBox from '@/components/LoadingBox'
@@ -64,8 +64,7 @@ export const GitHubEnhancementSettingsForm: React.FC<
 	const githubOptions = useMemo(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
-				id: repo.key,
-				label: repo.name.split('/').pop(),
+				name: repo.name.split('/').pop() ?? '',
 				value: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
@@ -217,25 +216,27 @@ export const GitHubEnhancementSettingsForm: React.FC<
 						name="githubRepo"
 					>
 						<Box display="flex" alignItems="center" gap="8">
-							<Select
-								aria-label="GitHub repository"
-								className={styles.repoSelect}
-								placeholder="Search repos..."
-								onSelect={(repo: string) =>
-									formStore.setValue(
-										formStore.names.githubRepo,
-										repo,
-									)
-								}
+							<ComboboxSelect
+								label="GitHub repository"
 								value={formState.values.githubRepo
 									?.split('/')
-									.pop()}
+									.pop() ?? ''}
+								valueRender={
+									<Text>
+										{formState.values.githubRepo
+											?.split('/')
+											.pop() || 'Search repos...'}
+									</Text>
+								}
 								options={githubOptions}
+								onChange={(val: string) =>
+									formStore.setValue(
+										formStore.names.githubRepo,
+										val,
+									)
+								}
 								disabled={disabled || testLoading}
-								notFoundContent={<span>No repos found</span>}
-								optionFilterProp="label"
-								filterOption
-								showSearch
+								cssClass={styles.repoSelect}
 							/>
 							<ButtonIcon
 								kind="secondary"

--- a/frontend/src/pages/Graphing/EventSelection/EventSteps.tsx
+++ b/frontend/src/pages/Graphing/EventSelection/EventSteps.tsx
@@ -18,7 +18,6 @@ import {
 	Text,
 } from '@highlight-run/ui/components'
 import { LabeledRow } from '@pages/Graphing/LabeledRow'
-import { Divider } from 'antd'
 import { EventSelection } from '@pages/Graphing/EventSelection/index'
 import {
 	EventSelectionDetails,
@@ -180,7 +179,7 @@ const AddEventStep: React.FC<AddEventStepProps> = ({
 					}}
 				/>
 			</LabeledRow>
-			<Divider className="m-0" />
+			<Box borderTop="dividerWeak" />
 			<EventSelection
 				initialQuery={query}
 				setQuery={setQuery}

--- a/frontend/src/pages/Graphing/GraphingEditor/FormPanel/VisualizationSection.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor/FormPanel/VisualizationSection.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
-import { Input, Select, Text } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
+import { Box, Input, Select, Text } from '@highlight-run/ui/components'
 
 import { useProjectId } from '@/hooks/useProjectId'
 import { useGraphingEditorContext } from '@/pages/Graphing/GraphingEditor/GraphingEditorContext'
@@ -102,7 +101,7 @@ export const VisualizationSection: React.FC<Props> = ({ isPreview }) => {
 					disabled={isPreview}
 				/>
 			</LabeledRow>
-			<Divider className="m-0" />
+			<Box borderTop="dividerWeak" />
 			<Text weight="bold">Visualization</Text>
 			<LabeledRow label="View type" name="viewType">
 				<OptionDropdown

--- a/frontend/src/pages/Graphing/GraphingEditor/FormPanel/index.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor/FormPanel/index.tsx
@@ -1,5 +1,4 @@
 import { Box, Form, Stack } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
 import React, { useMemo } from 'react'
 
 import { OptionDropdown } from '@/pages/Graphing/OptionDropdown'
@@ -74,7 +73,7 @@ export const FormPanel: React.FC<Props> = ({
 			<Form>
 				<Stack gap="16">
 					<VisualizationSection isPreview={isPreview} />
-					<Divider className="m-0" />
+					<Box borderTop="dividerWeak" />
 					<SidebarSection isError={errors.length > 0}>
 						<Box>
 							<Box cssClass={style.editorHeader}>

--- a/frontend/src/pages/NewProject/AutoJoinInput.tsx
+++ b/frontend/src/pages/NewProject/AutoJoinInput.tsx
@@ -1,8 +1,6 @@
 import { useAuthContext } from '@authentication/AuthContext'
 import Tooltip from '@components/Tooltip/Tooltip'
 import { Box, Text } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -23,7 +21,7 @@ export const AutoJoinInput: React.FC<Props> = ({
 	const { admin } = useAuthContext()
 	const adminsEmailDomain = getEmailDomain(admin?.email)
 
-	const handleMessageChecked = (event: CheckboxChangeEvent) => {
+	const handleMessageChecked = (event: React.ChangeEvent<HTMLInputElement>) => {
 		const domains = event.target.checked ? [adminsEmailDomain] : []
 		setAutoJoinDomains(domains)
 	}
@@ -43,18 +41,19 @@ export const AutoJoinInput: React.FC<Props> = ({
 		>
 			<div className={styles.container}>
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
+					<input
+						type="checkbox"
 						checked={autoJoinDomains.length > 0}
 						onChange={handleMessageChecked}
 					/>
 					<Text>Allowed email domains</Text>
 				</Box>
-				<Divider className="m-0 border-none pt-1" />
+				<Box pt="4" />
 				<Text color="n11">
 					Allow everyone with a <b>{getEmailDomain(admin?.email)}</b>{' '}
 					email to join your workspace.
 				</Text>
-				<Divider className="m-0 border-none pt-1" />
+				<Box pt="4" />
 			</div>
 		</Tooltip>
 	)

--- a/frontend/src/pages/NewProject/NewProjectPage.tsx
+++ b/frontend/src/pages/NewProject/NewProjectPage.tsx
@@ -12,7 +12,6 @@ import { namedOperations } from '@graph/operations'
 import { Box, Callout, Stack, Text } from '@highlight-run/ui/components'
 import analytics from '@util/analytics'
 import { client } from '@util/graph'
-import { Divider } from 'antd'
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
@@ -147,7 +146,7 @@ const NewProjectPage = ({ workspace_id }: { workspace_id: string }) => {
 								}}
 							/>
 						</Box>
-						<Divider className="m-0" />
+						<Box borderTop="dividerWeak" />
 						<Box
 							py="8"
 							px="12"

--- a/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineBar/TimelineBar.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineBar/TimelineBar.tsx
@@ -7,7 +7,6 @@ import { getAnnotationColor } from '@pages/Player/Toolbar/Toolbar'
 import { getTimelineEventDisplayName } from '@pages/Player/utils/utils'
 import { serializeErrorIdentifier } from '@util/error'
 import { clamp } from '@util/numbers'
-import { TooltipPlacement } from 'antd/es/tooltip'
 import clsx from 'clsx'
 import { useEffect, useLayoutEffect, useMemo, useState } from 'react'
 
@@ -124,7 +123,7 @@ const TimelineIndicatorsBar = ({
 		if (!viewportDiv || !viewportBbox) {
 			return {
 				rightOffset: 0,
-				placement: 'top' as TooltipPlacement,
+				placement: 'top' as const,
 			}
 		}
 		const { scrollWidth, scrollLeft } = viewportDiv
@@ -144,7 +143,7 @@ const TimelineIndicatorsBar = ({
 		// move by the 8th of the bar width
 		let offset = (scrollWidth * (width / 100)) / 8
 
-		let placement: TooltipPlacement = 'top'
+		let placement: string = 'top'
 		if (relPos === 2) {
 			placement = 'topRight'
 		} else if (relPos === 1) {

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -8,7 +8,6 @@ import {
 import { namedOperations } from '@graph/operations'
 import { Box, Select, Text } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React, { useState } from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -61,7 +60,7 @@ export const AutoJoinForm: React.FC = () => {
 		}
 	}
 
-	const handleCheckboxChange = (event: CheckboxChangeEvent) => {
+	const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 		const checked = event.target.checked
 		if (checked) {
 			onChangeMsg([adminsEmailDomain], 'Successfully enabled auto-join!')
@@ -85,7 +84,8 @@ export const AutoJoinForm: React.FC = () => {
 		>
 			<div className={styles.container}>
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
+					<input
+						type="checkbox"
 						checked={autoJoinDomains.length > 0}
 						onChange={handleCheckboxChange}
 					/>


### PR DESCRIPTION
## Summary

Removes `antd` imports from 10 files across workspace/project settings pages, replacing them with highlight native equivalents.

Part of #8635

## Changes

| File | antd removed | Replacement |
|---|---|---|
| AlertForm/index.tsx | `Divider` (5 usages) | `<Box borderTop="dividerWeak" />` |
| EventSteps.tsx | `Divider` | `<Box borderTop="dividerWeak" />` |
| FormPanel/index.tsx | `Divider` | `<Box borderTop="dividerWeak" />` |
| VisualizationSection.tsx | `Divider` | `<Box borderTop="dividerWeak" />` |
| NewProjectPage.tsx | `Divider` | `<Box borderTop="dividerWeak" />` |
| TimelineBar.tsx | `TooltipPlacement` type | native `string` type |
| ErrorDistributions.tsx | `Progress` | native `Box` progress bar |
| AutoJoinInput.tsx | `Checkbox`, `Divider` | native `<input type="checkbox" />`, `<Box pt="4" />` |
| AutoJoinForm.tsx | `Checkbox` | native `<input type="checkbox" />` |
| GitHubEnhancementSettingsForm.tsx | `Select` | `ComboboxSelect` from `@highlight-run/ui` |

Remaining antd components: `Table` in Accounts.tsx and `DatePicker` in ErrorStateSelect.tsx require more involved refactoring and will follow in a separate PR.