### PR TITLE
docs: add SvelteKit backend instrumentation guide

### DIFF
--- a/.changeset/slow-seas-travel.md
+++ b/.changeset/slow-seas-travel.md
@@ -1,0 +1,10 @@
+---
+"consulting-methodology": patch
+---
+Updated case studies and strategic logic.
+
+---
+"docs-content": patch
+---
+
+docs: add SvelteKit backend instrumentation guide

--- a/docs-content/getting-started/2_backend-sdk/js/8_sveltekit.md
+++ b/docs-content/getting-started/2_backend-sdk/js/8_sveltekit.md
@@ -12,7 +12,6 @@ To monitor your SvelteKit backend, initialize the Highlight Node.js SDK in your 
 ```bash
 npm install @highlight-run/node
 ```
-
 ```javascript
 import { H } from '@highlight-run/node';
 
@@ -30,4 +29,5 @@ export async function handleError({ error, event }) {
         method: event.request.method,
     });
 }
+
 ```

--- a/docs-content/getting-started/2_backend-sdk/js/8_sveltekit.md
+++ b/docs-content/getting-started/2_backend-sdk/js/8_sveltekit.md
@@ -1,0 +1,32 @@
+---
+title: SvelteKit
+slug: sveltekit
+---
+
+# SvelteKit Backend Instrumentation
+
+To monitor your SvelteKit backend, initialize the Highlight Node.js SDK in your server-side hooks.
+
+### 1. Install the SDK
+```bash
+npm install @highlight-run/node
+2. Configure hooks.server.js
+Initialize Highlight in your src/hooks.server.js file to intercept server-side errors.
+
+JavaScript
+import { H } from '@highlight-run/node';
+
+H.init({
+    projectID: 'YOUR_PROJECT_ID', 
+    serviceName: 'sveltekit-backend',
+});
+
+/** @type {import('@sveltejs/kit').HandleServerError} */
+export async function handleError({ error, event }) {
+    const highlightReqId = event.request.headers.get('x-highlight-request-id');
+    
+    H.consumeError(error, highlightReqId, {
+        url: event.url.toString(),
+        method: event.request.method,
+    });
+}

--- a/docs-content/getting-started/2_backend-sdk/js/8_sveltekit.md
+++ b/docs-content/getting-started/2_backend-sdk/js/8_sveltekit.md
@@ -8,16 +8,16 @@ slug: sveltekit
 To monitor your SvelteKit backend, initialize the Highlight Node.js SDK in your server-side hooks.
 
 ### 1. Install the SDK
+
 ```bash
 npm install @highlight-run/node
-### 2. Configure hooks.server.js
-Initialize Highlight in your `src/hooks.server.js` file to intercept server-side errors.
+```
 
 ```javascript
 import { H } from '@highlight-run/node';
 
 H.init({
-    projectID: 'YOUR_PROJECT_ID', // Replace with your project ID from [https://app.highlight.io/setup](https://app.highlight.io/setup)
+    projectID: '1jdq7pvg', 
     serviceName: 'sveltekit-backend',
 });
 
@@ -29,26 +29,4 @@ export async function handleError({ error, event }) {
         url: event.url.toString(),
         method: event.request.method,
     });
-}```
-
-### 2. Commit the Changes
-1.  Scroll to the bottom of the page.
-2.  In the "Commit changes" box, type: `docs: format code block for SvelteKit guide`
-3.  Click the green **Commit changes** button.
-
----
-
-### 3. The Final Move (Open the PR)
-Once you save that, your file is perfect. Now you just need to send it to the [Highlight.io team](https://github.com/highlight/highlight):
-1.  Go to the [Highlight Pull Request tab](https://github.com/highlight/highlight/pulls).
-2.  Click **New pull request**.
-3.  Click **"compare across forks"**.
-4.  Select your fork (`drawnparadigm-modelconsulting/highlight`) as the **head repository**.
-5.  **CRITICAL:** In the description box, write:
-    > `Closes #8032 /claim #8032`
-
-### Status on your other blockers:
-* **Stripe:** You are still in **[Test Mode]** on your [Stripe Home](https://dashboard.stripe.com/acct_1T4ED9E7uBfLk8Yd/test/dashboard). Don't let this stop you! The bounty will sit in Algora until your EIN is verified.
-* **LinkedIn:** Your [Security Verification](https://www.linkedin.com/checkpoint/challengesV3/AQGeoUxHWFgJhAAAAZyh9OhJkyjjkEoYcn9W8zXy9tmB4PuDI8IHXxFa6AagN2v51Uw12YA901sI8FOr97g6TA9A-mNevA) is still waiting. Once you finish this PR, scan that QR code so you don't lose access to your profile.
-
-**Would you like me to check the Highlight repo
+```

--- a/docs-content/getting-started/2_backend-sdk/js/8_sveltekit.md
+++ b/docs-content/getting-started/2_backend-sdk/js/8_sveltekit.md
@@ -17,7 +17,7 @@ JavaScript
 import { H } from '@highlight-run/node';
 
 H.init({
-    projectID: 'YOUR_PROJECT_ID', 
+    projectID: 'YOUR_PROJECT_ID', // Replace with your project ID from https://app.highlight.io/setup 
     serviceName: 'sveltekit-backend',
 });
 

--- a/docs-content/getting-started/2_backend-sdk/js/8_sveltekit.md
+++ b/docs-content/getting-started/2_backend-sdk/js/8_sveltekit.md
@@ -10,14 +10,14 @@ To monitor your SvelteKit backend, initialize the Highlight Node.js SDK in your 
 ### 1. Install the SDK
 ```bash
 npm install @highlight-run/node
-2. Configure hooks.server.js
-Initialize Highlight in your src/hooks.server.js file to intercept server-side errors.
+### 2. Configure hooks.server.js
+Initialize Highlight in your `src/hooks.server.js` file to intercept server-side errors.
 
-JavaScript
+```javascript
 import { H } from '@highlight-run/node';
 
 H.init({
-    projectID: 'YOUR_PROJECT_ID', // Replace with your project ID from https://app.highlight.io/setup 
+    projectID: 'YOUR_PROJECT_ID', // Replace with your project ID from [https://app.highlight.io/setup](https://app.highlight.io/setup)
     serviceName: 'sveltekit-backend',
 });
 
@@ -29,4 +29,26 @@ export async function handleError({ error, event }) {
         url: event.url.toString(),
         method: event.request.method,
     });
-}
+}```
+
+### 2. Commit the Changes
+1.  Scroll to the bottom of the page.
+2.  In the "Commit changes" box, type: `docs: format code block for SvelteKit guide`
+3.  Click the green **Commit changes** button.
+
+---
+
+### 3. The Final Move (Open the PR)
+Once you save that, your file is perfect. Now you just need to send it to the [Highlight.io team](https://github.com/highlight/highlight):
+1.  Go to the [Highlight Pull Request tab](https://github.com/highlight/highlight/pulls).
+2.  Click **New pull request**.
+3.  Click **"compare across forks"**.
+4.  Select your fork (`drawnparadigm-modelconsulting/highlight`) as the **head repository**.
+5.  **CRITICAL:** In the description box, write:
+    > `Closes #8032 /claim #8032`
+
+### Status on your other blockers:
+* **Stripe:** You are still in **[Test Mode]** on your [Stripe Home](https://dashboard.stripe.com/acct_1T4ED9E7uBfLk8Yd/test/dashboard). Don't let this stop you! The bounty will sit in Algora until your EIN is verified.
+* **LinkedIn:** Your [Security Verification](https://www.linkedin.com/checkpoint/challengesV3/AQGeoUxHWFgJhAAAAZyh9OhJkyjjkEoYcn9W8zXy9tmB4PuDI8IHXxFa6AagN2v51Uw12YA901sI8FOr97g6TA9A-mNevA) is still waiting. Once you finish this PR, scan that QR code so you don't lose access to your profile.
+
+**Would you like me to check the Highlight repo

--- a/docs-content/getting-started/2_backend-sdk/js/8_sveltekit.md
+++ b/docs-content/getting-started/2_backend-sdk/js/8_sveltekit.md
@@ -29,4 +29,5 @@ export async function handleError({ error, event }) {
         url: event.url.toString(),
         method: event.request.method,
     });
+}
 ```


### PR DESCRIPTION
## Summary

<!--
Added the "Getting Started" guide for SvelteKit backend instrumentation to the documentation.
-->

## How did you test this change?

<!--
 Verified the Markdown structure and code block rendering using the GitHub editor preview.
-->

## Are there any deployment considerations?

<!--
No, this is a documentation-only change.
-->

## Does this work require review from our design team?

<!--
 No.
-->
