### PR TITLE
fix: replace remaining antd Select components with ComboboxSelect

### DIFF
--- a/.changeset/fix-antd-select-migration.md
+++ b/.changeset/fix-antd-select-migration.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/frontend': patch
+---
+
+fix: replace remaining antd Select components with ComboboxSelect

--- a/frontend/src/pages/ErrorsV2/GitHubEnhancementSettings/GitHubEnhancementSettingsForm.tsx
+++ b/frontend/src/pages/ErrorsV2/GitHubEnhancementSettings/GitHubEnhancementSettingsForm.tsx
@@ -2,6 +2,7 @@ import { Button } from '@components/Button'
 import {
 	Box,
 	ButtonIcon,
+	ComboboxSelect,
 	Form,
 	IconSolidBeaker,
 	IconSolidInformationCircle,
@@ -14,7 +15,6 @@ import {
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import React, { useEffect, useMemo, useState } from 'react'
 
 import LoadingBox from '@/components/LoadingBox'
@@ -65,7 +65,7 @@ export const GitHubEnhancementSettingsForm: React.FC<
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
 				id: repo.key,
-				label: repo.name.split('/').pop(),
+				render: repo.name.split('/').pop(),
 				value: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
@@ -217,25 +217,20 @@ export const GitHubEnhancementSettingsForm: React.FC<
 						name="githubRepo"
 					>
 						<Box display="flex" alignItems="center" gap="8">
-							<Select
-								aria-label="GitHub repository"
-								className={styles.repoSelect}
-								placeholder="Search repos..."
-								onSelect={(repo: string) =>
+							<ComboboxSelect
+								label="GitHub repository"
+								queryPlaceholder="Search repos..."
+								value={formState.values.githubRepo || undefined}
+								onChange={(value: string) => {
 									formStore.setValue(
 										formStore.names.githubRepo,
-										repo,
+										value || null,
 									)
-								}
-								value={formState.values.githubRepo
-									?.split('/')
-									.pop()}
+								}}
 								options={githubOptions}
+								cssClass={styles.repoSelect}
 								disabled={disabled || testLoading}
-								notFoundContent={<span>No repos found</span>}
-								optionFilterProp="label"
-								filterOption
-								showSearch
+								emptyStateRender={<Text size="small">No repos found</Text>}
 							/>
 							<ButtonIcon
 								kind="secondary"
@@ -279,7 +274,7 @@ export const GitHubEnhancementSettingsForm: React.FC<
 							</Box>
 							<Text>
 								Report service & connect to GitHub before being
-								able to access the enhancement settings.
+								abled to access the enhancement settings.
 							</Text>
 						</Box>
 					)}

--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -5,6 +5,7 @@ import ModalBody from '@components/ModalBody/ModalBody'
 import {
 	Box,
 	ButtonIcon,
+	ComboboxSelect,
 	Form,
 	IconSolidInformationCircle,
 	IconSolidQuestionMarkCircle,
@@ -15,7 +16,6 @@ import {
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -121,7 +121,7 @@ const GithubSettingsForm = ({
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
 				id: repo.key,
-				label: repo.name.split('/').pop(),
+				render: repo.name.split('/').pop(),
 				value: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
@@ -151,24 +151,19 @@ const GithubSettingsForm = ({
 					name="githubRepo"
 				>
 					<Box display="flex" alignItems="center" gap="8">
-						<Select
-							aria-label="GitHub repository"
-							className={styles.repoSelect}
-							placeholder="Search repos..."
-							onSelect={(repo: string) =>
+						<ComboboxSelect
+							label="GitHub repository"
+							queryPlaceholder="Search repos..."
+							value={formState.values.githubRepo || undefined}
+							onChange={(value: string) => {
 								formStore.setValue(
 									formStore.names.githubRepo,
-									repo,
+									value || null,
 								)
-							}
-							value={formState.values.githubRepo
-								?.split('/')
-								.pop()}
+							}}
 							options={githubOptions}
-							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
-							filterOption
-							showSearch
+							cssClass={styles.repoSelect}
+							emptyStateRender={<Text size="small">No repos found</Text>}
 						/>
 						<ButtonIcon
 							kind="secondary"


### PR DESCRIPTION
## Summary

This PR removes remaining antd `Select` components from the project settings and error enhancement pages, replacing them with `@highlight-run/ui` `ComboboxSelect` to maintain consistent styling and reduce antd dependencies.

## Changes

- **GitHubSettingsModal.tsx**: Replaced antd `Select` with `ComboboxSelect` from @highlight-run/ui
- **GitHubEnhancementSettingsForm.tsx**: Replaced antd `Select` with `ComboboxSelect` from @highlight-run/ui

## Migration Details

The antd Select component was replaced with ComboboxSelect which provides:
- Consistent styling with the rest of the Highlight UI
- Better accessibility support
- Search/filter functionality
- Same core functionality (selecting from a list of GitHub repositories)

## Testing

- Verified imports are correct
- Component props migrated appropriately:
  - `placeholder` → `queryPlaceholder`
  - `onSelect` → `onChange`
  - `options` (with label/value) → `options` (with id/render/value)
  - `notFoundContent` → `emptyStateRender`

/claim #8635

Fixes highlight/highlight#8635