### PR TITLE
feat: update integrations page design to sidebar + detail panel layout

### DIFF
--- a/.changeset/integrations-page-redesign.md
+++ b/.changeset/integrations-page-redesign.md
@@ -1,0 +1,10 @@
+---
+"@highlight-run/frontend": patch
+---
+
+feat: update integrations page design to sidebar + detail panel layout
+
+- Implements new sidebar layout with "Enabled" and "Available" sections
+- Adds integration detail panel with status and configuration
+- Updates routing to support /integrations/:integration_type for deep linking
+- Uses Vanilla Extract CSS matching SettingsRouter pattern

--- a/frontend/src/__generated/ve/pages/IntegrationsPage/IntegrationsPage.css.js
+++ b/frontend/src/__generated/ve/pages/IntegrationsPage/IntegrationsPage.css.js
@@ -1,0 +1,15 @@
+// src/pages/IntegrationsPage/IntegrationsPage.css.ts
+var integrationIcon = "n1yl345";
+var integrationIconLarge = "n1yl346";
+var menuItem = "n1yl341";
+var menuItemActive = "n1yl342";
+var menuTitle = "n1yl340";
+var sidebarScroll = "n1yl344 mt0ih28s mt0ih28p _14ud0dc1";
+export {
+  integrationIcon,
+  integrationIconLarge,
+  menuItem,
+  menuItemActive,
+  menuTitle,
+  sidebarScroll
+};

--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.css.ts
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.css.ts
@@ -1,0 +1,63 @@
+import { sprinkles } from '@highlight-run/ui/sprinkles'
+import { themeVars } from '@highlight-run/ui/theme'
+import { vars } from '@highlight-run/ui/vars'
+import { style } from '@vanilla-extract/css'
+
+import { styledVerticalScrollbar } from '@/style/common.css'
+
+export const menuTitle = style({
+	height: 12,
+})
+
+export const menuItem = style({
+	alignItems: 'center',
+	borderRadius: 4,
+	color: themeVars.interactive.fill.secondary.content.text,
+	cursor: 'pointer',
+	display: 'flex',
+	gap: 8,
+	height: 28,
+	padding: '8px 8px',
+	textDecoration: 'none',
+	width: 250,
+	selectors: {
+		'&:hover': {
+			backgroundColor: themeVars.interactive.overlay.secondary.hover,
+			color: themeVars.interactive.fill.secondary.content.onEnabled,
+		},
+	},
+})
+
+export const menuItemActive = style({
+	backgroundColor: themeVars.interactive.overlay.secondary.pressed,
+	color: themeVars.interactive.fill.secondary.content.onEnabled,
+})
+
+export const sidebarScroll = style([
+	sprinkles({
+		overflowY: 'auto',
+		overflowX: 'hidden',
+	}),
+	styledVerticalScrollbar,
+	{
+		selectors: {
+			'& + &': {
+				borderTop: vars.border.secondary,
+			},
+		},
+	},
+])
+
+export const integrationIcon = style({
+	borderRadius: '50%',
+	height: 16,
+	width: 16,
+	flexShrink: 0,
+})
+
+export const integrationIconLarge = style({
+	borderRadius: '50%',
+	height: 24,
+	width: 24,
+	flexShrink: 0,
+})

--- a/frontend/src/pages/IntegrationsPage/components/IntegrationDetail.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/IntegrationDetail.tsx
@@ -1,0 +1,174 @@
+import {
+	Box,
+	Button,
+	IconSolidExternalLink,
+	Stack,
+	Text,
+	TextLink,
+} from '@highlight-run/ui/components'
+import { Integration } from '@pages/IntegrationsPage/Integrations'
+import clsx from 'clsx'
+import { useState } from 'react'
+
+import BorderBox from '@/components/BorderBox/BorderBox'
+import { IntegrationAction } from '@/pages/IntegrationsPage/components/Integration'
+import { IntegrationModal } from '@/pages/IntegrationsPage/components/IntegrationModal/IntegrationModal'
+
+import * as styles from '../IntegrationsPage.css'
+
+interface Props {
+	integration: Integration
+}
+
+const IntegrationDetail = ({ integration }: Props) => {
+	const [showConfiguration, setShowConfiguration] = useState(false)
+	const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
+	const [integrationEnabled, setIntegrationEnabled] = useState(
+		integration.defaultEnable ?? false,
+	)
+
+	const configurationPage = integration.configurationPage
+
+	const handleConnect = () => {
+		setShowConfiguration(true)
+	}
+
+	const handleDisconnect = () => {
+		setShowDeleteConfirmation(true)
+	}
+
+	return (
+		<>
+			<Box
+				display="flex"
+				justifyContent="space-between"
+				alignItems="center"
+				padding="12"
+				borderBottom="divider"
+			>
+				<Text color="secondaryContentText" size="large">
+					{integration.name}
+				</Text>
+				{integration.docs && (
+					<TextLink href={integration.docs} target="_blank">
+						<Stack direction="row" align="center" gap="4">
+							<Text size="xSmall">Docs</Text>
+							<IconSolidExternalLink size={12} />
+						</Stack>
+					</TextLink>
+				)}
+			</Box>
+
+			<Stack my="40" mx="48" padding="12" gap="24">
+				<Stack direction="row" gap="8" align="center">
+					<img
+						src={integration.icon}
+						alt=""
+						className={clsx(styles.integrationIconLarge, {
+							['rounded-none']: integration.noRoundedIcon,
+						})}
+					/>
+					<Text size="large" weight="bold">
+						{integration.name}
+					</Text>
+				</Stack>
+
+				<BorderBox>
+					<Box
+						display="flex"
+						justifyContent="space-between"
+						alignItems="center"
+					>
+						<Stack gap="4">
+							<Text color="secondaryContentText" size="xSmall">
+								Status
+							</Text>
+							<Text weight="bold">
+								{integration.defaultEnable
+									? 'Connected'
+									: 'Not connected'}
+							</Text>
+						</Stack>
+						<Box>
+							{integration.defaultEnable ? (
+								<Button
+									trackingId={`integration-${integration.key}-disconnect`}
+									kind="danger"
+									emphasis="low"
+									onClick={handleDisconnect}
+								>
+									Disconnect
+								</Button>
+							) : (
+								<Button
+									trackingId={`integration-${integration.key}-connect`}
+									kind="primary"
+									emphasis="high"
+									onClick={handleConnect}
+								>
+									Connect
+								</Button>
+							)}
+						</Box>
+					</Box>
+				</BorderBox>
+
+				<Stack gap="8">
+					<Text weight="bold">About</Text>
+					<Text color="secondaryContentText">
+						{integration.description}
+					</Text>
+				</Stack>
+
+				{integration.defaultEnable && integration.hasSettings && (
+					<Stack gap="8">
+						<Text weight="bold">Configuration</Text>
+						<BorderBox>
+							{configurationPage({
+								setModalOpen: setShowConfiguration,
+								setIntegrationEnabled,
+								action: IntegrationAction.Settings,
+							})}
+						</BorderBox>
+					</Stack>
+				)}
+			</Stack>
+
+			<IntegrationModal
+				width={integration.modalWidth}
+				visible={showConfiguration || showDeleteConfirmation}
+				onCancel={() => {
+					if (showConfiguration) {
+						setShowConfiguration(false)
+					} else if (showDeleteConfirmation) {
+						setShowDeleteConfirmation(false)
+						setIntegrationEnabled(true)
+					}
+				}}
+				title={
+					showDeleteConfirmation
+						? 'Are you sure?'
+						: `Configuring ${integration.name} Integration`
+				}
+				configurationPage={() => {
+					if (showConfiguration) {
+						return configurationPage({
+							setModalOpen: setShowConfiguration,
+							setIntegrationEnabled,
+							action: IntegrationAction.Setup,
+						})
+					}
+					if (showDeleteConfirmation) {
+						return configurationPage({
+							setModalOpen: setShowDeleteConfirmation,
+							setIntegrationEnabled,
+							action: IntegrationAction.Disconnect,
+						})
+					}
+				}}
+			/>
+		</>
+	)
+}
+
+export default IntegrationDetail

--- a/frontend/src/routers/ProjectRouter/ApplicationRouter.tsx
+++ b/frontend/src/routers/ProjectRouter/ApplicationRouter.tsx
@@ -51,7 +51,7 @@ const ApplicationRouter: React.FC = () => {
 						/>
 						<Route path="connect/*" element={<ConnectRouter />} />
 						<Route
-							path="integrations/*"
+							path="integrations/:integration_type?"
 							element={<IntegrationsPage />}
 						/>
 						<Route


### PR DESCRIPTION
## Summary
Redesigns the integrations page from a card grid layout to a **sidebar + detail panel** layout, matching the existing SettingsRouter pattern used across the Highlight dashboard.

## Changes
- **Left sidebar**: lists integrations split into "Enabled" and "Available" sections with icons and hover/active states
- **Right content panel**: shows the selected integration's details with status indicator, connect/disconnect button, description, and configuration section
- Uses @highlight-run/ui components (Box, Stack, Text, Button, TextLink) and Vanilla Extract CSS
- Reuses SettingsRouter design patterns: sidebar scroll, menu items, content panel with border/shadow
- Clean URL routing with :integration_type? param for deep linking to specific integrations
- Auto-navigates to first integration when none is selected

## Files Changed
| File | Change |
|------|--------|
| IntegrationsPage.tsx | Rewritten from card grid to sidebar + content panel |
| IntegrationsPage.css.ts | New Vanilla Extract styles (sidebar, menu items, icons) |
| IntegrationsPage.css.js | Generated CSS output |
| IntegrationDetail.tsx | New component for integration detail view |
| ApplicationRouter.tsx | Route updated from integrations/* to integrations/:integration_type? |

## Testing
- Verified sidebar navigation works correctly
- Verified integration detail panel displays correctly
- Verified connect/disconnect flow works
- Verified URL routing and deep linking

## Deployment Considerations
No migrations or backfilling needed. Frontend-only change.

/claim #8614
/closes #8614