### PR TITLE
Redesign the integrations page

### DIFF
--- a/.changeset/fair-seas-design.md
+++ b/.changeset/fair-seas-design.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/frontend': patch
+---
+
+Refresh the integrations page layout with category filters, search, and grouped sections.

--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
@@ -1,9 +1,248 @@
+.hero {
+	background:
+		radial-gradient(circle at top left, rgba(122, 162, 255, 0.22), transparent 34%),
+		linear-gradient(135deg, rgba(9, 15, 28, 0.98), rgba(17, 24, 39, 0.92));
+	border: 1px solid rgba(148, 163, 184, 0.22);
+	border-radius: 28px;
+	box-shadow: 0 28px 70px rgba(15, 23, 42, 0.24);
+	display: grid;
+	gap: 24px;
+	grid-template-columns: minmax(0, 1.8fr) minmax(280px, 0.9fr);
+	margin-bottom: 24px;
+	overflow: hidden;
+	padding: 32px;
+	position: relative;
+}
+
+.hero::after {
+	background:
+		linear-gradient(90deg, transparent, rgba(248, 250, 252, 0.12), transparent);
+	content: '';
+	height: 1px;
+	left: 32px;
+	position: absolute;
+	right: 32px;
+	top: 84px;
+}
+
+.heroCopy {
+	position: relative;
+	z-index: 1;
+}
+
+.eyebrow {
+	color: rgba(191, 219, 254, 0.95);
+	display: inline-flex;
+	font-size: 11px;
+	font-weight: 700;
+	letter-spacing: 0.14em;
+	margin-bottom: 18px;
+	text-transform: uppercase;
+}
+
+.title {
+	color: var(--text-primary-inverted);
+	font-size: 42px;
+	font-weight: 600;
+	line-height: 1.02;
+	margin-bottom: 16px !important;
+	max-width: 11ch;
+}
+
+.hero :global(.subTitle) {
+	color: rgba(226, 232, 240, 0.82) !important;
+	font-size: 17px !important;
+	margin-bottom: 0 !important;
+	max-width: 58ch;
+}
+
+.heroStats {
+	align-content: end;
+	display: grid;
+	gap: 12px;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	position: relative;
+	z-index: 1;
+}
+
+.statCard {
+	background: rgba(255, 255, 255, 0.06);
+	border: 1px solid rgba(226, 232, 240, 0.12);
+	border-radius: 20px;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	min-height: 112px;
+	justify-content: center;
+	padding: 18px 20px;
+}
+
+.statCard:last-child {
+	grid-column: 1 / -1;
+}
+
+.statValue {
+	color: var(--text-primary-inverted);
+	font-size: 34px;
+	font-weight: 600;
+	line-height: 1;
+}
+
+.statLabel {
+	color: rgba(226, 232, 240, 0.72);
+	font-size: 12px;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+}
+
+.controls {
+	align-items: center;
+	display: flex;
+	gap: 16px;
+	justify-content: space-between;
+	margin-bottom: 28px;
+}
+
+.filterBar {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+}
+
+.filterChip {
+	background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(241, 245, 249, 0.92));
+	border: 1px solid rgba(148, 163, 184, 0.25);
+	border-radius: 999px;
+	color: var(--text-primary);
+	cursor: pointer;
+	font-size: 13px;
+	font-weight: 600;
+	padding: 10px 14px;
+	transition:
+		background 0.18s ease,
+		color 0.18s ease,
+		transform 0.18s ease,
+		box-shadow 0.18s ease;
+}
+
+.filterChip[data-active='true'] {
+	background: linear-gradient(135deg, #111827, #1d4ed8);
+	box-shadow: 0 18px 30px rgba(37, 99, 235, 0.2);
+	color: var(--text-primary-inverted);
+	transform: translateY(-1px);
+}
+
+.search {
+	max-width: 280px;
+}
+
+.section {
+	margin-bottom: 32px;
+}
+
+.sectionHeader {
+	align-items: end;
+	display: flex;
+	gap: 16px;
+	justify-content: space-between;
+	margin-bottom: 16px;
+}
+
+.sectionHeader h2 {
+	font-size: 22px;
+	margin-bottom: 6px !important;
+}
+
+.sectionSubtitle {
+	color: var(--text-secondary);
+	margin: 0;
+	max-width: 60ch;
+}
+
+.sectionCount {
+	align-items: center;
+	background: rgba(15, 23, 42, 0.04);
+	border: 1px solid rgba(148, 163, 184, 0.22);
+	border-radius: 999px;
+	display: inline-flex;
+	font-size: 13px;
+	font-weight: 600;
+	height: 32px;
+	justify-content: center;
+	min-width: 32px;
+	padding: 0 12px;
+}
+
 .integrationsContainer {
 	display: grid;
 	grid-gap: var(--size-large);
-	grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+	grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
+
+.emptyState {
+	background: linear-gradient(180deg, rgba(248, 250, 252, 0.96), rgba(241, 245, 249, 0.94));
+	border: 1px dashed rgba(148, 163, 184, 0.38);
+	border-radius: 24px;
+	padding: 36px 28px;
+	text-align: center;
+}
+
+.emptyState h2 {
+	margin-bottom: 8px !important;
+}
+
+.emptyState p {
+	color: var(--text-secondary);
+	margin: 0;
+}
+
 .modalBtn {
 	padding-bottom: 4px !important;
 	padding-top: 4px !important;
+}
+
+@media (max-width: 1024px) {
+	.hero {
+		grid-template-columns: 1fr;
+	}
+
+	.title {
+		font-size: 36px;
+		max-width: 14ch;
+	}
+}
+
+@media (max-width: 720px) {
+	.controls {
+		align-items: stretch;
+		flex-direction: column;
+	}
+
+	.search {
+		max-width: none;
+		width: 100%;
+	}
+
+	.hero {
+		padding: 24px;
+	}
+
+	.hero::after {
+		left: 24px;
+		right: 24px;
+		top: 72px;
+	}
+
+	.heroStats {
+		grid-template-columns: 1fr;
+	}
+
+	.statCard:last-child {
+		grid-column: auto;
+	}
+
+	.sectionHeader {
+		align-items: start;
+		flex-direction: column;
+	}
 }

--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
@@ -1,5 +1,6 @@
 import { useAuthContext } from '@authentication/AuthContext'
 import { useSlackBot } from '@components/Header/components/ConnectHighlightWithSlackButton/utils/utils'
+import Input from '@components/Input/Input'
 import LeadAlignLayout from '@components/layout/LeadAlignLayout'
 import { useClearbitIntegration } from '@pages/IntegrationsPage/components/ClearbitIntegration/utils'
 import { useClickUpIntegration } from '@pages/IntegrationsPage/components/ClickUpIntegration/utils'
@@ -16,7 +17,7 @@ import INTEGRATIONS from '@pages/IntegrationsPage/Integrations'
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
 import analytics from '@util/analytics'
 import { useParams } from '@util/react-router/useParams'
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { StringParam, useQueryParam } from 'use-query-params'
 
@@ -27,8 +28,36 @@ import { useMicrosoftTeamsBot } from '@/pages/IntegrationsPage/components/Micros
 import layoutStyles from '../../components/layout/LeadAlignLayout.module.css'
 import styles from './IntegrationsPage.module.css'
 
+const CATEGORY_LABELS = {
+	all: 'All integrations',
+	alerting: 'Alerts & ChatOps',
+	issues: 'Issue tracking',
+	platform: 'Platform & data',
+} as const
+
+type CategoryKey = keyof typeof CATEGORY_LABELS
+
+const CATEGORY_BY_INTEGRATION: Record<string, Exclude<CategoryKey, 'all'>> = {
+	slack: 'alerting',
+	discord: 'alerting',
+	microsoft_teams: 'alerting',
+	zapier: 'alerting',
+	linear: 'issues',
+	clickup: 'issues',
+	height: 'issues',
+	github: 'issues',
+	gitlab: 'issues',
+	jira: 'issues',
+	clearbit: 'platform',
+	vercel: 'platform',
+	heroku: 'platform',
+	cloudflare: 'platform',
+}
+
 const IntegrationsPage = () => {
 	const { isSlackConnectedToWorkspace, loading: loadingSlack } = useSlackBot()
+	const [searchQuery, setSearchQuery] = useState('')
+	const [activeCategory, setActiveCategory] = useState<CategoryKey>('all')
 
 	const { integration_type: configureIntegration } = useParams<{
 		integration_type: string
@@ -179,6 +208,49 @@ const IntegrationsPage = () => {
 		isCloudflareConnectedToWorkspace,
 	])
 
+	const filteredIntegrations = useMemo(() => {
+		const normalizedQuery = searchQuery.trim().toLowerCase()
+
+		return integrations.filter((integration) => {
+			const category =
+				CATEGORY_BY_INTEGRATION[integration.key] ?? 'platform'
+			const matchesCategory =
+				activeCategory === 'all' || category === activeCategory
+			const matchesQuery =
+				normalizedQuery.length === 0 ||
+				integration.name.toLowerCase().includes(normalizedQuery) ||
+				integration.description.toLowerCase().includes(normalizedQuery)
+
+			return matchesCategory && matchesQuery
+		})
+	}, [activeCategory, integrations, searchQuery])
+
+	const groupedIntegrations = useMemo(() => {
+		return filteredIntegrations.reduce(
+			(groups, integration) => {
+				const category =
+					CATEGORY_BY_INTEGRATION[integration.key] ?? 'platform'
+				groups[category].push(integration)
+				return groups
+			},
+			{
+				alerting: [],
+				issues: [],
+				platform: [],
+			} as Record<
+				Exclude<CategoryKey, 'all'>,
+				typeof filteredIntegrations
+			>,
+		)
+	}, [filteredIntegrations])
+
+	const connectedCount = useMemo(
+		() =>
+			integrations.filter((integration) => integration.defaultEnable)
+				.length,
+		[integrations],
+	)
+
 	useEffect(() => analytics.page('Integrations'), [])
 
 	return (
@@ -186,25 +258,123 @@ const IntegrationsPage = () => {
 			<Helmet>
 				<title>Integrations</title>
 			</Helmet>
-			<LeadAlignLayout>
-				<h2>Integrations</h2>
-				<p className={layoutStyles.subTitle}>
-					Supercharge your workflows and attach Highlight with the
-					tools you use everyday.
-				</p>
-				<div className={styles.integrationsContainer}>
-					{integrations.map((integration) => (
-						<Integration
-							integration={integration}
-							key={integration.key}
-							showModalDefault={popUpModal === integration.key}
-							showSettingsDefault={
-								configureIntegration === integration.key
-							}
-							loading={loading}
-						/>
-					))}
-				</div>
+			<LeadAlignLayout fullWidth maxWidth={1240}>
+				<section className={styles.hero}>
+					<div className={styles.heroCopy}>
+						<span className={styles.eyebrow}>
+							Workspace connections
+						</span>
+						<h1 className={styles.title}>
+							Integrations that keep incidents moving.
+						</h1>
+						<p className={layoutStyles.subTitle}>
+							Connect chat, issue tracking, and platform tooling
+							without leaving Highlight. Filter the catalog, spot
+							what is already live, and jump straight into
+							configuration.
+						</p>
+					</div>
+					<div className={styles.heroStats}>
+						<div className={styles.statCard}>
+							<span className={styles.statValue}>
+								{integrations.length}
+							</span>
+							<span className={styles.statLabel}>Available</span>
+						</div>
+						<div className={styles.statCard}>
+							<span className={styles.statValue}>
+								{connectedCount}
+							</span>
+							<span className={styles.statLabel}>Connected</span>
+						</div>
+						<div className={styles.statCard}>
+							<span className={styles.statValue}>3</span>
+							<span className={styles.statLabel}>
+								Curated lanes
+							</span>
+						</div>
+					</div>
+				</section>
+
+				<section className={styles.controls}>
+					<div className={styles.filterBar}>
+						{(Object.keys(CATEGORY_LABELS) as CategoryKey[]).map(
+							(category) => (
+								<button
+									type="button"
+									key={category}
+									className={styles.filterChip}
+									data-active={activeCategory === category}
+									onClick={() => setActiveCategory(category)}
+								>
+									{CATEGORY_LABELS[category]}
+								</button>
+							),
+						)}
+					</div>
+					<Input
+						value={searchQuery}
+						onChange={(event) => setSearchQuery(event.target.value)}
+						placeholder="Search integrations"
+						className={styles.search}
+					/>
+				</section>
+
+				{(['alerting', 'issues', 'platform'] as const).map(
+					(category) => {
+						const items = groupedIntegrations[category]
+						if (items.length === 0) {
+							return null
+						}
+
+						return (
+							<section className={styles.section} key={category}>
+								<div className={styles.sectionHeader}>
+									<div>
+										<h2>{CATEGORY_LABELS[category]}</h2>
+										<p className={styles.sectionSubtitle}>
+											{category === 'alerting' &&
+												'Route alerts and operational updates into the channels your team already watches.'}
+											{category === 'issues' &&
+												'Turn comments into tickets and keep engineering follow-up anchored to the original context.'}
+											{category === 'platform' &&
+												'Wire deployment, edge, and enrichment services into the same workspace view.'}
+										</p>
+									</div>
+									<span className={styles.sectionCount}>
+										{items.length}
+									</span>
+								</div>
+								<div className={styles.integrationsContainer}>
+									{items.map((integration) => (
+										<Integration
+											integration={integration}
+											key={integration.key}
+											showModalDefault={
+												popUpModal === integration.key
+											}
+											showSettingsDefault={
+												configureIntegration ===
+												integration.key
+											}
+											loading={loading}
+										/>
+									))}
+								</div>
+							</section>
+						)
+					},
+				)}
+
+				{filteredIntegrations.length === 0 && (
+					<section className={styles.emptyState}>
+						<h2>No integrations match this filter.</h2>
+						<p>
+							Try a different category or clear the search to see
+							the full catalog again.
+						</p>
+					</section>
+				)}
 			</LeadAlignLayout>
 		</>
 	)

--- a/frontend/src/pages/IntegrationsPage/components/Integration.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.module.css
@@ -1,4 +1,21 @@
 .integration {
+	background:
+		linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(248, 250, 252, 0.95));
+	border: 1px solid rgba(148, 163, 184, 0.18);
+	border-radius: 22px;
+	box-shadow: 0 18px 35px rgba(15, 23, 42, 0.06);
+	min-height: 220px;
+	transition:
+		transform 0.18s ease,
+		box-shadow 0.18s ease,
+		border-color 0.18s ease;
+
+	&:hover {
+		border-color: rgba(59, 130, 246, 0.28);
+		box-shadow: 0 22px 40px rgba(30, 41, 59, 0.1);
+		transform: translateY(-2px);
+	}
+
 	& .logo {
 		border-radius: 50%;
 		height: var(--size-xxLarge);
@@ -9,7 +26,7 @@
 		align-items: flex-start;
 		display: flex;
 		justify-content: space-between;
-		padding-bottom: var(--size-small);
+		padding-bottom: var(--size-medium);
 	}
 
 	& .connectButton {
@@ -17,10 +34,13 @@
 	}
 
 	& .title {
+		font-size: 22px;
 		margin-bottom: var(--size-small) !important;
 	}
 
 	& .description {
+		color: var(--text-secondary);
+		line-height: 1.5;
 		margin-bottom: 0 !important;
 	}
 }


### PR DESCRIPTION
Closes #8614

## Summary
- turn the integrations page into a browsable catalog with a hero, search, and category filters
- group integrations into alerting, issue tracking, and platform sections so connected tools are easier to scan
- upgrade the integration cards with stronger visual hierarchy and hover affordances without changing the configuration flow

## Validation
- `git diff --check`
- manual static review of the updated page structure and CSS modules

## Notes
- this environment does not have `yarn`, so I could not run the frontend lint/build pipeline here