### PR TITLE
fix(ui): standardize session identifier naming to 'Fingerprint'

### DIFF
--- a/frontend/src/components/Comment/SessionComment/SessionCommentHeader.tsx
+++ b/frontend/src/components/Comment/SessionComment/SessionCommentHeader.tsx
@@ -73,7 +73,7 @@ const SessionCommentHeader: React.FC<Props> = ({ comment, isReply }) => {
 			return `Highlight Comment: ${session?.identifier}'s session`
 		}
 		if (session?.fingerprint) {
-			return `Highlight Comment: session with device ID ${session?.fingerprint}`
+			return `Highlight Comment: session with fingerprint ${session?.fingerprint}`
 		}
 		return `Highlight Comment for a session`
 	}, [session])

--- a/frontend/src/pages/Player/MetadataBox/MetadataBox.tsx
+++ b/frontend/src/pages/Player/MetadataBox/MetadataBox.tsx
@@ -90,7 +90,7 @@ export const MetadataBox = React.memo(() => {
 				lines: '1',
 			},
 			{
-				keyDisplayValue: 'UserID',
+				keyDisplayValue: 'Fingerprint',
 				valueDisplayValue: session?.fingerprint?.toString(),
 			},
 			{

--- a/frontend/src/pages/Player/MetadataPanel/MetadataPanel.tsx
+++ b/frontend/src/pages/Player/MetadataPanel/MetadataPanel.tsx
@@ -226,14 +226,14 @@ const MetadataPanel = () => {
 
 	if (session?.fingerprint) {
 		deviceData.push({
-			keyDisplayValue: 'Device ID',
+			keyDisplayValue: 'Fingerprint',
 			valueDisplayValue: (
 				<ButtonLink
 					onClick={(e) => {
 						e.stopPropagation()
 
 						toast.success(
-							`Showing sessions created by device #${session.fingerprint}`,
+							`Showing sessions with fingerprint #${session.fingerprint}`,
 						)
 						onSubmit(`device_id=${session.fingerprint}`)
 					}}


### PR DESCRIPTION
## Summary

Standardizes the inconsistent naming of the generated session identifier across the frontend UI to use **Fingerprint** everywhere, as requested in #6293.

### Changes

| File | Before | After |
|------|--------|-------|
| `MetadataPanel.tsx` | 'Device ID' | 'Fingerprint' |
| `MetadataBox.tsx` | 'UserID' | 'Fingerprint' |
| `SessionCommentHeader.tsx` | 'device ID' | 'fingerprint' |
| `MetadataPanel.tsx` (toast) | 'sessions created by device' | 'sessions with fingerprint' |

### What stays unchanged

- The `device_id` search/query key used in search expressions and URL params — this is a backend contract, not a display label.
- The `client_id` field in GraphQL queries (backend naming).

Fixes #6293