### PR TITLE
refactor: replace antd Divider with Box in Graphing pages

### DIFF
--- a/.changeset/remove-antd-divider-graphing.md
+++ b/.changeset/remove-antd-divider-graphing.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/ui': patch
+---
+
+Replace antd Divider with native Box component in Graphing pages (EventSteps, VisualizationSection, FormPanel)

--- a/frontend/src/pages/Graphing/EventSelection/EventSteps.tsx
+++ b/frontend/src/pages/Graphing/EventSelection/EventSteps.tsx
@@ -18,7 +18,6 @@ import {
 	Text,
 } from '@highlight-run/ui/components'
 import { LabeledRow } from '@pages/Graphing/LabeledRow'
-import { Divider } from 'antd'
 import { EventSelection } from '@pages/Graphing/EventSelection/index'
 import {
 	EventSelectionDetails,
@@ -180,7 +179,7 @@ const AddEventStep: React.FC<AddEventStepProps> = ({
 					}}
 				/>
 			</LabeledRow>
-			<Divider className="m-0" />
+			<Box borderTop="dividerWeak" />
 			<EventSelection
 				initialQuery={query}
 				setQuery={setQuery}

--- a/frontend/src/pages/Graphing/GraphingEditor/FormPanel/VisualizationSection.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor/FormPanel/VisualizationSection.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
-import { Input, Select, Text } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
+import { Box, Input, Select, Text } from '@highlight-run/ui/components'
 
 import { useProjectId } from '@/hooks/useProjectId'
 import { useGraphingEditorContext } from '@/pages/Graphing/GraphingEditor/GraphingEditorContext'
@@ -102,7 +101,7 @@ export const VisualizationSection: React.FC<Props> = ({ isPreview }) => {
 					disabled={isPreview}
 				/>
 			</LabeledRow>
-			<Divider className="m-0" />
+			<Box borderTop="dividerWeak" />
 			<Text weight="bold">Visualization</Text>
 			<LabeledRow label="View type" name="viewType">
 				<OptionDropdown

--- a/frontend/src/pages/Graphing/GraphingEditor/FormPanel/index.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor/FormPanel/index.tsx
@@ -1,5 +1,4 @@
 import { Box, Form, Stack } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
 import React, { useMemo } from 'react'
 
 import { OptionDropdown } from '@/pages/Graphing/OptionDropdown'
@@ -74,7 +73,7 @@ export const FormPanel: React.FC<Props> = ({
 			<Form>
 				<Stack gap="16">
 					<VisualizationSection isPreview={isPreview} />
-					<Divider className="m-0" />
+					<Box borderTop="dividerWeak" />
 					<SidebarSection isError={errors.length > 0}>
 						<Box>
 							<Box cssClass={style.editorHeader}>


### PR DESCRIPTION
## Summary

Replace antd `Divider` component with native `@highlight-run/ui` `Box` component using `borderTop="dividerWeak"` across Graphing pages to reduce antd dependencies.

### Changes

| File | antd Component Removed | Replacement |
|------|----------------------|-------------|
| `EventSteps.tsx` | `Divider` from `antd` | `Box` with `borderTop="dividerWeak"` |
| `VisualizationSection.tsx` | `Divider` from `antd` | `Box` with `borderTop="dividerWeak"` |
| `FormPanel/index.tsx` | `Divider` from `antd` | `Box` with `borderTop="dividerWeak"` |

This follows the existing pattern used throughout the codebase (e.g., `UpdatePlanPage.tsx`, `SignIn.tsx`, `ProjectFilters.tsx`) where `Box` with border props is used as a divider.

Part of the ongoing effort to remove antd dependencies from workspace and project settings.

/claim #8635

https://github.com/user-attachments/assets/placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)