### PR TITLE
refactor: replace antd Divider with Box in AlertForm

### DIFF
--- a/.changeset/remove-antd-divider-alert-form.md
+++ b/.changeset/remove-antd-divider-alert-form.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/ui': patch
+---
+
+Replace antd Divider with native Box component in AlertForm

--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -13,7 +13,6 @@ import {
 	Tag,
 	Text,
 } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
 import React, { PropsWithChildren, useEffect, useMemo, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { useNavigate, useSearchParams } from 'react-router-dom'
@@ -640,7 +639,7 @@ export const AlertForm: React.FC = () => {
 										/>
 									</LabeledRow>
 								</SidebarSection>
-								<Divider className="m-0" />
+								<Box borderTop="dividerWeak" />
 								<SidebarSection>
 									<Box cssClass={style.editorSection}>
 										<Box cssClass={style.editorHeader}>
@@ -718,7 +717,7 @@ export const AlertForm: React.FC = () => {
 															</Callout>
 														)}
 												</SidebarSection>
-												<Divider className="m-0" />
+												<Box borderTop="dividerWeak" />
 												<SidebarSection>
 													{productType ===
 													ProductType.Events ? (
@@ -775,7 +774,7 @@ export const AlertForm: React.FC = () => {
 														!isErrorAlert)) && (
 													<>
 														<Box px="12">
-															<Divider className="m-0" />
+															<Box borderTop="dividerWeak" />
 														</Box>
 														<SidebarSection>
 															<LabeledRow
@@ -850,7 +849,7 @@ export const AlertForm: React.FC = () => {
 										)}
 									</Box>
 								</SidebarSection>
-								<Divider className="m-0" />
+								<Box borderTop="dividerWeak" />
 								<SidebarSection>
 									<LabeledRow
 										label="Alert threshold type"
@@ -970,7 +969,7 @@ export const AlertForm: React.FC = () => {
 										</>
 									)}
 								</SidebarSection>
-								<Divider className="m-0" />
+								<Box borderTop="dividerWeak" />
 								<SidebarSection>
 									<DestinationInput
 										initialDestinations={


### PR DESCRIPTION
## Summary

Replace all 5 antd `Divider` components with native `@highlight-run/ui` `Box` using `borderTop="dividerWeak"` in the AlertForm page to reduce antd dependencies.

### Changes

| File | antd Component Removed | Replacement |
|------|----------------------|-------------|
| `AlertForm/index.tsx` | 5x `Divider` from `antd` | `Box` with `borderTop="dividerWeak"` |

This follows the existing pattern used throughout the codebase (e.g., `UpdatePlanPage.tsx`, `SignIn.tsx`, `ProjectFilters.tsx`).

Part of the ongoing effort to remove antd dependencies from workspace and project settings.

/claim #8635

🤖 Generated with [Claude Code](https://claude.com/claude-code)