### PR TITLE
refactor: replace antd Divider and Checkbox in NewProject pages

### DIFF
--- a/.changeset/remove-antd-new-project.md
+++ b/.changeset/remove-antd-new-project.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/ui': patch
+---
+
+Replace antd Divider and Checkbox with native components in NewProject pages

--- a/frontend/src/pages/NewProject/AutoJoinInput.tsx
+++ b/frontend/src/pages/NewProject/AutoJoinInput.tsx
@@ -1,8 +1,6 @@
 import { useAuthContext } from '@authentication/AuthContext'
 import Tooltip from '@components/Tooltip/Tooltip'
 import { Box, Text } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -23,7 +21,7 @@ export const AutoJoinInput: React.FC<Props> = ({
 	const { admin } = useAuthContext()
 	const adminsEmailDomain = getEmailDomain(admin?.email)
 
-	const handleMessageChecked = (event: CheckboxChangeEvent) => {
+	const handleMessageChecked = (event: React.ChangeEvent<HTMLInputElement>) => {
 		const domains = event.target.checked ? [adminsEmailDomain] : []
 		setAutoJoinDomains(domains)
 	}
@@ -43,18 +41,19 @@ export const AutoJoinInput: React.FC<Props> = ({
 		>
 			<div className={styles.container}>
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
+					<input
+						type="checkbox"
 						checked={autoJoinDomains.length > 0}
 						onChange={handleMessageChecked}
 					/>
 					<Text>Allowed email domains</Text>
 				</Box>
-				<Divider className="m-0 border-none pt-1" />
+				<Box pt="4" />
 				<Text color="n11">
 					Allow everyone with a <b>{getEmailDomain(admin?.email)}</b>{' '}
 					email to join your workspace.
 				</Text>
-				<Divider className="m-0 border-none pt-1" />
+				<Box pt="4" />
 			</div>
 		</Tooltip>
 	)

--- a/frontend/src/pages/NewProject/NewProjectPage.tsx
+++ b/frontend/src/pages/NewProject/NewProjectPage.tsx
@@ -12,7 +12,6 @@ import { namedOperations } from '@graph/operations'
 import { Box, Callout, Stack, Text } from '@highlight-run/ui/components'
 import analytics from '@util/analytics'
 import { client } from '@util/graph'
-import { Divider } from 'antd'
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
@@ -147,7 +146,7 @@ const NewProjectPage = ({ workspace_id }: { workspace_id: string }) => {
 								}}
 							/>
 						</Box>
-						<Divider className="m-0" />
+						<Box borderTop="dividerWeak" />
 						<Box
 							py="8"
 							px="12"


### PR DESCRIPTION
## Summary

Replace antd `Divider` and `Checkbox` components with native alternatives in the NewProject pages to reduce antd dependencies.

### Changes

| File | antd Component Removed | Replacement |
|------|----------------------|-------------|
| `NewProjectPage.tsx` | `Divider` from `antd` | `Box` with `borderTop="dividerWeak"` |
| `AutoJoinInput.tsx` | `Divider` from `antd` | `Box` with `pt="4"` (spacing-only divider) |
| `AutoJoinInput.tsx` | `Checkbox` from `antd/es/checkbox` | Native `<input type="checkbox">` |

The Divider in `AutoJoinInput.tsx` was used purely for spacing (`border-none pt-1`), so it was replaced with a `Box` using padding. The Checkbox was a simple boolean toggle that works identically with a native HTML checkbox.

Part of the ongoing effort to remove antd dependencies from workspace and project settings.

/claim #8635

🤖 Generated with [Claude Code](https://claude.com/claude-code)