### PR TITLE
refactor: replace antd Progress with native Box in ErrorDistributions

### DIFF
--- a/.changeset/remove-antd-progress-distributions.md
+++ b/.changeset/remove-antd-progress-distributions.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/ui': patch
+---
+
+Replace antd Progress with native Box-based progress bar in ErrorDistributions

--- a/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorDistributions.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorDistributions.tsx
@@ -8,7 +8,6 @@ import {
 } from '@graph/schemas'
 import { colors } from '@highlight-run/ui/colors'
 import { Badge, Box, Stack, Text } from '@highlight-run/ui/components'
-import { Progress } from 'antd'
 import React, { useEffect, useState } from 'react'
 
 type Props = {
@@ -151,14 +150,24 @@ const Buckets: React.FC<
 								</Text>
 							</Box>
 						</Box>
-						<Progress
-							percent={Math.floor(bucket.percent * 100)}
-							showInfo={false}
-							strokeColor={colors.n8}
-							trailColor={colors.n4}
-							strokeWidth={4}
-							status="normal"
-						/>
+						<Box
+							style={{
+								width: '100%',
+								height: 4,
+								backgroundColor: colors.n4,
+								borderRadius: 2,
+								overflow: 'hidden',
+							}}
+						>
+							<Box
+								style={{
+									width: `${Math.floor(bucket.percent * 100)}%`,
+									height: '100%',
+									backgroundColor: colors.n8,
+									borderRadius: 2,
+								}}
+							/>
+						</Box>
 					</Box>
 				)
 			})}


### PR DESCRIPTION
## Summary

Replace antd `Progress` bar component with a native `Box`-based progress bar in the ErrorDistributions page to reduce antd dependencies.

### Changes

| File | antd Component Removed | Replacement |
|------|----------------------|-------------|
| `ErrorDistributions.tsx` | `Progress` from `antd` | Native `Box` elements with inline styles |

The replacement preserves identical visual behavior:
- Same stroke color (`colors.n8`)
- Same trail color (`colors.n4`)
- Same height (4px)
- Same border radius (2px)
- Same percentage calculation

Part of the ongoing effort to remove antd dependencies from workspace and project settings.

/claim #8635

🤖 Generated with [Claude Code](https://claude.com/claude-code)