### PR TITLE
refactor: replace antd Divider and Dropdown in Header components

### DIFF
--- a/.changeset/remove-antd-divider-header.md
+++ b/.changeset/remove-antd-divider-header.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/ui': patch
+---
+
+Replace antd Divider with native Box component in Header

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -54,7 +54,6 @@ import analytics from '@util/analytics'
 import { auth } from '@util/auth'
 import { isProjectWithinTrial } from '@util/billing/billing'
 import { titleCaseString } from '@util/string'
-import { Divider } from 'antd'
 import clsx from 'clsx'
 import moment from 'moment'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
@@ -561,7 +560,7 @@ export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 																		)
 																	},
 																)}
-														<Divider className="mb-0 mt-1" />
+														<Box borderBottom="dividerWeak" mt="4" />
 														<Link
 															to="/new"
 															state={{

--- a/frontend/src/components/Header/UserDropdown/UserDropdown.tsx
+++ b/frontend/src/components/Header/UserDropdown/UserDropdown.tsx
@@ -1,4 +1,4 @@
-import { Dropdown, Skeleton } from 'antd'
+import { Menu } from '@highlight-run/ui/components'
 import { FiLogOut } from 'react-icons/fi'
 import { Link } from 'react-router-dom'
 
@@ -15,11 +15,32 @@ interface Props {
 export const UserDropdown = ({ border, workspaceId }: Props) => {
 	const { admin, signOut } = useAuthContext()
 
-	const menu = (
-		<div className={styles.dropdownMenu}>
-			<div className={styles.dropdownInner}>
+	return (
+		<Menu placement="bottom-end">
+			<Menu.Button
+				emphasis="low"
+				kind="secondary"
+				cssClass={styles.accountIconWrapper}
+			>
+				{admin ? (
+					<AdminAvatar
+						adminInfo={{
+							name: admin?.name,
+							email: admin?.email,
+							photo_url: admin?.photo_url ?? '',
+						}}
+						size={35}
+						border={border}
+					/>
+				) : (
+					<p>loading</p>
+				)}
+			</Menu.Button>
+			<Menu.List>
 				{!admin ? (
-					<Skeleton />
+					<Menu.Item>
+						<span>Loading...</span>
+					</Menu.Item>
 				) : (
 					<>
 						<div className={styles.userInfoWrapper}>
@@ -43,15 +64,16 @@ export const UserDropdown = ({ border, workspaceId }: Props) => {
 							</div>
 						</div>
 						{workspaceId && (
-							<Link
-								className={styles.dropdownMyAccount}
-								to={`/w/${workspaceId}/account`}
-							>
-								My Account
-							</Link>
+							<Menu.Item>
+								<Link
+									className={styles.dropdownMyAccount}
+									to={`/w/${workspaceId}/account`}
+								>
+									My Account
+								</Link>
+							</Menu.Item>
 						)}
-						<div
-							className={styles.dropdownLogout}
+						<Menu.Item
 							onClick={async () => {
 								try {
 									signOut()
@@ -60,33 +82,16 @@ export const UserDropdown = ({ border, workspaceId }: Props) => {
 								}
 							}}
 						>
-							<span className={styles.dropdownLogoutText}>
-								Logout
-							</span>
-							<FiLogOut className={styles.logoutIcon} />
-						</div>
+							<div className={styles.dropdownLogout}>
+								<span className={styles.dropdownLogoutText}>
+									Logout
+								</span>
+								<FiLogOut className={styles.logoutIcon} />
+							</div>
+						</Menu.Item>
 					</>
 				)}
-			</div>
-		</div>
-	)
-	return (
-		<Dropdown overlay={menu} placement="bottomRight" trigger={['click']}>
-			<div className={styles.accountIconWrapper}>
-				{admin ? (
-					<AdminAvatar
-						adminInfo={{
-							name: admin?.name,
-							email: admin?.email,
-							photo_url: admin?.photo_url ?? '',
-						}}
-						size={35}
-						border={border}
-					/>
-				) : (
-					<p>loading</p>
-				)}
-			</div>
-		</Dropdown>
+			</Menu.List>
+		</Menu>
 	)
 }


### PR DESCRIPTION
## Summary

Replace antd components in the Header area to reduce antd dependencies.

### Changes

| File | antd Component Removed | Replacement |
|------|----------------------|-------------|
| `Header.tsx` | `Divider` from `antd` | `Box` with `borderBottom="dividerWeak"` |
| `UserDropdown.tsx` | `Dropdown` from `antd` | `Menu` from `@highlight-run/ui` |
| `UserDropdown.tsx` | `Skeleton` from `antd` | Simple loading text |

The UserDropdown now uses the same `Menu` component pattern that is already extensively used throughout the Header component, providing a consistent dropdown behavior with the rest of the UI.

Part of the ongoing effort to remove antd dependencies from workspace and project settings.

/claim #8635

🤖 Generated with [Claude Code](https://claude.com/claude-code)