### PR TITLE
refactor: replace antd Spin with native IconSolidLoading in CircularSpinner

### DIFF
--- a/.changeset/remove-antd-spin-loading.md
+++ b/.changeset/remove-antd-spin-loading.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/ui': patch
+---
+
+Replace antd Spin and @ant-design/icons with native IconSolidLoading in CircularSpinner

--- a/frontend/src/components/Loading/Loading.tsx
+++ b/frontend/src/components/Loading/Loading.tsx
@@ -1,11 +1,9 @@
-import { LoadingOutlined } from '@ant-design/icons'
 import {
 	AppLoadingState,
 	useAppLoadingContext,
 } from '@context/AppLoadingContext'
 import { IconSolidLoading } from '@highlight-run/ui/components'
 import SvgHighlightLogoWithNoBackground from '@icons/HighlightLogoWithNoBackground'
-import { Spin } from 'antd'
 import clsx from 'clsx'
 import { AnimatePresence, motion } from 'framer-motion'
 import React from 'react'
@@ -15,18 +13,22 @@ import styles from './Loading.module.css'
 
 export const CircularSpinner = ({ style }: { style?: React.CSSProperties }) => {
 	return (
-		<Spin
-			indicator={
-				// @ts-ignore onPointerEnterCapture, onPointerLeaveCapture ignored by autoresize lib
-				<LoadingOutlined
-					style={{
-						fontSize: 24,
-						...style,
-					}}
-					spin
-				/>
-			}
-		/>
+		<motion.div
+			animate={{ rotate: 360 }}
+			transition={{
+				duration: 1,
+				repeat: Infinity,
+				ease: 'linear',
+			}}
+			style={{
+				display: 'inline-flex',
+				justifyContent: 'center',
+				alignItems: 'center',
+				...style,
+			}}
+		>
+			<IconSolidLoading size={style?.fontSize ?? 24} />
+		</motion.div>
 	)
 }
 


### PR DESCRIPTION
## Summary

Replace antd `Spin` and `@ant-design/icons` `LoadingOutlined` with native `@highlight-run/ui` `IconSolidLoading` in the `CircularSpinner` component.

### Changes

| File | antd Component Removed | Replacement |
|------|----------------------|-------------|
| `Loading.tsx` | `Spin` from `antd` | `motion.div` with rotation animation |
| `Loading.tsx` | `LoadingOutlined` from `@ant-design/icons` | `IconSolidLoading` from `@highlight-run/ui` |

The replacement uses framer-motion for the rotation animation, which is consistent with the existing `IconAnimatedLoading` component defined in the same file. The `CircularSpinner` component is used in 7 files across the codebase, so this change eliminates antd usage from all of those locations without requiring changes to consumers.

The spinner preserves the same default size (24px) and supports custom sizing via the existing `style` prop.

Part of the ongoing effort to remove antd dependencies from workspace and project settings.

/claim #8635

🤖 Generated with [Claude Code](https://claude.com/claude-code)