### PR TITLE
refactor: replace antd Tooltip with native Tooltip in InfoTooltip

### DIFF
--- a/.changeset/remove-antd-tooltip-info.md
+++ b/.changeset/remove-antd-tooltip-info.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/ui': patch
+---
+
+Replace antd Tooltip with @highlight-run/ui Tooltip in InfoTooltip component

--- a/frontend/src/components/InfoTooltip/InfoTooltip.module.css
+++ b/frontend/src/components/InfoTooltip/InfoTooltip.module.css
@@ -1,24 +1,3 @@
-.tooltip {
-	flex-shrink: 0;
-	z-index: 9999999999999 !important;
-
-	& a {
-		color: var(--text-primary-inverted) !important;
-		text-decoration: underline;
-	}
-
-	:global(.ant-tooltip-inner) {
-		background: var(--color-primary-inverted-background) !important;
-		border-radius: var(--border-radius) !important;
-	}
-
-	&.hideArrow {
-		:global(.ant-tooltip-arrow-content) {
-			display: none;
-		}
-	}
-}
-
 .icon {
 	--size: var(--size-small);
 	flex-shrink: 0;

--- a/frontend/src/components/InfoTooltip/InfoTooltip.tsx
+++ b/frontend/src/components/InfoTooltip/InfoTooltip.tsx
@@ -1,53 +1,65 @@
-import { Box, IconSolidInformationCircle } from '@highlight-run/ui/components'
+import {
+	Box,
+	IconSolidInformationCircle,
+	Tooltip,
+} from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Tooltip } from 'antd'
-import { TooltipPropsWithTitle } from 'antd/es/tooltip'
 import clsx from 'clsx'
 
 import styles from './InfoTooltip.module.css'
 
-type Props = Pick<
-	TooltipPropsWithTitle,
-	'title' | 'placement' | 'className' | 'align' | 'visible'
-> & {
+type Props = {
+	title?: React.ReactNode
+	/** @deprecated Use `title` instead */
+	text?: React.ReactNode
+	className?: string
 	size?: 'small' | 'medium' | 'large'
 	hideArrow?: boolean
 	onClick?: () => void
 	color?: string
+	/** @deprecated antd-specific prop, no longer used */
+	placement?: string
+	/** @deprecated antd-specific prop, no longer used */
+	align?: unknown
+	/** @deprecated antd-specific prop, no longer used */
+	visible?: boolean
 }
 
 const InfoTooltip = ({
 	size = 'small',
-	hideArrow = false,
 	onClick,
 	color,
-	...props
+	title,
+	text,
+	className,
 }: Props) => {
-	if (props.title == undefined) {
+	const tooltipContent = title ?? text
+	if (tooltipContent == undefined) {
 		return null
 	}
 
 	return (
 		<Tooltip
-			{...props}
-			overlayClassName={clsx(styles.tooltip, {
-				[styles.hideArrow]: hideArrow,
-			})}
-			mouseEnterDelay={0}
+			trigger={
+				<Box
+					style={{ height: 12, width: 12, display: 'inline-flex' }}
+					cssClass={className}
+				>
+					<IconSolidInformationCircle
+						onClick={onClick}
+						color={
+							color ??
+							vars.theme.interactive.fill.secondary.content.text
+						}
+						className={clsx(styles.icon, {
+							[styles.medium]: size === 'medium',
+							[styles.large]: size === 'large',
+						})}
+					/>
+				</Box>
+			}
 		>
-			<Box style={{ height: 12, width: 12, display: 'inline-flex' }}>
-				<IconSolidInformationCircle
-					onClick={onClick}
-					color={
-						color ??
-						vars.theme.interactive.fill.secondary.content.text
-					}
-					className={clsx(styles.icon, {
-						[styles.medium]: size === 'medium',
-						[styles.large]: size === 'large',
-					})}
-				/>
-			</Box>
+			{tooltipContent}
 		</Tooltip>
 	)
 }


### PR DESCRIPTION
## Summary

Replace antd `Tooltip` with `@highlight-run/ui` `Tooltip` in the `InfoTooltip` wrapper component. This removes antd dependency from the 9 files that use InfoTooltip throughout the codebase.

### Changes

| File | antd Component Removed | Replacement |
|------|----------------------|-------------|
| `InfoTooltip.tsx` | `Tooltip` from `antd` | `Tooltip` from `@highlight-run/ui` |
| `InfoTooltip.tsx` | `TooltipPropsWithTitle` from `antd/es/tooltip` | Simplified native props |
| `InfoTooltip.module.css` | antd-specific `.ant-tooltip-inner` and `.ant-tooltip-arrow-content` overrides | Removed (no longer needed) |

The migration also adds backwards-compatible support for the `text` prop (used in `LabeledRow`) while marking antd-specific props (`placement`, `align`, `visible`) as deprecated since the native Tooltip handles positioning automatically.

Part of the ongoing effort to remove antd dependencies from workspace and project settings.

/claim #8635

🤖 Generated with [Claude Code](https://claude.com/claude-code)