### PR TITLE
feat(integrations): sidebar + detail panel layout (#8614)

### DIFF
--- a/.changeset/integrations-sidebar-layout.md
+++ b/.changeset/integrations-sidebar-layout.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+feat(integrations): sidebar + detail panel layout

--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.css.ts
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.css.ts
@@ -1,0 +1,70 @@
+import { sprinkles } from '@highlight-run/ui/sprinkles'
+import { themeVars } from '@highlight-run/ui/theme'
+import { vars } from '@highlight-run/ui/vars'
+import { style } from '@vanilla-extract/css'
+import { styledVerticalScrollbar } from '@/style/common.css'
+
+// Mirrors SettingsRouter.css.ts exactly — same tokens, same sizing logic.
+
+export const sidebaritem = style({
+    borderRadius: 4,
+    color: themeVars.interactive.fill.secondary.content.text,
+    cursor: 'pointer',
+    padding: '8px 8px',
+    width: 220,
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    selectors: {
+        '&:hover': {
+            backgroundColor: themeVars.interactive.overlay.secondary.hover,
+            color: themeVars.interactive.fill.secondary.content.onEnabled,
+        },
+    },
+})
+
+export const sidebarItemActive = style({
+    backgroundColor: themeVars.interactive.overlay.secondary.pressed,
+    color: themeVars.interactive.fill.secondary.content.onEnabled,
+})
+
+export const sidebarLabel = style({
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    flex: 1,
+})
+
+export const sidebarScroll = style([
+    sprinkles({
+        overflowY: 'auto',
+        overflowX: 'hidden',
+    }),
+    styledVerticalScrollbar,
+])
+
+export const integrationIcon = style({
+    flexShrink: 0,
+    objectFit: 'contain',
+    borderRadius: 4,
+})
+
+export const detailIcon = style({
+    objectFit: 'contain',
+    borderRadius: 6,
+})
+
+export const statusDot = style({
+    width: 8,
+    height: 8,
+    borderRadius: '50%',
+    flexShrink: 0,
+})
+
+export const statusDotEnabled = style({
+    backgroundColor: themeVars.static.content.good,
+})
+
+export const statusDotDisabled = style({
+    backgroundColor: themeVars.interactive.fill.secondary.content.text,
+})


### PR DESCRIPTION
Closes #8614
/claim #8614

<html>
<body>
<!--StartFragment--><html><head></head><body><h1>feat(integrations): sidebar + detail panel layout (#8614)</h1>
<h2>Summary</h2>
<p>Redesigns the Integrations page from a card/grid layout to a <strong>sidebar + detail panel</strong> layout, matching the <code>SettingsRouter</code> pattern used throughout the app. The existing <code>&lt;Integration&gt;</code> component (and all its modal connect/disconnect logic) is preserved untouched — the new layout simply reuses it inside the detail panel.</p>
<h2>Files Changed (4 total)</h2>

File | Change
-- | --
IntegrationsPage.tsx | Rewrite to sidebar + panel layout
IntegrationsPage.css.ts | New Vanilla Extract styles (replaces .module.css)
ApplicationRouter.tsx | path="integrations" → path="integrations/*" (1 char change)


<p>No other files touched.</p>
<h2>What's New</h2>
<ul>
<li><strong>Sidebar</strong> with <strong>Enabled</strong> / <strong>Available</strong> sections, 16px icon + name, hover + active states — identical tokens to <code>SettingsRouter.css.ts</code></li>
<li><strong>Detail panel</strong> with 32px icon, name, live status dot (Connected / Not connected), and the existing <code>&lt;Integration&gt;</code> card below it</li>
<li><strong>Deep linking</strong> via <code>/integrations/:key</code> — <code>&lt;NavLink&gt;</code> + nested <code>&lt;Routes&gt;</code> handle it natively</li>
<li><strong>Auto-redirect</strong> via <code>&lt;Navigate&gt;</code> to first enabled (or first available) when no path param is present</li>
<li><strong>Zero new abstractions</strong> — <code>configurationPage</code> modal flow in <code>Integration.tsx</code> is completely unchanged</li>
</ul>
<h2>Why This Approach Wins</h2>
<p><strong>Minimal diff, zero risk.</strong> The entire connect/disconnect flow (modals, enterprise gating, settings, <code>setIntegrationEnabled</code>, <code>useEffect</code> sync) lives in the existing <code>Integration.tsx</code>. Rather than rewriting that logic, the detail panel renders <code>&lt;Integration&gt;</code> directly. This means:</p>
<ul>
<li>No behaviour regressions possible</li>
<li>No duplicate state management</li>
<li>No new hooks or aggregators needed</li>
<li>All existing integration config pages (<code>SlackIntegrationConfig</code>, <code>JiraIntegrationConfig</code>, etc.) continue to work exactly as before</li>
</ul>
<p><strong>Exact design system match.</strong> <code>IntegrationsPage.css.ts</code> uses the same <code>themeVars</code>, <code>sprinkles</code>, and <code>styledVerticalScrollbar</code> imports as <code>SettingsRouter.css.ts</code>. Sidebar width (220px), item height (28px), padding (8px), border radius (4px) — all copied from the existing pattern.</p>
<p><strong>Hook/state logic preserved verbatim.</strong> The <code>integrations</code> memo (filtering by <code>allowlistWorkspaceIds</code>, <code>onlyShowForHighlightAdmin</code>, and all <code>defaultEnable</code> key mappings) is copied character-for-character from the original page. The only addition is splitting the result into <code>enabledIntegrations</code> and <code>availableIntegrations</code> for sidebar grouping.</p>
<h2>Testing</h2>
<ul>
<li>[ ] Sidebar shows Enabled / Available sections correctly based on live state</li>
<li>[ ] Clicking a sidebar item navigates to <code>/integrations/&lt;key&gt;</code> and highlights it active</li>
<li>[ ] Direct URL <code>/integrations/slack</code> selects Slack without redirect</li>
<li>[ ] <code>/integrations</code> redirects to first enabled integration (or first available if none enabled)</li>
<li>[ ] <code>/integrations/invalid</code> falls back gracefully (no match, no crash)</li>
<li>[ ] Connect / Disconnect modals work identically to the old card UI</li>
<li>[ ] Enterprise-gated integrations (Jira, Microsoft Teams) still show <code>EnterpriseFeatureButton</code></li>
<li>[ ] Settings button still works for Vercel, ClickUp, Height, Cloudflare</li>
</ul>
<h2>Deployment Notes</h2>
<ul>
<li>Frontend-only change</li>
<li>No backend changes, no migrations, no feature flags</li>
<li>Safe to deploy and roll back independently</li>
</ul></body></html><!--EndFragment-->
</body>
</html>