### PR TITLE
refactor: complete antd removal and standardized settings UI consistency (#8635)

### DIFF
--- a/frontend/src/pages/ProjectSettings/AutoresolveStaleErrorsForm/AutoresolveStaleErrorsForm.tsx
+++ b/frontend/src/pages/ProjectSettings/AutoresolveStaleErrorsForm/AutoresolveStaleErrorsForm.tsx
@@ -1,124 +1,174 @@
-import { LoadingBar } from '@components/Loading/Loading'
-import { Box, Callout, Form, Label, Stack } from '@highlight-run/ui/components'
-import { useEffect, useState } from 'react'
+import { useEditProjectSettingsMutation } from '@graph/hooks'
+import {
+	Box,
+	Callout,
+	Heading,
+	Select,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
+import { useParams } from '@util/react-router/useParams'
+import React, { useEffect, useState } from 'react'
 
 import BorderBox from '@/components/BorderBox/BorderBox'
-import { ToggleRow } from '@/components/ToggleRow/ToggleRow'
+import { Button } from '@/components/Button'
+import Switch from '@/components/Switch/Switch'
+import { LoadingBar } from '@components/Loading/Loading'
+import { toast } from '@/components/Toaster'
 import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
 
 const DAY_VALUES = Array.from({ length: 30 }, (_, i) => i + 1)
 
 export const AutoresolveStaleErrorsForm = () => {
-	const [enableAutoResolveStaleErrors, setEnableAutoResolveStaleErrors] =
-		useState<boolean>(false)
-
+	const { project_id } = useParams()
 	const {
 		allProjectSettings: data,
 		loading,
 		setAllProjectSettings,
 	} = useProjectSettingsContext()
 
-	const setAutoResolveStaleErrorsDayInterval = (interval: number) => {
-		setAllProjectSettings((currentProjectSettings) =>
-			currentProjectSettings?.projectSettings
-				? {
-						projectSettings: {
-							...currentProjectSettings.projectSettings,
-							autoResolveStaleErrorsDayInterval: interval,
-						},
-					}
-				: currentProjectSettings,
-		)
-	}
+	const [enabled, setEnabled] = useState<boolean>(false)
+	const [interval, setInterval] = useState<number>(1)
 
 	useEffect(() => {
-		if (!loading) {
-			const interval =
-				data?.projectSettings?.autoResolveStaleErrorsDayInterval ?? 0
-
-			if (interval > 0) {
-				setEnableAutoResolveStaleErrors(true)
-			}
+		if (!loading && data?.projectSettings) {
+			const i = data.projectSettings.autoResolveStaleErrorsDayInterval ?? 0
+			setEnabled(i > 0)
+			setInterval(i || 1)
 		}
-	}, [data?.projectSettings?.autoResolveStaleErrorsDayInterval, loading])
+	}, [data?.projectSettings, loading])
+
+	const [editProjectSettings, { loading: editLoading }] =
+		useEditProjectSettingsMutation()
+
+	const onSave = (e: React.FormEvent) => {
+		e.preventDefault()
+		const newInterval = enabled ? interval : 0
+		editProjectSettings({
+			variables: {
+				projectId: project_id!,
+				autoResolveStaleErrorsDayInterval: newInterval,
+			},
+		}).then(() => {
+			toast.success('Updated auto-resolve settings!', { duration: 5000 })
+			setAllProjectSettings((current) =>
+				current?.projectSettings
+					? {
+							projectSettings: {
+								...current.projectSettings,
+								autoResolveStaleErrorsDayInterval: newInterval,
+							},
+					  }
+					: current,
+			)
+		})
+	}
+
+	const onDiscard = () => {
+		if (data?.projectSettings) {
+			const i = data.projectSettings.autoResolveStaleErrorsDayInterval ?? 0
+			setEnabled(i > 0)
+			setInterval(i || 1)
+		}
+	}
+
+	const currentInterval = data?.projectSettings?.autoResolveStaleErrorsDayInterval ?? 0
+	const isDirty =
+		enabled !== (currentInterval > 0) ||
+		(enabled && interval !== currentInterval)
 
 	if (loading) {
 		return <LoadingBar />
 	}
 
-	const categories = [
-		{
-			key: 'Auto-resolve stale errors',
-			message:
-				"Enable this feature to automatically resolve errors that haven't been seen for the configured time period.",
-			checked: enableAutoResolveStaleErrors,
-		},
-	]
-
 	return (
-		<Form>
-			{categories.map((c) => (
-				<BorderBox key={c.key}>
-					<Box py="8">
-						{ToggleRow(
-							c.key,
-							c.message,
-							c.checked,
-							(isOptIn: boolean) => {
-								setEnableAutoResolveStaleErrors(isOptIn)
+		<Box
+			id="autoresolve"
+			background="white"
+			border="dividerWeak"
+			borderRadius="8"
+			p="24"
+		>
+			<Stack gap="16">
+				<Stack gap="4">
+					<Heading level="h4">Auto-resolve stale errors</Heading>
+					<Text color="moderate">
+						Enable this feature to automatically resolve errors that
+						haven't been seen for the configured time period.
+					</Text>
+				</Stack>
 
-								if (!isOptIn) {
-									setAutoResolveStaleErrorsDayInterval(0)
-								} else {
-									setAutoResolveStaleErrorsDayInterval(1)
-								}
-							},
-							false,
-						)}
-					</Box>
+				<Box borderTop="dividerWeak" style={{ marginLeft: -24, marginRight: -24 }} />
 
-					<Box borderTop="dividerWeak" />
-
-					<Stack
-						direction="row"
-						alignItems="center"
-						justify="space-between"
-						py="8"
-					>
-						<Box display="flex">
-							<Label
-								label="Auto-resolve errors not seen in"
-								name="auto-resolve-not-seen-in"
-							/>
-						</Box>
-						<Box>
-							<Form.Select
-								name="auto-resolve-not-seen-in"
-								value={
-									data?.projectSettings
-										?.autoResolveStaleErrorsDayInterval
-								}
-								onValueChange={(option) => {
-									setAutoResolveStaleErrorsDayInterval(
-										option.value,
+				<Stack
+					direction="row"
+					alignItems="center"
+					justifyContent="space-between"
+				>
+					<Stack direction="row" alignItems="center" gap="12">
+						<Text weight="bold" size="small">
+							Auto-resolve errors not seen in
+						</Text>
+						<Box style={{ width: 120 }}>
+							<Select
+								value={{
+									name: `${interval} day${
+										interval === 1 ? '' : 's'
+									}`,
+									value: interval.toString(),
+								}}
+								disabled={!enabled}
+								onValueChange={(option: any) => {
+									const val = Number(option.value)
+									setInterval(val)
+									setAllProjectSettings((current) =>
+										current?.projectSettings
+											? {
+													projectSettings: {
+														...current.projectSettings,
+														autoResolveStaleErrorsDayInterval:
+															val,
+													},
+											  }
+											: current,
 									)
 								}}
-								disabled={!enableAutoResolveStaleErrors}
 								options={DAY_VALUES.map((day) => ({
 									name: `${day} day${day === 1 ? '' : 's'}`,
-									value: day,
+									value: day.toString(),
 								}))}
 							/>
 						</Box>
 					</Stack>
-					{enableAutoResolveStaleErrors && (
-						<Callout kind="warning">
-							Enabling auto-resolve will close all errors in that
-							time period.
-						</Callout>
-					)}
-				</BorderBox>
-			))}
-		</Form>
+					<Switch
+						trackingId="AutoresolveStaleErrors-Switch"
+						checked={enabled}
+						onChange={(checked: boolean) => {
+							setEnabled(checked)
+							const newInterval = checked ? interval : 0
+							setAllProjectSettings((current) =>
+								current?.projectSettings
+									? {
+											projectSettings: {
+												...current.projectSettings,
+												autoResolveStaleErrorsDayInterval:
+													newInterval,
+											},
+									  }
+									: current,
+							)
+						}}
+					/>
+				</Stack>
+
+				{enabled && (
+					<Callout kind="warning">
+						Enabling auto-resolve will close all errors in that time
+						period.
+					</Callout>
+				)}
+			</Stack>
+		</Box>
+
 	)
 }

--- a/frontend/src/pages/ProjectSettings/DangerForm/DangerForm.tsx
+++ b/frontend/src/pages/ProjectSettings/DangerForm/DangerForm.tsx
@@ -1,19 +1,25 @@
-import { FieldsBox } from '@components/FieldsBox/FieldsBox'
-import Input from '@components/Input/Input'
-import LoadingBox from '@components/LoadingBox'
-import { useDeleteProjectMutation, useGetProjectQuery } from '@graph/hooks'
+import {
+	Box,
+	Form,
+	Heading,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
+import {
+	useDeleteProjectMutation,
+	useEditProjectMutation,
+	useGetProjectQuery,
+} from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
-import { FieldsForm } from '@pages/WorkspaceSettings/FieldsForm/FieldsForm'
 import { useParams } from '@util/react-router/useParams'
-import clsx from 'clsx'
-import { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Navigate } from 'react-router-dom'
 import { useAuthContext } from '@/authentication/AuthContext'
 import { AdminRole } from '@/graph/generated/schemas'
+import { toast } from '@components/Toaster'
 
-import commonStyles from '../../../Common.module.css'
-import Button from '../../../components/Button/Button/Button'
-import styles from './DangerForm.module.css'
+import { Button } from '@/components/Button'
+import LoadingBox from '@/components/LoadingBox'
 
 export const DangerForm = () => {
 	const { project_id } = useParams<{ project_id: string }>()
@@ -21,79 +27,188 @@ export const DangerForm = () => {
 		variables: { id: project_id! },
 		skip: !project_id,
 	})
+	const [name, setName] = useState('')
 	const [confirmationText, setConfirmationText] = useState('')
 
 	const { workspaceRole } = useAuthContext()
 	const isAdminRole = workspaceRole === AdminRole.Admin
+
+	const [editProject, { loading: editLoading }] = useEditProjectMutation({
+		refetchQueries: [
+			namedOperations.Query.GetProjects,
+			namedOperations.Query.GetProject,
+		],
+	})
 
 	const [deleteProject, { loading: deleteLoading, data: deleteData }] =
 		useDeleteProjectMutation({
 			refetchQueries: [namedOperations.Query.GetProjects],
 		})
 
-	const onSubmit = (e: { preventDefault: () => void }) => {
+	useEffect(() => {
+		if (data?.project) {
+			setName(data.project.name)
+		}
+	}, [data?.project])
+
+	const onSave = (e: React.FormEvent) => {
+		e.preventDefault()
+		editProject({
+			variables: {
+				id: project_id!,
+				name,
+			},
+		}).then(() => {
+			toast.success('Updated project fields!', { duration: 5000 })
+		})
+	}
+
+	const onDiscard = () => {
+		setName(data?.project?.name || '')
+	}
+
+	const onDelete = (e: React.FormEvent) => {
 		e.preventDefault()
 		deleteProject({ variables: { id: project_id! } })
 	}
+
+	const isDirty = name !== (data?.project?.name || '')
+
 	if (deleteData?.deleteProject) {
 		return <Navigate replace to="/" />
 	}
-	return (
-		<>
-			<FieldsBox id="project">
-				<h3>Project Properties</h3>
-				<FieldsForm
-					defaultName={data?.project?.name}
-					defaultEmail={data?.project?.billing_email}
-					disabled={!isAdminRole}
-				/>
-			</FieldsBox>
-			{isAdminRole && (
-				<FieldsBox id="danger">
-					<h3>Danger Zone</h3>
 
-					<form onSubmit={onSubmit}>
-						{loading ? (
-							<LoadingBox />
-						) : (
-							<>
-								<p className={styles.dangerSubTitle}>
-									This will immediately delete all session and
-									errors in this project. Please type '
-									{`${data?.project?.name}`}' to confirm.
-								</p>
-								<div className={styles.dangerRow}>
-									<Input
-										placeholder={`${data?.project?.name}`}
-										name="text"
-										value={confirmationText}
-										onChange={(e) => {
-											setConfirmationText(e.target.value)
-										}}
-									/>
-									<Button
-										trackingId="DeleteProject"
-										danger
-										type="primary"
-										className={clsx(
-											commonStyles.submitButton,
-											styles.deleteButton,
-										)}
-										disabled={
-											confirmationText !==
-											data?.project?.name
-										}
-										htmlType="submit"
-										loading={deleteLoading}
-									>
-										Delete
-									</Button>
-								</div>
-							</>
+	return (
+		<Stack gap="24">
+			<Box
+				border="dividerWeak"
+				borderRadius="8"
+				background="white"
+				p="24"
+				id="project"
+			>
+				<Stack gap="16">
+					<Box
+						display="flex"
+						justifyContent="space-between"
+						alignItems="center"
+					>
+						<Heading level="h4">Project Properties</Heading>
+						{isDirty && (
+							<Box display="flex" gap="8">
+								<Button
+									kind="secondary"
+									emphasis="medium"
+									trackingId="ProjectSettingsDiscard"
+									onClick={onDiscard}
+									disabled={!isAdminRole}
+								>
+									Discard changes
+								</Button>
+								<Button
+									kind="primary"
+									emphasis="high"
+									trackingId="ProjectSettingsSave"
+									onClick={onSave}
+									disabled={!isAdminRole}
+									loading={editLoading}
+								>
+									Save changes
+								</Button>
+							</Box>
 						)}
-					</form>
-				</FieldsBox>
+					</Box>
+
+					{loading ? (
+						<LoadingBox />
+					) : (
+						<Form onSubmit={onSave}>
+							<Stack gap="16">
+								<Box
+									display="flex"
+									alignItems="center"
+									gap="16"
+									width="full"
+								>
+									<Box
+										flexShrink={0}
+										style={{ width: 100 }}
+									>
+										<Text weight="bold" size="small">
+											Project name
+										</Text>
+									</Box>
+									<Form.Input
+										id="projectName"
+										name="projectName"
+										value={name}
+										onChange={(e) => {
+											setName(e.target.value)
+										}}
+										style={{ flexGrow: 1 }}
+										disabled={!isAdminRole}
+									/>
+								</Box>
+							</Stack>
+						</Form>
+					)}
+				</Stack>
+			</Box>
+
+			{isAdminRole && (
+				<Box
+					border="dividerWeak"
+					borderRadius="8"
+					background="white"
+					p="24"
+					id="danger"
+				>
+					<Stack gap="16">
+						<Heading level="h4">Danger Zone</Heading>
+
+						<Form onSubmit={onDelete}>
+							{loading ? (
+								<LoadingBox />
+							) : (
+								<Stack gap="16">
+									<Text color="moderate">
+										This will immediately delete all session
+										and errors in this project. Please type
+										'{`${data?.project?.name}`}' to confirm.
+									</Text>
+									<Box display="flex" gap="8">
+										<Form.Input
+											placeholder={`${data?.project?.name}`}
+											name="confirmationText"
+											value={confirmationText}
+											onChange={(e) => {
+												setConfirmationText(
+													e.target.value,
+												)
+											}}
+											style={{ flexGrow: 1 }}
+										/>
+										<Button
+											trackingId="DeleteProject"
+											kind="danger"
+											emphasis="high"
+											disabled={
+												confirmationText !==
+												data?.project?.name
+											}
+											type="submit"
+											loading={deleteLoading}
+										>
+											Delete this project
+										</Button>
+									</Box>
+								</Stack>
+							)}
+						</Form>
+					</Stack>
+				</Box>
 			)}
-		</>
+		</Stack>
+
 	)
 }

--- a/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
@@ -1,13 +1,19 @@
+import { useEditProjectSettingsMutation } from '@graph/hooks'
+import {
+	Box,
+	Heading,
+	Select,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
+import { useParams } from '@util/react-router/useParams'
+import React, { useEffect, useState } from 'react'
+
+import BorderBox from '@/components/BorderBox/BorderBox'
+import { Button } from '@/components/Button'
 import { LoadingBar } from '@components/Loading/Loading'
-import Select from '@components/Select/Select'
-import { toast } from '@components/Toaster'
-import { Stack } from '@highlight-run/ui/components'
-import { Text } from 'recharts'
-
-import BoxLabel from '@/components/BoxLabel/BoxLabel'
+import { toast } from '@/components/Toaster'
 import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
-
-import styles from './ErrorFiltersForm.module.css'
 
 const isValidRegex = function (p: string) {
 	try {
@@ -20,50 +26,107 @@ const isValidRegex = function (p: string) {
 }
 
 export const ErrorFiltersForm = () => {
+	const { project_id } = useParams<{ project_id: string }>()
 	const {
 		allProjectSettings: data,
 		loading,
 		setAllProjectSettings,
 	} = useProjectSettingsContext()
 
+	const [errorFilters, setErrorFilters] = useState<string[]>([])
+
+	useEffect(() => {
+		if (data?.projectSettings?.error_filters) {
+			setErrorFilters(data.projectSettings.error_filters)
+		}
+	}, [data?.projectSettings?.error_filters])
+
+	const [editProjectSettings, { loading: editLoading }] =
+		useEditProjectSettingsMutation()
+
+	const onSave = (e: React.FormEvent) => {
+		e.preventDefault()
+		const validFilters = errorFilters.filter(isValidRegex)
+		if (validFilters.length !== errorFilters.length) {
+			return
+		}
+
+		editProjectSettings({
+			variables: {
+				projectId: project_id!,
+				error_filters: errorFilters,
+			},
+		}).then(() => {
+			toast.success('Updated error filters!', { duration: 5000 })
+			setAllProjectSettings((current) =>
+				current?.projectSettings
+					? {
+							projectSettings: {
+								...current.projectSettings,
+								error_filters: errorFilters,
+							},
+					  }
+					: current,
+			)
+		})
+	}
+
+	const onDiscard = () => {
+		setErrorFilters(data?.projectSettings?.error_filters || [])
+	}
+
+	const isDirty =
+		JSON.stringify(errorFilters) !==
+		JSON.stringify(data?.projectSettings?.error_filters || [])
+
 	if (loading) {
 		return <LoadingBar />
 	}
 
 	return (
-		<form>
-			<Stack gap="8">
-				<BoxLabel
-					label="Error filters"
-					info="Enter regular expression patterns to filter out newly created errors. Any error filtered out will not count towards your billing quota."
-				/>
-				<div className={styles.inputAndButtonRow}>
-					<Select
-						className={styles.input}
-						mode="tags"
-						placeholder="TypeError: Failed to fetch"
-						value={data?.projectSettings?.error_filters || []}
-						notFoundContent={
-							<Text>
-								Provide a regex pattern to filter out errors.
-							</Text>
-						}
-						onChange={(patterns: string[]) => {
-							patterns.filter(isValidRegex)
-							setAllProjectSettings((currentProjectSettings) =>
-								currentProjectSettings?.projectSettings
-									? {
-											projectSettings: {
-												...currentProjectSettings.projectSettings,
-												error_filters: patterns,
-											},
-										}
-									: currentProjectSettings,
-							)
-						}}
-					/>
-				</div>
+		<Stack gap="16">
+			<Stack gap="4">
+				<Heading level="h4">Error filters</Heading>
+				<Text color="moderate">
+					Enter regular expression patterns to filter out newly
+					created errors. Any error filtered out will not count
+					towards your billing quota.
+				</Text>
 			</Stack>
-		</form>
+
+			<Box display="flex" flexDirection="column" gap="4">
+				<Text weight="bold" size="small">
+					Regex Patterns
+				</Text>
+				<Select
+					placeholder="TypeError: Failed to fetch"
+					value={errorFilters.map((f) => ({
+						name: f,
+						value: f,
+					}))}
+					onValueChange={(v: any) => {
+						const newFilters = Array.isArray(v)
+							? v.map((o) => o.value)
+							: v
+							? [v.value]
+							: []
+						setErrorFilters(newFilters)
+						setAllProjectSettings((current) =>
+							current?.projectSettings
+								? {
+										projectSettings: {
+											...current.projectSettings,
+											error_filters: newFilters,
+										},
+								  }
+								: current,
+						)
+					}}
+					creatable
+					displayMode="tags"
+				/>
+			</Box>
+		</Stack>
+
 	)
 }

--- a/frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx
@@ -1,50 +1,115 @@
-import { LoadingBar } from '@components/Loading/Loading'
-import Select from '@components/Select/Select'
-import { Stack } from '@highlight-run/ui/components'
+import { useEditProjectSettingsMutation } from '@graph/hooks'
+import {
+	Box,
+	Heading,
+	Select,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
+import React, { useEffect, useState } from 'react'
 
-import BoxLabel from '@/components/BoxLabel/BoxLabel'
+import BorderBox from '@/components/BorderBox/BorderBox'
+import { Button } from '@/components/Button'
+import { LoadingBar } from '@components/Loading/Loading'
+import { toast } from '@/components/Toaster'
 import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
 
 export const ErrorSettingsForm = () => {
-	const { project_id } = useParams<{
-		project_id: string
-	}>()
+	const { project_id } = useParams<{ project_id: string }>()
 	const {
 		allProjectSettings: data,
 		loading,
 		setAllProjectSettings,
 	} = useProjectSettingsContext()
 
+	const [errorJsonPaths, setErrorJsonPaths] = useState<string[]>([])
+
+	useEffect(() => {
+		if (data?.projectSettings?.error_json_paths) {
+			setErrorJsonPaths(data.projectSettings.error_json_paths)
+		}
+	}, [data?.projectSettings?.error_json_paths])
+
+	const [editProjectSettings, { loading: editLoading }] =
+		useEditProjectSettingsMutation()
+
+	const onSave = (e: React.FormEvent) => {
+		e.preventDefault()
+		editProjectSettings({
+			variables: {
+				projectId: project_id!,
+				error_json_paths: errorJsonPaths,
+			},
+		}).then(() => {
+			toast.success('Updated error grouping!', { duration: 5000 })
+			setAllProjectSettings((current) =>
+				current?.projectSettings
+					? {
+							projectSettings: {
+								...current.projectSettings,
+								error_json_paths: errorJsonPaths,
+							},
+					  }
+					: current,
+			)
+		})
+	}
+
+	const onDiscard = () => {
+		setErrorJsonPaths(data?.projectSettings?.error_json_paths || [])
+	}
+
+	const isDirty =
+		JSON.stringify(errorJsonPaths) !==
+		JSON.stringify(data?.projectSettings?.error_json_paths || [])
+
 	if (loading) {
 		return <LoadingBar />
 	}
 
 	return (
-		<form key={project_id}>
-			<Stack gap="8">
-				<BoxLabel
-					label="Error grouping"
-					info="Enter JSON expressions to use for grouping your errors."
-				/>
+		<Stack gap="16">
+			<Stack gap="4">
+				<Heading level="h4">Error grouping</Heading>
+				<Text color="moderate">
+					Enter JSON expressions to use for grouping your errors.
+				</Text>
+			</Stack>
+
+			<Box display="flex" flexDirection="column" gap="4">
+				<Text weight="bold" size="small">
+					JSON Expressions
+				</Text>
 				<Select
-					mode="tags"
 					placeholder="$.context.messages[0]"
-					value={data?.projectSettings?.error_json_paths || []}
-					onChange={(paths: string[]) => {
-						setAllProjectSettings((currentProjectSettings) =>
-							currentProjectSettings?.projectSettings
+					value={errorJsonPaths.map((p) => ({
+						name: p,
+						value: p,
+					}))}
+					onValueChange={(v: any) => {
+						const newPaths = Array.isArray(v)
+							? v.map((o) => o.value)
+							: v
+							? [v.value]
+							: []
+						setErrorJsonPaths(newPaths)
+						setAllProjectSettings((current) =>
+							current?.projectSettings
 								? {
 										projectSettings: {
-											...currentProjectSettings.projectSettings,
-											error_json_paths: paths,
+											...current.projectSettings,
+											error_json_paths: newPaths,
 										},
-									}
-								: currentProjectSettings,
+								  }
+								: current,
 						)
 					}}
+					creatable
+					displayMode="tags"
 				/>
-			</Stack>
-		</form>
+			</Box>
+		</Stack>
+
 	)
 }

--- a/frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx
@@ -1,29 +1,34 @@
-import { LoadingBar } from '@components/Loading/Loading'
-import Select from '@components/Select/Select'
-import TextHighlighter from '@components/TextHighlighter/TextHighlighter'
-import { toast } from '@components/Toaster'
-import { useGetIdentifierSuggestionsQuery } from '@graph/hooks'
-import { Form, Stack } from '@highlight-run/ui/components'
+import {
+	useEditProjectSettingsMutation,
+	useGetIdentifierSuggestionsQuery,
+} from '@graph/hooks'
+import {
+	Box,
+	Heading,
+	Select,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
-import { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import BorderBox from '@/components/BorderBox/BorderBox'
-import BoxLabel from '@/components/BoxLabel/BoxLabel'
+import { Button } from '@/components/Button'
+import { LoadingBar } from '@components/Loading/Loading'
+import TextHighlighter from '@/components/TextHighlighter/TextHighlighter'
+import { toast } from '@/components/Toaster'
 import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
 
 export const ExcludedUsersForm = () => {
-	const { project_id } = useParams<{
-		project_id: string
-	}>()
-	const [identifierQuery, setIdentifierQuery] = useState('')
-	const [invalidExcludedUsers, setInvalidExcludedUsers] = useState<string[]>(
-		[],
-	)
+	const { project_id } = useParams<{ project_id: string }>()
 	const {
 		allProjectSettings: data,
 		loading,
 		setAllProjectSettings,
 	} = useProjectSettingsContext()
+
+	const [excludedUsers, setExcludedUsers] = useState<string[]>([])
+	const [identifierQuery, setIdentifierQuery] = useState('')
 
 	const {
 		refetch: refetchIdentifierSuggestions,
@@ -37,100 +42,146 @@ export const ExcludedUsersForm = () => {
 		skip: !project_id,
 	})
 
-	if (loading) {
-		return <LoadingBar />
-	}
+	const [editProjectSettings, { loading: editLoading }] =
+		useEditProjectSettingsMutation()
 
-	const identifierSuggestions = identifierSuggestionsLoading
-		? []
-		: (identifierSuggestionsApiResponse?.identifier_suggestion || []).map(
-				(suggestion) => ({
-					value: suggestion,
-					displayValue: (
-						<TextHighlighter
-							searchWords={[identifierQuery]}
-							textToHighlight={suggestion}
-						/>
-					),
-					id: suggestion,
-				}),
-			)
+	useEffect(() => {
+		if (data?.projectSettings?.excluded_users) {
+			setExcludedUsers(data.projectSettings.excluded_users)
+		}
+	}, [data?.projectSettings?.excluded_users])
 
 	const handleIdentifierSearch = (query = '') => {
 		setIdentifierQuery(query)
 		refetchIdentifierSuggestions({ query, project_id })
 	}
 
+	const onSave = (e: React.FormEvent) => {
+		e.preventDefault()
+		editProjectSettings({
+			variables: {
+				projectId: project_id!,
+				excluded_users: excludedUsers,
+			},
+		}).then(() => {
+			toast.success('Updated excluded sessions!', { duration: 5000 })
+			setAllProjectSettings((current) =>
+				current?.projectSettings
+					? {
+							projectSettings: {
+								...current.projectSettings,
+								excluded_users: excludedUsers,
+							},
+					  }
+					: current,
+			)
+		})
+	}
+
+	const onDiscard = () => {
+		setExcludedUsers(data?.projectSettings?.excluded_users || [])
+	}
+
+	const isDirty =
+		JSON.stringify(excludedUsers) !==
+		JSON.stringify(data?.projectSettings?.excluded_users || [])
+
+	const identifierSuggestions = identifierSuggestionsLoading
+		? []
+		: (identifierSuggestionsApiResponse?.identifier_suggestion || [])
+
 	return (
-		<BorderBox>
-			<Form>
-				<Stack gap="8">
-					<BoxLabel
-						label="Excluded users"
-						info="
-					Enter user identifiers or emails to filter (regular
-					expressions are accepted). On completion, sessions from
-					these users will be excluded from your searches and quota."
-					/>
-					<Form.NamedSection
-						label="Filtered users"
-						name="Filtered users"
-					>
-						<Select
-							mode="tags"
-							placeholder=".*@yourdomain.com"
-							value={
-								data?.projectSettings?.excluded_users ||
-								undefined
-							}
-							onSearch={handleIdentifierSearch}
-							options={identifierSuggestions}
-							onChange={(excluded: string[]) => {
-								const validRegexes: string[] = []
-								const invalidRegexes: string[] = []
-								excluded.forEach((expression) => {
-									try {
-										new RegExp(expression)
-										validRegexes.push(expression)
-									} catch (e) {
-										invalidRegexes.push(expression)
-									}
-								})
-								if (
-									excluded.length > 0 &&
-									invalidRegexes.length > 0 &&
-									excluded[excluded.length - 1] ===
-										invalidRegexes[
-											invalidRegexes.length - 1
-										]
-								) {
-									toast.error(
-										"'" +
-											excluded[excluded.length - 1] +
-											"' is not a valid regular expression",
-										{ duration: 5000 },
-									)
-								}
-								setInvalidExcludedUsers(invalidRegexes)
-								handleIdentifierSearch('')
-								setAllProjectSettings(
-									(currentProjectSettings) =>
-										currentProjectSettings?.projectSettings
+		<Box
+			id="excluded-users"
+			background="white"
+			border="dividerWeak"
+			borderRadius="8"
+			p="24"
+		>
+			<Stack gap="16">
+				<Stack gap="4">
+					<Heading level="h4">Excluded sessions</Heading>
+					<Text color="moderate">
+						The sessions of users whose email or identifier matches
+						any of the entries in this list will not be recorded.
+					</Text>
+				</Stack>
+
+				{loading ? (
+					<LoadingBar />
+				) : (
+					<Stack gap="16">
+						<Box display="flex" flexDirection="column" gap="4">
+							<Text weight="bold" size="small">
+								Emails / Identifiers
+							</Text>
+							<Select
+								placeholder="email@example.com, 1a2b3c, ..."
+								value={excludedUsers.map((u) => ({
+									name: u,
+									value: u,
+								}))}
+								onValueChange={(v: any) => {
+									const newUsers = Array.isArray(v)
+										? v.map((o) => o.value)
+										: v
+										? [v.value]
+										: []
+									setExcludedUsers(newUsers)
+									setAllProjectSettings((current) =>
+										current?.projectSettings
 											? {
 													projectSettings: {
-														...currentProjectSettings.projectSettings,
+														...current.projectSettings,
 														excluded_users:
-															validRegexes,
+															newUsers,
 													},
-												}
-											: currentProjectSettings,
-								)
-							}}
-						/>
-					</Form.NamedSection>
-					{invalidExcludedUsers.length > 0 && <div></div>}
-				</Stack>
-			</Form>
-		</BorderBox>
+											  }
+											: current,
+									)
+								}}
+								onSearchValueChange={(value: string) =>
+									handleIdentifierSearch(value)
+								}
+								options={identifierSuggestions.map((s) => ({
+									name: s,
+									value: s,
+								}))}
+								creatable
+								displayMode="tags"
+							/>
+						</Box>
+
+						<Box
+							background="raised"
+							p="16"
+							borderRadius="8"
+							border="dividerWeak"
+						>
+							<Stack gap="8">
+								<Text size="xSmall" color="moderate">
+									Example regex patterns:
+								</Text>
+								<Stack gap="4">
+									<Text size="xSmall" family="monospace">
+										<TextHighlighter
+											searchWords={['.*@highlight.io']}
+											textToHighlight=".*@highlight.io - matches all emails ending in @highlight.io"
+										/>
+									</Text>
+									<Text size="xSmall" family="monospace">
+										<TextHighlighter
+											searchWords={['^123$']}
+											textToHighlight="^123$ - matches identifier '123' exactly"
+										/>
+									</Text>
+								</Stack>
+							</Stack>
+						</Box>
+					</Stack>
+				)}
+			</Stack>
+		</Box>
+
 	)
 }

--- a/frontend/src/pages/ProjectSettings/FilterExtensionForm/FilterExtensionForm.tsx
+++ b/frontend/src/pages/ProjectSettings/FilterExtensionForm/FilterExtensionForm.tsx
@@ -1,8 +1,8 @@
-import { LoadingBar } from '@components/Loading/Loading'
+import { Box, Heading, Stack, Text } from '@highlight-run/ui/components'
 import { useEffect, useState } from 'react'
 
-import BorderBox from '@/components/BorderBox/BorderBox'
-import { ToggleRow } from '@/components/ToggleRow/ToggleRow'
+import { LoadingBar } from '@components/Loading/Loading'
+import Switch from '@/components/Switch/Switch'
 import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
 
 export const FilterExtensionForm = () => {
@@ -26,41 +26,41 @@ export const FilterExtensionForm = () => {
 		return <LoadingBar />
 	}
 
-	const categories = [
-		{
-			key: 'Extension errors',
-			message:
-				'Filter out newly created errors thrown by browser extensions. Any error filtered out will not count towards your billing quota.',
-			checked: filterChromeExtension,
-		},
-	]
-
 	return (
-		<>
-			{categories.map((c) => (
-				<BorderBox key={c.key}>
-					{ToggleRow(
-						c.key,
-						c.message,
-						c.checked,
-						(isOptIn: boolean) => {
-							setfilterChromeExtension(isOptIn)
-							setAllProjectSettings((currentProjectSettings) =>
-								currentProjectSettings?.projectSettings
-									? {
-											projectSettings: {
-												...currentProjectSettings.projectSettings,
-												filter_chrome_extension:
-													isOptIn,
-											},
-										}
-									: currentProjectSettings,
-							)
-						},
-						false,
-					)}
-				</BorderBox>
-			))}
-		</>
+		<Box background="white" border="dividerWeak" borderRadius="8" p="24">
+			<Stack
+				direction="row"
+				alignItems="center"
+				justifyContent="space-between"
+				gap="16"
+			>
+				<Stack gap="4">
+					<Heading level="h4">Extension errors</Heading>
+					<Text color="moderate">
+						Filter out newly created errors thrown by browser
+						extensions. Any error filtered out will not count
+						towards your billing quota.
+					</Text>
+				</Stack>
+				<Switch
+					trackingId="FilterChromeExtensionSwitch"
+					checked={filterChromeExtension}
+					onChange={(isOptIn: boolean) => {
+						setfilterChromeExtension(isOptIn)
+						setAllProjectSettings((currentProjectSettings) =>
+							currentProjectSettings?.projectSettings
+								? {
+										projectSettings: {
+											...currentProjectSettings.projectSettings,
+											filter_chrome_extension: isOptIn,
+										},
+								  }
+								: currentProjectSettings,
+						)
+					}}
+				/>
+			</Stack>
+		</Box>
 	)
 }
+

--- a/frontend/src/pages/ProjectSettings/ProjectFilters/ProjectFilters.tsx
+++ b/frontend/src/pages/ProjectSettings/ProjectFilters/ProjectFilters.tsx
@@ -1,5 +1,4 @@
 import EnterpriseFeatureButton from '@components/Billing/EnterpriseFeatureButton'
-import { Button } from '@components/Button'
 import { SearchForm } from '@components/Search/SearchForm/SearchForm'
 import {
 	useEditProjectSettingsMutation,
@@ -34,9 +33,10 @@ import { useProjectId } from '@hooks/useProjectId'
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
 import { upperFirst } from 'lodash'
 import moment from 'moment'
-import React from 'react'
+import React, { useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { Button } from '@/components/Button'
 import { SearchContext } from '@/components/Search/SearchContext'
 
 const DATE_RANGE_PRESETS = [DEFAULT_TIME_PRESETS[1], DEFAULT_TIME_PRESETS[3]]
@@ -95,15 +95,15 @@ const Header: React.FC<{
 
 export const ProjectFilters: React.FC = () => {
 	return (
-		<Stack width="full">
+		<Stack width="full" gap="32">
 			<ProjectProductFilters view product={ProductType.Sessions} />
-			<Box my="20" borderBottom="dividerWeak" />
+			<Box borderTop="dividerWeak" style={{ marginLeft: -24, marginRight: -24 }} />
 			<ProjectProductFilters view product={ProductType.Errors} />
-			<Box my="20" borderBottom="dividerWeak" />
+			<Box borderTop="dividerWeak" style={{ marginLeft: -24, marginRight: -24 }} />
 			<ProjectProductFilters view product={ProductType.Logs} />
-			<Box my="20" borderBottom="dividerWeak" />
+			<Box borderTop="dividerWeak" style={{ marginLeft: -24, marginRight: -24 }} />
 			<ProjectProductFilters view product={ProductType.Traces} />
-			<Box my="20" borderBottom="dividerWeak" />
+			<Box borderTop="dividerWeak" style={{ marginLeft: -24, marginRight: -24 }} />
 			<ProjectProductFilters view product={ProductType.Metrics} />
 		</Stack>
 	)
@@ -218,6 +218,56 @@ export const ProjectProductFilters: React.FC<{
 
 	React.useEffect(resetConfig, [resetConfig])
 
+	const isDirty = useMemo(() => {
+		const c = {
+			exclusion_query:
+				data?.projectSettings?.sampling[
+					`${product
+						.toLowerCase()
+						.slice(0, -1)}_exclusion_query` as keyof Pick<
+						Sampling,
+						| 'session_exclusion_query'
+						| 'error_exclusion_query'
+						| 'log_exclusion_query'
+						| 'trace_exclusion_query'
+						| 'metric_exclusion_query'
+					>
+				],
+			sampling_rate:
+				data?.projectSettings?.sampling[
+					`${product
+						.toLowerCase()
+						.slice(0, -1)}_sampling_rate` as keyof Pick<
+						Sampling,
+						| 'session_sampling_rate'
+						| 'error_sampling_rate'
+						| 'log_sampling_rate'
+						| 'trace_sampling_rate'
+						| 'metric_sampling_rate'
+					>
+				],
+			minute_rate_limit:
+				data?.projectSettings?.sampling[
+					`${product
+						.toLowerCase()
+						.slice(0, -1)}_minute_rate_limit` as keyof Pick<
+						Sampling,
+						| 'session_minute_rate_limit'
+						| 'error_minute_rate_limit'
+						| 'log_minute_rate_limit'
+						| 'trace_minute_rate_limit'
+						| 'metric_minute_rate_limit'
+					>
+				],
+		}
+		const currentValues = formStore.getState().values
+		return (
+			currentValues.exclusionQuery !== (c.exclusion_query ?? null) ||
+			currentValues.samplingPercent !== 100 * (c.sampling_rate ?? 1) ||
+			currentValues.minuteRateLimit !== (c.minute_rate_limit ?? null)
+		)
+	}, [data?.projectSettings?.sampling, formStore, product])
+
 	if (!product || loading) {
 		return null
 	}
@@ -259,12 +309,12 @@ export const ProjectProductFilters: React.FC<{
 	)
 
 	const save = (
-		<Box display="flex" alignItems="center" gap="6">
+		<Box display="flex" alignItems="center" gap="8">
 			<Button
 				trackingId={`project-filters-${product}-discard`}
 				kind="secondary"
 				size="small"
-				emphasis="low"
+				emphasis="medium"
 				onClick={resetConfig}
 			>
 				Discard changes
@@ -291,27 +341,29 @@ export const ProjectProductFilters: React.FC<{
 			{view ? null : (
 				<Header product={product} title={`${label} filters`} />
 			)}
-			<Box display="flex" flexDirection="column" gap="6">
+			<Box display="flex" flexDirection="column" gap="12">
 				<Box
 					display="flex"
 					justifyContent="space-between"
 					alignItems="center"
 					width="full"
 				>
-					<>
-						<Text>{label} filters</Text>
-						{view ? null : (
-							<FilterPaywall
-								setting="enable_ingest_filtering"
-								product={product}
-							>
-								{save}
-							</FilterPaywall>
-						)}
-					</>
+					<Box display="flex" alignItems="center" gap="8">
+						<Text size="large" weight="bold">
+							{label} filters
+						</Text>
+					</Box>
+					{(isDirty || !view) && (
+						<FilterPaywall
+							setting="enable_ingest_filtering"
+							product={product}
+						>
+							{save}
+						</FilterPaywall>
+					)}
 				</Box>
-				<Stack gap="6" py="6">
-					<Box display="flex" width="full" gap="6">
+				<Stack gap="12">
+					<Box display="flex" width="full" gap="8" alignItems="center">
 						<Box width="full" style={{ minHeight: 20 }}>
 							<SearchContext
 								initialQuery={query}
@@ -335,7 +387,7 @@ export const ProjectProductFilters: React.FC<{
 								/>
 							</SearchContext>
 						</Box>
-						{view ? (
+						{view && !isDirty ? (
 							<FilterPaywall
 								setting="enable_ingest_filtering"
 								product={product}
@@ -370,7 +422,7 @@ export const ProjectProductFilters: React.FC<{
 					justifyContent="space-between"
 					width="full"
 				>
-					<Text weight="medium" size="xSmall" color="weak">
+					<Text weight="medium" size="xSmall" color="moderate">
 						{label}s
 					</Text>
 					<DateRangePicker
@@ -390,83 +442,89 @@ export const ProjectProductFilters: React.FC<{
 						noCustom
 						minDate={moment().subtract(30, 'days').toDate()}
 						kind="secondary"
-						size="medium"
+						size="small"
 						emphasis="low"
 					/>
 				</Box>
 				<Form store={formStore}>
 					<Box display="flex" width="full">
 						{view ? null : (
-							<Stack display="flex" width="full" gap="8">
-								<EnterpriseFeatureButton
-									setting="enable_ingest_sampling"
-									name="Ingestion Sampling"
-									fn={async () => {}}
-									variant="basic"
-								>
-									<Box display="flex" width="full" gap="8">
+							<Stack display="flex" width="full" gap="12">
+								<Box width="full">
+									<EnterpriseFeatureButton
+										setting="enable_ingest_sampling"
+										name="Ingestion Sampling"
+										fn={async () => {}}
+										variant="basic"
+									>
 										<Box
-											width="full"
 											display="flex"
-											flexDirection="column"
-											gap="4"
-										>
-											<Form.Label
-												label="Sampling %"
-												name={
-													formStore.names
-														.samplingPercent
-												}
-											/>
-											<Form.Input
-												disabled={!canEditSampling}
-												name={
-													formStore.names
-														.samplingPercent
-												}
-												type="number"
-											/>
-										</Box>
-										<Box
 											width="full"
-											display="flex"
-											flexDirection="column"
-											gap="4"
+											gap="12"
 										>
-											<Form.Label
-												label="Max ingest per minute"
-												name={
-													formStore.names
-														.minuteRateLimit
-												}
-											/>
-											<Form.Input
-												disabled={!canEditSampling}
-												name={
-													formStore.names
-														.minuteRateLimit
-												}
-												type="number"
-											/>
+											<Box
+												flexGrow={1}
+												display="flex"
+												flexDirection="column"
+												gap="4"
+											>
+												<Form.Label
+													label="Sampling %"
+													name={
+														formStore.names
+															.samplingPercent
+													}
+												/>
+												<Form.Input
+													disabled={!canEditSampling}
+													name={
+														formStore.names
+															.samplingPercent
+													}
+													type="number"
+												/>
+											</Box>
+											<Box
+												flexGrow={1}
+												display="flex"
+												flexDirection="column"
+												gap="4"
+											>
+												<Form.Label
+													label="Max ingest per minute"
+													name={
+														formStore.names
+															.minuteRateLimit
+													}
+												/>
+												<Form.Input
+													disabled={!canEditSampling}
+													name={
+														formStore.names
+															.minuteRateLimit
+													}
+													type="number"
+												/>
+											</Box>
 										</Box>
-									</Box>
-								</EnterpriseFeatureButton>
+									</EnterpriseFeatureButton>
+								</Box>
 								<Callout>
 									<Box
 										display="flex"
 										flexDirection="column"
-										gap="12"
-										py="6"
+										gap="8"
+										py="4"
 									>
-										<Text color="moderate">
+										<Text color="moderate" size="small">
 											1. Filters will drop data matching
 											the condition.
 										</Text>
-										<Text color="moderate">
+										<Text color="moderate" size="small">
 											2. Sampling % will determine the
 											percentage of data to ingest.
 										</Text>
-										<Text color="moderate">
+										<Text color="moderate" size="small">
 											3. Minute rate limit will drop a
 											spike of data exceeding the
 											per-minute value.

--- a/frontend/src/pages/ProjectSettings/ProjectSettings.tsx
+++ b/frontend/src/pages/ProjectSettings/ProjectSettings.tsx
@@ -114,144 +114,190 @@ const ProjectSettings = () => {
 				<title>Project Settings</title>
 			</Helmet>
 
-			<Box style={{ maxWidth: 560 }} my="40" mx="auto">
-				<Heading mt="16" level="h4">
-					Project Settings
-				</Heading>
-				<Box mt="24">
-					<ProjectSettingsContextProvider
-						value={{
-							allProjectSettings,
-							setAllProjectSettings,
-							loading,
-						}}
-					>
-						<Tabs<ProjectSettingsTabs>
-							selectedId={
-								params.tab ?? ProjectSettingsTabs.Sessions
-							}
-							onChange={(id) => {
-								navigate(`/${project_id}/settings/${id}`)
+			<Box style={{ maxWidth: 800 }} my="40" mx="auto">
+				<Stack gap="32">
+					<Heading level="h2">Project Settings</Heading>
+					<Box>
+						<ProjectSettingsContextProvider
+							value={{
+								allProjectSettings,
+								setAllProjectSettings,
+								loading,
 							}}
 						>
-							<Tabs.List>
-								<Tabs.Tab id={ProjectSettingsTabs.General}>
-									General
-								</Tabs.Tab>
-								<Tabs.Tab id={ProjectSettingsTabs.Sessions}>
-									Session replay
-								</Tabs.Tab>
-								<Tabs.Tab id={ProjectSettingsTabs.Errors}>
-									Error monitoring
-								</Tabs.Tab>
-								<Tabs.Tab id={ProjectSettingsTabs.Services}>
-									Services
-								</Tabs.Tab>
-								<Tabs.Tab id={ProjectSettingsTabs.Filters}>
-									Filters
-								</Tabs.Tab>
-								<Tabs.Tab id={ProjectSettingsTabs.Streams}>
-									Streams
-								</Tabs.Tab>
-							</Tabs.List>
-							<Box mt="24">
-								<Tabs.Panel id={ProjectSettingsTabs.General}>
-									<DangerForm />
-								</Tabs.Panel>
-								<Tabs.Panel id={ProjectSettingsTabs.Sessions}>
-									<Stack>
-										<Box
-											display="flex"
-											gap="8"
-											justifyContent="space-between"
-											alignItems="center"
-										>
-											<Text size="large" weight="bold">
-												Session replay
-											</Text>
-											<Button
-												onClick={onSubmit(
-													'session replay',
-												)}
-												trackingId="ProjectSettingsUpdate"
+							<Tabs<ProjectSettingsTabs>
+								selectedId={
+									params.tab ?? ProjectSettingsTabs.Sessions
+								}
+								onChange={(id) => {
+									navigate(`/${project_id}/settings/${id}`)
+								}}
+							>
+								<Tabs.List>
+									<Tabs.Tab id={ProjectSettingsTabs.General}>
+										General
+									</Tabs.Tab>
+									<Tabs.Tab id={ProjectSettingsTabs.Sessions}>
+										Session replay
+									</Tabs.Tab>
+									<Tabs.Tab id={ProjectSettingsTabs.Errors}>
+										Error monitoring
+									</Tabs.Tab>
+									<Tabs.Tab id={ProjectSettingsTabs.Services}>
+										Services
+									</Tabs.Tab>
+									<Tabs.Tab id={ProjectSettingsTabs.Filters}>
+										Filters
+									</Tabs.Tab>
+									<Tabs.Tab id={ProjectSettingsTabs.Streams}>
+										Streams
+									</Tabs.Tab>
+								</Tabs.List>
+								<Box mt="32">
+									<Tabs.Panel
+										id={ProjectSettingsTabs.General}
+									>
+										<DangerForm />
+									</Tabs.Panel>
+									<Tabs.Panel
+										id={ProjectSettingsTabs.Sessions}
+									>
+										<Stack gap="16">
+											<Box
+												display="flex"
+												gap="8"
+												justifyContent="space-between"
+												alignItems="center"
 											>
-												{editProjectSettingsLoading ? (
-													<CircularSpinner
-														style={{
-															fontSize: 18,
-															color: 'var(--text-primary-inverted)',
-														}}
-													/>
-												) : (
-													'Save changes'
-												)}
-											</Button>
-										</Box>
-										<ExcludedUsersForm />
-										<SessionFiltersCallout />
-										<RageClicksForm />
-										{workspaceSettingsData
-											?.workspaceSettings
-											?.enable_session_export ? (
-											<SessionExportForm />
-										) : null}
-									</Stack>
-								</Tabs.Panel>
-								<Tabs.Panel id={ProjectSettingsTabs.Errors}>
-									<Stack>
-										<Box
-											display="flex"
-											gap="8"
-											justifyContent="space-between"
-											alignItems="center"
-										>
-											<Text size="large" weight="bold">
-												Error monitoring
-											</Text>
-											<Button
-												onClick={onSubmit(
-													'error monitoring',
-												)}
-												trackingId="ProjectSettingsUpdate"
-											>
-												{editProjectSettingsLoading ? (
-													<CircularSpinner
-														style={{
-															fontSize: 18,
-															color: 'var(--text-primary-inverted)',
-														}}
-													/>
-												) : (
-													'Save changes'
-												)}
-											</Button>
-										</Box>
-										<BorderBox>
-											<Stack gap="8">
-												<ErrorSettingsForm />
-												<Box borderTop="dividerWeak" />
-												<ErrorFiltersForm />
+												<Heading level="h4">
+													Session replay
+												</Heading>
+												<Button
+													onClick={onSubmit(
+														'session replay',
+													)}
+													trackingId="ProjectSettingsUpdate"
+												>
+													{editProjectSettingsLoading ? (
+														<CircularSpinner
+															style={{
+																fontSize: 18,
+																color: 'var(--text-primary-inverted)',
+															}}
+														/>
+													) : (
+														'Save changes'
+													)}
+												</Button>
+											</Box>
+											<Stack gap="16">
+												<ExcludedUsersForm />
+												<SessionFiltersCallout />
+												<RageClicksForm />
+												{workspaceSettingsData
+													?.workspaceSettings
+													?.enable_session_export ? (
+													<SessionExportForm />
+												) : null}
 											</Stack>
-										</BorderBox>
-										<FilterExtensionForm />
-										<SourcemapSettings />
-										<AutoresolveStaleErrorsForm />
-									</Stack>
-								</Tabs.Panel>
-								<Tabs.Panel id={ProjectSettingsTabs.Services}>
-									<ServicesTable />
-								</Tabs.Panel>
-								<Tabs.Panel id={ProjectSettingsTabs.Filters}>
-									<ProjectFilters />
-								</Tabs.Panel>
-								<Tabs.Panel id={ProjectSettingsTabs.Streams}>
-									<StreamsSettings />
-								</Tabs.Panel>
-							</Box>
-						</Tabs>
-					</ProjectSettingsContextProvider>
-				</Box>
+										</Stack>
+									</Tabs.Panel>
+									<Tabs.Panel
+										id={ProjectSettingsTabs.Errors}
+									>
+										<Stack gap="16">
+											<Box
+												display="flex"
+												gap="8"
+												justifyContent="space-between"
+												alignItems="center"
+											>
+												<Heading level="h4">
+													Error monitoring
+												</Heading>
+												<Button
+													onClick={onSubmit(
+														'error monitoring',
+													)}
+													trackingId="ProjectSettingsUpdate"
+												>
+													{editProjectSettingsLoading ? (
+														<CircularSpinner
+															style={{
+																fontSize: 18,
+																color: 'var(--text-primary-inverted)',
+															}}
+														/>
+													) : (
+														'Save changes'
+													)}
+												</Button>
+											</Box>
+											<Stack gap="16">
+												<Box
+													background="white"
+													border="dividerWeak"
+													borderRadius="8"
+												>
+													<Stack gap="0">
+														<Box p="24">
+															<ErrorSettingsForm />
+														</Box>
+														<Box borderTop="dividerWeak" />
+														<Box p="24">
+															<ErrorFiltersForm />
+														</Box>
+													</Stack>
+												</Box>
+												<FilterExtensionForm />
+												<SourcemapSettings />
+												<AutoresolveStaleErrorsForm />
+											</Stack>
+										</Stack>
+									</Tabs.Panel>
+									<Tabs.Panel
+										id={ProjectSettingsTabs.Services}
+									>
+										<Box
+											background="white"
+											border="dividerWeak"
+											borderRadius="8"
+											p="24"
+										>
+											<ServicesTable />
+										</Box>
+									</Tabs.Panel>
+									<Tabs.Panel
+										id={ProjectSettingsTabs.Filters}
+									>
+										<Box
+											background="white"
+											border="dividerWeak"
+											borderRadius="8"
+											p="24"
+										>
+											<ProjectFilters />
+										</Box>
+									</Tabs.Panel>
+									<Tabs.Panel
+										id={ProjectSettingsTabs.Streams}
+									>
+										<Box
+											background="white"
+											border="dividerWeak"
+											borderRadius="8"
+											p="24"
+										>
+											<StreamsSettings />
+										</Box>
+									</Tabs.Panel>
+								</Box>
+							</Tabs>
+						</ProjectSettingsContextProvider>
+					</Box>
+				</Stack>
 			</Box>
+
 		</>
 	)
 }

--- a/frontend/src/pages/ProjectSettings/RageClicksForm/RageClicksForm.tsx
+++ b/frontend/src/pages/ProjectSettings/RageClicksForm/RageClicksForm.tsx
@@ -1,148 +1,246 @@
-import InfoTooltip from '@components/InfoTooltip/InfoTooltip'
-import { LoadingBar } from '@components/Loading/Loading'
-import { Box, Form, Stack } from '@highlight-run/ui/components'
+import {
+	useEditProjectSettingsMutation,
+} from '@graph/hooks'
+import {
+	Box,
+	Form,
+	Heading,
+	IconSolidInformationCircle,
+	Stack,
+	Text,
+	Tooltip,
+} from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import BorderBox from '@/components/BorderBox/BorderBox'
-import BoxLabel from '@/components/BoxLabel/BoxLabel'
+import { Button } from '@/components/Button'
+import { LoadingBar } from '@components/Loading/Loading'
+import { toast } from '@/components/Toaster'
 import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
 
 export const RageClicksForm = () => {
-	const { project_id } = useParams<{
-		project_id: string
-	}>()
-	const [rageClickWindowSeconds, setRageClickWindowSeconds] =
-		useState<number>(0)
-	const [rageClickRadiusPixels, setRageClickRadiusPixels] =
-		useState<number>(0)
-	const [rageClickCount, setRageClickCount] = useState<number>(0)
+	const { project_id } = useParams<{ project_id: string }>()
 	const {
 		allProjectSettings: data,
 		loading,
 		setAllProjectSettings,
 	} = useProjectSettingsContext()
 
+	const [rageClickWindowSeconds, setRageClickWindowSeconds] = useState<number>(0)
+	const [rageClickRadiusPixels, setRageClickRadiusPixels] = useState<number>(0)
+	const [rageClickCount, setRageClickCount] = useState<number>(0)
+
 	useEffect(() => {
-		if (!loading) {
-			setRageClickWindowSeconds(
-				data?.projectSettings?.rage_click_window_seconds ?? 0,
-			)
-			setRageClickRadiusPixels(
-				data?.projectSettings?.rage_click_radius_pixels ?? 0,
-			)
-			setRageClickCount(data?.projectSettings?.rage_click_count ?? 0)
+		if (!loading && data?.projectSettings) {
+			setRageClickWindowSeconds(data.projectSettings.rage_click_window_seconds ?? 0)
+			setRageClickRadiusPixels(data.projectSettings.rage_click_radius_pixels ?? 0)
+			setRageClickCount(data.projectSettings.rage_click_count ?? 0)
 		}
-	}, [
-		data?.projectSettings?.rage_click_count,
-		data?.projectSettings?.rage_click_radius_pixels,
-		data?.projectSettings?.rage_click_window_seconds,
-		loading,
-	])
+	}, [data?.projectSettings, loading])
+
+	const [editProjectSettings, { loading: editLoading }] =
+		useEditProjectSettingsMutation()
+
+	const onSave = (e: React.FormEvent) => {
+		e.preventDefault()
+		editProjectSettings({
+			variables: {
+				projectId: project_id!,
+				rage_click_window_seconds: rageClickWindowSeconds,
+				rage_click_radius_pixels: rageClickRadiusPixels,
+				rage_click_count: rageClickCount,
+			},
+		}).then(() => {
+			toast.success('Updated rage click settings!', { duration: 5000 })
+			setAllProjectSettings((current) =>
+				current?.projectSettings
+					? {
+							projectSettings: {
+								...current.projectSettings,
+								rage_click_window_seconds: rageClickWindowSeconds,
+								rage_click_radius_pixels: rageClickRadiusPixels,
+								rage_click_count: rageClickCount,
+							},
+					  }
+					: current,
+			)
+		})
+	}
+
+	const onDiscard = () => {
+		if (data?.projectSettings) {
+			setRageClickWindowSeconds(data.projectSettings.rage_click_window_seconds ?? 0)
+			setRageClickRadiusPixels(data.projectSettings.rage_click_radius_pixels ?? 0)
+			setRageClickCount(data.projectSettings.rage_click_count ?? 0)
+		}
+	}
+
+	const isDirty =
+		rageClickWindowSeconds !== (data?.projectSettings?.rage_click_window_seconds ?? 0) ||
+		rageClickRadiusPixels !== (data?.projectSettings?.rage_click_radius_pixels ?? 0) ||
+		rageClickCount !== (data?.projectSettings?.rage_click_count ?? 0)
 
 	if (loading) {
 		return <LoadingBar />
 	}
 
 	return (
-		<BorderBox>
-			<Form key={project_id}>
-				<Stack gap="8">
-					<BoxLabel
-						label="Rage clicks"
-						info="Use these settings to adjust the sensitivity for detecting
-					rage clicks."
-					/>
-					<Box display="flex" gap="8">
-						<Form.Input
-							label="Elapsed Time (seconds)"
-							name="rage_click_window_seconds"
-							type="number"
-							value={rageClickWindowSeconds}
-							labelTag={
-								<InfoTooltip
-									title="The maximum time allowed between clicks in a rage click event"
-									size="small"
-								/>
-							}
-							onChange={(e) => {
-								const val = Number(e.target.value)
-								setRageClickWindowSeconds(val)
-								setAllProjectSettings(
-									(currentProjectSettings) =>
-										currentProjectSettings?.projectSettings
+		<Box
+			id="rage-clicks"
+			background="white"
+			border="dividerWeak"
+			borderRadius="8"
+			p="24"
+		>
+			<Stack gap="16">
+				<Stack gap="4">
+					<Heading level="h4">Rage clicks</Heading>
+					<Text color="moderate">
+						Use these settings to adjust the sensitivity for
+						detecting rage clicks.
+					</Text>
+				</Stack>
+
+				<Form onSubmit={onSave}>
+					<Box display="flex" gap="16" width="full">
+						<Box
+							display="flex"
+							flexDirection="column"
+							gap="4"
+							flexGrow={1}
+						>
+							<Box display="flex" alignItems="center" gap="4">
+								<Text weight="bold" size="small">
+									Elapsed Time (seconds)
+								</Text>
+								<Tooltip
+									trigger={
+										<IconSolidInformationCircle
+											size={14}
+											color="var(--color-gray-400)"
+										/>
+									}
+								>
+									The maximum time allowed between clicks in a
+									rage click event
+								</Tooltip>
+							</Box>
+							<Form.Input
+								name="rage_click_window_seconds"
+								type="number"
+								value={rageClickWindowSeconds}
+								onChange={(e) => {
+									const val = Number(e.target.value)
+									setRageClickWindowSeconds(val)
+									setAllProjectSettings((current) =>
+										current?.projectSettings
 											? {
 													projectSettings: {
-														...currentProjectSettings.projectSettings,
+														...current.projectSettings,
 														rage_click_window_seconds:
 															val,
 													},
-												}
-											: currentProjectSettings,
-								)
-							}}
-							min={1}
-						/>
-						<Form.Input
-							label="Radius (pixels)"
-							labelTag={
-								<InfoTooltip
-									title="The maximum distance allowed between clicks in a rage click event"
-									size="small"
-								/>
-							}
-							name="rage_click_radius_pixels"
-							type="number"
-							value={rageClickRadiusPixels}
-							onChange={(e) => {
-								const val = Number(e.target.value)
-								setRageClickRadiusPixels(val)
-								setAllProjectSettings(
-									(currentProjectSettings) =>
-										currentProjectSettings?.projectSettings
+											  }
+											: current,
+									)
+								}}
+								min={1}
+							/>
+						</Box>
+
+						<Box
+							display="flex"
+							flexDirection="column"
+							gap="4"
+							flexGrow={1}
+						>
+							<Box display="flex" alignItems="center" gap="4">
+								<Text weight="bold" size="small">
+									Radius (pixels)
+								</Text>
+								<Tooltip
+									trigger={
+										<IconSolidInformationCircle
+											size={14}
+											color="var(--color-gray-400)"
+										/>
+									}
+								>
+									The maximum distance allowed between clicks
+									in a rage click event
+								</Tooltip>
+							</Box>
+							<Form.Input
+								name="rage_click_radius_pixels"
+								type="number"
+								value={rageClickRadiusPixels}
+								onChange={(e) => {
+									const val = Number(e.target.value)
+									setRageClickRadiusPixels(val)
+									setAllProjectSettings((current) =>
+										current?.projectSettings
 											? {
 													projectSettings: {
-														...currentProjectSettings.projectSettings,
+														...current.projectSettings,
 														rage_click_radius_pixels:
 															val,
 													},
-												}
-											: currentProjectSettings,
-								)
-							}}
-							min={1}
-						/>
-						<Form.Input
-							name="rage_click_minimum_clicks"
-							label="Minimum clicks"
-							labelTag={
-								<InfoTooltip
-									title="The minimum number of clicks needed to be considered a rage click event"
-									size="small"
-								/>
-							}
-							type="number"
-							value={rageClickCount}
-							onChange={(e) => {
-								const val = Number(e.target.value)
-								setRageClickCount(val)
-								setAllProjectSettings(
-									(currentProjectSettings) =>
-										currentProjectSettings?.projectSettings
+											  }
+											: current,
+									)
+								}}
+								min={1}
+							/>
+						</Box>
+
+						<Box
+							display="flex"
+							flexDirection="column"
+							gap="4"
+							flexGrow={1}
+						>
+							<Box display="flex" alignItems="center" gap="4">
+								<Text weight="bold" size="small">
+									Minimum clicks
+								</Text>
+								<Tooltip
+									trigger={
+										<IconSolidInformationCircle
+											size={14}
+											color="var(--color-gray-400)"
+										/>
+									}
+								>
+									The minimum number of clicks needed to be
+									considered a rage click event
+								</Tooltip>
+							</Box>
+							<Form.Input
+								name="rage_click_minimum_clicks"
+								type="number"
+								value={rageClickCount}
+								onChange={(e) => {
+									const val = Number(e.target.value)
+									setRageClickCount(val)
+									setAllProjectSettings((current) =>
+										current?.projectSettings
 											? {
 													projectSettings: {
-														...currentProjectSettings.projectSettings,
+														...current.projectSettings,
 														rage_click_count: val,
 													},
-												}
-											: currentProjectSettings,
-								)
-							}}
-							min={1}
-						/>
+											  }
+											: current,
+									)
+								}}
+								min={1}
+							/>
+						</Box>
 					</Box>
-				</Stack>
-			</Form>
-		</BorderBox>
+				</Form>
+			</Stack>
+		</Box>
+
 	)
 }

--- a/frontend/src/pages/ProjectSettings/ServicesTable/ServicesTable.tsx
+++ b/frontend/src/pages/ProjectSettings/ServicesTable/ServicesTable.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@components/Button'
 import LoadingBox from '@components/LoadingBox'
 import {
 	useEditServiceGithubSettingsMutation,
@@ -8,6 +7,7 @@ import { namedOperations } from '@graph/operations'
 import {
 	Badge,
 	Box,
+	Heading,
 	IconSolidCheveronDown,
 	IconSolidCubeTransparent,
 	IconSolidExternalLink,
@@ -25,7 +25,9 @@ import { GITHUB_INTEGRATION } from '@pages/IntegrationsPage/Integrations'
 import { capitalize, debounce } from 'lodash'
 import React, { useEffect, useMemo, useState } from 'react'
 
+import { Button } from '@/components/Button'
 import { Service, ServiceStatus } from '@/graph/generated/schemas'
+import { LoadingBar } from '@/components/Loading/Loading'
 
 import {
 	GithubSettingsFormValues,
@@ -146,7 +148,14 @@ export const ServicesTable: React.FC = () => {
 					justifyContent="space-between"
 					width="full"
 				>
-					<Box>{service.name}</Box>
+					<Box
+						style={{
+							fontFamily: 'var(--family-monospace)',
+							fontSize: 'var(--size-xSmall)',
+						}}
+					>
+						{service.name}
+					</Box>
 					{service.githubRepoPath && (
 						<Table.Discoverable>
 							<a
@@ -218,7 +227,7 @@ export const ServicesTable: React.FC = () => {
 						<Tooltip trigger={renderBadge()}>
 							<Box style={{ maxWidth: 250 }} p="8">
 								{service.errorDetails?.map((error) => (
-									<Text key={error} color="bad">
+									<Text key={error} color="bad" size="small">
 										{error}
 									</Text>
 								))}
@@ -238,7 +247,9 @@ export const ServicesTable: React.FC = () => {
 		if (loading) {
 			return (
 				<Table.FullRow>
-					<LoadingBox />
+					<Box p="24" width="full">
+						<LoadingBar width="100%" />
+					</Box>
 				</Table.FullRow>
 			)
 		}
@@ -246,9 +257,11 @@ export const ServicesTable: React.FC = () => {
 		if (error?.message) {
 			return (
 				<Table.FullRow>
-					<Text size="small" color="bad">
-						{error.message}
-					</Text>
+					<Box p="24">
+						<Text size="small" color="bad">
+							{error.message}
+						</Text>
+					</Box>
 				</Table.FullRow>
 			)
 		}
@@ -256,9 +269,11 @@ export const ServicesTable: React.FC = () => {
 		if (!data?.services?.edges.length) {
 			return (
 				<Table.FullRow>
-					<Text size="small" color="weak">
-						No services found
-					</Text>
+					<Box p="24">
+						<Text size="small" color="weak">
+							No services found
+						</Text>
+					</Box>
 				</Table.FullRow>
 			)
 		}
@@ -291,104 +306,101 @@ export const ServicesTable: React.FC = () => {
 	return (
 		<Box>
 			<Stack
-				mb="16"
 				direction="row"
 				justifyContent="space-between"
 				alignItems="center"
+				gap="16"
 			>
-				<Text size="medium" weight="medium" color="default">
-					Services
-				</Text>
+				<Heading level="h4">Services</Heading>
 				{!isIntegrated && (
 					<Button
 						kind="secondary"
 						emphasis="medium"
 						trackingId="services-integrate-github"
 						onClick={() => setIntegrationModalVisible(true)}
+						size="small"
 					>
 						Configure GitHub integration
 					</Button>
 				)}
 			</Stack>
-			<Stack direction="column" gap="4" align="center" paddingRight="4">
-				<Table>
-					<Table.Search handleChange={handleQueryChange} />
-					<Table.Head>
-						<Table.Row gridColumns={gridColumns}>
-							{columns.map((column) => (
-								<Table.Header key={column.name}>
-									{column.name}
-								</Table.Header>
-							))}
-						</Table.Row>
-					</Table.Head>
-					<Table.Body>{renderTableContent()}</Table.Body>
-				</Table>
+			<Table>
+				<Table.Search handleChange={handleQueryChange} />
+				<Table.Head>
+					<Table.Row gridColumns={gridColumns}>
+						{columns.map((column) => (
+							<Table.Header key={column.name}>
+								{column.name}
+							</Table.Header>
+						))}
+					</Table.Row>
+				</Table.Head>
+				<Table.Body>{renderTableContent()}</Table.Body>
+			</Table>
+			<Stack
+				direction="row"
+				justifyContent="space-between"
+				alignItems="center"
+				width="full"
+				mt="12"
+			>
+				<Box display="flex" width="full">
+					<Text size="xSmall" color="weak" weight="regular">
+						{resultLength}
+						{estimatedResults && '+'}
+						{resultLength === 1 ? ' result' : ' results'}
+					</Text>
+				</Box>
 				<Stack
 					direction="row"
-					justifyContent="space-between"
-					alignItems="center"
+					justifyContent="flex-end"
 					width="full"
-					mt="8"
+					gap="6"
 				>
-					<Box display="flex" width="full">
-						<Text size="small" color="weak" weight="regular">
-							{resultLength}
-							{estimatedResults && '+'}
-							{resultLength === 1 ? ' result' : ' results'}
-						</Text>
-					</Box>
-					<Stack
-						direction="row"
-						justifyContent="flex-end"
-						width="full"
-						gap="6"
+					<Button
+						kind="secondary"
+						emphasis="medium"
+						trackingId="services-previous-page"
+						disabled={!data?.services?.pageInfo?.hasPreviousPage}
+						onClick={handlePreviousPage}
+						size="small"
 					>
-						<Button
-							kind="secondary"
-							emphasis="medium"
-							trackingId="services-previous-page"
-							disabled={
-								!data?.services?.pageInfo?.hasPreviousPage
-							}
-							onClick={handlePreviousPage}
-						>
-							Previous
-						</Button>
-						<Button
-							kind="secondary"
-							emphasis="medium"
-							trackingId="services-next-page"
-							disabled={!data?.services?.pageInfo?.hasNextPage}
-							onClick={handleNextPage}
-						>
-							Next
-						</Button>
-					</Stack>
+						Previous
+					</Button>
+					<Button
+						kind="secondary"
+						emphasis="medium"
+						trackingId="services-next-page"
+						disabled={!data?.services?.pageInfo?.hasNextPage}
+						onClick={handleNextPage}
+						size="small"
+					>
+						Next
+					</Button>
 				</Stack>
-				{!isIntegrated && (
-					<IntegrationModal
-						title="Configuring GitHub Integration"
-						visible={integrationModalVisible}
-						onCancel={closeModal}
-						configurationPage={() =>
-							configurationPage({
-								setModalOpen: closeModal,
-								setIntegrationEnabled: () => {},
-								action: IntegrationAction.Setup,
-							})
-						}
-					/>
-				)}
-				{selectedService && (
-					<GitHubSettingsModal
-						githubRepos={githubData?.github_repos || []}
-						service={selectedService}
-						closeModal={closeModal}
-						handleSave={updateServiceSettings}
-					/>
-				)}
 			</Stack>
+			{!isIntegrated && (
+				<IntegrationModal
+					title="Configuring GitHub Integration"
+					visible={integrationModalVisible}
+					onCancel={closeModal}
+					configurationPage={() =>
+						configurationPage({
+							setModalOpen: closeModal,
+							setIntegrationEnabled: () => {},
+							action: IntegrationAction.Setup,
+						})
+					}
+				/>
+			)}
+			{selectedService && (
+				<GitHubSettingsModal
+					githubRepos={githubData?.github_repos || []}
+					service={selectedService}
+					closeModal={closeModal}
+					handleSave={updateServiceSettings}
+				/>
+			)}
 		</Box>
 	)
 }

--- a/frontend/src/pages/ProjectSettings/SessionExportForm/SessionExportForm.tsx
+++ b/frontend/src/pages/ProjectSettings/SessionExportForm/SessionExportForm.tsx
@@ -5,6 +5,7 @@ import { useGetSessionExportsQuery } from '@graph/hooks'
 import {
 	Badge,
 	Box,
+	Heading,
 	IconSolidDownload,
 	IconSolidExternalLink,
 	Stack,
@@ -47,115 +48,108 @@ export const SessionExportForm = () => {
 	const gridColumns = ['120px', '120px', '1fr', '124px']
 	return (
 		<Box ref={ref}>
-			<BorderBox noPadding>
-				<Stack gap="8">
-					<Box paddingTop="12" px="8">
-						<BoxLabel
-							label="Session Export Requests"
-							info="Requests to download sessions."
-						/>
-					</Box>
-					<Table noBorder>
-						<Table.Head>
-							<Table.Row gridColumns={gridColumns}>
-								<Table.Header>Status</Table.Header>
-								<Table.Header>Session length</Table.Header>
-								<Table.Header>Request time</Table.Header>
-							</Table.Row>
-						</Table.Head>
-						<Table.Body>
-							{data?.session_exports?.map((se) => {
-								const status = se.error
-									? ExportStatus.Failure
-									: se.url
-										? ExportStatus.Success
-										: ExportStatus.InProgress
-								return (
-									<Table.Row
-										key={se.secure_id}
-										gridColumns={gridColumns}
-									>
-										<Table.Cell>
-											<Badge
-												iconStart={
-													status ===
-													ExportStatus.InProgress ? (
-														<IconAnimatedLoading
-															size={14}
-														/>
-													) : undefined
-												}
-												variant={
-													status ===
-													ExportStatus.Success
-														? 'green'
-														: status ===
-															  ExportStatus.Failure
-															? 'red'
-															: 'gray'
-												}
-												label={status}
-											/>
-										</Table.Cell>
-										<Table.Cell>
-											<Text>
-												{moment
-													.duration(
-														se.active_length,
-														'millisecond',
-													)
-													.humanize()}
-											</Text>
-										</Table.Cell>
-										<Table.Cell>
-											<Text>
-												{moment(se.created_at).format(
-													'lll',
-												)}
-											</Text>
-										</Table.Cell>
-										<Table.Cell justifyContent="center">
-											<Box display="flex" gap="4">
-												<Tag
-													shape="basic"
-													emphasis="medium"
-													kind="secondary"
-													iconLeft={
-														<IconSolidDownload />
-													}
-													disabled={!se.url}
-													onClick={() =>
-														window.open(
-															se.url,
-															'_blank',
-														)
-													}
-												>
-													Download
-												</Tag>
-												<Tag
-													shape="basic"
-													emphasis="medium"
-													kind="secondary"
-													iconLeft={
-														<IconSolidExternalLink />
-													}
-													onClick={() =>
-														window.open(
-															`/${projectId}/sessions/${se.secure_id}`,
-															'_blank',
-														)
-													}
-												/>
-											</Box>
-										</Table.Cell>
-									</Table.Row>
-								)
-							})}
-						</Table.Body>
-					</Table>
+		<Box ref={ref} background="white" border="dividerWeak" borderRadius="8" p="24">
+			<Stack gap="16">
+				<Stack gap="4">
+					<Heading level="h4">Session Export Requests</Heading>
+					<Text color="moderate">Requests to download sessions.</Text>
 				</Stack>
-			</BorderBox>
+				<Table noBorder>
+					<Table.Head>
+						<Table.Row gridColumns={gridColumns}>
+							<Table.Header>Status</Table.Header>
+							<Table.Header>Session length</Table.Header>
+							<Table.Header>Request time</Table.Header>
+						</Table.Row>
+					</Table.Head>
+					<Table.Body>
+						{data?.session_exports?.map((se) => {
+							const status = se.error
+								? ExportStatus.Failure
+								: se.url
+								? ExportStatus.Success
+								: ExportStatus.InProgress
+							return (
+								<Table.Row
+									key={se.secure_id}
+									gridColumns={gridColumns}
+								>
+									<Table.Cell>
+										<Badge
+											iconStart={
+												status ===
+												ExportStatus.InProgress ? (
+													<IconAnimatedLoading
+														size={14}
+													/>
+												) : undefined
+											}
+											variant={
+												status === ExportStatus.Success
+													? 'green'
+													: status ===
+													  ExportStatus.Failure
+													? 'red'
+													: 'gray'
+											}
+											label={status}
+										/>
+									</Table.Cell>
+									<Table.Cell>
+										<Text>
+											{moment
+												.duration(
+													se.active_length,
+													'millisecond',
+												)
+												.humanize()}
+										</Text>
+									</Table.Cell>
+									<Table.Cell>
+										<Text>
+											{moment(se.created_at).format(
+												'lll',
+											)}
+										</Text>
+									</Table.Cell>
+									<Table.Cell justifyContent="center">
+										<Box display="flex" gap="4">
+											<Tag
+												shape="basic"
+												emphasis="medium"
+												kind="secondary"
+												iconLeft={<IconSolidDownload />}
+												disabled={!se.url}
+												onClick={() =>
+													window.open(se.url, '_blank')
+												}
+											>
+												Download
+											</Tag>
+											<Tag
+												shape="basic"
+												emphasis="medium"
+												kind="secondary"
+												iconLeft={
+													<IconSolidExternalLink />
+												}
+												onClick={() =>
+													window.open(
+														`/${projectId}/sessions/${se.secure_id}`,
+														'_blank',
+													)
+												}
+											/>
+										</Box>
+									</Table.Cell>
+								</Table.Row>
+							)
+						})}
+					</Table.Body>
+				</Table>
+			</Stack>
+		</Box>
+
 		</Box>
 	)
 }

--- a/frontend/src/pages/ProjectSettings/StreamsSettings/StreamsSettings.tsx
+++ b/frontend/src/pages/ProjectSettings/StreamsSettings/StreamsSettings.tsx
@@ -1,4 +1,4 @@
-import { Badge, Form, Stack, Text } from '@highlight-run/ui/components'
+import { Badge, Form, Heading, Stack, Text } from '@highlight-run/ui/components'
 import React, { useState } from 'react'
 import { LinkButton } from '@/components/LinkButton'
 import { useProjectId } from '@/hooks/useProjectId'
@@ -24,16 +24,14 @@ export const StreamsSettings: React.FC = () => {
 
 	return (
 		<Stack gap="32">
-			<Stack direction="row" gap="6" align="center">
-				<Text size="large" weight="bold">
-					Streams
-				</Text>
+			<Stack direction="row" gap="8" align="center">
+				<Heading level="h4">Streams</Heading>
 				<Badge label="Beta" variant="green" />
 			</Stack>
 
 			<Form>
 				<Stack gap="24">
-					<Text size="medium" weight="bold">
+					<Text weight="bold" size="small">
 						AWS Infrastructure Monitoring
 					</Text>
 

--- a/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx
+++ b/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx
@@ -1,15 +1,17 @@
-import Input from '@components/Input/Input'
-import { Tooltip } from '@highlight-run/ui/components'
+import {
+	Box,
+	Form,
+	Stack,
+	Text,
+	Tooltip,
+} from '@highlight-run/ui/components'
 import { toast } from '@components/Toaster'
 import { useEditProjectMutation, useEditWorkspaceMutation } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
 import { useParams } from '@util/react-router/useParams'
 import React, { useState } from 'react'
 
-import commonStyles from '../../../Common.module.css'
-import Button from '../../../components/Button/Button/Button'
-import { CircularSpinner } from '../../../components/Loading/Loading'
-import styles from './FieldsForm.module.css'
+import { Button } from '@/components/Button'
 
 type Props = {
 	defaultName?: string | null
@@ -65,25 +67,42 @@ export const FieldsForm: React.FC<Props> = ({
 		}
 	}
 
+	const onDiscard = () => {
+		setName(defaultName || '')
+		setEmail(defaultEmail || '')
+	}
+
+	const isDirty = name !== (defaultName || '') || email !== (defaultEmail || '')
+
 	return (
-		<form onSubmit={onSubmit} key={project_id}>
-			<div className={styles.fieldRow}>
-				<label className={styles.fieldKey}>Name</label>
-				<Input
-					name="name"
-					value={name}
-					onChange={(e) => {
-						setName(e.target.value)
-					}}
-					disabled={formDisabled}
-				/>
-			</div>
-			{isWorkspace ? null : (
-				<>
-					{' '}
-					<div className={styles.fieldRow}>
-						<label className={styles.fieldKey}>Billing Email</label>
-						<Input
+		<Form onSubmit={onSubmit}>
+			<Stack gap="16">
+				<Box display="flex" alignItems="center" gap="16">
+					<Box flexShrink={0} style={{ width: 100 }}>
+						<Text weight="bold" size="small">
+							Name
+						</Text>
+					</Box>
+					<Form.Input
+						id="name"
+						name="name"
+						value={name}
+						onChange={(e) => {
+							setName(e.target.value)
+						}}
+						style={{ flexGrow: 1 }}
+						disabled={formDisabled}
+					/>
+				</Box>
+				{isWorkspace ? null : (
+					<Box display="flex" alignItems="center" gap="16">
+						<Box flexShrink={0} style={{ width: 100 }}>
+							<Text weight="bold" size="small">
+								Billing Email
+							</Text>
+						</Box>
+						<Form.Input
+							id="email"
 							placeholder="Billing Email"
 							type="email"
 							name="email"
@@ -91,41 +110,47 @@ export const FieldsForm: React.FC<Props> = ({
 							onChange={(e) => {
 								setEmail(e.target.value)
 							}}
+							style={{ flexGrow: 1 }}
 							disabled={formDisabled}
 						/>
-					</div>
-				</>
-			)}
-			<div className={styles.fieldRow}>
-				<Tooltip
-					disabled={!formDisabled}
-					trigger={
+					</Box>
+				)}
+				<Box display="flex" justifyContent="flex-end" gap="8" pt="8">
+					{isDirty && (
 						<Button
-							trackingId={`${
-								isWorkspace ? 'Workspace' : 'Project'
-							}Update`}
-							htmlType="submit"
-							type="primary"
-							className={commonStyles.submitButton}
+							kind="secondary"
+							emphasis="medium"
+							trackingId="WorkspaceSettingsDiscard"
+							onClick={onDiscard}
 							disabled={formDisabled}
 						>
-							{editProjectLoading || editWorkspaceLoading ? (
-								<CircularSpinner
-									style={{
-										fontSize: 18,
-										color: 'var(--text-primary-inverted)',
-									}}
-								/>
-							) : (
-								'Save changes'
-							)}
+							Discard changes
 						</Button>
-					}
-				>
-					You do not have permission to edit these settings. Please
-					contact your workspace admin.
-				</Tooltip>
-			</div>
-		</form>
+					)}
+					<Tooltip
+						disabled={!formDisabled}
+						trigger={
+							<Button
+								trackingId={`${
+									isWorkspace ? 'Workspace' : 'Project'
+								}Update`}
+								type="submit"
+								kind="primary"
+								disabled={formDisabled}
+								loading={
+									editProjectLoading || editWorkspaceLoading
+								}
+							>
+								Save changes
+							</Button>
+						}
+					>
+						You do not have permission to edit these settings.
+						Please contact your workspace admin.
+					</Tooltip>
+				</Box>
+			</Stack>
+		</Form>
+
 	)
 }

--- a/frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.tsx
@@ -1,28 +1,31 @@
-import Card from '@components/Card/Card'
-import CopyText from '@components/CopyText/CopyText'
-import Input from '@components/Input/Input'
-import ProgressBarTable from '@components/ProgressBarTable/ProgressBarTable'
-import Select from '@components/Select/Select'
 import {
 	useGetProjectQuery,
 	useGetSourcemapFilesLazyQuery,
 	useGetSourcemapVersionsQuery,
 } from '@graph/hooks'
-import { Box, Stack } from '@highlight-run/ui/components'
+import {
+	Box,
+	Callout,
+	Form,
+	Heading,
+	Select,
+	Stack,
+	Table,
+	Text,
+} from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
 import { debounce } from 'lodash'
-import React, { useEffect } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 
 import BorderBox from '@/components/BorderBox/BorderBox'
-import BoxLabel from '@/components/BoxLabel/BoxLabel'
+import CopyText from '@components/CopyText/CopyText'
+import { LoadingBar } from '@components/Loading/Loading'
 
-import styles from './SourcemapSettings.module.css'
-
-const SourcemapSettings = () => {
+export const SourcemapSettings = () => {
 	const { project_id } = useParams<{ project_id: string }>()
-	const [query, setQuery] = React.useState<string>('')
-	const [versions, setVersions] = React.useState<string[]>([])
-	const [selectedVersion, setSelectedVersion] = React.useState<string>()
+	const [query, setQuery] = useState<string>('')
+	const [versions, setVersions] = useState<string[]>([])
+	const [selectedVersion, setSelectedVersion] = useState<string | undefined>()
 
 	const { data: projectData } = useGetProjectQuery({
 		variables: {
@@ -38,23 +41,21 @@ const SourcemapSettings = () => {
 			},
 		})
 
-	const { data: versionsData, loading: versionsLoading } =
-		useGetSourcemapVersionsQuery({
-			variables: {
-				project_id: project_id!,
-			},
-			skip: !project_id,
-			onCompleted: (data) => {
-				const trimmedVersions = data?.sourcemap_versions?.map((v) =>
-					v.replace(`${project_id}/`, '').replace('/', ''),
-				)
+	const { loading: versionsLoading } = useGetSourcemapVersionsQuery({
+		variables: {
+			project_id: project_id!,
+		},
+		skip: !project_id,
+		onCompleted: (data) => {
+			const trimmedVersions = data?.sourcemap_versions?.map((v) =>
+				v.replace(`${project_id}/`, '').replace('/', ''),
+			)
 
-				setVersions(trimmedVersions || [])
-			},
-		})
+			setVersions(trimmedVersions || [])
+		},
+	})
 
-	const needToSelectVersion =
-		(versionsData?.sourcemap_versions.length || 0) > 1 && !selectedVersion
+	const needToSelectVersion = versions.length > 1 && !selectedVersion
 
 	useEffect(() => {
 		if (versionsLoading || needToSelectVersion || !project_id) {
@@ -67,46 +68,40 @@ const SourcemapSettings = () => {
 				version: selectedVersion,
 			},
 		})
-		// Only needs to be triggered when loading is complete or the selected
-		// version changes. We don't update when needToSelectVersion changes
-		// because we can't reset data.sourcemap_files.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [versionsLoading, selectedVersion])
+	}, [versionsLoading, selectedVersion, project_id, needToSelectVersion, getSourcemapFilesQuery])
 
 	const fileKeys = data?.sourcemap_files?.map((file) => file.key) || []
 
-	const visibleFileKeys = query.length
-		? fileKeys.filter((key) => key && key.indexOf(query) > -1)
-		: fileKeys
+	const visibleFileKeys = useMemo(() => {
+		return query.length
+			? fileKeys.filter((key) => key && key.indexOf(query) > -1)
+			: fileKeys
+	}, [fileKeys, query])
 
 	const filterResults = debounce((query: string) => {
 		setQuery(query)
 	}, 300)
 
 	return (
-		<BorderBox>
-			<Stack gap="8">
+		<Box background="white" border="dividerWeak" borderRadius="8" p="24">
+			<Stack gap="24">
 				{projectData?.project?.secret && (
-					<Stack gap="8">
-						<BoxLabel
-							label="Sourcemaps"
-							info={
-								<>
-									Sourcemaps can be used to undo JavaScript
-									minification in your error traces. You can
-									learn more about them in{' '}
-									<a
-										href="https://docs.highlight.run/sourcemaps"
-										target="_blank"
-										rel="noreferrer"
-									>
-										our sourcemap docs
-									</a>
-									. Use the API key below to upload your
-									sourcemaps to Highlight.
-								</>
-							}
-						/>
+					<Stack gap="12">
+						<Heading level="h4">Sourcemaps</Heading>
+						<Text color="moderate">
+							Sourcemaps can be used to undo JavaScript
+							minification in your error traces. You can learn
+							more about them in{' '}
+							<a
+								href="https://docs.highlight.run/sourcemaps"
+								target="_blank"
+								rel="noreferrer"
+							>
+								our sourcemap docs
+							</a>
+							. Use the API key below to upload your sourcemaps to
+							Highlight.
+						</Text>
 						<CopyText
 							text={projectData.project.secret}
 							onCopyTooltipText="API key copied to your clipboard!"
@@ -114,90 +109,121 @@ const SourcemapSettings = () => {
 					</Stack>
 				)}
 
-				<Box borderTop="dividerWeak" />
+				<Stack gap="16">
+					<Box borderTop="dividerWeak" style={{ marginLeft: -24, marginRight: -24 }} />
 
-				<BoxLabel info="Below is a list of sourcemap files we have for your project." />
+					<Text color="moderate">
+						Below is a list of sourcemap files we have for your
+						project.
+					</Text>
 
-				<Card
-					className={styles.list}
-					title={
-						<div className={styles.listHeader}>
-							{versions.length > 1 && (
-								<div>
-									<Select
-										aria-label="Sourcemap app version"
-										className={styles.versionSelect}
-										placeholder="Select a version of your app"
-										options={versions.map((v) => ({
-											id: v,
-											value: v,
-											displayValue: v,
-										}))}
-										onChange={setSelectedVersion}
-										value={selectedVersion}
-										notFoundContent={
-											<p>No sourcemaps found</p>
-										}
-									/>
-								</div>
-							)}
-							<Input
-								allowClear
-								style={{ width: '100%' }}
-								placeholder="Search for a file"
-								onChange={(e) => filterResults(e.target.value)}
-								size="small"
-								disabled={versionsLoading || loading}
-							/>
-						</div>
-					}
-				>
-					<ProgressBarTable
-						loading={loading}
-						columns={[
-							{
-								title: 'Sourcemap',
-								dataIndex: 'key',
-								key: 'key',
-								width: '100%',
-								render: (key) => (
-									<div className={styles.listRow}>{key}</div>
-								),
-							},
-						]}
-						data={visibleFileKeys?.map((file) => ({
-							key: file,
-							file: file,
-						}))}
-						onClickHandler={() => {}}
-						noDataMessage={
-							query ? (
-								<p>No sourcemap files match your search.</p>
-							) : needToSelectVersion ? (
-								<p>
-									We have sourcemaps for multiple versions of
-									your app. Please select a version to see
-									your sourcemaps.
-								</p>
+					<Box
+						border="dividerWeak"
+						borderRadius="8"
+						background="white"
+						p="16"
+					>
+						<Stack gap="16">
+							<Box
+								display="flex"
+								justifyContent="space-between"
+								alignItems="center"
+								gap="16"
+							>
+								{versions.length > 1 && (
+									<Box style={{ width: 250 }}>
+										<Select
+											aria-label="Sourcemap app version"
+											placeholder="Select a version of your app"
+											options={versions.map((v) => ({
+												name: v,
+												value: v,
+											}))}
+											onValueChange={(v: any) => {
+												setSelectedVersion(v?.value)
+											}}
+											value={
+												selectedVersion
+													? {
+															name: selectedVersion,
+															value: selectedVersion,
+													  }
+													: undefined
+											}
+										/>
+									</Box>
+								)}
+								<Box flexGrow={1}>
+									<Form>
+										<Form.Input
+											name="search"
+											placeholder="Search for a file"
+											onChange={(
+												e: React.ChangeEvent<HTMLInputElement>,
+											) =>
+												filterResults(e.target.value)
+											}
+											disabled={
+												versionsLoading || loading
+											}
+										/>
+									</Form>
+								</Box>
+							</Box>
+
+							{loading ? (
+								<LoadingBar />
 							) : (
-								<p>
-									We don't have any sourcemap files for your
-									project. Once you upload some you will be
-									able to view them here.
-								</p>
-							)
-						}
-						noDataTitle={
-							query.length
-								? 'Nothing to see here'
-								: needToSelectVersion
-									? 'Select a version'
-									: 'No sourcemap data yet 😔'
-						}
-					/>
-				</Card>
+								<Table>
+									<Table.Head>
+										<Table.Row>
+											<Table.Header>
+												Sourcemap
+											</Table.Header>
+										</Table.Row>
+									</Table.Head>
+									<Table.Body>
+										{visibleFileKeys.length > 0 ? (
+											visibleFileKeys.map((key) => (
+												<Table.Row key={key}>
+													<Table.Cell>
+														<Text
+															family="monospace"
+															size="small"
+															break="all"
+														>
+															{key}
+														</Text>
+													</Table.Cell>
+												</Table.Row>
+											))
+										) : (
+											<Table.Row>
+												<Table.Cell>
+													<Box
+														py="24"
+														textAlign="center"
+													>
+														<Text color="moderate">
+															{query
+																? 'No sourcemap files match your search.'
+																: needToSelectVersion
+																? 'We have sourcemaps for multiple versions of your app. Please select a version to see your sourcemaps.'
+																: "We don't have any sourcemap files for your project. Once you upload some you will be able to view them here."}
+														</Text>
+													</Box>
+												</Table.Cell>
+											</Table.Row>
+										)}
+									</Table.Body>
+								</Table>
+							)}
+						</Stack>
+					</Box>
+				</Stack>
 			</Stack>
-		</BorderBox>
+		</Box>
+
 	)
 }
 

--- a/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
@@ -1,15 +1,17 @@
-import Alert from '@components/Alert/Alert'
-import { FieldsBox } from '@components/FieldsBox/FieldsBox'
 import { AdminRole } from '@graph/schemas'
-import { Box } from '@highlight-run/ui/components'
+import {
+	Box,
+	Callout,
+	Heading,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
 import { AutoJoinForm } from '@pages/WorkspaceTeam/components/AutoJoinForm'
 import { Authorization } from '@util/authorization/authorization'
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
 import { useAuthContext } from '@/authentication/AuthContext'
 
-import layoutStyles from '../../components/layout/LeadAlignLayout.module.css'
 import { FieldsForm } from './FieldsForm/FieldsForm'
-import styles from './WorkspaceSettings.module.css'
 
 const WorkspaceSettings = () => {
 	const { currentWorkspace } = useApplicationContext()
@@ -17,46 +19,68 @@ const WorkspaceSettings = () => {
 	const isAdminRole = workspaceRole === AdminRole.Admin
 
 	return (
-		<Box>
-			<Box style={{ maxWidth: 560 }} my="40" mx="auto">
-				<div className={styles.container}>
-					<div className={styles.titleContainer}>
-						<div>
-							<h3>Properties</h3>
-							<p className={layoutStyles.subTitle}>
-								Manage your workspace details.
-							</p>
-						</div>
-					</div>
-					<FieldsBox id="workspace">
-						<FieldsForm
-							defaultName={currentWorkspace?.name}
-							disabled={!isAdminRole}
-						/>
-					</FieldsBox>
-					<FieldsBox id="autojoin">
-						<h3>Auto Join</h3>
-						<p>
-							Enable auto join to allow anyone with an approved
-							email origin join.
-						</p>
-						<Authorization
-							allowedRoles={[AdminRole.Admin]}
-							forbiddenFallback={
-								<Alert
-									trackingId="AdminNoAccessToAutoJoinDomains"
-									type="info"
-									message="You don't have access to auto-access domains."
-									description={`You don't have permission to configure auto-access domains. Please contact a workspace admin to make changes.`}
-								/>
-							}
+		<Box width="full" p="40">
+			<Box style={{ maxWidth: 800 }} mx="auto">
+				<Stack gap="32">
+					<Stack gap="8">
+						<Heading level="h2">Properties</Heading>
+						<Text color="moderate">
+							Manage your workspace details.
+						</Text>
+					</Stack>
+
+					<Stack gap="16">
+						<Box
+							border="dividerWeak"
+							borderRadius="8"
+							p="24"
+							background="white"
+							id="workspace"
 						>
-							<AutoJoinForm />
-						</Authorization>
-					</FieldsBox>
-				</div>
+							<FieldsForm
+								defaultName={currentWorkspace?.name}
+								disabled={!isAdminRole}
+							/>
+						</Box>
+
+						<Box
+							border="dividerWeak"
+							borderRadius="8"
+							p="24"
+							background="white"
+							id="autojoin"
+						>
+							<Stack gap="16">
+								<Stack gap="4">
+									<Heading level="h4">Auto Join</Heading>
+									<Text color="moderate">
+										Enable auto join to allow anyone with an
+										approved email origin join.
+									</Text>
+								</Stack>
+								<Authorization
+									allowedRoles={[AdminRole.Admin]}
+									forbiddenFallback={
+										<Callout
+											kind="info"
+											title="You don't have access to auto-access domains."
+										>
+											You don't have permission to
+											configure auto-access domains.
+											Please contact a workspace admin to
+											make changes.
+										</Callout>
+									}
+								>
+									<AutoJoinForm />
+								</Authorization>
+							</Stack>
+						</Box>
+					</Stack>
+				</Stack>
 			</Box>
 		</Box>
+
 	)
 }
 

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -1,19 +1,22 @@
 import { useAuthContext } from '@authentication/AuthContext'
 import { toast } from '@components/Toaster'
-import Tooltip from '@components/Tooltip/Tooltip'
 import {
 	useGetWorkspaceAdminsQuery,
 	useUpdateAllowedEmailOriginsMutation,
 } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
-import { Box, Select, Text } from '@highlight-run/ui/components'
+import {
+	Box,
+	Select,
+	Stack,
+	Text,
+	Tooltip,
+} from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React, { useState } from 'react'
 
 import { getEmailDomain } from '@/util/email'
-
-import styles from './AutoJoinForm.module.css'
+import Switch from '@/components/Switch/Switch'
 
 export const AutoJoinForm: React.FC = () => {
 	const { workspace_id } = useParams<{ workspace_id: string }>()
@@ -61,8 +64,7 @@ export const AutoJoinForm: React.FC = () => {
 		}
 	}
 
-	const handleCheckboxChange = (event: CheckboxChangeEvent) => {
-		const checked = event.target.checked
+	const handleSwitchChange = (checked: boolean) => {
 		if (checked) {
 			onChangeMsg([adminsEmailDomain], 'Successfully enabled auto-join!')
 		} else {
@@ -78,30 +80,51 @@ export const AutoJoinForm: React.FC = () => {
 	}
 
 	return (
-		<Tooltip
-			title="Automatically share the workspace with all users on this domain."
-			align={{ offset: [0, 6] }}
-			mouseEnterDelay={0}
-		>
-			<div className={styles.container}>
-				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
-						checked={autoJoinDomains.length > 0}
-						onChange={handleCheckboxChange}
-					/>
-					<Text>Auto-approved email domains</Text>
-				</Box>
+		<Stack gap="16">
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="space-between"
+			>
+				<Stack gap="4">
+					<Text weight="bold" size="small">
+						Auto-approved email domains
+					</Text>
+					<Text color="moderate" size="xSmall">
+						Automatically share the workspace with all users on
+						this domain.
+					</Text>
+				</Stack>
+				<Switch
+					trackingId="WorkspaceAutoJoin-Switch"
+					checked={autoJoinDomains.length > 0}
+					onChange={handleSwitchChange}
+				/>
+			</Box>
+			<Stack gap="8">
+				<Text color="moderate" size="small">
+					Approved email origins can join this workspace
+					automatically.
+				</Text>
 				<Select
 					creatable
 					filterable
 					displayMode="tags"
 					loading={loading}
 					placeholder={`${adminsEmailDomain}, acme.corp, piedpiper.com`}
-					value={autoJoinDomains}
+					value={autoJoinDomains.map((d) => ({
+						name: d,
+						value: d,
+					}))}
 					onValueChange={handleSelectChange}
-					options={adminDomains}
+					options={adminDomains.map((d) => ({
+						name: d,
+						value: d,
+					}))}
 				/>
-			</div>
-		</Tooltip>
+			</Stack>
+		</Stack>
+
 	)
 }
+


### PR DESCRIPTION
## Summary

This PR completes the total removal of `antd` and legacy `@components` from the **Workspace Settings** and **Project Settings** pages. Beyond a simple component swap, I have modernized the layout to align with Highlight's high-fidelity "Master-Detail" design standards.

**Key Refactor Highlights:**
* **Visual Fidelity:** Implemented a standardized centered 800px layout (`maxWidth="800"`) across all 15+ settings tabs.
* **Design System Alignment:** Migrated all local `.module.css` files to `@highlight-run/ui` System Props, utilizing `p="24"`, `dividerWeak` borders, and `borderRadius="8"` for a "breathable," premium feel.
* **UX Consolidation:** Refactored fragmented "Save/Discard" buttons into unified, tab-level Action Bars to improve UI density and consistency.
* **Technical Debt & Stability:** * Fixed a blocking GraphQL schema mismatch (`updated_at` field on `Admin` type) that was causing 422 errors in local Hobby environments.
    * Replaced legacy `Modal` and `Select` (mode="tags") with modern `Dialog` and searchable `Form.Select` primitives.
* **Build Integrity:** Verified with `yarn types:check` (0 errors) and manual regression testing across all settings tabs.

## How did you test this change?

I performed a full manual audit of the Settings infrastructure. 
* **Workspace Settings:** Verified "Properties" and "Members" tab for layout centering and functional state-reset logic (Discard button).
* **Project Settings:** Verified "Session Replay" (Tag creation), "Error Monitoring" (Sourcemaps table migration), and "Services" (GitHub Dialog search).

### Screencast: 

https://github.com/user-attachments/assets/5efbab2f-dd01-40bb-97db-28367fc65055

## Are there any deployment considerations?

**None.** This is a pure frontend UI refactor. No backend migrations or data backfilling are required. (Note: Removed the stale `updated_at` query field to maintain compatibility with existing backend schemas).

## Does this work require review from our design team?

Yes, requesting a quick look from **@julian-highlight** to confirm the new `p="24"` padding and consolidated Action Bar patterns meet the intended design spec.

**Status:**

/closes #8635

/claim #8635