### PR TITLE
Remove direct antd imports from settings pages

### DIFF
--- a/.changeset/remove-antd-settings.md
+++ b/.changeset/remove-antd-settings.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/frontend': patch
+---
+
+Remove direct antd imports from settings pages

--- a/frontend/src/pages/ErrorsV2/GitHubEnhancementSettings/GitHubEnhancementSettingsForm.tsx
+++ b/frontend/src/pages/ErrorsV2/GitHubEnhancementSettings/GitHubEnhancementSettingsForm.tsx
@@ -64,10 +64,7 @@ export const GitHubEnhancementSettingsForm: React.FC<
 	const githubOptions = useMemo(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
-				key: repo.repo_id.replace(
-					'https://api.github.com/repos/',
-					'',
-				),
+				key: repo.repo_id.replace('https://api.github.com/repos/', ''),
 				render: repo.name.split('/').pop() ?? repo.name,
 			})),
 		[githubRepos],
@@ -225,9 +222,7 @@ export const GitHubEnhancementSettingsForm: React.FC<
 										repo,
 									)
 								}
-								value={
-									formState.values.githubRepo ?? ''
-								}
+								value={formState.values.githubRepo ?? ''}
 								options={githubOptions}
 								disabled={disabled || testLoading}
 								cssClass={styles.repoSelect}

--- a/frontend/src/pages/ErrorsV2/GitHubEnhancementSettings/GitHubEnhancementSettingsForm.tsx
+++ b/frontend/src/pages/ErrorsV2/GitHubEnhancementSettings/GitHubEnhancementSettingsForm.tsx
@@ -14,7 +14,7 @@ import {
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
+import { ComboboxSelect } from '@highlight-run/ui/components'
 import React, { useEffect, useMemo, useState } from 'react'
 
 import LoadingBox from '@/components/LoadingBox'
@@ -64,12 +64,11 @@ export const GitHubEnhancementSettingsForm: React.FC<
 	const githubOptions = useMemo(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
-				id: repo.key,
-				label: repo.name.split('/').pop(),
-				value: repo.repo_id.replace(
+				key: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
 				),
+				render: repo.name.split('/').pop() ?? repo.name,
 			})),
 		[githubRepos],
 	)
@@ -217,25 +216,21 @@ export const GitHubEnhancementSettingsForm: React.FC<
 						name="githubRepo"
 					>
 						<Box display="flex" alignItems="center" gap="8">
-							<Select
-								aria-label="GitHub repository"
-								className={styles.repoSelect}
-								placeholder="Search repos..."
-								onSelect={(repo: string) =>
+							<ComboboxSelect
+								label="GitHub repository"
+								queryPlaceholder="Search repos..."
+								onChange={(repo: string) =>
 									formStore.setValue(
 										formStore.names.githubRepo,
 										repo,
 									)
 								}
-								value={formState.values.githubRepo
-									?.split('/')
-									.pop()}
+								value={
+									formState.values.githubRepo ?? ''
+								}
 								options={githubOptions}
 								disabled={disabled || testLoading}
-								notFoundContent={<span>No repos found</span>}
-								optionFilterProp="label"
-								filterOption
-								showSearch
+								cssClass={styles.repoSelect}
 							/>
 							<ButtonIcon
 								kind="secondary"

--- a/frontend/src/pages/ProjectSettings/DangerForm/DangerForm.module.css
+++ b/frontend/src/pages/ProjectSettings/DangerForm/DangerForm.module.css
@@ -17,3 +17,20 @@
 	margin-bottom: 10px;
 	margin-top: 10px;
 }
+
+.dangerInput {
+	width: 100%;
+	padding: 6px 12px;
+	border: 1px solid var(--color-border-primary, #d9d9d9);
+	border-radius: 6px;
+	font-size: 14px;
+	line-height: 1.5;
+	color: var(--color-text-primary, inherit);
+	background: var(--color-bg-primary, transparent);
+	outline: none;
+	transition: border-color 0.2s;
+}
+
+.dangerInput:focus {
+	border-color: var(--color-red-400, #f5222d);
+}

--- a/frontend/src/pages/ProjectSettings/DangerForm/DangerForm.tsx
+++ b/frontend/src/pages/ProjectSettings/DangerForm/DangerForm.tsx
@@ -1,18 +1,15 @@
 import { FieldsBox } from '@components/FieldsBox/FieldsBox'
-import Input from '@components/Input/Input'
 import LoadingBox from '@components/LoadingBox'
 import { useDeleteProjectMutation, useGetProjectQuery } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
 import { FieldsForm } from '@pages/WorkspaceSettings/FieldsForm/FieldsForm'
 import { useParams } from '@util/react-router/useParams'
-import clsx from 'clsx'
 import { useState } from 'react'
 import { Navigate } from 'react-router-dom'
 import { useAuthContext } from '@/authentication/AuthContext'
 import { AdminRole } from '@/graph/generated/schemas'
 
-import commonStyles from '../../../Common.module.css'
-import Button from '../../../components/Button/Button/Button'
+import { Button } from '@components/Button'
 import styles from './DangerForm.module.css'
 
 export const DangerForm = () => {
@@ -63,7 +60,8 @@ export const DangerForm = () => {
 									{`${data?.project?.name}`}' to confirm.
 								</p>
 								<div className={styles.dangerRow}>
-									<Input
+									<input
+										className={styles.dangerInput}
 										placeholder={`${data?.project?.name}`}
 										name="text"
 										value={confirmationText}
@@ -73,17 +71,13 @@ export const DangerForm = () => {
 									/>
 									<Button
 										trackingId="DeleteProject"
-										danger
-										type="primary"
-										className={clsx(
-											commonStyles.submitButton,
-											styles.deleteButton,
-										)}
+										kind="danger"
+										type="submit"
+										size="small"
 										disabled={
 											confirmationText !==
 											data?.project?.name
 										}
-										htmlType="submit"
 										loading={deleteLoading}
 									>
 										Delete

--- a/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
@@ -1,8 +1,6 @@
 import { LoadingBar } from '@components/Loading/Loading'
-import Select from '@components/Select/Select'
 import { toast } from '@components/Toaster'
-import { Stack } from '@highlight-run/ui/components'
-import { Text } from 'recharts'
+import { Select, Stack, Text } from '@highlight-run/ui/components'
 
 import BoxLabel from '@/components/BoxLabel/BoxLabel'
 import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
@@ -39,16 +37,13 @@ export const ErrorFiltersForm = () => {
 				/>
 				<div className={styles.inputAndButtonRow}>
 					<Select
-						className={styles.input}
-						mode="tags"
+						creatable
+						filterable
+						displayMode="tags"
 						placeholder="TypeError: Failed to fetch"
 						value={data?.projectSettings?.error_filters || []}
-						notFoundContent={
-							<Text>
-								Provide a regex pattern to filter out errors.
-							</Text>
-						}
-						onChange={(patterns: string[]) => {
+						onValueChange={(items: { name: string; value: string }[]) => {
+							const patterns = items.map((i) => i.value)
 							patterns.filter(isValidRegex)
 							setAllProjectSettings((currentProjectSettings) =>
 								currentProjectSettings?.projectSettings

--- a/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
@@ -1,6 +1,6 @@
 import { LoadingBar } from '@components/Loading/Loading'
 import { toast } from '@components/Toaster'
-import { Select, Stack, Text } from '@highlight-run/ui/components'
+import { Select, Stack } from '@highlight-run/ui/components'
 
 import BoxLabel from '@/components/BoxLabel/BoxLabel'
 import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
@@ -42,7 +42,9 @@ export const ErrorFiltersForm = () => {
 						displayMode="tags"
 						placeholder="TypeError: Failed to fetch"
 						value={data?.projectSettings?.error_filters || []}
-						onValueChange={(items: { name: string; value: string }[]) => {
+						onValueChange={(
+							items: { name: string; value: string }[],
+						) => {
 							const patterns = items.map((i) => i.value)
 							patterns.filter(isValidRegex)
 							setAllProjectSettings((currentProjectSettings) =>

--- a/frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx
@@ -1,6 +1,5 @@
 import { LoadingBar } from '@components/Loading/Loading'
-import Select from '@components/Select/Select'
-import { Stack } from '@highlight-run/ui/components'
+import { Select, Stack } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
 
 import BoxLabel from '@/components/BoxLabel/BoxLabel'
@@ -28,16 +27,18 @@ export const ErrorSettingsForm = () => {
 					info="Enter JSON expressions to use for grouping your errors."
 				/>
 				<Select
-					mode="tags"
+					creatable
+					filterable
+					displayMode="tags"
 					placeholder="$.context.messages[0]"
 					value={data?.projectSettings?.error_json_paths || []}
-					onChange={(paths: string[]) => {
+					onValueChange={(items: { name: string; value: string }[]) => {
 						setAllProjectSettings((currentProjectSettings) =>
 							currentProjectSettings?.projectSettings
 								? {
 										projectSettings: {
 											...currentProjectSettings.projectSettings,
-											error_json_paths: paths,
+											error_json_paths: items.map((i) => i.value),
 										},
 									}
 								: currentProjectSettings,

--- a/frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx
@@ -32,13 +32,17 @@ export const ErrorSettingsForm = () => {
 					displayMode="tags"
 					placeholder="$.context.messages[0]"
 					value={data?.projectSettings?.error_json_paths || []}
-					onValueChange={(items: { name: string; value: string }[]) => {
+					onValueChange={(
+						items: { name: string; value: string }[],
+					) => {
 						setAllProjectSettings((currentProjectSettings) =>
 							currentProjectSettings?.projectSettings
 								? {
 										projectSettings: {
 											...currentProjectSettings.projectSettings,
-											error_json_paths: items.map((i) => i.value),
+											error_json_paths: items.map(
+												(i) => i.value,
+											),
 										},
 									}
 								: currentProjectSettings,

--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -120,10 +120,7 @@ const GithubSettingsForm = ({
 	const githubOptions = useMemo(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
-				key: repo.repo_id.replace(
-					'https://api.github.com/repos/',
-					'',
-				),
+				key: repo.repo_id.replace('https://api.github.com/repos/', ''),
 				render: repo.name.split('/').pop() ?? repo.name,
 			})),
 		[githubRepos],
@@ -159,9 +156,7 @@ const GithubSettingsForm = ({
 									repo,
 								)
 							}
-							value={
-								formState.values.githubRepo ?? ''
-							}
+							value={formState.values.githubRepo ?? ''}
 							options={githubOptions}
 							cssClass={styles.repoSelect}
 						/>

--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -15,7 +15,7 @@ import {
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
+import { ComboboxSelect } from '@highlight-run/ui/components'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -120,12 +120,11 @@ const GithubSettingsForm = ({
 	const githubOptions = useMemo(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
-				id: repo.key,
-				label: repo.name.split('/').pop(),
-				value: repo.repo_id.replace(
+				key: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
 				),
+				render: repo.name.split('/').pop() ?? repo.name,
 			})),
 		[githubRepos],
 	)
@@ -151,24 +150,20 @@ const GithubSettingsForm = ({
 					name="githubRepo"
 				>
 					<Box display="flex" alignItems="center" gap="8">
-						<Select
-							aria-label="GitHub repository"
-							className={styles.repoSelect}
-							placeholder="Search repos..."
-							onSelect={(repo: string) =>
+						<ComboboxSelect
+							label="GitHub repository"
+							queryPlaceholder="Search repos..."
+							onChange={(repo: string) =>
 								formStore.setValue(
 									formStore.names.githubRepo,
 									repo,
 								)
 							}
-							value={formState.values.githubRepo
-								?.split('/')
-								.pop()}
+							value={
+								formState.values.githubRepo ?? ''
+							}
 							options={githubOptions}
-							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
-							filterOption
-							showSearch
+							cssClass={styles.repoSelect}
 						/>
 						<ButtonIcon
 							kind="secondary"

--- a/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.module.css
+++ b/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.module.css
@@ -13,3 +13,25 @@
 	display: flex;
 	height: 100%;
 }
+
+.fieldInput {
+	width: 100%;
+	padding: 6px 12px;
+	border: 1px solid var(--color-border-primary, #d9d9d9);
+	border-radius: 6px;
+	font-size: 14px;
+	line-height: 1.5;
+	color: var(--color-text-primary, inherit);
+	background: var(--color-bg-primary, transparent);
+	outline: none;
+	transition: border-color 0.2s;
+}
+
+.fieldInput:focus {
+	border-color: var(--color-primary, #6c37f4);
+}
+
+.fieldInput:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}

--- a/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx
+++ b/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx
@@ -1,4 +1,4 @@
-import { Box, Tooltip } from '@highlight-run/ui/components'
+import { Tooltip } from '@highlight-run/ui/components'
 import { toast } from '@components/Toaster'
 import { useEditProjectMutation, useEditWorkspaceMutation } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
@@ -6,7 +6,6 @@ import { useParams } from '@util/react-router/useParams'
 import React, { useState } from 'react'
 
 import { Button } from '@components/Button'
-import commonStyles from '../../../Common.module.css'
 import { CircularSpinner } from '../../../components/Loading/Loading'
 import styles from './FieldsForm.module.css'
 

--- a/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx
+++ b/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx
@@ -1,13 +1,12 @@
-import Input from '@components/Input/Input'
-import { Tooltip } from '@highlight-run/ui/components'
+import { Box, Tooltip } from '@highlight-run/ui/components'
 import { toast } from '@components/Toaster'
 import { useEditProjectMutation, useEditWorkspaceMutation } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
 import { useParams } from '@util/react-router/useParams'
 import React, { useState } from 'react'
 
+import { Button } from '@components/Button'
 import commonStyles from '../../../Common.module.css'
-import Button from '../../../components/Button/Button/Button'
 import { CircularSpinner } from '../../../components/Loading/Loading'
 import styles from './FieldsForm.module.css'
 
@@ -69,7 +68,8 @@ export const FieldsForm: React.FC<Props> = ({
 		<form onSubmit={onSubmit} key={project_id}>
 			<div className={styles.fieldRow}>
 				<label className={styles.fieldKey}>Name</label>
-				<Input
+				<input
+					className={styles.fieldInput}
 					name="name"
 					value={name}
 					onChange={(e) => {
@@ -83,7 +83,8 @@ export const FieldsForm: React.FC<Props> = ({
 					{' '}
 					<div className={styles.fieldRow}>
 						<label className={styles.fieldKey}>Billing Email</label>
-						<Input
+						<input
+							className={styles.fieldInput}
 							placeholder="Billing Email"
 							type="email"
 							name="email"
@@ -104,9 +105,9 @@ export const FieldsForm: React.FC<Props> = ({
 							trackingId={`${
 								isWorkspace ? 'Workspace' : 'Project'
 							}Update`}
-							htmlType="submit"
-							type="primary"
-							className={commonStyles.submitButton}
+							type="submit"
+							kind="primary"
+							size="small"
 							disabled={formDisabled}
 						>
 							{editProjectLoading || editWorkspaceLoading ? (

--- a/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
@@ -47,11 +47,9 @@ const WorkspaceSettings = () => {
 									title="You don't have access to auto-access domains."
 								>
 									<Text size="xSmall" color="moderate">
-										You don't have permission to
-										configure auto-access
-										domains. Please contact a
-										workspace admin to make
-										changes.
+										You don't have permission to configure
+										auto-access domains. Please contact a
+										workspace admin to make changes.
 									</Text>
 								</Callout>
 							}

--- a/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
@@ -1,7 +1,6 @@
-import Alert from '@components/Alert/Alert'
 import { FieldsBox } from '@components/FieldsBox/FieldsBox'
 import { AdminRole } from '@graph/schemas'
-import { Box } from '@highlight-run/ui/components'
+import { Box, Callout, Text } from '@highlight-run/ui/components'
 import { AutoJoinForm } from '@pages/WorkspaceTeam/components/AutoJoinForm'
 import { Authorization } from '@util/authorization/authorization'
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
@@ -43,12 +42,18 @@ const WorkspaceSettings = () => {
 						<Authorization
 							allowedRoles={[AdminRole.Admin]}
 							forbiddenFallback={
-								<Alert
-									trackingId="AdminNoAccessToAutoJoinDomains"
-									type="info"
-									message="You don't have access to auto-access domains."
-									description={`You don't have permission to configure auto-access domains. Please contact a workspace admin to make changes.`}
-								/>
+								<Callout
+									kind="info"
+									title="You don't have access to auto-access domains."
+								>
+									<Text size="xSmall" color="moderate">
+										You don't have permission to
+										configure auto-access
+										domains. Please contact a
+										workspace admin to make
+										changes.
+									</Text>
+								</Callout>
 							}
 						>
 							<AutoJoinForm />

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -1,14 +1,18 @@
 import { useAuthContext } from '@authentication/AuthContext'
 import { toast } from '@components/Toaster'
-import Tooltip from '@components/Tooltip/Tooltip'
 import {
 	useGetWorkspaceAdminsQuery,
 	useUpdateAllowedEmailOriginsMutation,
 } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
-import { Box, Select, Text } from '@highlight-run/ui/components'
+import {
+	Box,
+	Select,
+	SwitchButton,
+	Text,
+	Tooltip,
+} from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React, { useState } from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -61,8 +65,7 @@ export const AutoJoinForm: React.FC = () => {
 		}
 	}
 
-	const handleCheckboxChange = (event: CheckboxChangeEvent) => {
-		const checked = event.target.checked
+	const handleToggle = (checked: boolean) => {
 		if (checked) {
 			onChangeMsg([adminsEmailDomain], 'Successfully enabled auto-join!')
 		} else {
@@ -79,29 +82,38 @@ export const AutoJoinForm: React.FC = () => {
 
 	return (
 		<Tooltip
-			title="Automatically share the workspace with all users on this domain."
-			align={{ offset: [0, 6] }}
-			mouseEnterDelay={0}
-		>
-			<div className={styles.container}>
-				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
-						checked={autoJoinDomains.length > 0}
-						onChange={handleCheckboxChange}
+			trigger={
+				<div className={styles.container}>
+					<Box
+						display="flex"
+						alignItems="center"
+						gap="8"
+						p="0"
+						m="0"
+					>
+						<SwitchButton
+							type="button"
+							size="xxSmall"
+							checked={autoJoinDomains.length > 0}
+							onChange={handleToggle}
+						/>
+						<Text>Auto-approved email domains</Text>
+					</Box>
+					<Select
+						creatable
+						filterable
+						displayMode="tags"
+						loading={loading}
+						placeholder={`${adminsEmailDomain}, acme.corp, piedpiper.com`}
+						value={autoJoinDomains}
+						onValueChange={handleSelectChange}
+						options={adminDomains}
 					/>
-					<Text>Auto-approved email domains</Text>
-				</Box>
-				<Select
-					creatable
-					filterable
-					displayMode="tags"
-					loading={loading}
-					placeholder={`${adminsEmailDomain}, acme.corp, piedpiper.com`}
-					value={autoJoinDomains}
-					onValueChange={handleSelectChange}
-					options={adminDomains}
-				/>
-			</div>
+				</div>
+			}
+		>
+			Automatically share the workspace with all users on this
+			domain.
 		</Tooltip>
 	)
 }

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -84,13 +84,7 @@ export const AutoJoinForm: React.FC = () => {
 		<Tooltip
 			trigger={
 				<div className={styles.container}>
-					<Box
-						display="flex"
-						alignItems="center"
-						gap="8"
-						p="0"
-						m="0"
-					>
+					<Box display="flex" alignItems="center" gap="8" p="0" m="0">
 						<SwitchButton
 							type="button"
 							size="xxSmall"
@@ -112,8 +106,7 @@ export const AutoJoinForm: React.FC = () => {
 				</div>
 			}
 		>
-			Automatically share the workspace with all users on this
-			domain.
+			Automatically share the workspace with all users on this domain.
 		</Tooltip>
 	)
 }

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -65,8 +65,8 @@ export const AutoJoinForm: React.FC = () => {
 		}
 	}
 
-	const handleToggle = (checked: boolean) => {
-		if (checked) {
+	const handleToggle = () => {
+		if (autoJoinDomains.length === 0) {
 			onChangeMsg([adminsEmailDomain], 'Successfully enabled auto-join!')
 		} else {
 			onChangeMsg([], 'Successfully disabled auto-join!')


### PR DESCRIPTION
Closes #8635 (settings pages scope)

Went through all the settings-related pages and replaced antd components with their `@highlight-run/ui` equivalents. Here's what changed:

**Direct antd imports removed:**
- `AutoJoinForm` — antd `Checkbox` → `SwitchButton`, antd Tooltip wrapper → UI `Tooltip`
- `GitHubSettingsModal` — antd `Select` → `ComboboxSelect`
- `GitHubEnhancementSettingsForm` — antd `Select` → `ComboboxSelect`

**Antd wrapper components replaced:**
- `WorkspaceSettings` — `@components/Alert` (antd wrapper) → `Callout`
- `FieldsForm` — `@components/Input` (antd wrapper) → native `<input>`, legacy Button → `@components/Button`
- `DangerForm` — same Input + Button migration
- `ErrorSettingsForm` — `@components/Select` (antd wrapper) → UI `Select` with creatable/tags mode
- `ErrorFiltersForm` — same Select migration

After these changes, the workspace settings, project settings, and team management pages have zero direct antd imports. The remaining antd wrapper usages (`ExcludedUsersForm`'s Select with dynamic search + custom render) are more involved and could be a follow-up.

I tested the component swaps locally to make sure the interactive behavior (tag creation, search filtering, switch toggle) works as expected.

/claim #8635