### PR TITLE
refactor(project-settings): use shared Select in GitHub settings modal

### DIFF
--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -15,7 +15,7 @@ import {
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
+import Select from '@components/Select/Select'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -121,7 +121,7 @@ const GithubSettingsForm = ({
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
 				id: repo.key,
-				label: repo.name.split('/').pop(),
+				displayValue: repo.name.split('/').pop(),
 				value: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',


### PR DESCRIPTION
PR Title

/claim #8635 
Closes #8635 

refactor(project-settings): use shared Select in GitHub settings modal

PR Description

Summary
This updates the Project Settings GitHub settings modal to use the repository’s shared Select component instead of importing Select directly from antd.

Changes

Replaced direct antd Select usage in frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
Updated the options shape from label to displayValue to match the shared wrapper API
Kept modal behavior and existing value/filtering logic unchanged
Testing

Reviewed the shared Select wrapper API and confirmed it accepts the props used in this modal
Confirmed the wrapper expects displayValue and internally maps it to Ant Design label
Compared this usage against existing repository patterns in nearby settings pages
Local app-wide validation was limited by workspace bootstrap/build dependencies in other local packages, but the frontend-specific path was brought far enough to verify that the original @highlight-run/react import-resolution issue was unrelated to this change
Scope

Scoped to a single file only:
frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
This change follows existing repository patterns for shared UI abstractions and keeps the modal behavior intact.


