### PR TITLE
feat(integrations): refine integrations page card layout and responsive grid

### DIFF
--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
@@ -1,9 +1,21 @@
+.pageHeader {
+	margin-bottom: var(--size-large);
+}
+
 .integrationsContainer {
 	display: grid;
-	grid-gap: var(--size-large);
-	grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+	gap: var(--size-large);
+	grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+	align-items: stretch;
 }
+
 .modalBtn {
 	padding-bottom: 4px !important;
 	padding-top: 4px !important;
+}
+
+@media (max-width: 768px) {
+	.integrationsContainer {
+		grid-template-columns: 1fr;
+	}
 }

--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
@@ -187,11 +187,13 @@ const IntegrationsPage = () => {
 				<title>Integrations</title>
 			</Helmet>
 			<LeadAlignLayout>
-				<h2>Integrations</h2>
-				<p className={layoutStyles.subTitle}>
-					Supercharge your workflows and attach Highlight with the
-					tools you use everyday.
-				</p>
+				<div className={styles.pageHeader}>
+					<h2>Integrations</h2>
+					<p className={layoutStyles.subTitle}>
+						Supercharge your workflows and attach Highlight with the
+						tools you use everyday.
+					</p>
+				</div>
 				<div className={styles.integrationsContainer}>
 					{integrations.map((integration) => (
 						<Integration

--- a/frontend/src/pages/IntegrationsPage/components/Integration.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.module.css
@@ -1,14 +1,21 @@
 .integration {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	min-height: 220px;
+
 	& .logo {
 		border-radius: 50%;
 		height: var(--size-xxLarge);
 		width: var(--size-xxLarge);
+		flex-shrink: 0;
 	}
 
 	& .header {
 		align-items: flex-start;
 		display: flex;
 		justify-content: space-between;
+		gap: var(--size-medium);
 		padding-bottom: var(--size-small);
 	}
 


### PR DESCRIPTION
/claim #8614

This PR ships a focused UI refresh for the integrations page to improve consistency and readability without broad behavioral changes.

### What changed
- Refined page header spacing with a dedicated `pageHeader` container
- Updated integrations grid to a cleaner responsive card layout (`auto-fill`, wider min card width)
- Improved card visual structure by making integration cards full-height with better spacing/gap behavior

### Files
- `frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx`
- `frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css`
- `frontend/src/pages/IntegrationsPage/components/Integration.module.css`

### Notes
- Scoped to layout/design improvements only (no integration logic changes)
- Kept diff intentionally small for faster maintainer review
