### PR TITLE
replace antd select in project github settings modal

### DIFF
--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -10,12 +10,13 @@ import {
 	IconSolidQuestionMarkCircle,
 	IconSolidTrash,
 	IconSolidX,
+	Select,
 	Text,
 	TextLink,
 	Tooltip,
 } from '@highlight-run/ui/components'
+import type { SelectOption } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -117,11 +118,11 @@ const GithubSettingsForm = ({
 	handleSubmit,
 	handleCancel,
 }: GithubSettingsFormProps) => {
-	const githubOptions = useMemo(
+	const githubOptions = useMemo<SelectOption[]>(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
 				id: repo.key,
-				label: repo.name.split('/').pop(),
+				name: repo.name.split('/').pop() ?? repo.name,
 				value: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
@@ -151,25 +152,22 @@ const GithubSettingsForm = ({
 					name="githubRepo"
 				>
 					<Box display="flex" alignItems="center" gap="8">
-						<Select
-							aria-label="GitHub repository"
-							className={styles.repoSelect}
-							placeholder="Search repos..."
-							onSelect={(repo: string) =>
-								formStore.setValue(
-									formStore.names.githubRepo,
-									repo,
-								)
-							}
-							value={formState.values.githubRepo
-								?.split('/')
-								.pop()}
-							options={githubOptions}
-							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
-							filterOption
-							showSearch
-						/>
+						<Box width="full">
+							<Select<string>
+								aria-label="GitHub repository"
+								className={styles.repoSelect}
+								placeholder="Search repos..."
+								filterable
+								options={githubOptions}
+								value={formState.values.githubRepo ?? undefined}
+								onValueChange={(repo: SelectOption) =>
+									formStore.setValue(
+										formStore.names.githubRepo,
+										String(repo.value),
+									)
+								}
+							/>
+						</Box>
 						<ButtonIcon
 							kind="secondary"
 							emphasis="medium"


### PR DESCRIPTION
/claim #8635


## Summary

Removes one remaining direct antd usage from project settings by replacing the repo picker in the GitHub settings modal with the shared Highlight UI `Select`.

Closes part of #8635.

## How did you test this change?

- Ran:
  - `corepack yarn eslint src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx`
- Attempted local frontend verification, but this fresh checkout is currently blocked by unrelated workspace package build issues in `highlight.run` / `rrweb`, not by this modal change.
- This PR is intentionally scoped to a single replacement of the direct antd repo picker in project settings.

## Are there any deployment considerations?

No.

## Does this work require review from our design team?

No.
