### PR TITLE
refactor: replace antd Dropdown/Skeleton with @highlight-run/ui in UserDropdown

### DIFF
--- a/frontend/src/components/Header/UserDropdown/UserDropdown.module.css
+++ b/frontend/src/components/Header/UserDropdown/UserDropdown.module.css
@@ -11,7 +11,6 @@
 
 .logoutIcon {
 	height: 16px;
-	margin-left: auto;
 	width: 16px;
 }
 
@@ -24,54 +23,18 @@
 
 .userInfoWrapper {
 	align-items: center;
-	border-bottom: 1px solid var(--color-gray-300);
 	display: flex;
 	flex-direction: row;
 	justify-self: center;
-}
-
-.dropdownInner {
-	background-color: var(--color-primary-background);
-	border: 1px solid var(--color-gray-300);
-	border-radius: 8px;
-	box-shadow: var(--box-shadow);
-	color: var(--text-primary);
-	margin-top: -10px;
-	overflow: hidden;
+	padding: 4px 8px;
 }
 
 .dropdownMyAccount {
-	align-items: center;
-	display: flex;
-	padding: var(--size-xSmall) var(--size-medium);
-	transition: 0.2s;
+	display: block;
 	width: 100%;
-
-	&:hover {
-		background-color: var(--color-purple-200);
-	}
-}
-
-.dropdownLogout {
-	align-items: center;
-	color: var(--color-red-400);
-	cursor: pointer;
-	display: flex;
-	padding: var(--size-xSmall) var(--size-medium);
-	transition: 0.2s;
-	width: 100%;
-
-	&:hover {
-		background-color: var(--color-red-200);
-	}
-}
-
-.dropdownLogoutText {
-	font-size: 16px;
 }
 
 .dropdownMenu {
-	box-shadow: none;
 	min-width: 200px;
 }
 
@@ -81,14 +44,6 @@
 	display: flex;
 	height: 100%;
 	justify-content: center;
-}
-
-.accountIcon {
-	cursor: pointer;
-	fill: var(--color-purple);
-	height: 25px;
-	margin-right: 30px;
-	width: 25px;
 }
 
 .userCopy {

--- a/frontend/src/components/Header/UserDropdown/UserDropdown.tsx
+++ b/frontend/src/components/Header/UserDropdown/UserDropdown.tsx
@@ -1,8 +1,8 @@
-import { Dropdown, Skeleton } from 'antd'
 import { FiLogOut } from 'react-icons/fi'
 import { Link } from 'react-router-dom'
 
 import { useAuthContext } from '@/authentication/AuthContext'
+import { Box, IconSolidLoading, Menu, Text } from '@highlight-run/ui/components'
 
 import { AdminAvatar } from '../../Avatar/Avatar'
 import styles from './UserDropdown.module.css'
@@ -15,11 +15,37 @@ interface Props {
 export const UserDropdown = ({ border, workspaceId }: Props) => {
 	const { admin, signOut } = useAuthContext()
 
-	const menu = (
-		<div className={styles.dropdownMenu}>
-			<div className={styles.dropdownInner}>
+	return (
+		<Menu>
+			<Menu.Button
+				cssClass={styles.accountIconWrapper}
+				kind="secondary"
+				emphasis="low"
+			>
+				{admin ? (
+					<AdminAvatar
+						adminInfo={{
+							name: admin?.name,
+							email: admin?.email,
+							photo_url: admin?.photo_url ?? '',
+						}}
+						size={35}
+						border={border}
+					/>
+				) : (
+					<Text>loading</Text>
+				)}
+			</Menu.Button>
+			<Menu.List cssClass={styles.dropdownMenu}>
 				{!admin ? (
-					<Skeleton />
+					<Box
+						display="flex"
+						alignItems="center"
+						justifyContent="center"
+						padding="12"
+					>
+						<IconSolidLoading size={16} />
+					</Box>
 				) : (
 					<>
 						<div className={styles.userInfoWrapper}>
@@ -47,11 +73,11 @@ export const UserDropdown = ({ border, workspaceId }: Props) => {
 								className={styles.dropdownMyAccount}
 								to={`/w/${workspaceId}/account`}
 							>
-								My Account
+								<Menu.Item>My Account</Menu.Item>
 							</Link>
 						)}
-						<div
-							className={styles.dropdownLogout}
+						<Menu.Divider />
+						<Menu.Item
 							onClick={async () => {
 								try {
 									signOut()
@@ -60,33 +86,22 @@ export const UserDropdown = ({ border, workspaceId }: Props) => {
 								}
 							}}
 						>
-							<span className={styles.dropdownLogoutText}>
-								Logout
-							</span>
-							<FiLogOut className={styles.logoutIcon} />
-						</div>
+							<Box
+								display="flex"
+								alignItems="center"
+								justifyContent="space-between"
+								width="full"
+							>
+								<Text color="bad">Logout</Text>
+								<FiLogOut
+									className={styles.logoutIcon}
+									color="var(--color-red-400)"
+								/>
+							</Box>
+						</Menu.Item>
 					</>
 				)}
-			</div>
-		</div>
-	)
-	return (
-		<Dropdown overlay={menu} placement="bottomRight" trigger={['click']}>
-			<div className={styles.accountIconWrapper}>
-				{admin ? (
-					<AdminAvatar
-						adminInfo={{
-							name: admin?.name,
-							email: admin?.email,
-							photo_url: admin?.photo_url ?? '',
-						}}
-						size={35}
-						border={border}
-					/>
-				) : (
-					<p>loading</p>
-				)}
-			</div>
-		</Dropdown>
+			</Menu.List>
+		</Menu>
 	)
 }


### PR DESCRIPTION
## Summary

Replaces antd `Dropdown` and `Skeleton` components in the `UserDropdown` component (`frontend/src/components/Header/UserDropdown/`) with native `@highlight-run/ui` equivalents:

- **`antd.Dropdown`** → `@highlight-run/ui Menu` (`Menu.Button` + `Menu.List` + `Menu.Item` + `Menu.Divider`)
- **`antd.Skeleton`** → `@highlight-run/ui IconSolidLoading` + `Box` for loading state
- Cleaned up `UserDropdown.module.css` to remove antd-specific overlay styling (`.dropdownInner`, `.dropdownLogout`, `.dropdownLogoutText` classes removed)
- Uses proper Ariakit-based `Menu` component for accessible dropdown semantics

### Changes

| Before (antd) | After (@highlight-run/ui) |
|---|---|
| `Dropdown` with `overlay` prop | `Menu` > `Menu.Button` + `Menu.List` |
| `Skeleton` loading placeholder | `IconSolidLoading` spinner in `Box` |
| Custom `.dropdownLogout` div | `Menu.Item` with `Text color="bad"` |
| Custom `.dropdownMyAccount` link | `Link` wrapping `Menu.Item` |

/claim #8635

## Test plan

- [ ] Verify UserDropdown renders correctly on the Landing page when logged in
- [ ] Verify the dropdown opens on click and shows user info (avatar, name, email)
- [ ] Verify "My Account" link navigates correctly when workspaceId is provided
- [ ] Verify "Logout" action works correctly
- [ ] Verify loading state shows spinner instead of antd Skeleton
- [ ] Verify no remaining antd imports in UserDropdown.tsx