### PR TITLE
fix: replace antd Select with native ComboboxSelect in GitHub settings

### DIFF
--- a/frontend/src/pages/ErrorsV2/GitHubEnhancementSettings/GitHubEnhancementSettingsForm.tsx
+++ b/frontend/src/pages/ErrorsV2/GitHubEnhancementSettings/GitHubEnhancementSettingsForm.tsx
@@ -2,6 +2,7 @@ import { Button } from '@components/Button'
 import {
 	Box,
 	ButtonIcon,
+	ComboboxSelect,
 	Form,
 	IconSolidBeaker,
 	IconSolidInformationCircle,
@@ -14,7 +15,6 @@ import {
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import React, { useEffect, useMemo, useState } from 'react'
 
 import LoadingBox from '@/components/LoadingBox'
@@ -64,12 +64,11 @@ export const GitHubEnhancementSettingsForm: React.FC<
 	const githubOptions = useMemo(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
-				id: repo.key,
-				label: repo.name.split('/').pop(),
-				value: repo.repo_id.replace(
+				key: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
 				),
+				render: repo.name.split('/').pop() ?? repo.name,
 			})),
 		[githubRepos],
 	)
@@ -217,25 +216,31 @@ export const GitHubEnhancementSettingsForm: React.FC<
 						name="githubRepo"
 					>
 						<Box display="flex" alignItems="center" gap="8">
-							<Select
-								aria-label="GitHub repository"
-								className={styles.repoSelect}
-								placeholder="Search repos..."
-								onSelect={(repo: string) =>
+							<ComboboxSelect
+								label="GitHub repository"
+								queryPlaceholder="Search repos..."
+								value={
+									formState.values.githubRepo ?? undefined
+								}
+								valueRender={
+									formState.values.githubRepo
+										?.split('/')
+										.pop() ?? undefined
+								}
+								options={githubOptions}
+								onChange={(repo: string) =>
 									formStore.setValue(
 										formStore.names.githubRepo,
 										repo,
 									)
 								}
-								value={formState.values.githubRepo
-									?.split('/')
-									.pop()}
-								options={githubOptions}
 								disabled={disabled || testLoading}
-								notFoundContent={<span>No repos found</span>}
-								optionFilterProp="label"
-								filterOption
-								showSearch
+								emptyStateRender={
+									<Text size="xSmall" color="weak">
+										No repos found
+									</Text>
+								}
+								wrapperCssClass={styles.repoSelect}
 							/>
 							<ButtonIcon
 								kind="secondary"

--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -5,6 +5,7 @@ import ModalBody from '@components/ModalBody/ModalBody'
 import {
 	Box,
 	ButtonIcon,
+	ComboboxSelect,
 	Form,
 	IconSolidInformationCircle,
 	IconSolidQuestionMarkCircle,
@@ -15,7 +16,6 @@ import {
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -120,12 +120,11 @@ const GithubSettingsForm = ({
 	const githubOptions = useMemo(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
-				id: repo.key,
-				label: repo.name.split('/').pop(),
-				value: repo.repo_id.replace(
+				key: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
 				),
+				render: repo.name.split('/').pop() ?? repo.name,
 			})),
 		[githubRepos],
 	)
@@ -151,24 +150,28 @@ const GithubSettingsForm = ({
 					name="githubRepo"
 				>
 					<Box display="flex" alignItems="center" gap="8">
-						<Select
-							aria-label="GitHub repository"
-							className={styles.repoSelect}
-							placeholder="Search repos..."
-							onSelect={(repo: string) =>
+						<ComboboxSelect
+							label="GitHub repository"
+							queryPlaceholder="Search repos..."
+							value={formState.values.githubRepo ?? undefined}
+							valueRender={
+								formState.values.githubRepo
+									?.split('/')
+									.pop() ?? undefined
+							}
+							options={githubOptions}
+							onChange={(repo: string) =>
 								formStore.setValue(
 									formStore.names.githubRepo,
 									repo,
 								)
 							}
-							value={formState.values.githubRepo
-								?.split('/')
-								.pop()}
-							options={githubOptions}
-							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
-							filterOption
-							showSearch
+							emptyStateRender={
+								<Text size="xSmall" color="weak">
+									No repos found
+								</Text>
+							}
+							wrapperCssClass={styles.repoSelect}
 						/>
 						<ButtonIcon
 							kind="secondary"


### PR DESCRIPTION
/claim #8635

## Summary

- Replace the antd `Select` component with the native `ComboboxSelect` from `@highlight-run/ui/components` in two files that are part of the workspace/project settings:
  - `frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx`
  - `frontend/src/pages/ErrorsV2/GitHubEnhancementSettings/GitHubEnhancementSettingsForm.tsx`
- Update the options format from antd's `{id, label, value}` to the native `{key, render}` format used by `ComboboxSelect`
- Preserve all existing behavior: searchable dropdown, repo filtering, clear/trash button, disabled states

## Changes

Both files follow the same pattern:

1. **Import**: Replaced `import { Select } from 'antd'` with `ComboboxSelect` from `@highlight-run/ui/components`
2. **Options format**: Changed from `{id, label, value}` to `{key, render}` to match `ComboboxSelect` API
3. **Component swap**: Replaced antd `Select` with `ComboboxSelect`, mapping props:
   - `showSearch` + `filterOption` + `optionFilterProp` -> built-in search in `ComboboxSelect`
   - `placeholder` -> `queryPlaceholder`
   - `onSelect` -> `onChange`
   - `notFoundContent` -> `emptyStateRender`
   - `className` -> `wrapperCssClass`
   - `value` (display text) -> `valueRender`

## Test plan

- [ ] Open Project Settings > click a service's GitHub settings gear icon -> verify the repo picker dropdown works with search
- [ ] Open Error Enhancement Settings panel -> verify the repo picker dropdown works with search
- [ ] Verify repo selection updates the form state correctly
- [ ] Verify the trash/clear button still works
- [ ] Verify disabled state renders correctly