### PR TITLE
fix: apply correct Monotype/S font styles for monospace text

### DIFF
--- a/packages/ui/src/components/Text/styles.css.ts
+++ b/packages/ui/src/components/Text/styles.css.ts
@@ -35,7 +35,7 @@ export const large = createStyleObject({
 
 // Monospace
 export const sMonotype = createStyleObject({
-	fontSize: 13,
+	fontSize: 14,
 	leading: 20,
 	fontMetrics: plexoFontMetrics,
 })
@@ -131,7 +131,11 @@ export const variants = recipe({
 	compoundVariants: [
 		{
 			variants: { family: 'monospace', size: 'small' },
-			style: { ...sMonotype, letterSpacing: -0.4 },
+			style: {
+				...sMonotype,
+				fontWeight: fontWeights.medium,
+				letterSpacing: -0.4,
+			},
 		},
 		{
 			variants: { family: 'monospace', size: 'xSmall' },


### PR DESCRIPTION
## Summary
- Updated `sMonotype` font size from 13px to 14px to match the Monotype/S design spec
- Added `fontWeight: 500` (medium) to the monospace small compound variant
- These changes ensure error body text and other monospace small text renders with the correct Monotype/S properties: `IBM Plex Mono, 14px, 500 weight, 20px line-height, -0.4px letter-spacing`

## Relates to
Fixes #4963

## Changes
- `packages/ui/src/components/Text/styles.css.ts` — corrected `sMonotype` fontSize (13→14) and added fontWeight to compound variant

## Test plan
- Verified the Monotype/S design spec values from the issue comments (provided by @julian-highlight)
- The change applies to all `<Text family="monospace" size="small">` usages, including the ErrorBodyText component at `frontend/src/pages/ErrorsV2/ErrorBody/components/ErrorBodyText/index.tsx`