### PR TITLE
Remove antd components from workspace/project settings

### DIFF
--- a/frontend/src/pages/NewProject/AutoJoinInput.module.css
+++ b/frontend/src/pages/NewProject/AutoJoinInput.module.css
@@ -9,13 +9,5 @@
 }
 
 .select {
-	&:global(.ant-select-disabled .ant-select-selector) {
-		background-color: transparent !important;
-	}
-
-	:global(.ant-select-selector) {
-		padding: 0 !important;
-		border: 0px solid var(--color-gray-300) !important;
-		background-color: transparent !important;
-	}
+	width: 100%;
 }

--- a/frontend/src/pages/NewProject/AutoJoinInput.tsx
+++ b/frontend/src/pages/NewProject/AutoJoinInput.tsx
@@ -1,8 +1,6 @@
 import { useAuthContext } from '@authentication/AuthContext'
 import Tooltip from '@components/Tooltip/Tooltip'
-import { Box, Text } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
+import { Box, SwitchButton, Text } from '@highlight-run/ui/components'
 import React from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -23,8 +21,9 @@ export const AutoJoinInput: React.FC<Props> = ({
 	const { admin } = useAuthContext()
 	const adminsEmailDomain = getEmailDomain(admin?.email)
 
-	const handleMessageChecked = (event: CheckboxChangeEvent) => {
-		const domains = event.target.checked ? [adminsEmailDomain] : []
+	const handleMessageChecked = () => {
+		const isCurrentlyChecked = autoJoinDomains.length > 0
+		const domains = !isCurrentlyChecked ? [adminsEmailDomain] : []
 		setAutoJoinDomains(domains)
 	}
 
@@ -43,18 +42,21 @@ export const AutoJoinInput: React.FC<Props> = ({
 		>
 			<div className={styles.container}>
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
+					<SwitchButton
+						type="button"
+						size="xxSmall"
 						checked={autoJoinDomains.length > 0}
 						onChange={handleMessageChecked}
-					/>
-					<Text>Allowed email domains</Text>
+					>
+						Allowed email domains
+					</SwitchButton>
 				</Box>
-				<Divider className="m-0 border-none pt-1" />
+				<Box py="4" />
 				<Text color="n11">
 					Allow everyone with a <b>{getEmailDomain(admin?.email)}</b>{' '}
 					email to join your workspace.
 				</Text>
-				<Divider className="m-0 border-none pt-1" />
+				<Box py="4" />
 			</div>
 		</Tooltip>
 	)

--- a/frontend/src/pages/NewProject/NewProjectPage.tsx
+++ b/frontend/src/pages/NewProject/NewProjectPage.tsx
@@ -12,7 +12,6 @@ import { namedOperations } from '@graph/operations'
 import { Box, Callout, Stack, Text } from '@highlight-run/ui/components'
 import analytics from '@util/analytics'
 import { client } from '@util/graph'
-import { Divider } from 'antd'
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
@@ -147,7 +146,7 @@ const NewProjectPage = ({ workspace_id }: { workspace_id: string }) => {
 								}}
 							/>
 						</Box>
-						<Divider className="m-0" />
+						<Box borderTop="divider" />
 						<Box
 							py="8"
 							px="12"

--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.css.ts
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.css.ts
@@ -1,10 +1,6 @@
 import { vars } from '@highlight-run/ui/vars'
 import { style } from '@vanilla-extract/css'
 
-export const repoSelect = style({
-	width: '100%',
-})
-
 export const example = style({
 	background: vars.color.n5,
 	border: `${vars.theme.interactive.outline.secondary.enabled} solid 1px`,

--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -10,12 +10,12 @@ import {
 	IconSolidQuestionMarkCircle,
 	IconSolidTrash,
 	IconSolidX,
+	Select,
 	Text,
 	TextLink,
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -120,8 +120,7 @@ const GithubSettingsForm = ({
 	const githubOptions = useMemo(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
-				id: repo.key,
-				label: repo.name.split('/').pop(),
+				name: repo.name.split('/').pop() ?? repo.name,
 				value: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
@@ -153,22 +152,26 @@ const GithubSettingsForm = ({
 					<Box display="flex" alignItems="center" gap="8">
 						<Select
 							aria-label="GitHub repository"
-							className={styles.repoSelect}
+							filterable
 							placeholder="Search repos..."
-							onSelect={(repo: string) =>
+							onValueChange={(
+								option:
+									| {
+											name: string
+											value: string
+									  }
+									| undefined,
+							) => {
 								formStore.setValue(
 									formStore.names.githubRepo,
-									repo,
+									option?.value ?? null,
 								)
+							}}
+							value={
+								formState.values.githubRepo ??
+								undefined
 							}
-							value={formState.values.githubRepo
-								?.split('/')
-								.pop()}
 							options={githubOptions}
-							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
-							filterOption
-							showSearch
 						/>
 						<ButtonIcon
 							kind="secondary"

--- a/frontend/src/pages/WorkspaceTeam/WorkspaceTeam.module.css
+++ b/frontend/src/pages/WorkspaceTeam/WorkspaceTeam.module.css
@@ -12,17 +12,3 @@
 .tabTitle {
 	font-weight: 500 !important;
 }
-
-.teamTabs {
-	:global(.ant-tabs-tab.ant-tabs-tab-active .ant-tabs-tab-btn) {
-		color: var(--color-purple) !important;
-	}
-
-	:global(.ant-tabs-ink-bar) {
-		background: var(--color-purple) !important;
-	}
-
-	:global(.ant-tabs-tab) {
-		margin-left: 0 !important;
-	}
-}

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.module.css
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.module.css
@@ -10,8 +10,4 @@
 
 .select {
 	width: 100%;
-
-	&:global(.ant-select-disabled .ant-select-selector) {
-		background-color: var(--color-primary-background) !important;
-	}
 }

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -6,9 +6,13 @@ import {
 	useUpdateAllowedEmailOriginsMutation,
 } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
-import { Box, Select, Text } from '@highlight-run/ui/components'
+import {
+	Box,
+	Select,
+	SwitchButton,
+	Text,
+} from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React, { useState } from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -61,9 +65,9 @@ export const AutoJoinForm: React.FC = () => {
 		}
 	}
 
-	const handleCheckboxChange = (event: CheckboxChangeEvent) => {
-		const checked = event.target.checked
-		if (checked) {
+	const handleCheckboxChange = () => {
+		const isCurrentlyChecked = autoJoinDomains.length > 0
+		if (!isCurrentlyChecked) {
 			onChangeMsg([adminsEmailDomain], 'Successfully enabled auto-join!')
 		} else {
 			onChangeMsg([], 'Successfully disabled auto-join!')
@@ -85,11 +89,14 @@ export const AutoJoinForm: React.FC = () => {
 		>
 			<div className={styles.container}>
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
+					<SwitchButton
+						type="button"
+						size="xxSmall"
 						checked={autoJoinDomains.length > 0}
 						onChange={handleCheckboxChange}
-					/>
-					<Text>Auto-approved email domains</Text>
+					>
+						Auto-approved email domains
+					</SwitchButton>
 				</Box>
 				<Select
 					creatable


### PR DESCRIPTION
## Summary
- Replace antd `Select` with highlight `Select` (filterable) in GitHubSettingsModal
- Replace antd `Checkbox` with highlight `SwitchButton` in AutoJoinForm and AutoJoinInput
- Replace antd `Divider` with `Box` in NewProjectPage and AutoJoinInput
- Clean up dead antd-specific CSS overrides in related style files

Closes #8635

## Test plan
- [ ] Verify GitHubSettingsModal repo search/select works correctly
- [ ] Verify AutoJoinForm toggle and domain select works
- [ ] Verify NewProject page layout renders correctly
- [ ] Confirm no remaining antd imports in workspace/project settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)