### PR TITLE
refactor: replace antd components in AutoJoin and NewProject pages

### DIFF
--- a/.changeset/popular-grapes-care.md
+++ b/.changeset/popular-grapes-care.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+refactor: replace antd components in AutoJoin and NewProject pages

--- a/frontend/src/pages/NewProject/AutoJoinInput.tsx
+++ b/frontend/src/pages/NewProject/AutoJoinInput.tsx
@@ -1,8 +1,6 @@
 import { useAuthContext } from '@authentication/AuthContext'
 import Tooltip from '@components/Tooltip/Tooltip'
 import { Box, Text } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -23,7 +21,9 @@ export const AutoJoinInput: React.FC<Props> = ({
 	const { admin } = useAuthContext()
 	const adminsEmailDomain = getEmailDomain(admin?.email)
 
-	const handleMessageChecked = (event: CheckboxChangeEvent) => {
+	const handleMessageChecked = (
+		event: React.ChangeEvent<HTMLInputElement>,
+	) => {
 		const domains = event.target.checked ? [adminsEmailDomain] : []
 		setAutoJoinDomains(domains)
 	}
@@ -43,18 +43,19 @@ export const AutoJoinInput: React.FC<Props> = ({
 		>
 			<div className={styles.container}>
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
+					<input
+						type="checkbox"
 						checked={autoJoinDomains.length > 0}
 						onChange={handleMessageChecked}
 					/>
 					<Text>Allowed email domains</Text>
 				</Box>
-				<Divider className="m-0 border-none pt-1" />
+				<Box pb="4" />
 				<Text color="n11">
 					Allow everyone with a <b>{getEmailDomain(admin?.email)}</b>{' '}
 					email to join your workspace.
 				</Text>
-				<Divider className="m-0 border-none pt-1" />
+				<Box pb="4" />
 			</div>
 		</Tooltip>
 	)

--- a/frontend/src/pages/NewProject/NewProjectPage.tsx
+++ b/frontend/src/pages/NewProject/NewProjectPage.tsx
@@ -12,7 +12,6 @@ import { namedOperations } from '@graph/operations'
 import { Box, Callout, Stack, Text } from '@highlight-run/ui/components'
 import analytics from '@util/analytics'
 import { client } from '@util/graph'
-import { Divider } from 'antd'
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
@@ -21,7 +20,7 @@ import { Navigate, useLocation } from 'react-router-dom'
 import { authRedirect } from '@/pages/Auth/utils'
 import SvgCloseIcon from '@/static/CloseIcon'
 
-import Button from '../../components/Button/Button/Button'
+import { Button } from '@/components/Button'
 import styles from './NewProject.module.css'
 
 const NewProjectPage = ({ workspace_id }: { workspace_id: string }) => {
@@ -147,7 +146,7 @@ const NewProjectPage = ({ workspace_id }: { workspace_id: string }) => {
 								}}
 							/>
 						</Box>
-						<Divider className="m-0" />
+						<Box borderBottom="dividerWeak" />
 						<Box
 							py="8"
 							px="12"
@@ -226,7 +225,7 @@ const NewProjectPage = ({ workspace_id }: { workspace_id: string }) => {
 									</ButtonLink>
 								)}
 							<Button
-								type="primary"
+								kind="primary"
 								htmlType="submit"
 								disabled={name.length === 0}
 								className={clsx(

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -8,7 +8,6 @@ import {
 import { namedOperations } from '@graph/operations'
 import { Box, Select, Text } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React, { useState } from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -61,7 +60,9 @@ export const AutoJoinForm: React.FC = () => {
 		}
 	}
 
-	const handleCheckboxChange = (event: CheckboxChangeEvent) => {
+	const handleCheckboxChange = (
+		event: React.ChangeEvent<HTMLInputElement>,
+	) => {
 		const checked = event.target.checked
 		if (checked) {
 			onChangeMsg([adminsEmailDomain], 'Successfully enabled auto-join!')
@@ -85,7 +86,8 @@ export const AutoJoinForm: React.FC = () => {
 		>
 			<div className={styles.container}>
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
+					<input
+						type="checkbox"
 						checked={autoJoinDomains.length > 0}
 						onChange={handleCheckboxChange}
 					/>


### PR DESCRIPTION
/claim #8635

## Summary

Removes `antd` imports from three settings-related pages, replacing them with native HTML or `@highlight-run/ui` components:

### `WorkspaceTeam/components/AutoJoinForm.tsx`
- Replace `import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'` with a native `<input type="checkbox" />`
- Update handler signature from `CheckboxChangeEvent` → `React.ChangeEvent<HTMLInputElement>`

### `NewProject/AutoJoinInput.tsx`
- Replace `import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'` with native `<input type="checkbox" />`
- Replace `import { Divider } from 'antd'` (border-none spacers) with `<Box pb="4" />`
- Update handler signature from `CheckboxChangeEvent` → `React.ChangeEvent<HTMLInputElement>`

### `NewProject/NewProjectPage.tsx`
- Replace `import { Divider } from 'antd'` with `<Box borderBottom="dividerWeak" />`
- Replace `import Button from '../../components/Button/Button/Button'` with `import { Button } from '@/components/Button'`
- Update `type="primary"` → `kind="primary"` on the Button

## Test plan
- [ ] Workspace Settings > Auto Join: toggle checkbox enables/disables auto-join domains
- [ ] New Project modal: the header divider renders correctly, Create Project button submits the form
- [ ] New Workspace creation: Auto Join checkbox toggles the domain list correctly
- [ ] No antd imports remain in the three modified files