### PR TITLE
refactor: replace antd Divider with Box in AlertForm

### DIFF
--- a/.changeset/silver-cups-walk.md
+++ b/.changeset/silver-cups-walk.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+refactor: replace antd Divider with Box in AlertForm

--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -13,7 +13,6 @@ import {
 	Tag,
 	Text,
 } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
 import React, { PropsWithChildren, useEffect, useMemo, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { useNavigate, useSearchParams } from 'react-router-dom'
@@ -640,7 +639,7 @@ export const AlertForm: React.FC = () => {
 										/>
 									</LabeledRow>
 								</SidebarSection>
-								<Divider className="m-0" />
+								<Box borderBottom="dividerWeak" />
 								<SidebarSection>
 									<Box cssClass={style.editorSection}>
 										<Box cssClass={style.editorHeader}>
@@ -718,7 +717,7 @@ export const AlertForm: React.FC = () => {
 															</Callout>
 														)}
 												</SidebarSection>
-												<Divider className="m-0" />
+												<Box borderBottom="dividerWeak" />
 												<SidebarSection>
 													{productType ===
 													ProductType.Events ? (
@@ -775,7 +774,7 @@ export const AlertForm: React.FC = () => {
 														!isErrorAlert)) && (
 													<>
 														<Box px="12">
-															<Divider className="m-0" />
+															<Box borderBottom="dividerWeak" />
 														</Box>
 														<SidebarSection>
 															<LabeledRow
@@ -850,7 +849,7 @@ export const AlertForm: React.FC = () => {
 										)}
 									</Box>
 								</SidebarSection>
-								<Divider className="m-0" />
+								<Box borderBottom="dividerWeak" />
 								<SidebarSection>
 									<LabeledRow
 										label="Alert threshold type"
@@ -970,7 +969,7 @@ export const AlertForm: React.FC = () => {
 										</>
 									)}
 								</SidebarSection>
-								<Divider className="m-0" />
+								<Box borderBottom="dividerWeak" />
 								<SidebarSection>
 									<DestinationInput
 										initialDestinations={


### PR DESCRIPTION
## Summary

Removes the `antd` dependency from `frontend/src/pages/Alerts/AlertForm/index.tsx` as part of the antd migration effort.

### Changes

- Removed `import { Divider } from 'antd'` (only antd usage in the file)
- Replaced 4 standalone `<Divider className="m-0" />` with `<Box borderBottom="dividerWeak" />` from `@highlight-run/ui/components`
- Replaced 1 padding-wrapped `<Divider className="m-0" />` with `<Box borderBottom="dividerWeak" />` preserving the outer `<Box px="12">` wrapper
- No new imports needed — `Box` was already imported from `@highlight-run/ui/components`

## Test Plan

- [ ] AlertForm renders correctly with visual dividers between sections
- [ ] Inset divider (inside `<Box px="12">`) respects the horizontal padding
- [ ] No antd import remains in the file (`grep -r "from 'antd'" frontend/src/pages/Alerts/AlertForm/`)

/claim #8635