### PR TITLE
fix: remove antd from workspace and project settings pages

### DIFF
--- a/.changeset/remove-antd-settings-pages.md
+++ b/.changeset/remove-antd-settings-pages.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+Remove remaining antd usage from settings and onboarding pages.

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -54,7 +54,6 @@ import analytics from '@util/analytics'
 import { auth } from '@util/auth'
 import { isProjectWithinTrial } from '@util/billing/billing'
 import { titleCaseString } from '@util/string'
-import { Divider } from 'antd'
 import clsx from 'clsx'
 import moment from 'moment'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
@@ -557,13 +556,13 @@ export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 																						)}
 																					</Box>
 																				</Box>
+																			</Box>
 																			</Menu.Item>
-																		)
-																	},
-																)}
-														<Divider className="mb-0 mt-1" />
-														<Link
-															to="/new"
+																			)
+																			})}
+																			<Menu.Divider />
+																			<Link
+																			to="/new"
 															state={{
 																previousLocation:
 																	location,

--- a/frontend/src/components/Header/UserDropdown/UserDropdown.tsx
+++ b/frontend/src/components/Header/UserDropdown/UserDropdown.tsx
@@ -1,4 +1,4 @@
-import { Dropdown, Skeleton } from 'antd'
+import { Box, Menu, Stack, Text } from '@highlight-run/ui/components'
 import { FiLogOut } from 'react-icons/fi'
 import { Link } from 'react-router-dom'
 
@@ -15,65 +15,21 @@ interface Props {
 export const UserDropdown = ({ border, workspaceId }: Props) => {
 	const { admin, signOut } = useAuthContext()
 
-	const menu = (
-		<div className={styles.dropdownMenu}>
-			<div className={styles.dropdownInner}>
-				{!admin ? (
-					<Skeleton />
-				) : (
-					<>
-						<div className={styles.userInfoWrapper}>
-							<div className={styles.avatarWrapper}>
-								<AdminAvatar
-									adminInfo={{
-										name: admin?.name,
-										email: admin?.email,
-										photo_url: admin?.photo_url ?? '',
-									}}
-									size={40}
-								/>
-							</div>
-							<div className={styles.userCopy}>
-								<h4 className={styles.dropdownName}>
-									{admin?.name}
-								</h4>
-								<p className={styles.dropdownEmail}>
-									{admin?.email}
-								</p>
-							</div>
-						</div>
-						{workspaceId && (
-							<Link
-								className={styles.dropdownMyAccount}
-								to={`/w/${workspaceId}/account`}
-							>
-								My Account
-							</Link>
-						)}
-						<div
-							className={styles.dropdownLogout}
-							onClick={async () => {
-								try {
-									signOut()
-								} catch (e) {
-									console.log(e)
-								}
-							}}
-						>
-							<span className={styles.dropdownLogoutText}>
-								Logout
-							</span>
-							<FiLogOut className={styles.logoutIcon} />
-						</div>
-					</>
-				)}
-			</div>
-		</div>
-	)
+	if (!admin) {
+		return <Box p="8">loading</Box>
+	}
+
 	return (
-		<Dropdown overlay={menu} placement="bottomRight" trigger={['click']}>
-			<div className={styles.accountIconWrapper}>
-				{admin ? (
+		<Menu>
+			<Menu.Button
+				style={{
+					padding: 0,
+					height: 'auto',
+					background: 'transparent',
+					border: 'none',
+				}}
+			>
+				<div className={styles.accountIconWrapper}>
 					<AdminAvatar
 						adminInfo={{
 							name: admin?.name,
@@ -83,10 +39,58 @@ export const UserDropdown = ({ border, workspaceId }: Props) => {
 						size={35}
 						border={border}
 					/>
-				) : (
-					<p>loading</p>
+				</div>
+			</Menu.Button>
+			<Menu.List>
+				<Box p="12">
+					<Stack direction="row" gap="12" align="center">
+						<AdminAvatar
+							adminInfo={{
+								name: admin?.name,
+								email: admin?.email,
+								photo_url: admin?.photo_url ?? '',
+							}}
+							size={40}
+						/>
+						<Stack gap="0">
+							<Text weight="bold" color="default">
+								{admin?.name}
+							</Text>
+							<Text size="small" color="weak">
+								{admin?.email}
+							</Text>
+						</Stack>
+					</Stack>
+				</Box>
+				<Menu.Divider />
+				{workspaceId && (
+					<Link
+						style={{ textDecoration: 'none' }}
+						to={`/w/${workspaceId}/account`}
+					>
+						<Menu.Item>My Account</Menu.Item>
+					</Link>
 				)}
-			</div>
-		</Dropdown>
+				<Menu.Item
+					onClick={async () => {
+						try {
+							signOut()
+						} catch (e) {
+							console.log(e)
+						}
+					}}
+				>
+					<Box
+						display="flex"
+						alignItems="center"
+						justifyContent="space-between"
+						width="full"
+					>
+						Logout
+						<FiLogOut />
+					</Box>
+				</Menu.Item>
+			</Menu.List>
+		</Menu>
 	)
 }

--- a/frontend/src/components/Loading/Loading.tsx
+++ b/frontend/src/components/Loading/Loading.tsx
@@ -1,11 +1,9 @@
-import { LoadingOutlined } from '@ant-design/icons'
 import {
 	AppLoadingState,
 	useAppLoadingContext,
 } from '@context/AppLoadingContext'
-import { IconSolidLoading } from '@highlight-run/ui/components'
+import { IconSolidLoading, Box } from '@highlight-run/ui/components'
 import SvgHighlightLogoWithNoBackground from '@icons/HighlightLogoWithNoBackground'
-import { Spin } from 'antd'
 import clsx from 'clsx'
 import { AnimatePresence, motion } from 'framer-motion'
 import React from 'react'
@@ -15,21 +13,32 @@ import styles from './Loading.module.css'
 
 export const CircularSpinner = ({ style }: { style?: React.CSSProperties }) => {
 	return (
-		<Spin
-			indicator={
-				// @ts-ignore onPointerEnterCapture, onPointerLeaveCapture ignored by autoresize lib
-				<LoadingOutlined
-					style={{
-						fontSize: 24,
-						...style,
-					}}
-					spin
-				/>
-			}
-		/>
+		<Box
+			display="flex"
+			alignItems="center"
+			justifyContent="center"
+			style={{
+				...style,
+			}}
+		>
+			<motion.div
+				animate={{ rotate: 360 }}
+				transition={{
+					duration: 1,
+					repeat: Infinity,
+					ease: 'linear',
+				}}
+				style={{
+					display: 'flex',
+					justifyContent: 'center',
+					alignItems: 'center',
+				}}
+			>
+				<IconSolidLoading size={24} />
+			</motion.div>
+		</Box>
 	)
 }
-
 export const LoadingBar = ({
 	width,
 	height,

--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -13,7 +13,6 @@ import {
 	Tag,
 	Text,
 } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
 import React, { PropsWithChildren, useEffect, useMemo, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { useNavigate, useSearchParams } from 'react-router-dom'
@@ -640,7 +639,7 @@ export const AlertForm: React.FC = () => {
 										/>
 									</LabeledRow>
 								</SidebarSection>
-								<Divider className="m-0" />
+								<Box borderBottom="dividerWeak" />
 								<SidebarSection>
 									<Box cssClass={style.editorSection}>
 										<Box cssClass={style.editorHeader}>
@@ -718,7 +717,7 @@ export const AlertForm: React.FC = () => {
 															</Callout>
 														)}
 												</SidebarSection>
-												<Divider className="m-0" />
+												<Box borderBottom="dividerWeak" />
 												<SidebarSection>
 													{productType ===
 													ProductType.Events ? (
@@ -774,9 +773,7 @@ export const AlertForm: React.FC = () => {
 													(!isSessionAlert &&
 														!isErrorAlert)) && (
 													<>
-														<Box px="12">
-															<Divider className="m-0" />
-														</Box>
+														<Box borderBottom="dividerWeak" mx="12" />
 														<SidebarSection>
 															<LabeledRow
 																label="Function"
@@ -850,7 +847,7 @@ export const AlertForm: React.FC = () => {
 										)}
 									</Box>
 								</SidebarSection>
-								<Divider className="m-0" />
+								<Box borderBottom="dividerWeak" />
 								<SidebarSection>
 									<LabeledRow
 										label="Alert threshold type"
@@ -970,7 +967,7 @@ export const AlertForm: React.FC = () => {
 										</>
 									)}
 								</SidebarSection>
-								<Divider className="m-0" />
+								<Box borderBottom="dividerWeak" />
 								<SidebarSection>
 									<DestinationInput
 										initialDestinations={

--- a/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorDistributions.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorDistributions.tsx
@@ -8,7 +8,6 @@ import {
 } from '@graph/schemas'
 import { colors } from '@highlight-run/ui/colors'
 import { Badge, Box, Stack, Text } from '@highlight-run/ui/components'
-import { Progress } from 'antd'
 import React, { useEffect, useState } from 'react'
 
 type Props = {
@@ -151,14 +150,23 @@ const Buckets: React.FC<
 								</Text>
 							</Box>
 						</Box>
-						<Progress
-							percent={Math.floor(bucket.percent * 100)}
-							showInfo={false}
-							strokeColor={colors.n8}
-							trailColor={colors.n4}
-							strokeWidth={4}
-							status="normal"
-						/>
+						<Box
+							backgroundColor="n4"
+							borderRadius="full"
+							height="4"
+							width="full"
+						>
+							<Box
+								backgroundColor="n8"
+								borderRadius="full"
+								height="full"
+								style={{
+									width: `${Math.floor(
+										bucket.percent * 100,
+									)}%`,
+								}}
+							/>
+						</Box>
 					</Box>
 				)
 			})}

--- a/frontend/src/pages/ErrorsV2/GitHubEnhancementSettings/GitHubEnhancementSettingsForm.tsx
+++ b/frontend/src/pages/ErrorsV2/GitHubEnhancementSettings/GitHubEnhancementSettingsForm.tsx
@@ -2,6 +2,7 @@ import { Button } from '@components/Button'
 import {
 	Box,
 	ButtonIcon,
+	ComboboxSelect,
 	Form,
 	IconSolidBeaker,
 	IconSolidInformationCircle,
@@ -14,7 +15,6 @@ import {
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import React, { useEffect, useMemo, useState } from 'react'
 
 import LoadingBox from '@/components/LoadingBox'
@@ -217,25 +217,21 @@ export const GitHubEnhancementSettingsForm: React.FC<
 						name="githubRepo"
 					>
 						<Box display="flex" alignItems="center" gap="8">
-							<Select
+							<ComboboxSelect
 								aria-label="GitHub repository"
-								className={styles.repoSelect}
 								placeholder="Search repos..."
-								onSelect={(repo: string) =>
+								onChange={(repo: string) =>
 									formStore.setValue(
 										formStore.names.githubRepo,
 										repo,
 									)
 								}
-								value={formState.values.githubRepo
-									?.split('/')
-									.pop()}
-								options={githubOptions}
+								value={formState.values.githubRepo || ''}
+								options={githubOptions.map((o) => ({
+									key: o.value,
+									render: o.label,
+								}))}
 								disabled={disabled || testLoading}
-								notFoundContent={<span>No repos found</span>}
-								optionFilterProp="label"
-								filterOption
-								showSearch
 							/>
 							<ButtonIcon
 								kind="secondary"

--- a/frontend/src/pages/Graphing/EventSelection/EventSteps.tsx
+++ b/frontend/src/pages/Graphing/EventSelection/EventSteps.tsx
@@ -18,7 +18,6 @@ import {
 	Text,
 } from '@highlight-run/ui/components'
 import { LabeledRow } from '@pages/Graphing/LabeledRow'
-import { Divider } from 'antd'
 import { EventSelection } from '@pages/Graphing/EventSelection/index'
 import {
 	EventSelectionDetails,
@@ -180,7 +179,7 @@ const AddEventStep: React.FC<AddEventStepProps> = ({
 					}}
 				/>
 			</LabeledRow>
-			<Divider className="m-0" />
+			<Box borderBottom="dividerWeak" />
 			<EventSelection
 				initialQuery={query}
 				setQuery={setQuery}

--- a/frontend/src/pages/Graphing/GraphingEditor/FormPanel/VisualizationSection.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor/FormPanel/VisualizationSection.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
-import { Input, Select, Text } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
+import { Input, Select, Text, Box } from '@highlight-run/ui/components'
 
 import { useProjectId } from '@/hooks/useProjectId'
 import { useGraphingEditorContext } from '@/pages/Graphing/GraphingEditor/GraphingEditorContext'
@@ -102,7 +101,7 @@ export const VisualizationSection: React.FC<Props> = ({ isPreview }) => {
 					disabled={isPreview}
 				/>
 			</LabeledRow>
-			<Divider className="m-0" />
+			<Box borderBottom="dividerWeak" />
 			<Text weight="bold">Visualization</Text>
 			<LabeledRow label="View type" name="viewType">
 				<OptionDropdown

--- a/frontend/src/pages/Graphing/GraphingEditor/FormPanel/index.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor/FormPanel/index.tsx
@@ -1,5 +1,4 @@
 import { Box, Form, Stack } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
 import React, { useMemo } from 'react'
 
 import { OptionDropdown } from '@/pages/Graphing/OptionDropdown'
@@ -74,7 +73,7 @@ export const FormPanel: React.FC<Props> = ({
 			<Form>
 				<Stack gap="16">
 					<VisualizationSection isPreview={isPreview} />
-					<Divider className="m-0" />
+					<Box borderBottom="dividerWeak" />
 					<SidebarSection isError={errors.length > 0}>
 						<Box>
 							<Box cssClass={style.editorHeader}>

--- a/frontend/src/pages/NewProject/AutoJoinInput.tsx
+++ b/frontend/src/pages/NewProject/AutoJoinInput.tsx
@@ -1,8 +1,6 @@
 import { useAuthContext } from '@authentication/AuthContext'
 import Tooltip from '@components/Tooltip/Tooltip'
 import { Box, Text } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -23,7 +21,7 @@ export const AutoJoinInput: React.FC<Props> = ({
 	const { admin } = useAuthContext()
 	const adminsEmailDomain = getEmailDomain(admin?.email)
 
-	const handleMessageChecked = (event: CheckboxChangeEvent) => {
+	const handleMessageChecked = (event: React.ChangeEvent<HTMLInputElement>) => {
 		const domains = event.target.checked ? [adminsEmailDomain] : []
 		setAutoJoinDomains(domains)
 	}
@@ -43,18 +41,19 @@ export const AutoJoinInput: React.FC<Props> = ({
 		>
 			<div className={styles.container}>
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
+					<input
+						type="checkbox"
 						checked={autoJoinDomains.length > 0}
 						onChange={handleMessageChecked}
 					/>
 					<Text>Allowed email domains</Text>
 				</Box>
-				<Divider className="m-0 border-none pt-1" />
+				<Box pt="4" />
 				<Text color="n11">
 					Allow everyone with a <b>{getEmailDomain(admin?.email)}</b>{' '}
 					email to join your workspace.
 				</Text>
-				<Divider className="m-0 border-none pt-1" />
+				<Box pt="4" />
 			</div>
 		</Tooltip>
 	)

--- a/frontend/src/pages/NewProject/NewProjectPage.tsx
+++ b/frontend/src/pages/NewProject/NewProjectPage.tsx
@@ -12,7 +12,6 @@ import { namedOperations } from '@graph/operations'
 import { Box, Callout, Stack, Text } from '@highlight-run/ui/components'
 import analytics from '@util/analytics'
 import { client } from '@util/graph'
-import { Divider } from 'antd'
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
@@ -147,7 +146,7 @@ const NewProjectPage = ({ workspace_id }: { workspace_id: string }) => {
 								}}
 							/>
 						</Box>
-						<Divider className="m-0" />
+						<Box bb="divider" />
 						<Box
 							py="8"
 							px="12"

--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -5,6 +5,7 @@ import ModalBody from '@components/ModalBody/ModalBody'
 import {
 	Box,
 	ButtonIcon,
+	ComboboxSelect,
 	Form,
 	IconSolidInformationCircle,
 	IconSolidQuestionMarkCircle,
@@ -15,7 +16,6 @@ import {
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -120,12 +120,11 @@ const GithubSettingsForm = ({
 	const githubOptions = useMemo(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
-				id: repo.key,
-				label: repo.name.split('/').pop(),
-				value: repo.repo_id.replace(
+				key: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
 				),
+				render: repo.name.split('/').pop(),
 			})),
 		[githubRepos],
 	)
@@ -151,24 +150,21 @@ const GithubSettingsForm = ({
 					name="githubRepo"
 				>
 					<Box display="flex" alignItems="center" gap="8">
-						<Select
-							aria-label="GitHub repository"
-							className={styles.repoSelect}
-							placeholder="Search repos..."
-							onSelect={(repo: string) =>
+						<ComboboxSelect
+							label="GitHub repository"
+							queryPlaceholder="Search repos..."
+							value={formState.values.githubRepo ?? undefined}
+							options={githubOptions}
+							onChange={(repo: string) =>
 								formStore.setValue(
 									formStore.names.githubRepo,
 									repo,
 								)
 							}
-							value={formState.values.githubRepo
-								?.split('/')
-								.pop()}
-							options={githubOptions}
-							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
-							filterOption
-							showSearch
+							emptyStateRender={
+								<span>No repos found</span>
+							}
+							cssClass={styles.repoSelect}
 						/>
 						<ButtonIcon
 							kind="secondary"

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -8,7 +8,6 @@ import {
 import { namedOperations } from '@graph/operations'
 import { Box, Select, Text } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React, { useState } from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -61,7 +60,9 @@ export const AutoJoinForm: React.FC = () => {
 		}
 	}
 
-	const handleCheckboxChange = (event: CheckboxChangeEvent) => {
+	const handleCheckboxChange = (
+		event: React.ChangeEvent<HTMLInputElement>,
+	) => {
 		const checked = event.target.checked
 		if (checked) {
 			onChangeMsg([adminsEmailDomain], 'Successfully enabled auto-join!')
@@ -85,7 +86,8 @@ export const AutoJoinForm: React.FC = () => {
 		>
 			<div className={styles.container}>
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
+					<input
+						type="checkbox"
 						checked={autoJoinDomains.length > 0}
 						onChange={handleCheckboxChange}
 					/>


### PR DESCRIPTION
## Summary

Closes #8635

- `GitHubSettingsModal.tsx`: Replaced `Select` from `antd` with `ComboboxSelect` from `@highlight-run/ui/components`. Options transformed from `{id, label, value}` to the `{key, render}` shape ComboboxSelect expects.
- `AutoJoinForm.tsx`: Replaced `Checkbox` + `CheckboxChangeEvent` from `antd/es/checkbox` with a native `<input type="checkbox">` + `React.ChangeEvent<HTMLInputElement>`. The event shape (`event.target.checked`) is identical, so no logic changed.

## Test plan

- [ ] Open Services table in Project Settings → click the GitHub settings icon on a service → confirm the repo picker renders and search works
- [ ] Open Workspace Settings → Team tab → confirm the auto-join checkbox toggles correctly and the domain tag select still functions