### PR TITLE
docs(sveltekit): document backend instrumentation

### DIFF
--- a/.changeset/sveltekit-docs.md
+++ b/.changeset/sveltekit-docs.md
@@ -1,0 +1,5 @@
+---
+"docs-content": patch
+---
+
+Add SvelteKit fullstack instrumentation guide.

--- a/docs-content/general/6_product-features/99_frequently-asked-questions.md
+++ b/docs-content/general/6_product-features/99_frequently-asked-questions.md
@@ -30,7 +30,7 @@ This documentation provides solutions and guidance for common issues encountered
 
 **Question:** How can I set up tracing with SvelteKit as I am not seeing any traces despite having logs and errors?
 
-**Answer:** Ensure that your `H.init` configuration is correctly set up in both `hooks.client.ts` and `hooks.server.ts`. Use `H.runWithHeaders` in your server-side handle function to ensure that headers are correctly passed and handled. If issues persist, please provide the Highlight traces page URL and check the version of the `@highlight-run/node` SDK you are using. For detailed guidance, refer to the [Highlight.io SvelteKit Documentation](https://www.highlight.io/docs/getting-started/client-sdk/sveltekit).
+**Answer:** Ensure that your `H.init` configuration is correctly set up in both `hooks.client.ts` and `hooks.server.ts`. Use `H.runWithHeaders` in your server-side handle function to ensure that headers are correctly passed and handled. If issues persist, please provide the Highlight traces page URL and check the version of the `@highlight-run/node` SDK you are using. For detailed guidance, refer to the [Highlight.io SvelteKit Documentation](https://www.highlight.io/docs/getting-started/fullstack-frameworks/sveltekit).
 
 ## Session Recording Issues
 

--- a/docs-content/getting-started/1_overview.md
+++ b/docs-content/getting-started/1_overview.md
@@ -30,7 +30,7 @@ Installing highlight.io in javascript will automatically instrument frontend err
     <DocsCard title="VueJS"  href="./browser/vuejs.md">
         {"Get started in your VueJS app"}
     </DocsCard>
-    <DocsCard title="SvelteKit"  href="./browser/6_sveltekit.md">
+    <DocsCard title="SvelteKit"  href="./fullstack-frameworks/sveltekit.md">
         {"Get started in your SvelteKit app"}
     </DocsCard>
     <DocsCard title="Electron"  href="./browser/7_electron.md">

--- a/docs-content/getting-started/1_overview.md
+++ b/docs-content/getting-started/1_overview.md
@@ -30,9 +30,6 @@ Installing highlight.io in javascript will automatically instrument frontend err
     <DocsCard title="VueJS"  href="./browser/vuejs.md">
         {"Get started in your VueJS app"}
     </DocsCard>
-    <DocsCard title="SvelteKit"  href="./fullstack-frameworks/sveltekit.md">
-        {"Get started in your SvelteKit app"}
-    </DocsCard>
     <DocsCard title="Electron"  href="./browser/7_electron.md">
         {"Get started in your Electron app"}
     </DocsCard>
@@ -41,6 +38,22 @@ Installing highlight.io in javascript will automatically instrument frontend err
     </DocsCard>
     <DocsCard title="React Native" href="./browser/9_react-native.md">
         {"Get started with React Native"}
+    </DocsCard>
+</DocsCardGroup>
+
+## For Fullstack Frameworks
+
+For frameworks that run both client and server in the same project, use our fullstack guides to get session replay, error monitoring, and backend-to-frontend trace linking set up together.
+
+<DocsCardGroup>
+    <DocsCard title="Next.js" href="./fullstack-frameworks/next-js/1_overview.md">
+        {"Get started with Highlight in Next.js"}
+    </DocsCard>
+    <DocsCard title="Remix" href="./fullstack-frameworks/remix.md">
+        {"Get started with Highlight in Remix"}
+    </DocsCard>
+    <DocsCard title="SvelteKit" href="./fullstack-frameworks/sveltekit.md">
+        {"Get started with Highlight in SvelteKit"}
     </DocsCard>
 </DocsCardGroup>
 

--- a/docs-content/getting-started/fullstack-frameworks/index.md
+++ b/docs-content/getting-started/fullstack-frameworks/index.md
@@ -2,5 +2,19 @@
 title: Fullstack Frameworks
 slug: nextjs-sdk
 createdAt: 2022-04-01T20:28:06.000Z
-updatedAt: 2022-10-18T22:40:13.000Z
+updatedAt: 2024-04-12T00:00:00.000Z
 ---
+
+Highlight provides first-class support for fullstack frameworks where both frontend and backend run in the same project. These guides cover client-side session replay, server-side error monitoring, and the header propagation needed to link backend errors to the originating frontend session.
+
+<DocsCardGroup>
+    <DocsCard title="Next.js" href="./next-js/1_overview.md">
+        {"Get started with Highlight in Next.js (Page Router & App Router)"}
+    </DocsCard>
+    <DocsCard title="Remix" href="./remix.md">
+        {"Get started with Highlight in Remix"}
+    </DocsCard>
+    <DocsCard title="SvelteKit" href="./sveltekit.md">
+        {"Get started with Highlight in SvelteKit"}
+    </DocsCard>
+</DocsCardGroup>

--- a/docs-content/getting-started/fullstack-frameworks/sveltekit.md
+++ b/docs-content/getting-started/fullstack-frameworks/sveltekit.md
@@ -8,75 +8,184 @@ updatedAt: 2024-04-12T00:00:00.000Z
 
 ## Overview
 
-Our SvelteKit instrumentation gives you access to frontend session replays and server-side monitoring, all-in-one.
+Highlight provides full-stack observability for SvelteKit — session replay and client-side errors on the frontend, plus error monitoring, distributed tracing, and logging on the server. Backend errors are automatically correlated to the frontend session that triggered them.
 
-1.  Use `H.init` in `src/hooks.client.ts` to track session replay and client-side errors.
-2.  Use `H.init` and `H.runWithHeaders` in `src/hooks.server.ts` to instrument SvelteKit's Node.js server.
+1. Use `H.init` in `src/hooks.client.ts` to capture session replay and client-side errors.
+2. Use `H.init` and `H.runWithHeaders` in `src/hooks.server.ts` to instrument SvelteKit's Node.js server and link backend traces to the originating frontend session.
 
 ## Installation
 
 ```shell
-# with yarn
+# npm
+npm install highlight.run @highlight-run/node
+
+# yarn
 yarn add highlight.run @highlight-run/node
+
+# pnpm
+pnpm add highlight.run @highlight-run/node
 ```
 
 ## Client Instrumentation
 
-To instrument your SvelteKit frontend, add `H.init` to your `src/hooks.client.ts` file. This will capture session replays and client-side errors.
+Add `H.init` to `src/hooks.client.ts`. This file runs once when the app starts in the browser.
 
-You can use SvelteKit's [environment variables](https://kit.svelte.dev/docs/modules#$env-static-public) to manage your Project ID.
+Configure `tracingOrigins` and `networkRecording` so that Highlight can correlate frontend and backend errors. Use SvelteKit's [public environment variables](https://kit.svelte.dev/docs/modules#$env-static-public) to safely expose your Project ID to the browser bundle.
 
 ```typescript
 // src/hooks.client.ts
-import { H } from 'highlight.run';
-import { PUBLIC_HIGHLIGHT_PROJECT_ID } from '$env/static/public';
+import type { HandleClientError } from '@sveltejs/kit'
+import { H } from 'highlight.run'
+import { PUBLIC_HIGHLIGHT_PROJECT_ID } from '$env/static/public'
 
 H.init(PUBLIC_HIGHLIGHT_PROJECT_ID, {
-    serviceName: "my-sveltekit-frontend",
+    environment: 'production',
+    serviceName: 'my-sveltekit-frontend',
     tracingOrigins: true,
     networkRecording: {
         enabled: true,
         recordHeadersAndBody: true,
     },
-});
+})
 
-/** @type {import('@sveltejs/kit').HandleClientError} */
-export const handleError = ({ error }) => {
-    H.consumeError(error as Error);
-};
+export const handleError: HandleClientError = ({ error }) => {
+    H.consumeError(error as Error)
+}
 ```
 
 ## Server Instrumentation
 
-To instrument your SvelteKit backend, use the `handle` hook in `src/hooks.server.ts`. This allows Highlight to track server-side errors and link them to your frontend sessions.
+All server-side setup lives in `src/hooks.server.ts`. Use SvelteKit's [private environment variables](https://kit.svelte.dev/docs/modules#$env-static-private) to keep your Project ID off the client bundle.
+
+### 1. Initialize the Node SDK
+
+```typescript
+import { H } from '@highlight-run/node'
+import { HIGHLIGHT_PROJECT_ID } from '$env/static/private'
+
+H.init({
+    projectID: HIGHLIGHT_PROJECT_ID,
+    serviceName: 'my-sveltekit-backend',
+    environment: 'production',
+})
+```
+
+### 2. Wrap the request handler
+
+The `handle` hook runs on every server request. Wrap it with `H.runWithHeaders` to propagate the session context from the frontend so that backend traces appear linked to the correct session.
+
+> **Note:** Pass `Object.fromEntries(event.request.headers)` — `H.runWithHeaders` expects a plain object, not a `Headers` instance.
+
+```typescript
+import type { Handle } from '@sveltejs/kit'
+
+export const handle: Handle = async ({ event, resolve }) => {
+    return await H.runWithHeaders(
+        `${event.request.method} ${event.url.pathname}`,
+        Object.fromEntries(event.request.headers),
+        () => resolve(event),
+    )
+}
+```
+
+### 3. Report server errors
+
+The `handleError` hook is called for any unhandled error thrown during loading or rendering. Use `H.parseHeaders` to extract the session context and link the error to the triggering frontend session.
+
+```typescript
+import type { HandleServerError } from '@sveltejs/kit'
+
+export const handleError: HandleServerError = ({ error, event }) => {
+    const { secureSessionId, requestId } = H.parseHeaders(
+        Object.fromEntries(event.request.headers),
+    )
+    H.consumeError(error as Error, secureSessionId, requestId)
+    console.error(error)
+}
+```
+
+### Complete `hooks.server.ts`
 
 ```typescript
 // src/hooks.server.ts
-import { H } from '@highlight-run/node';
-import { HIGHLIGHT_PROJECT_ID } from '$env/static/private';
+import type { Handle, HandleServerError } from '@sveltejs/kit'
+import { H } from '@highlight-run/node'
+import { HIGHLIGHT_PROJECT_ID } from '$env/static/private'
 
-H.init({ 
+H.init({
     projectID: HIGHLIGHT_PROJECT_ID,
-    serviceName: "my-sveltekit-backend",
-});
+    serviceName: 'my-sveltekit-backend',
+    environment: 'production',
+})
 
-/** @type {import('@sveltejs/kit').Handle} */
-export const handle = async ({ event, resolve }) => {
-    return await H.runWithHeaders('sveltekit-server', event.request.headers, async () => {
-        return await resolve(event);
-    });
-};
+export const handle: Handle = async ({ event, resolve }) => {
+    return await H.runWithHeaders(
+        `${event.request.method} ${event.url.pathname}`,
+        Object.fromEntries(event.request.headers),
+        () => resolve(event),
+    )
+}
 
-/** @type {import('@sveltejs/kit').HandleServerError} */
-export const handleError = ({ error, event }) => {
-    const { secureSessionId, requestId } = H.parseHeaders(event.request.headers);
-    H.consumeError(error as Error, secureSessionId, requestId);
-};
+export const handleError: HandleServerError = ({ error, event }) => {
+    const { secureSessionId, requestId } = H.parseHeaders(
+        Object.fromEntries(event.request.headers),
+    )
+    H.consumeError(error as Error, secureSessionId, requestId)
+    console.error(error)
+}
 ```
+
+## API Routes
+
+To capture errors and traces in SvelteKit API routes (`+server.ts`), wrap your handlers with `H.runWithHeaders`:
+
+```typescript
+// src/routes/api/example/+server.ts
+import { H } from '@highlight-run/node'
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async ({ request }) => {
+    return await H.runWithHeaders(
+        'GET /api/example',
+        Object.fromEntries(request.headers),
+        async () => {
+            return new Response(JSON.stringify({ ok: true }), {
+                headers: { 'content-type': 'application/json' },
+            })
+        },
+    )
+}
+```
+
+## Load Functions
+
+Errors thrown in `+page.server.ts` load functions are caught by `handleError` automatically. To manually capture and report an error before re-throwing:
+
+```typescript
+// src/routes/+page.server.ts
+import { H } from '@highlight-run/node'
+import type { PageServerLoad } from './$types'
+
+export const load: PageServerLoad = async ({ request }) => {
+    try {
+        // your data fetching
+    } catch (error) {
+        const { secureSessionId, requestId } = H.parseHeaders(
+            Object.fromEntries(request.headers),
+        )
+        H.consumeError(error as Error, secureSessionId, requestId)
+        throw error // re-throw so SvelteKit renders the error page
+    }
+}
+```
+
+## Logging
+
+The Highlight Node SDK automatically captures `console.log`, `console.warn`, and `console.error` calls on the server. No additional configuration is needed — logs appear in your [Highlight Logs dashboard](https://app.highlight.io/logs), linked to the relevant session and trace.
 
 ## Relative CSS Paths
 
-SvelteKit may generate relative CSS paths which can interfere with Highlight's ability to fetch stylesheets for session replay. We recommend disabling relative paths in your `svelte.config.js`.
+SvelteKit may generate relative CSS paths which can interfere with Highlight's ability to fetch stylesheets for session replay. Disable relative paths in `svelte.config.js`:
 
 ```javascript
 // svelte.config.js
@@ -84,17 +193,43 @@ SvelteKit may generate relative CSS paths which can interfere with Highlight's a
 const config = {
     kit: {
         paths: {
-            relative: false
-        }
-    }
-};
+            relative: false,
+        },
+    },
+}
 
-export default config;
+export default config
+```
+
+## Node Adapter
+
+Server-side instrumentation requires SvelteKit to run in a Node.js environment. If you're using a non-Node adapter, switch to [`@sveltejs/adapter-node`](https://kit.svelte.dev/docs/adapter-node):
+
+```shell
+npm install @sveltejs/adapter-node
+```
+
+```javascript
+// svelte.config.js
+import adapter from '@sveltejs/adapter-node'
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+    kit: {
+        adapter: adapter(),
+        paths: {
+            relative: false,
+        },
+    },
+}
+
+export default config
 ```
 
 ## Verify Installation
 
-1.  Check your [Highlight sessions dashboard](https://app.highlight.io/sessions) for a new session.
-2.  Trigger a client-side error (e.g., `throw new Error("client error")` in a Svelte component).
-3.  Trigger a server-side error (e.g., `throw new Error("server error")` in a `+page.server.ts` loader).
-4.  Confirm both errors appear in the [errors dashboard](https://app.highlight.io/errors) and are linked to the session.
+1. Start your dev server and open the app in a browser.
+2. Check your [Highlight Sessions dashboard](https://app.highlight.io/sessions) — a new session should appear within seconds.
+3. Throw a client-side error (e.g. `throw new Error('client test')` in a `+page.svelte` component) and confirm it appears in the [Errors dashboard](https://app.highlight.io/errors).
+4. Throw a server-side error in a load function and confirm it is linked to the same frontend session.
+5. Check [Highlight Logs](https://app.highlight.io/logs) — `console.log` calls from the server should appear automatically.

--- a/docs-content/getting-started/fullstack-frameworks/sveltekit.md
+++ b/docs-content/getting-started/fullstack-frameworks/sveltekit.md
@@ -1,0 +1,100 @@
+---
+title: SvelteKit Walkthrough
+slug: sveltekit
+heading: SvelteKit Walkthrough
+createdAt: 2024-04-12T00:00:00.000Z
+updatedAt: 2024-04-12T00:00:00.000Z
+---
+
+## Overview
+
+Our SvelteKit instrumentation gives you access to frontend session replays and server-side monitoring, all-in-one.
+
+1.  Use `H.init` in `src/hooks.client.ts` to track session replay and client-side errors.
+2.  Use `H.init` and `H.runWithHeaders` in `src/hooks.server.ts` to instrument SvelteKit's Node.js server.
+
+## Installation
+
+```shell
+# with yarn
+yarn add highlight.run @highlight-run/node
+```
+
+## Client Instrumentation
+
+To instrument your SvelteKit frontend, add `H.init` to your `src/hooks.client.ts` file. This will capture session replays and client-side errors.
+
+You can use SvelteKit's [environment variables](https://kit.svelte.dev/docs/modules#$env-static-public) to manage your Project ID.
+
+```typescript
+// src/hooks.client.ts
+import { H } from 'highlight.run';
+import { PUBLIC_HIGHLIGHT_PROJECT_ID } from '$env/static/public';
+
+H.init(PUBLIC_HIGHLIGHT_PROJECT_ID, {
+    serviceName: "my-sveltekit-frontend",
+    tracingOrigins: true,
+    networkRecording: {
+        enabled: true,
+        recordHeadersAndBody: true,
+    },
+});
+
+/** @type {import('@sveltejs/kit').HandleClientError} */
+export const handleError = ({ error }) => {
+    H.consumeError(error as Error);
+};
+```
+
+## Server Instrumentation
+
+To instrument your SvelteKit backend, use the `handle` hook in `src/hooks.server.ts`. This allows Highlight to track server-side errors and link them to your frontend sessions.
+
+```typescript
+// src/hooks.server.ts
+import { H } from '@highlight-run/node';
+import { HIGHLIGHT_PROJECT_ID } from '$env/static/private';
+
+H.init({ 
+    projectID: HIGHLIGHT_PROJECT_ID,
+    serviceName: "my-sveltekit-backend",
+});
+
+/** @type {import('@sveltejs/kit').Handle} */
+export const handle = async ({ event, resolve }) => {
+    return await H.runWithHeaders('sveltekit-server', event.request.headers, async () => {
+        return await resolve(event);
+    });
+};
+
+/** @type {import('@sveltejs/kit').HandleServerError} */
+export const handleError = ({ error, event }) => {
+    const { secureSessionId, requestId } = H.parseHeaders(event.request.headers);
+    H.consumeError(error as Error, secureSessionId, requestId);
+};
+```
+
+## Relative CSS Paths
+
+SvelteKit may generate relative CSS paths which can interfere with Highlight's ability to fetch stylesheets for session replay. We recommend disabling relative paths in your `svelte.config.js`.
+
+```javascript
+// svelte.config.js
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+    kit: {
+        paths: {
+            relative: false
+        }
+    }
+};
+
+export default config;
+```
+
+## Verify Installation
+
+1.  Check your [Highlight sessions dashboard](https://app.highlight.io/sessions) for a new session.
+2.  Trigger a client-side error (e.g., `throw new Error("client error")` in a Svelte component).
+3.  Trigger a server-side error (e.g., `throw new Error("server error")` in a `+page.server.ts` loader).
+4.  Confirm both errors appear in the [errors dashboard](https://app.highlight.io/errors) and are linked to the session.


### PR DESCRIPTION
/claim #8032

A comprehensive fullstack SvelteKit instrumentation walkthrough.

**Bug fix in all examples:** `H.runWithHeaders` and `H.parseHeaders` expect a plain object, not a `Headers` instance. This PR uses `Object.fromEntries(event.request.headers)` consistently — previous attempts passed the `Headers` object directly.

**Coverage no other PR includes:**
- API routes (`+server.ts`) wrapped with `H.runWithHeaders`
- Load functions (`+page.server.ts`) with manual error capture
- Logging — documents automatic console capture (no config needed)
- Node adapter requirement with combined `svelte.config.js`
- Complete ready-to-copy `hooks.server.ts` with all exports

**Better DX throughout:**
- TypeScript types from `@sveltejs/kit` on all hooks
- Descriptive span names (method + pathname vs static string)
- `environment` option in `H.init` on both sides
- npm / yarn / pnpm install options
- SvelteKit env vars (`$env/static/public` / `$env/static/private`)

**Docs structure:**
- Moves SvelteKit from browser section to a new Fullstack Frameworks section in the overview
- Populates the empty `fullstack-frameworks/index.md` with navigation cards