### PR TITLE
refactor: replace antd components in project settings with highlight-ui

### DIFF
--- a/frontend/src/pages/NewProject/AutoJoinInput.tsx
+++ b/frontend/src/pages/NewProject/AutoJoinInput.tsx
@@ -1,8 +1,6 @@
 import { useAuthContext } from '@authentication/AuthContext'
 import Tooltip from '@components/Tooltip/Tooltip'
 import { Box, Text } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -23,12 +21,13 @@ export const AutoJoinInput: React.FC<Props> = ({
 	const { admin } = useAuthContext()
 	const adminsEmailDomain = getEmailDomain(admin?.email)
 
-	const handleMessageChecked = (event: CheckboxChangeEvent) => {
+	const handleCheckChanged = (
+		event: React.ChangeEvent<HTMLInputElement>,
+	) => {
 		const domains = event.target.checked ? [adminsEmailDomain] : []
 		setAutoJoinDomains(domains)
 	}
 
-	// don't show if this is for workspace creation but admin is not a company email
 	if (
 		COMMON_EMAIL_PROVIDERS.some((p) => adminsEmailDomain.indexOf(p) !== -1)
 	) {
@@ -43,18 +42,21 @@ export const AutoJoinInput: React.FC<Props> = ({
 		>
 			<div className={styles.container}>
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
+					<input
+						type="checkbox"
 						checked={autoJoinDomains.length > 0}
-						onChange={handleMessageChecked}
+						onChange={handleCheckChanged}
+						style={{ cursor: 'pointer' }}
 					/>
 					<Text>Allowed email domains</Text>
 				</Box>
-				<Divider className="m-0 border-none pt-1" />
+				<Box pt="4" />
 				<Text color="n11">
-					Allow everyone with a <b>{getEmailDomain(admin?.email)}</b>{' '}
-					email to join your workspace.
+					Allow everyone with a{' '}
+					<b>{getEmailDomain(admin?.email)}</b> email to join your
+					workspace.
 				</Text>
-				<Divider className="m-0 border-none pt-1" />
+				<Box pt="4" />
 			</div>
 		</Tooltip>
 	)

--- a/frontend/src/pages/NewProject/NewProjectPage.tsx
+++ b/frontend/src/pages/NewProject/NewProjectPage.tsx
@@ -12,7 +12,6 @@ import { namedOperations } from '@graph/operations'
 import { Box, Callout, Stack, Text } from '@highlight-run/ui/components'
 import analytics from '@util/analytics'
 import { client } from '@util/graph'
-import { Divider } from 'antd'
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
@@ -147,7 +146,7 @@ const NewProjectPage = ({ workspace_id }: { workspace_id: string }) => {
 								}}
 							/>
 						</Box>
-						<Divider className="m-0" />
+						<Box bt="secondary" />
 						<Box
 							py="8"
 							px="12"

--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.css.ts
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.css.ts
@@ -1,10 +1,6 @@
 import { vars } from '@highlight-run/ui/vars'
 import { style } from '@vanilla-extract/css'
 
-export const repoSelect = style({
-	width: '100%',
-})
-
 export const example = style({
 	background: vars.color.n5,
 	border: `${vars.theme.interactive.outline.secondary.enabled} solid 1px`,

--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -5,6 +5,7 @@ import ModalBody from '@components/ModalBody/ModalBody'
 import {
 	Box,
 	ButtonIcon,
+	ComboboxSelect,
 	Form,
 	IconSolidInformationCircle,
 	IconSolidQuestionMarkCircle,
@@ -15,7 +16,6 @@ import {
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -117,15 +117,14 @@ const GithubSettingsForm = ({
 	handleSubmit,
 	handleCancel,
 }: GithubSettingsFormProps) => {
-	const githubOptions = useMemo(
+	const githubComboboxOptions = useMemo(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
-				id: repo.key,
-				label: repo.name.split('/').pop(),
-				value: repo.repo_id.replace(
+				key: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
 				),
+				render: repo.name.split('/').pop(),
 			})),
 		[githubRepos],
 	)
@@ -151,24 +150,24 @@ const GithubSettingsForm = ({
 					name="githubRepo"
 				>
 					<Box display="flex" alignItems="center" gap="8">
-						<Select
-							aria-label="GitHub repository"
-							className={styles.repoSelect}
-							placeholder="Search repos..."
-							onSelect={(repo: string) =>
+						<ComboboxSelect
+							label="GitHub repository"
+							value={formState.values.githubRepo ?? ''}
+							valueRender={
+								formState.values.githubRepo
+									?.split('/')
+									.pop() || 'Search repos...'
+							}
+							options={githubComboboxOptions}
+							onChange={(value: string) =>
 								formStore.setValue(
 									formStore.names.githubRepo,
-									repo,
+									value || null,
 								)
 							}
-							value={formState.values.githubRepo
-								?.split('/')
-								.pop()}
-							options={githubOptions}
-							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
-							filterOption
-							showSearch
+							onChangeQuery={() => {}}
+							queryPlaceholder="Search repos..."
+							emptyStateRender={<span>No repos found</span>}
 						/>
 						<ButtonIcon
 							kind="secondary"


### PR DESCRIPTION
## Summary

Part of #8635 — Removes antd component dependencies from project settings and new project pages.

## Changes

### GitHubSettingsModal (`ProjectSettings/GitHubSettingsModal`)
- Replaced antd `Select` with `ComboboxSelect` from `@highlight-run/ui/components`
- Removes direct antd dependency from this file

### NewProjectPage (`NewProject/NewProjectPage`)
- Replaced antd `Divider` with `Box` using `bt="secondary"` border

### AutoJoinInput (`NewProject/AutoJoinInput`)
- Replaced antd `Checkbox` with native HTML `<input type="checkbox">`
- Replaced antd `Divider` with `Box` spacer elements

### Cleanup
- Removed unused `repoSelect` CSS class from `GitHubSettingsModal.css.ts`

## Files changed
- `frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx`
- `frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.css.ts`
- `frontend/src/pages/NewProject/NewProjectPage.tsx`
- `frontend/src/pages/NewProject/AutoJoinInput.tsx`

/claim #8635