### PR TITLE
fix: Clear invite member modal state when reopening

### DIFF
--- a/frontend/src/pages/WorkspaceTeam/components/InviteMemberModal.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/InviteMemberModal.tsx
@@ -119,6 +119,13 @@ function InviteMemberModal({
 		[form, sendInviteReset, toggleShowModal],
 	)
 
+	useEffect(() => {
+		if (showModal && !autoinvite_email) {
+			form.reset()
+			sendInviteReset()
+		}
+	}, [showModal])
+
 	const projectOptions = useMemo(
 		() =>
 			allProjects?.map((p) => ({


### PR DESCRIPTION
## Summary

Fixes #8189

The invite member modal retains previous email and status when closed and reopened.

## Problem

After inviting a user (Enter email → Click Invite → Success toast → Close modal), reopening the modal shows the previous email and mutation status instead of a clean form.

## Fix

Added a `useEffect` that resets the form state and mutation state when the modal opens (`showModal` transitions to `true`), unless the modal was opened via the `autoinvite_email` query param (which pre-fills the email). This ensures a clean state every time the modal is opened by the user.

## Testing

1. Go to Workspace Team page
2. Click "Invite Users" → enter email → click "Invite"
3. Close the modal after success toast
4. Click "Invite Users" again
5. **Before fix:** Modal shows previous email and status
6. **After fix:** Modal shows clean form with empty email