### PR TITLE
refactor: modernized integrations UI with new design system

### DIFF
--- a/.changeset/proud-pets-decide.md
+++ b/.changeset/proud-pets-decide.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/frontend': patch
+---
+
+refactor: updated integrations UI components

--- a/frontend/src/pages/IntegrationsPage/components/ClearbitIntegration/ClearbitIntegrationConfig.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/ClearbitIntegration/ClearbitIntegrationConfig.module.css
@@ -1,15 +1,3 @@
-.modalBtn {
-	padding-bottom: 4px !important;
-	padding-top: 4px !important;
-}
-
-.modalBtnIcon {
-	margin-right: 0.5rem;
-}
-
-.modalSubTitle {
-	color: var(--color-gray-500) !important;
-	font-size: 16px;
-	margin-bottom: 20px;
-	margin-top: 0 !important;
+.container {
+	padding-top: 4px;
 }

--- a/frontend/src/pages/IntegrationsPage/components/ClearbitIntegration/ClearbitIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/ClearbitIntegration/ClearbitIntegrationConfig.tsx
@@ -1,8 +1,12 @@
-import Button from '@components/Button/Button/Button'
 import { toast } from '@components/Toaster'
 import { PlanType } from '@graph/schemas'
-import PlugIcon from '@icons/PlugIcon'
-import Sparkles2Icon from '@icons/Sparkles2Icon'
+import {
+	Box,
+	IconSolidLogout,
+	IconSolidSparkles,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
 import { useClearbitIntegration } from '@pages/IntegrationsPage/components/ClearbitIntegration/utils'
 import {
 	IntegrationAction,
@@ -10,6 +14,8 @@ import {
 } from '@pages/IntegrationsPage/components/Integration'
 import React, { useEffect } from 'react'
 import { Navigate, useNavigate } from 'react-router-dom'
+
+import { Button } from '@/components/Button'
 
 import styles from './ClearbitIntegrationConfig.module.css'
 
@@ -44,15 +50,22 @@ const ClearbitIntegrationConfig: React.FC<
 
 	if (action === IntegrationAction.Disconnect) {
 		return (
-			<>
-				<p className={styles.modalSubTitle}>
+			<Stack gap="16" cssClass={styles.container}>
+				<Text color="moderate" size="small">
 					Disabling Clearbit will mean new sessions will not have
 					enhanced metadata about identified users.
-				</p>
-				<footer>
+				</Text>
+				<Box
+					display="flex"
+					alignItems="center"
+					justifyContent="flex-end"
+					gap="8"
+				>
 					<Button
-						trackingId="IntegrationDisconnectCancel-Slack"
-						className={styles.modalBtn}
+						trackingId="IntegrationDisconnectCancel-Clearbit"
+						kind="secondary"
+						size="medium"
+						emphasis="medium"
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(true)
@@ -61,47 +74,55 @@ const ClearbitIntegrationConfig: React.FC<
 						Cancel
 					</Button>
 					<Button
-						trackingId="IntegrationDisconnectSave-Slack"
-						className={styles.modalBtn}
-						type="primary"
-						danger
+						trackingId="IntegrationDisconnectSave-Clearbit"
+						kind="danger"
+						size="medium"
+						emphasis="high"
+						iconLeft={<IconSolidLogout />}
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(false)
 							modifyClearbit({ enabled: false })
 						}}
 					>
-						<PlugIcon className={styles.modalBtnIcon} />
 						Disable Clearbit
 					</Button>
-				</footer>
-			</>
+				</Box>
+			</Stack>
 		)
 	}
+
 	if (redirectToBilling) {
 		return <Navigate replace to={`/w/${workspaceID}/current-plan`} />
 	}
 
 	return (
-		<>
-			<p className={styles.modalSubTitle}>
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
 				Enable Clearbit to scrape enhanced user details.
-			</p>
-			<p className={styles.modalSubTitle}>
+			</Text>
+			<Text color="moderate" size="small">
 				After a user is identified, we will collect information about
 				their online presence using Clearbit and display it in the
 				session metadata pane.
-			</p>
+			</Text>
 			{mustUpgradeToIntegrate ? (
 				<>
-					<p className={styles.modalSubTitle}>
+					<Text color="moderate" size="small">
 						To enable Clearbit integration, please upgrade your
 						workspace tier to <b>'{PlanType.Startup}'</b> or higher.
-					</p>
-					<footer>
+					</Text>
+					<Box
+						display="flex"
+						alignItems="center"
+						justifyContent="flex-end"
+						gap="8"
+					>
 						<Button
 							trackingId="IntegrationConfigurationCancelUpgrade-Clearbit"
-							className={styles.modalBtn}
+							kind="secondary"
+							size="medium"
+							emphasis="medium"
 							onClick={() => {
 								setModalOpen(false)
 								setIntegrationEnabled(false)
@@ -111,22 +132,30 @@ const ClearbitIntegrationConfig: React.FC<
 						</Button>
 						<Button
 							trackingId="IntegrationConfigurationViewUpgrade-Clearbit"
-							className={styles.modalBtn}
-							type="primary"
+							kind="primary"
+							size="medium"
+							emphasis="high"
 							onClick={() => {
 								navigate(`/${projectID}/integrations`)
 								setRedirectToBilling(true)
 							}}
 						>
-							View Upgrade Options
+							View upgrade options
 						</Button>
-					</footer>
+					</Box>
 				</>
 			) : (
-				<footer>
+				<Box
+					display="flex"
+					alignItems="center"
+					justifyContent="flex-end"
+					gap="8"
+				>
 					<Button
 						trackingId="IntegrationConfigurationCancel-Clearbit"
-						className={styles.modalBtn}
+						kind="secondary"
+						size="medium"
+						emphasis="medium"
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(false)
@@ -136,18 +165,19 @@ const ClearbitIntegrationConfig: React.FC<
 					</Button>
 					<Button
 						trackingId="IntegrationConfigurationSave-Clearbit"
-						className={styles.modalBtn}
-						type="primary"
+						kind="primary"
+						size="medium"
+						emphasis="high"
+						iconLeft={<IconSolidSparkles />}
 						onClick={() => {
 							modifyClearbit({ enabled: true })
 						}}
 					>
-						<Sparkles2Icon className={styles.modalBtnIcon} /> Enable
-						Clearbit
+						Enable Clearbit
 					</Button>
-				</footer>
+				</Box>
 			)}
-		</>
+		</Stack>
 	)
 }
 

--- a/frontend/src/pages/IntegrationsPage/components/ClickUpIntegration/ClickUpIntegrationConfig.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/ClickUpIntegration/ClickUpIntegrationConfig.module.css
@@ -1,31 +1,9 @@
-.modalBtn {
-	padding-bottom: 4px !important;
-	padding-top: 4px !important;
-}
-
-.modalBtnIcon {
-	margin-right: 0.5rem;
-}
-
-.modalSubTitle {
-	color: var(--color-gray-500) !important;
-	font-size: 16px;
-	margin-bottom: 20px;
-	margin-top: 0 !important;
-}
-
-.modalBtnText {
-	align-items: center;
-	display: inline-flex !important;
-	height: 100%;
+.container {
+	padding-top: 4px;
 }
 
 .select {
 	:global(.ant-select-selection-item-content) {
 		max-width: 150px;
 	}
-}
-
-.projectInput {
-	font-size: 14px !important;
 }

--- a/frontend/src/pages/IntegrationsPage/components/ClickUpIntegration/ClickUpIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/ClickUpIntegration/ClickUpIntegrationConfig.tsx
@@ -1,15 +1,17 @@
-import clsx from 'clsx'
-import React, { useEffect } from 'react'
-
-import Button from '@components/Button/Button/Button'
 import Card from '@components/Card/Card'
 import Select from '@components/Select/Select'
 import Table from '@components/Table/Table'
 import { toast } from '@components/Toaster'
 import { ClickUpProjectMappingInput } from '@graph/schemas'
+import {
+	Box,
+	IconSolidClickUp,
+	IconSolidLogout,
+	IconSolidSave,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
 import SvgHighlightLogoOnLight from '@icons/HighlightLogoOnLight'
-import PlugIcon from '@icons/PlugIcon'
-import Sparkles2Icon from '@icons/Sparkles2Icon'
 import { useClickUpIntegration } from '@pages/IntegrationsPage/components/ClickUpIntegration/utils'
 import {
 	IntegrationAction,
@@ -19,6 +21,9 @@ import { useApplicationContext } from '@routers/AppRouter/context/ApplicationCon
 import { useParams } from '@util/react-router/useParams'
 import useMap from '@util/useMap'
 import { GetBaseURL } from '@util/window'
+import React, { useEffect } from 'react'
+
+import { Button } from '@/components/Button'
 import { btoaSafe } from '@/util/string'
 
 import styles from './ClickUpIntegrationConfig.module.css'
@@ -68,15 +73,29 @@ const ClickUpIntegrationSetup: React.FC<IntegrationConfigProps> = ({
 	const { currentWorkspace } = useApplicationContext()
 	const redirectUri = `${GetBaseURL()}/callback/clickup`
 
+	const authUrl = `https://app.clickup.com/api?client_id=${CLICKUP_CLIENT_ID}&redirect_uri=${redirectUri}&state=${btoaSafe(
+		JSON.stringify({
+			project_id: project_id,
+			workspace_id: currentWorkspace?.id,
+		}),
+	)}`
+
 	return (
-		<>
-			<p className={styles.modalSubTitle}>
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
 				Connect Highlight with ClickUp.
-			</p>
-			<footer>
+			</Text>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
 				<Button
 					trackingId="IntegrationConfigurationCancel-ClickUp"
-					className={styles.modalBtn}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(false)
@@ -86,26 +105,18 @@ const ClickUpIntegrationSetup: React.FC<IntegrationConfigProps> = ({
 				</Button>
 				<Button
 					trackingId="IntegrationConfigurationSave-ClickUp"
-					className={styles.modalBtn}
-					type="primary"
-					target="_blank"
-					href={`https://app.clickup.com/api?client_id=${CLICKUP_CLIENT_ID}&redirect_uri=${redirectUri}&state=${btoaSafe(
-						JSON.stringify({
-							project_id: project_id,
-							workspace_id: currentWorkspace?.id,
-						}),
-					)}`}
-					rel="noreferrer"
+					kind="primary"
+					size="medium"
+					emphasis="high"
+					iconLeft={<IconSolidClickUp />}
+					onClick={() => {
+						window.open(authUrl, '_blank', 'noreferrer')
+					}}
 				>
-					<span className={styles.modalBtnText}>
-						<Sparkles2Icon className={styles.modalBtnIcon} />
-						<span style={{ marginTop: 4 }}>
-							Connect Highlight with ClickUp
-						</span>
-					</span>
+					Connect with ClickUp
 				</Button>
-			</footer>
-		</>
+			</Box>
+		</Stack>
 	)
 }
 
@@ -116,15 +127,22 @@ const ClickUpIntegrationDisconnect: React.FC<IntegrationConfigProps> = ({
 	const { removeIntegration } = useClickUpIntegration()
 
 	return (
-		<>
-			<p className={styles.modalSubTitle}>
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
 				Disconnecting ClickUp from Highlight will prevent you from
-				creating tasks from future comments
-			</p>
-			<footer>
+				creating tasks from future comments.
+			</Text>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
 				<Button
 					trackingId="IntegrationDisconnectCancel-ClickUp"
-					className={styles.modalBtn}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(true)
@@ -134,9 +152,10 @@ const ClickUpIntegrationDisconnect: React.FC<IntegrationConfigProps> = ({
 				</Button>
 				<Button
 					trackingId="IntegrationDisconnectSave-ClickUp"
-					className={styles.modalBtn}
-					type="primary"
-					danger
+					kind="danger"
+					size="medium"
+					emphasis="high"
+					iconLeft={<IconSolidLogout />}
 					onClick={() => {
 						removeIntegration()
 							.then(() => {
@@ -151,11 +170,10 @@ const ClickUpIntegrationDisconnect: React.FC<IntegrationConfigProps> = ({
 							})
 					}}
 				>
-					<PlugIcon className={styles.modalBtnIcon} />
 					Disconnect ClickUp
 				</Button>
-			</footer>
-		</>
+			</Box>
+		</Stack>
 	)
 }
 
@@ -268,13 +286,10 @@ export const ClickUpIntegrationSettings: React.FC<
 
 	const projectMappings: ClickUpProjectMappingInput[] = []
 	for (const [projectId, clickUpSpaceId] of projectMap.entries()) {
-		// Skip for clickUpSpaceIds the user no longer has access to
-		// (could be deleted or have had their permissions revoked)
 		if (!allSpaces.find((s) => s.id === clickUpSpaceId)) {
 			continue
 		}
 
-		// If this project hasn't been created yet, pass undefined as the project id
 		projectMappings.push({
 			project_id: projectId,
 			clickup_space_id: clickUpSpaceId,
@@ -296,27 +311,32 @@ export const ClickUpIntegrationSettings: React.FC<
 	}
 
 	return (
-		<div>
-			<p className={clsx(styles.modalSubTitle)}>
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
 				Select ClickUp spaces to use for each of your Highlight
 				projects.
-			</p>
-			<div className="my-6">
-				<Card noPadding>
-					<Table
-						dataSource={highlightProjects}
-						columns={tableColumns}
-						pagination={false}
-						showHeader={false}
-						rowHasPadding
-						smallPadding
-					></Table>
-				</Card>
-			</div>
-			<footer className="flex justify-end gap-2 pt-0">
+			</Text>
+			<Card noPadding>
+				<Table
+					dataSource={highlightProjects}
+					columns={tableColumns}
+					pagination={false}
+					showHeader={false}
+					rowHasPadding
+					smallPadding
+				></Table>
+			</Card>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
 				<Button
 					trackingId="IntegrationConfigurationCancel-ClickUp"
-					className={styles.modalBtn}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
 					onClick={() => {
 						onCancel && onCancel()
 						setModalOpen(false)
@@ -326,18 +346,16 @@ export const ClickUpIntegrationSettings: React.FC<
 				</Button>
 				<Button
 					trackingId="IntegrationConfigurationSave-ClickUp"
-					className={styles.modalBtn}
-					type="primary"
-					target="_blank"
+					kind="primary"
+					size="medium"
+					emphasis="high"
+					iconLeft={<IconSolidSave />}
 					onClick={onSave}
 				>
-					<span className={styles.modalBtnText}>
-						<Sparkles2Icon className={styles.modalBtnIcon} />
-						<span>Update Settings</span>
-					</span>
+					Update settings
 				</Button>
-			</footer>
-		</div>
+			</Box>
+		</Stack>
 	)
 }
 

--- a/frontend/src/pages/IntegrationsPage/components/CloudflareIntegration/CloudflareIntegration.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/CloudflareIntegration/CloudflareIntegration.tsx
@@ -1,7 +1,12 @@
-import Button from '@components/Button/Button/Button'
-import { Form, Stack } from '@highlight-run/ui/components'
-import AppsIcon from '@icons/AppsIcon'
-import PlugIcon from '@icons/PlugIcon'
+import {
+	Box,
+	Form,
+	IconSolidCloud,
+	IconSolidLogout,
+	Stack,
+	Text,
+	TextLink,
+} from '@highlight-run/ui/components'
 import {
 	IntegrationAction,
 	IntegrationConfigProps,
@@ -9,12 +14,14 @@ import {
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
 import React from 'react'
 
+import { Button } from '@/components/Button'
+
 import * as styles from './style.css'
 import { useCloudflareIntegration } from './utils'
 
 const CloudflareIntegration: React.FC<
 	React.PropsWithChildren<IntegrationConfigProps>
-> = ({ setModalOpen: setModalOpen, action }) => {
+> = ({ setModalOpen, action }) => {
 	const { addCloudflareToProject, removeCloudflareIntegrationFromProject } =
 		useCloudflareIntegration()
 	const { currentWorkspace } = useApplicationContext()
@@ -29,21 +36,32 @@ const CloudflareIntegration: React.FC<
 
 	if (action === IntegrationAction.Settings) {
 		return (
-			<p className={styles.modalSubTitle}>
-				Current proxy endpoint: {currentWorkspace?.cloudflare_proxy}
-			</p>
+			<Stack gap="8" cssClass={styles.container}>
+				<Text color="moderate" size="small">
+					Current proxy endpoint: {currentWorkspace?.cloudflare_proxy}
+				</Text>
+			</Stack>
 		)
-	} else if (action === IntegrationAction.Disconnect) {
+	}
+
+	if (action === IntegrationAction.Disconnect) {
 		return (
-			<>
-				<p className={styles.modalSubTitle}>
+			<Stack gap="16" cssClass={styles.container}>
+				<Text color="moderate" size="small">
 					Disconnecting your Cloudflare workspace from Highlight will
-					disable highlight's access to your proxy workers!
-				</p>
-				<footer>
+					disable Highlight&apos;s access to your proxy workers.
+				</Text>
+				<Box
+					display="flex"
+					alignItems="center"
+					justifyContent="flex-end"
+					gap="8"
+				>
 					<Button
 						trackingId="IntegrationDisconnectCancel-Cloudflare"
-						className={styles.modalBtn}
+						kind="secondary"
+						size="medium"
+						emphasis="medium"
 						onClick={() => {
 							setModalOpen(false)
 						}}
@@ -52,41 +70,41 @@ const CloudflareIntegration: React.FC<
 					</Button>
 					<Button
 						trackingId="IntegrationDisconnectSave-Cloudflare"
-						className={styles.modalBtn}
-						type="primary"
-						danger
+						kind="danger"
+						size="medium"
+						emphasis="high"
+						iconLeft={<IconSolidLogout />}
 						onClick={async () => {
 							setModalOpen(false)
 							await removeCloudflareIntegrationFromProject()
 						}}
 					>
-						<PlugIcon className={styles.modalBtnIcon} />
 						Disconnect Cloudflare
 					</Button>
-				</footer>
-			</>
+				</Box>
+			</Stack>
 		)
 	}
 
 	return (
-		<>
-			<p className={styles.modalSubTitle}>
-				A highlight data proxy via Cloudflare can avoid ad-blockers
-				detecting highlight tracking and blocking recording. Create{' '}
-				<a
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
+				A Highlight data proxy via Cloudflare can avoid ad-blockers
+				detecting Highlight tracking and blocking recording. Create{' '}
+				<TextLink
 					href="https://dash.cloudflare.com/profile/api-tokens"
 					target="_blank"
-					rel="noopener noreferrer"
 				>
 					a Cloudflare API token
-				</a>{' '}
+				</TextLink>{' '}
 				with minimal permissions of{' '}
 				<code>
 					account.workers_scripts.edit, zone.workers_routes.edit
 				</code>
-			</p>
+				.
+			</Text>
 			<Form store={formStore} resetOnSubmit={false}>
-				<Stack>
+				<Stack gap="12">
 					<Form.Input
 						name={formStore.names.token}
 						label="API Token"
@@ -98,14 +116,20 @@ const CloudflareIntegration: React.FC<
 						name={formStore.names.proxySubdomain}
 						label="Proxy Subdomain"
 						type="text"
-						autoFocus
 					/>
 				</Stack>
 			</Form>
-			<footer>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
 				<Button
 					trackingId="IntegrationConfigurationCancel-Cloudflare"
-					className={styles.modalBtn}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 					}}
@@ -114,19 +138,20 @@ const CloudflareIntegration: React.FC<
 				</Button>
 				<Button
 					trackingId="IntegrationConfigurationSave-Cloudflare"
-					className={styles.modalBtn}
-					type="primary"
+					kind="primary"
+					size="medium"
+					emphasis="high"
+					iconLeft={<IconSolidCloud />}
 					disabled={token.length < 40 || proxySubdomain.length < 3}
 					onClick={async () => {
 						setModalOpen(false)
 						await addCloudflareToProject(token, proxySubdomain)
 					}}
 				>
-					<AppsIcon className={styles.modalBtnIcon} /> Connect
-					Highlight with Cloudflare
+					Connect with Cloudflare
 				</Button>
-			</footer>
-		</>
+			</Box>
+		</Stack>
 	)
 }
 

--- a/frontend/src/pages/IntegrationsPage/components/CloudflareIntegration/style.css.ts
+++ b/frontend/src/pages/IntegrationsPage/components/CloudflareIntegration/style.css.ts
@@ -1,18 +1,5 @@
-import { vars } from '@highlight-run/ui/vars'
 import { style } from '@vanilla-extract/css'
 
-export const modalBtn = style({
-	paddingBottom: 4,
+export const container = style({
 	paddingTop: 4,
-})
-
-export const modalBtnIcon = style({
-	marginRight: '0.5rem',
-})
-
-export const modalSubTitle = style({
-	color: `${vars.theme.static.content.default} !important`,
-	fontSize: 16,
-	marginBottom: 20,
-	marginTop: 0,
 })

--- a/frontend/src/pages/IntegrationsPage/components/DiscordIntegration/DiscordIntegrationConfig.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/DiscordIntegration/DiscordIntegrationConfig.module.css
@@ -1,21 +1,3 @@
-.modalBtn {
-	padding-bottom: 4px !important;
-	padding-top: 4px !important;
-}
-
-.modalBtnIcon {
-	margin-right: 0.5rem;
-}
-
-.modalSubTitle {
-	color: var(--color-gray-500) !important;
-	font-size: 16px;
-	margin-bottom: 20px;
-	margin-top: 0 !important;
-}
-
-.modalBtnText {
-	align-items: center;
-	display: inline-flex !important;
-	height: 100%;
+.container {
+	padding-top: 4px;
 }

--- a/frontend/src/pages/IntegrationsPage/components/DiscordIntegration/DiscordIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/DiscordIntegration/DiscordIntegrationConfig.tsx
@@ -1,7 +1,11 @@
-import Button from '@components/Button/Button/Button'
 import { toast } from '@components/Toaster'
-import PlugIcon from '@icons/PlugIcon'
-import Sparkles2Icon from '@icons/Sparkles2Icon'
+import {
+	Box,
+	IconSolidDiscord,
+	IconSolidLogout,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
 import { useDiscordIntegration } from '@pages/IntegrationsPage/components/DiscordIntegration/utils'
 import {
 	IntegrationAction,
@@ -10,6 +14,8 @@ import {
 import { useParams } from '@util/react-router/useParams'
 import { GetBaseURL } from '@util/window'
 import React, { useEffect } from 'react'
+
+import { Button } from '@/components/Button'
 
 import styles from './DiscordIntegrationConfig.module.css'
 
@@ -29,13 +35,6 @@ export const getDiscordOauthUrl = (
 	)
 	const scope = ['bot']
 
-	// If the bot needs more permissions,
-	// visit https://discord.com/developers/applications/1024079182013149185/oauth2/url-generator
-	// and use the generator to get a new value
-	// Current bot permissions:
-	// * Manage Channels
-	// * Read Messages/View Channels
-	// * Send Messages
 	const botPermissions = '3088'
 
 	return `https://discord.com/api/oauth2/authorize?client_id=${DISCORD_CLIENT_ID}&permissions=${botPermissions}&redirect_uri=${redirectURI}&state=${state}&response_type=code&scope=${scope}`
@@ -46,9 +45,7 @@ const DiscordIntegrationConfig: React.FC<IntegrationConfigProps> = ({
 	setIntegrationEnabled,
 	action,
 }) => {
-	const { project_id } = useParams<{
-		project_id: string
-	}>()
+	const { project_id } = useParams<{ project_id: string }>()
 	const {
 		removeDiscordIntegrationFromProject,
 		isDiscordIntegratedWithProject,
@@ -70,75 +67,72 @@ const DiscordIntegrationConfig: React.FC<IntegrationConfigProps> = ({
 		action,
 	])
 
-	if (action === IntegrationAction.Disconnect) {
-		return (
-			<>
-				<p className={styles.modalSubTitle}>
-					Disconnecting Discord from Highlight will prevent alerts
-					from notifying Discord channels.
-				</p>
-				<footer>
-					<Button
-						trackingId="IntegrationDisconnectCancel-Discord"
-						className={styles.modalBtn}
-						onClick={() => {
-							setModalOpen(false)
-							setIntegrationEnabled(true)
-						}}
-					>
-						Cancel
-					</Button>
+	const isDisconnect = action === IntegrationAction.Disconnect
+
+	return (
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
+				{isDisconnect
+					? 'Disconnecting Discord from Highlight will prevent alerts from notifying Discord channels.'
+					: 'Connect Discord to your Highlight workspace to set up alerts.'}
+			</Text>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
+				<Button
+					trackingId={
+						isDisconnect
+							? 'IntegrationDisconnectCancel-Discord'
+							: 'IntegrationConfigurationCancel-Discord'
+					}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
+					onClick={() => {
+						setModalOpen(false)
+						setIntegrationEnabled(isDisconnect)
+					}}
+				>
+					Cancel
+				</Button>
+				{isDisconnect ? (
 					<Button
 						trackingId="IntegrationDisconnectSave-Discord"
-						className={styles.modalBtn}
-						type="primary"
-						danger
+						kind="danger"
+						size="medium"
+						emphasis="high"
+						iconLeft={<IconSolidLogout />}
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(false)
 							removeDiscordIntegrationFromProject()
 						}}
 					>
-						<PlugIcon className={styles.modalBtnIcon} />
 						Disconnect Discord
 					</Button>
-				</footer>
-			</>
-		)
-	}
-
-	return (
-		<>
-			<p className={styles.modalSubTitle}>
-				Connect Discord to your Highlight workspace to setup alerts.
-			</p>
-			<footer>
-				<Button
-					trackingId="IntegrationConfigurationCancel-Discord"
-					className={styles.modalBtn}
-					onClick={() => {
-						setModalOpen(false)
-						setIntegrationEnabled(false)
-					}}
-				>
-					Cancel
-				</Button>
-				<Button
-					trackingId="IntegrationConfigurationSave-Discord"
-					className={styles.modalBtn}
-					type="primary"
-					target="_blank"
-					href={getDiscordOauthUrl(project_id!)}
-				>
-					<span className={styles.modalBtnText}>
-						<Sparkles2Icon className={styles.modalBtnIcon} />
-						<span className="mt-1">
-							Connect Highlight with Discord
-						</span>
-					</span>
-				</Button>
-			</footer>
-		</>
+				) : (
+					<Button
+						trackingId="IntegrationConfigurationSave-Discord"
+						kind="primary"
+						size="medium"
+						emphasis="high"
+						iconLeft={<IconSolidDiscord />}
+						onClick={() => {
+							window.open(
+								getDiscordOauthUrl(project_id!),
+								'_blank',
+								'noreferrer',
+							)
+						}}
+					>
+						Connect with Discord
+					</Button>
+				)}
+			</Box>
+		</Stack>
 	)
 }
 

--- a/frontend/src/pages/IntegrationsPage/components/GitHubIntegration/GitHubIntegrationConfig.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/GitHubIntegration/GitHubIntegrationConfig.module.css
@@ -1,15 +1,3 @@
-.modalBtn {
-	padding-bottom: 4px !important;
-	padding-top: 4px !important;
-}
-
-.modalBtnIcon {
-	margin-right: 0.5rem;
-}
-
-.modalSubTitle {
-	color: var(--color-gray-500) !important;
-	font-size: 16px;
-	margin-bottom: 20px;
-	margin-top: 0 !important;
+.container {
+	padding-top: 4px;
 }

--- a/frontend/src/pages/IntegrationsPage/components/GitHubIntegration/GitHubIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/GitHubIntegration/GitHubIntegrationConfig.tsx
@@ -1,7 +1,11 @@
-import Button from '@components/Button/Button/Button'
+import {
+	Box,
+	IconSolidGithub,
+	IconSolidLogout,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
 import { useProjectId } from '@hooks/useProjectId'
-import AppsIcon from '@icons/AppsIcon'
-import PlugIcon from '@icons/PlugIcon'
 import {
 	getGitHubInstallationOAuthUrl,
 	useGitHubIntegration,
@@ -13,11 +17,13 @@ import {
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
 import React, { useMemo } from 'react'
 
+import { Button } from '@/components/Button'
+
 import styles from './GitHubIntegrationConfig.module.css'
 
 const GitHubIntegrationConfig: React.FC<
 	React.PropsWithChildren<IntegrationConfigProps>
-> = ({ setModalOpen: setModalOpen, setIntegrationEnabled, action }) => {
+> = ({ setModalOpen, setIntegrationEnabled, action }) => {
 	const { projectId } = useProjectId()
 	const { currentWorkspace } = useApplicationContext()
 	const { removeIntegration } = useGitHubIntegration()
@@ -29,72 +35,69 @@ const GitHubIntegrationConfig: React.FC<
 			),
 		[currentWorkspace?.id, projectId],
 	)
-	if (action === IntegrationAction.Disconnect) {
-		return (
-			<>
-				<p className={styles.modalSubTitle}>
-					Disconnecting your GitHub workspace from Highlight will
-					prevent you from linking issues to future comments and your
-					stacktraces will not be enhanced.
-				</p>
-				<footer>
-					<Button
-						trackingId="IntegrationDisconnectCancel-GitHub"
-						className={styles.modalBtn}
-						onClick={() => {
-							setModalOpen(false)
-							setIntegrationEnabled(true)
-						}}
-					>
-						Cancel
-					</Button>
+
+	const isDisconnect = action === IntegrationAction.Disconnect
+
+	return (
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
+				{isDisconnect
+					? 'Disconnecting GitHub from Highlight will prevent you from linking issues to future comments and your stacktraces will no longer be enhanced.'
+					: 'Connect GitHub to your Highlight workspace to enhance stacktraces and create issues from comments.'}
+			</Text>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
+				<Button
+					trackingId={
+						isDisconnect
+							? 'IntegrationDisconnectCancel-GitHub'
+							: 'IntegrationConfigurationCancel-GitHub'
+					}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
+					onClick={() => {
+						setModalOpen(false)
+						setIntegrationEnabled(isDisconnect)
+					}}
+				>
+					Cancel
+				</Button>
+				{isDisconnect ? (
 					<Button
 						trackingId="IntegrationDisconnectSave-GitHub"
-						className={styles.modalBtn}
-						type="primary"
-						danger
+						kind="danger"
+						size="medium"
+						emphasis="high"
+						iconLeft={<IconSolidLogout />}
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(false)
 							removeIntegration()
 						}}
 					>
-						<PlugIcon className={styles.modalBtnIcon} />
 						Disconnect GitHub
 					</Button>
-				</footer>
-			</>
-		)
-	}
-
-	return (
-		<>
-			<p className={styles.modalSubTitle}>
-				Connect GitHub to your Highlight workspace to enhance
-				stacktraces and create issues from comments.
-			</p>
-			<footer>
-				<Button
-					trackingId="IntegrationConfigurationCancel-GitHub"
-					className={styles.modalBtn}
-					onClick={() => {
-						setModalOpen(false)
-						setIntegrationEnabled(false)
-					}}
-				>
-					Cancel
-				</Button>
-				<Button
-					trackingId="IntegrationConfigurationSave-GitHub"
-					className={styles.modalBtn}
-					type="primary"
-					href={authUrl}
-				>
-					<AppsIcon className={styles.modalBtnIcon} /> Connect
-					Highlight with GitHub
-				</Button>
-			</footer>
-		</>
+				) : (
+					<Button
+						trackingId="IntegrationConfigurationSave-GitHub"
+						kind="primary"
+						size="medium"
+						emphasis="high"
+						iconLeft={<IconSolidGithub />}
+						onClick={() => {
+							window.location.assign(authUrl)
+						}}
+					>
+						Connect with GitHub
+					</Button>
+				)}
+			</Box>
+		</Stack>
 	)
 }
 

--- a/frontend/src/pages/IntegrationsPage/components/GitlabIntegration/GitlabIntegrationConfig.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/GitlabIntegration/GitlabIntegrationConfig.module.css
@@ -1,15 +1,3 @@
-.modalBtn {
-    padding-bottom: 4px !important;
-    padding-top: 4px !important;
-}
-
-.modalBtnIcon {
-    margin-right: 0.5rem;
-}
-
-.modalSubTitle {
-    color: var(--color-gray-500) !important;
-    font-size: 16px;
-    margin-bottom: 20px;
-    margin-top: 0 !important;
+.container {
+	padding-top: 4px;
 }

--- a/frontend/src/pages/IntegrationsPage/components/GitlabIntegration/GitlabIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/GitlabIntegration/GitlabIntegrationConfig.tsx
@@ -1,6 +1,10 @@
-import Button from '@components/Button/Button/Button'
-import AppsIcon from '@icons/AppsIcon'
-import PlugIcon from '@icons/PlugIcon'
+import {
+	Box,
+	IconSolidGitlab,
+	IconSolidLogout,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
 import {
 	getGitlabOAuthUrl,
 	useGitlabIntegration,
@@ -12,6 +16,8 @@ import {
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
 import { useParams } from '@util/react-router/useParams'
 import React, { useMemo } from 'react'
+
+import { Button } from '@/components/Button'
 
 import styles from './GitlabIntegrationConfig.module.css'
 
@@ -27,15 +33,22 @@ const GitlabIntegrationSetup: React.FC<IntegrationConfigProps> = ({
 	)
 
 	return (
-		<>
-			<p className={styles.modalSubTitle}>
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
 				Connect GitLab to your Highlight workspace to create issues from
 				comments.
-			</p>
-			<footer>
+			</Text>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
 				<Button
 					trackingId="IntegrationConfigurationCancel-GitLab"
-					className={styles.modalBtn}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(false)
@@ -45,33 +58,43 @@ const GitlabIntegrationSetup: React.FC<IntegrationConfigProps> = ({
 				</Button>
 				<Button
 					trackingId="IntegrationConfigurationSave-GitLab"
-					className={styles.modalBtn}
-					type="primary"
-					href={authUrl}
+					kind="primary"
+					size="medium"
+					emphasis="high"
+					iconLeft={<IconSolidGitlab />}
+					onClick={() => {
+						window.location.assign(authUrl)
+					}}
 				>
-					<AppsIcon className={styles.modalBtnIcon} /> Connect
-					Highlight with GitLab
+					Connect with GitLab
 				</Button>
-			</footer>
-		</>
+			</Box>
+		</Stack>
 	)
 }
 
 const GitlabIntegrationDisconnect: React.FC<
 	React.PropsWithChildren<IntegrationConfigProps>
-> = ({ setModalOpen: setModalOpen, setIntegrationEnabled }) => {
+> = ({ setModalOpen, setIntegrationEnabled }) => {
 	const { removeIntegration } = useGitlabIntegration()
 
 	return (
-		<>
-			<p className={styles.modalSubTitle}>
-				Disconnecting your GitLab from Highlight will prevent you from
-				linking issues to future comments
-			</p>
-			<footer>
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
+				Disconnecting GitLab from Highlight will prevent you from
+				linking issues to future comments.
+			</Text>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
 				<Button
 					trackingId="IntegrationDisconnectCancel-GitLab"
-					className={styles.modalBtn}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(true)
@@ -81,20 +104,20 @@ const GitlabIntegrationDisconnect: React.FC<
 				</Button>
 				<Button
 					trackingId="IntegrationDisconnectSave-GitLab"
-					className={styles.modalBtn}
-					type="primary"
-					danger
+					kind="danger"
+					size="medium"
+					emphasis="high"
+					iconLeft={<IconSolidLogout />}
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(false)
 						removeIntegration()
 					}}
 				>
-					<PlugIcon className={styles.modalBtnIcon} />
 					Disconnect GitLab
 				</Button>
-			</footer>
-		</>
+			</Box>
+		</Stack>
 	)
 }
 

--- a/frontend/src/pages/IntegrationsPage/components/HeightIntegration/HeightIntegrationConfig.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/HeightIntegration/HeightIntegrationConfig.module.css
@@ -1,31 +1,9 @@
-.modalBtn {
-	padding-bottom: 4px !important;
-	padding-top: 4px !important;
-}
-
-.modalBtnIcon {
-	margin-right: 0.5rem;
-}
-
-.modalSubTitle {
-	color: var(--color-gray-500) !important;
-	font-size: 16px;
-	margin-bottom: 20px;
-	margin-top: 0 !important;
-}
-
-.modalBtnText {
-	align-items: center;
-	display: inline-flex !important;
-	height: 100%;
+.container {
+	padding-top: 4px;
 }
 
 .select {
 	:global(.ant-select-selection-item-content) {
 		max-width: 150px;
 	}
-}
-
-.projectInput {
-	font-size: 14px !important;
 }

--- a/frontend/src/pages/IntegrationsPage/components/HeightIntegration/HeightIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/HeightIntegration/HeightIntegrationConfig.tsx
@@ -1,15 +1,17 @@
-import clsx from 'clsx'
-import React, { useEffect } from 'react'
-
-import Button from '@components/Button/Button/Button'
 import Card from '@components/Card/Card'
 import Select from '@components/Select/Select'
 import Table from '@components/Table/Table'
 import { toast } from '@components/Toaster'
 import { IntegrationProjectMappingInput, IntegrationType } from '@graph/schemas'
+import {
+	Box,
+	IconSolidHeight,
+	IconSolidLogout,
+	IconSolidSave,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
 import SvgHighlightLogoOnLight from '@icons/HighlightLogoOnLight'
-import PlugIcon from '@icons/PlugIcon'
-import Sparkles2Icon from '@icons/Sparkles2Icon'
 import { useHeightIntegration } from '@pages/IntegrationsPage/components/HeightIntegration/utils'
 import {
 	IntegrationAction,
@@ -19,6 +21,9 @@ import { useApplicationContext } from '@routers/AppRouter/context/ApplicationCon
 import { useParams } from '@util/react-router/useParams'
 import useMap from '@util/useMap'
 import { GetBaseURL } from '@util/window'
+import React, { useEffect } from 'react'
+
+import { Button } from '@/components/Button'
 import { btoaSafe } from '@/util/string'
 
 import styles from './HeightIntegrationConfig.module.css'
@@ -68,15 +73,29 @@ const HeightIntegrationSetup: React.FC<IntegrationConfigProps> = ({
 	const { currentWorkspace } = useApplicationContext()
 	const redirectUri = `${GetBaseURL()}/callback/height`
 
+	const authUrl = `https://height.app/oauth/authorization?client_id=${HEIGHT_CLIENT_ID}&redirect_uri=${redirectUri}&access_types=appWorkspace&scope=api&state=${btoaSafe(
+		JSON.stringify({
+			project_id: project_id,
+			workspace_id: currentWorkspace?.id,
+		}),
+	)}`
+
 	return (
-		<>
-			<p className={styles.modalSubTitle}>
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
 				Connect Highlight with Height.
-			</p>
-			<footer>
+			</Text>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
 				<Button
 					trackingId="IntegrationConfigurationCancel-Height"
-					className={styles.modalBtn}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(false)
@@ -86,26 +105,18 @@ const HeightIntegrationSetup: React.FC<IntegrationConfigProps> = ({
 				</Button>
 				<Button
 					trackingId="IntegrationConfigurationSave-Height"
-					className={styles.modalBtn}
-					type="primary"
-					target="_blank"
-					href={`https://height.app/oauth/authorization?client_id=${HEIGHT_CLIENT_ID}&redirect_uri=${redirectUri}&access_types=appWorkspace&scope=api&state=${btoaSafe(
-						JSON.stringify({
-							project_id: project_id,
-							workspace_id: currentWorkspace?.id,
-						}),
-					)}`}
-					rel="noreferrer"
+					kind="primary"
+					size="medium"
+					emphasis="high"
+					iconLeft={<IconSolidHeight />}
+					onClick={() => {
+						window.open(authUrl, '_blank', 'noreferrer')
+					}}
 				>
-					<span className={styles.modalBtnText}>
-						<Sparkles2Icon className={styles.modalBtnIcon} />
-						<span style={{ marginTop: 4 }}>
-							Connect Highlight with Height
-						</span>
-					</span>
+					Connect with Height
 				</Button>
-			</footer>
-		</>
+			</Box>
+		</Stack>
 	)
 }
 
@@ -116,15 +127,22 @@ const HeightIntegrationDisconnect: React.FC<IntegrationConfigProps> = ({
 	const { removeIntegration } = useHeightIntegration()
 
 	return (
-		<>
-			<p className={styles.modalSubTitle}>
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
 				Disconnecting Height from Highlight will prevent you from
-				creating tasks from future comments
-			</p>
-			<footer>
+				creating tasks from future comments.
+			</Text>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
 				<Button
 					trackingId="IntegrationDisconnectCancel-Height"
-					className={styles.modalBtn}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(true)
@@ -134,9 +152,10 @@ const HeightIntegrationDisconnect: React.FC<IntegrationConfigProps> = ({
 				</Button>
 				<Button
 					trackingId="IntegrationDisconnectSave-Height"
-					className={styles.modalBtn}
-					type="primary"
-					danger
+					kind="danger"
+					size="medium"
+					emphasis="high"
+					iconLeft={<IconSolidLogout />}
 					onClick={() => {
 						removeIntegration()
 							.then(() => {
@@ -151,11 +170,10 @@ const HeightIntegrationDisconnect: React.FC<IntegrationConfigProps> = ({
 							})
 					}}
 				>
-					<PlugIcon className={styles.modalBtnIcon} />
 					Disconnect Height
 				</Button>
-			</footer>
-		</>
+			</Box>
+		</Stack>
 	)
 }
 
@@ -273,7 +291,6 @@ export const HeightIntegrationSettings: React.FC<
 
 	const projectMappings: IntegrationProjectMappingInput[] = []
 	for (const [projectId, externalId] of projectMap.entries()) {
-		// If this project hasn't been created yet, pass undefined as the project id
 		projectMappings.push({
 			project_id: projectId,
 			external_id: externalId,
@@ -296,27 +313,32 @@ export const HeightIntegrationSettings: React.FC<
 	}
 
 	return (
-		<div>
-			<p className={clsx(styles.modalSubTitle)}>
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
 				Select Height workspaces to use for each of your Highlight
 				projects.
-			</p>
-			<div className="my-6">
-				<Card noPadding>
-					<Table
-						dataSource={highlightProjects}
-						columns={tableColumns}
-						pagination={false}
-						showHeader={false}
-						rowHasPadding
-						smallPadding
-					></Table>
-				</Card>
-			</div>
-			<footer className="flex justify-end gap-2 pt-0">
+			</Text>
+			<Card noPadding>
+				<Table
+					dataSource={highlightProjects}
+					columns={tableColumns}
+					pagination={false}
+					showHeader={false}
+					rowHasPadding
+					smallPadding
+				></Table>
+			</Card>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
 				<Button
 					trackingId="IntegrationConfigurationCancel-Height"
-					className={styles.modalBtn}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
 					onClick={() => {
 						onCancel && onCancel()
 						setModalOpen(false)
@@ -326,18 +348,16 @@ export const HeightIntegrationSettings: React.FC<
 				</Button>
 				<Button
 					trackingId="IntegrationConfigurationSave-Height"
-					className={styles.modalBtn}
-					type="primary"
-					target="_blank"
+					kind="primary"
+					size="medium"
+					emphasis="high"
+					iconLeft={<IconSolidSave />}
 					onClick={onSave}
 				>
-					<span className={styles.modalBtnText}>
-						<Sparkles2Icon className={styles.modalBtnIcon} />
-						<span>Update Settings</span>
-					</span>
+					Update settings
 				</Button>
-			</footer>
-		</div>
+			</Box>
+		</Stack>
 	)
 }
 

--- a/frontend/src/pages/IntegrationsPage/components/HerokuIntegration/HerokuIntegration.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/HerokuIntegration/HerokuIntegration.module.css
@@ -1,15 +1,7 @@
-.modalBtn {
-	padding-bottom: 4px !important;
-	padding-top: 4px !important;
+.container {
+	padding-top: 4px;
 }
 
-.modalBtnIcon {
-	margin-right: 0.5rem;
-}
-
-.modalSubTitle {
-	color: var(--color-gray-500) !important;
-	font-size: 16px;
-	margin-bottom: 20px;
-	margin-top: 0 !important;
+.selectContainer {
+	width: 100%;
 }

--- a/frontend/src/pages/IntegrationsPage/components/HerokuIntegration/HerokuIntegration.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/HerokuIntegration/HerokuIntegration.tsx
@@ -1,7 +1,13 @@
-import Button from '@components/Button/Button/Button'
-import { Form } from '@highlight-run/ui/components'
-import AppsIcon from '@icons/AppsIcon'
-import PlugIcon from '@icons/PlugIcon'
+import Select from '@components/Select/Select'
+import {
+	Box,
+	Form,
+	IconSolidLogout,
+	IconSolidPuzzle,
+	Stack,
+	Text,
+	TextLink,
+} from '@highlight-run/ui/components'
 import {
 	IntegrationAction,
 	IntegrationConfigProps,
@@ -9,13 +15,14 @@ import {
 import { useParams } from '@util/react-router/useParams'
 import React from 'react'
 
+import { Button } from '@/components/Button'
+
 import styles from './HerokuIntegration.module.css'
 import { useHerokuIntegration } from './utils'
-import Select from '@components/Select/Select'
 
 const HerokuIntegration: React.FC<
 	React.PropsWithChildren<IntegrationConfigProps>
-> = ({ setModalOpen: setModalOpen, setIntegrationEnabled, action }) => {
+> = ({ setModalOpen, setIntegrationEnabled, action }) => {
 	const { project_id } = useParams<{ project_id: string }>()
 	const { addHerokuToProject, removeHerokuIntegrationFromProject } =
 		useHerokuIntegration()
@@ -28,16 +35,23 @@ const HerokuIntegration: React.FC<
 
 	if (action === IntegrationAction.Disconnect) {
 		return (
-			<>
-				<p className={styles.modalSubTitle}>
+			<Stack gap="16" cssClass={styles.container}>
+				<Text color="moderate" size="small">
 					Disconnecting your Heroku workspace from Highlight will
 					break your Heroku log drains that may currently be sending
-					data!
-				</p>
-				<footer>
+					data.
+				</Text>
+				<Box
+					display="flex"
+					alignItems="center"
+					justifyContent="flex-end"
+					gap="8"
+				>
 					<Button
 						trackingId="IntegrationDisconnectCancel-Heroku"
-						className={styles.modalBtn}
+						kind="secondary"
+						size="medium"
+						emphasis="medium"
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(true)
@@ -47,38 +61,36 @@ const HerokuIntegration: React.FC<
 					</Button>
 					<Button
 						trackingId="IntegrationDisconnectSave-Heroku"
-						className={styles.modalBtn}
-						type="primary"
-						danger
+						kind="danger"
+						size="medium"
+						emphasis="high"
+						iconLeft={<IconSolidLogout />}
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(false)
 							removeHerokuIntegrationFromProject(project_id)
 						}}
 					>
-						<PlugIcon className={styles.modalBtnIcon} />
 						Disconnect Heroku
 					</Button>
-				</footer>
-			</>
+				</Box>
+			</Stack>
 		)
 	}
 
 	return (
-		<>
-			<p className={styles.modalSubTitle}>
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
 				Connect a Heroku Syslog drain pointed to{' '}
 				<code>syslog+tls://syslog.highlight.io:34302</code> to start
-				shipping your logs to highlight.{' '}
-				<a
-					className={styles.description}
+				shipping your logs to Highlight.{' '}
+				<TextLink
 					href="https://devcenter.heroku.com/articles/log-drains#syslog-drains"
 					target="_blank"
-					rel="noopener noreferrer"
 				>
-					Add the drain token to highlight.
-				</a>
-			</p>
+					Add the drain token to Highlight.
+				</TextLink>
+			</Text>
 			<Form store={formStore} resetOnSubmit={false}>
 				<Form.NamedSection
 					name={formStore.names.tokens}
@@ -96,10 +108,17 @@ const HerokuIntegration: React.FC<
 					/>
 				</Form.NamedSection>
 			</Form>
-			<footer>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
 				<Button
 					trackingId="IntegrationConfigurationCancel-Heroku"
-					className={styles.modalBtn}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(false)
@@ -109,19 +128,20 @@ const HerokuIntegration: React.FC<
 				</Button>
 				<Button
 					trackingId="IntegrationConfigurationSave-Heroku"
-					className={styles.modalBtn}
-					type="primary"
+					kind="primary"
+					size="medium"
+					emphasis="high"
+					iconLeft={<IconSolidPuzzle />}
 					disabled={!tokens.filter((t) => t.length >= 38).length}
 					onClick={async () => {
 						setModalOpen(false)
 						await addHerokuToProject(tokens, project_id)
 					}}
 				>
-					<AppsIcon className={styles.modalBtnIcon} /> Connect
-					Highlight with Heroku
+					Connect with Heroku
 				</Button>
-			</footer>
-		</>
+			</Box>
+		</Stack>
 	)
 }
 

--- a/frontend/src/pages/IntegrationsPage/components/Integration.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.tsx
@@ -1,12 +1,12 @@
-import Button from '@components/Button/Button/Button'
 import Card from '@components/Card/Card'
 import LoadingBox from '@components/LoadingBox'
 import Switch from '@components/Switch/Switch'
-import SettingsIcon from '@icons/SettingsIcon'
+import { IconSolidCog } from '@highlight-run/ui/components'
 import { Integration as IntegrationType } from '@pages/IntegrationsPage/Integrations'
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 
+import { Button } from '@/components/Button'
 import { IntegrationModal } from '@/pages/IntegrationsPage/components/IntegrationModal/IntegrationModal'
 
 import styles from './Integration.module.css'
@@ -147,14 +147,15 @@ const Integration = ({
 							<div className="flex h-[18px] w-full justify-end">
 								<Button
 									trackingId="IntegrationSettings"
-									iconButton
+									kind="secondary"
+									size="small"
+									emphasis="low"
+									iconLeft={<IconSolidCog />}
 									onClick={() => {
 										setShowUpdateSettings(true)
 									}}
 									disabled={!integrationEnabled}
-								>
-									<SettingsIcon />
-								</Button>
+								/>
 							</div>
 						)}
 					</div>

--- a/frontend/src/pages/IntegrationsPage/components/JiraIntegration/JiraIntegrationConfig.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/JiraIntegration/JiraIntegrationConfig.module.css
@@ -1,15 +1,3 @@
-.modalBtn {
-    padding-bottom: 4px !important;
-    padding-top: 4px !important;
-}
-
-.modalBtnIcon {
-    margin-right: 0.5rem;
-}
-
-.modalSubTitle {
-    color: var(--color-gray-500) !important;
-    font-size: 16px;
-    margin-bottom: 20px;
-    margin-top: 0 !important;
+.container {
+	padding-top: 4px;
 }

--- a/frontend/src/pages/IntegrationsPage/components/JiraIntegration/JiraIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/JiraIntegration/JiraIntegrationConfig.tsx
@@ -1,6 +1,10 @@
-import Button from '@components/Button/Button/Button'
-import AppsIcon from '@icons/AppsIcon'
-import PlugIcon from '@icons/PlugIcon'
+import {
+	Box,
+	IconSolidJira,
+	IconSolidLogout,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
 import {
 	IntegrationAction,
 	IntegrationConfigProps,
@@ -12,6 +16,8 @@ import {
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
 import { useParams } from '@util/react-router/useParams'
 import React, { useMemo } from 'react'
+
+import { Button } from '@/components/Button'
 
 import styles from './JiraIntegrationConfig.module.css'
 
@@ -27,15 +33,22 @@ const JiraIntegrationSetup: React.FC<IntegrationConfigProps> = ({
 	)
 
 	return (
-		<>
-			<p className={styles.modalSubTitle}>
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
 				Connect Jira to your Highlight workspace to create issues from
 				comments.
-			</p>
-			<footer>
+			</Text>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
 				<Button
 					trackingId="IntegrationConfigurationCancel-Jira"
-					className={styles.modalBtn}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(false)
@@ -45,33 +58,43 @@ const JiraIntegrationSetup: React.FC<IntegrationConfigProps> = ({
 				</Button>
 				<Button
 					trackingId="IntegrationConfigurationSave-Jira"
-					className={styles.modalBtn}
-					type="primary"
-					href={authUrl}
+					kind="primary"
+					size="medium"
+					emphasis="high"
+					iconLeft={<IconSolidJira />}
+					onClick={() => {
+						window.location.assign(authUrl)
+					}}
 				>
-					<AppsIcon className={styles.modalBtnIcon} /> Connect
-					Highlight with Jira
+					Connect with Jira
 				</Button>
-			</footer>
-		</>
+			</Box>
+		</Stack>
 	)
 }
 
 const JiraIntegrationDisconnect: React.FC<
 	React.PropsWithChildren<IntegrationConfigProps>
-> = ({ setModalOpen: setModalOpen, setIntegrationEnabled }) => {
+> = ({ setModalOpen, setIntegrationEnabled }) => {
 	const { removeIntegration } = useJiraIntegration()
 
 	return (
-		<>
-			<p className={styles.modalSubTitle}>
-				Disconnecting your Jira from Highlight will prevent you from
-				linking issues to future comments
-			</p>
-			<footer>
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
+				Disconnecting Jira from Highlight will prevent you from linking
+				issues to future comments.
+			</Text>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
 				<Button
 					trackingId="IntegrationDisconnectCancel-Jira"
-					className={styles.modalBtn}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(true)
@@ -81,20 +104,20 @@ const JiraIntegrationDisconnect: React.FC<
 				</Button>
 				<Button
 					trackingId="IntegrationDisconnectSave-Jira"
-					className={styles.modalBtn}
-					type="primary"
-					danger
+					kind="danger"
+					size="medium"
+					emphasis="high"
+					iconLeft={<IconSolidLogout />}
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(false)
 						removeIntegration()
 					}}
 				>
-					<PlugIcon className={styles.modalBtnIcon} />
 					Disconnect Jira
 				</Button>
-			</footer>
-		</>
+			</Box>
+		</Stack>
 	)
 }
 

--- a/frontend/src/pages/IntegrationsPage/components/LinearIntegration/LinearIntegrationConfig.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/LinearIntegration/LinearIntegrationConfig.module.css
@@ -1,15 +1,3 @@
-.modalBtn {
-	padding-bottom: 4px !important;
-	padding-top: 4px !important;
-}
-
-.modalBtnIcon {
-	margin-right: 0.5rem;
-}
-
-.modalSubTitle {
-	color: var(--color-gray-500) !important;
-	font-size: 16px;
-	margin-bottom: 20px;
-	margin-top: 0 !important;
+.container {
+	padding-top: 4px;
 }

--- a/frontend/src/pages/IntegrationsPage/components/LinearIntegration/LinearIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/LinearIntegration/LinearIntegrationConfig.tsx
@@ -1,6 +1,10 @@
-import Button from '@components/Button/Button/Button'
-import AppsIcon from '@icons/AppsIcon'
-import PlugIcon from '@icons/PlugIcon'
+import {
+	Box,
+	IconSolidLinear,
+	IconSolidLogout,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
 import {
 	IntegrationAction,
 	IntegrationConfigProps,
@@ -12,79 +16,79 @@ import {
 import { useParams } from '@util/react-router/useParams'
 import React, { useMemo } from 'react'
 
+import { Button } from '@/components/Button'
+
 import styles from './LinearIntegrationConfig.module.css'
 
 const LinearIntegrationConfig: React.FC<
 	React.PropsWithChildren<IntegrationConfigProps>
-> = ({ setModalOpen: setModalOpen, setIntegrationEnabled, action }) => {
+> = ({ setModalOpen, setIntegrationEnabled, action }) => {
 	const { project_id } = useParams<{ project_id: string }>()
 	const { removeLinearIntegrationFromProject } = useLinearIntegration()
 	const authUrl = useMemo(() => getLinearOAuthUrl(project_id!), [project_id])
-	if (action === IntegrationAction.Disconnect) {
-		return (
-			<>
-				<p className={styles.modalSubTitle}>
-					Disconnecting your Linear workspace from Highlight will
-					prevent you from linking issues to future comments
-				</p>
-				<footer>
+
+	const isDisconnect = action === IntegrationAction.Disconnect
+
+	return (
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
+				{isDisconnect
+					? 'Disconnecting your Linear workspace from Highlight will prevent you from linking issues to future comments.'
+					: 'Connect Linear to your Highlight workspace to create issues from comments.'}
+			</Text>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
+				<Button
+					trackingId={
+						isDisconnect
+							? 'IntegrationDisconnectCancel-Linear'
+							: 'IntegrationConfigurationCancel-Linear'
+					}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
+					onClick={() => {
+						setModalOpen(false)
+						setIntegrationEnabled(isDisconnect)
+					}}
+				>
+					Cancel
+				</Button>
+				{isDisconnect ? (
 					<Button
-						trackingId="IntegrationDisconnectCancel-Slack"
-						className={styles.modalBtn}
-						onClick={() => {
-							setModalOpen(false)
-							setIntegrationEnabled(true)
-						}}
-					>
-						Cancel
-					</Button>
-					<Button
-						trackingId="IntegrationDisconnectSave-Slack"
-						className={styles.modalBtn}
-						type="primary"
-						danger
+						trackingId="IntegrationDisconnectSave-Linear"
+						kind="danger"
+						size="medium"
+						emphasis="high"
+						iconLeft={<IconSolidLogout />}
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(false)
 							removeLinearIntegrationFromProject(project_id)
 						}}
 					>
-						<PlugIcon className={styles.modalBtnIcon} />
 						Disconnect Linear
 					</Button>
-				</footer>
-			</>
-		)
-	}
-
-	return (
-		<>
-			<p className={styles.modalSubTitle}>
-				Connect Linear to your Highlight workspace to create issues from
-				comments.
-			</p>
-			<footer>
-				<Button
-					trackingId="IntegrationConfigurationCancel-Slack"
-					className={styles.modalBtn}
-					onClick={() => {
-						setModalOpen(false)
-						setIntegrationEnabled(false)
-					}}
-				>
-					Cancel
-				</Button>
-				<Button
-					trackingId="IntegrationConfigurationSave-Slack"
-					className={styles.modalBtn}
-					type="primary"
-					href={authUrl}
-				>
-					<AppsIcon className={styles.modalBtnIcon} /> Connect
-					Highlight with Linear
-				</Button>
-			</footer>
-		</>
+				) : (
+					<Button
+						trackingId="IntegrationConfigurationSave-Linear"
+						kind="primary"
+						size="medium"
+						emphasis="high"
+						iconLeft={<IconSolidLinear />}
+						onClick={() => {
+							window.location.assign(authUrl)
+						}}
+					>
+						Connect with Linear
+					</Button>
+				)}
+			</Box>
+		</Stack>
 	)
 }
 

--- a/frontend/src/pages/IntegrationsPage/components/MicrosoftTeamsIntegration/MicrosoftTeamsIntegrationConfig.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/MicrosoftTeamsIntegration/MicrosoftTeamsIntegrationConfig.module.css
@@ -1,15 +1,3 @@
-.modalBtn {
-	padding-bottom: 4px !important;
-	padding-top: 4px !important;
-}
-
-.modalBtnIcon {
-	margin-right: 0.5rem;
-}
-
-.modalSubTitle {
-	color: var(--color-gray-500) !important;
-	font-size: 16px;
-	margin-bottom: 20px;
-	margin-top: 0 !important;
+.container {
+	padding-top: 4px;
 }

--- a/frontend/src/pages/IntegrationsPage/components/MicrosoftTeamsIntegration/MicrosoftTeamsIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/MicrosoftTeamsIntegration/MicrosoftTeamsIntegrationConfig.tsx
@@ -1,6 +1,10 @@
-import Button from '@components/Button/Button/Button'
-import AppsIcon from '@icons/AppsIcon'
-import PlugIcon from '@icons/PlugIcon'
+import {
+	Box,
+	IconSolidLogout,
+	IconSolidMicrosoftTeams,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
 import {
 	IntegrationAction,
 	IntegrationConfigProps,
@@ -8,41 +12,58 @@ import {
 import { useParams } from '@util/react-router/useParams'
 import React from 'react'
 
+import { Button } from '@/components/Button'
+
 import styles from './MicrosoftTeamsIntegrationConfig.module.css'
 import { useMicrosoftTeamsBot } from './utils'
 
 const MicrosoftTeamsIntegrationConfig: React.FC<
 	React.PropsWithChildren<IntegrationConfigProps>
-> = ({ setModalOpen: setModalOpen, setIntegrationEnabled, action }) => {
+> = ({ setModalOpen, setIntegrationEnabled, action }) => {
 	const { project_id } = useParams<{ project_id: string }>()
 	const {
 		microsoftTeamsAuthUrl,
 		removeMicrosoftTeamsIntegrationFromProject,
 	} = useMicrosoftTeamsBot()
 
-	if (action === IntegrationAction.Disconnect) {
-		return (
-			<>
-				<p className={styles.modalSubTitle}>
-					Disconnecting your Microsoft Teams workspace from Highlight
-					will require you to reconfigure any alerts you have made!
-				</p>
-				<footer>
-					<Button
-						trackingId="IntegrationDisconnectCancel-MicrosoftTeams"
-						className={styles.modalBtn}
-						onClick={() => {
-							setModalOpen(false)
-							setIntegrationEnabled(true)
-						}}
-					>
-						Cancel
-					</Button>
+	const isDisconnect = action === IntegrationAction.Disconnect
+
+	return (
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
+				{isDisconnect
+					? 'Disconnecting your Microsoft Teams workspace from Highlight will require you to reconfigure any alerts you have made.'
+					: 'Connect Microsoft Teams to your Highlight workspace to set up alerts and tag teammates in comments.'}
+			</Text>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
+				<Button
+					trackingId={
+						isDisconnect
+							? 'IntegrationDisconnectCancel-MicrosoftTeams'
+							: 'IntegrationConfigurationCancel-MicrosoftTeams'
+					}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
+					onClick={() => {
+						setModalOpen(false)
+						setIntegrationEnabled(isDisconnect)
+					}}
+				>
+					Cancel
+				</Button>
+				{isDisconnect ? (
 					<Button
 						trackingId="IntegrationDisconnectSave-MicrosoftTeams"
-						className={styles.modalBtn}
-						type="primary"
-						danger
+						kind="danger"
+						size="medium"
+						emphasis="high"
+						iconLeft={<IconSolidLogout />}
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(false)
@@ -51,42 +72,26 @@ const MicrosoftTeamsIntegrationConfig: React.FC<
 							)
 						}}
 					>
-						<PlugIcon className={styles.modalBtnIcon} />
 						Disconnect Microsoft Teams
 					</Button>
-				</footer>
-			</>
-		)
-	}
-
-	return (
-		<>
-			<p className={styles.modalSubTitle}>
-				Connect Microsoft Teams to your Highlight workspace to setup
-				alerts and tag teammates in comments
-			</p>
-			<footer>
-				<Button
-					trackingId="IntegrationConfigurationCancel-MicrosoftTeams"
-					className={styles.modalBtn}
-					onClick={() => {
-						setModalOpen(false)
-						setIntegrationEnabled(false)
-					}}
-				>
-					Cancel
-				</Button>
-				<Button
-					trackingId="IntegrationConfigurationSave-MicrosoftTeams"
-					className={styles.modalBtn}
-					type="primary"
-					href={microsoftTeamsAuthUrl}
-				>
-					<AppsIcon className={styles.modalBtnIcon} /> Connect
-					Highlight with Microsoft Teams
-				</Button>
-			</footer>
-		</>
+				) : (
+					<Button
+						trackingId="IntegrationConfigurationSave-MicrosoftTeams"
+						kind="primary"
+						size="medium"
+						emphasis="high"
+						iconLeft={<IconSolidMicrosoftTeams />}
+						onClick={() => {
+							if (microsoftTeamsAuthUrl) {
+								window.location.assign(microsoftTeamsAuthUrl)
+							}
+						}}
+					>
+						Connect with Microsoft Teams
+					</Button>
+				)}
+			</Box>
+		</Stack>
 	)
 }
 

--- a/frontend/src/pages/IntegrationsPage/components/SlackIntegration/SlackIntegrationConfig.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/SlackIntegration/SlackIntegrationConfig.module.css
@@ -1,15 +1,3 @@
-.modalBtn {
-	padding-bottom: 4px !important;
-	padding-top: 4px !important;
-}
-
-.modalBtnIcon {
-	margin-right: 0.5rem;
-}
-
-.modalSubTitle {
-	color: var(--color-gray-500) !important;
-	font-size: 16px;
-	margin-bottom: 20px;
-	margin-top: 0 !important;
+.container {
+	padding-top: 4px;
 }

--- a/frontend/src/pages/IntegrationsPage/components/SlackIntegration/SlackIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/SlackIntegration/SlackIntegrationConfig.tsx
@@ -1,7 +1,11 @@
-import Button from '@components/Button/Button/Button'
 import { useSlackBot } from '@components/Header/components/ConnectHighlightWithSlackButton/utils/utils'
-import AppsIcon from '@icons/AppsIcon'
-import PlugIcon from '@icons/PlugIcon'
+import {
+	Box,
+	IconSolidLogout,
+	IconSolidSlack,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
 import {
 	IntegrationAction,
 	IntegrationConfigProps,
@@ -9,79 +13,80 @@ import {
 import { useParams } from '@util/react-router/useParams'
 import React from 'react'
 
+import { Button } from '@/components/Button'
+
 import styles from './SlackIntegrationConfig.module.css'
 
 const SlackIntegrationConfig: React.FC<
 	React.PropsWithChildren<IntegrationConfigProps>
-> = ({ setModalOpen: setModalOpen, setIntegrationEnabled, action }) => {
+> = ({ setModalOpen, setIntegrationEnabled, action }) => {
 	const { project_id } = useParams<{ project_id: string }>()
 	const { slackUrl, removeSlackIntegrationFromProject } = useSlackBot()
 
-	if (action === IntegrationAction.Disconnect) {
-		return (
-			<>
-				<p className={styles.modalSubTitle}>
-					Disconnecting your Slack workspace from Highlight will
-					require you to reconfigure any alerts you have made!
-				</p>
-				<footer>
-					<Button
-						trackingId="IntegrationDisconnectCancel-Slack"
-						className={styles.modalBtn}
-						onClick={() => {
-							setModalOpen(false)
-							setIntegrationEnabled(true)
-						}}
-					>
-						Cancel
-					</Button>
+	const isDisconnect = action === IntegrationAction.Disconnect
+
+	return (
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
+				{isDisconnect
+					? 'Disconnecting your Slack workspace from Highlight will require you to reconfigure any alerts you have made.'
+					: 'Connect Slack to your Highlight workspace to set up alerts and tag teammates in comments.'}
+			</Text>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
+				<Button
+					trackingId={
+						isDisconnect
+							? 'IntegrationDisconnectCancel-Slack'
+							: 'IntegrationConfigurationCancel-Slack'
+					}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
+					onClick={() => {
+						setModalOpen(false)
+						setIntegrationEnabled(isDisconnect)
+					}}
+				>
+					Cancel
+				</Button>
+				{isDisconnect ? (
 					<Button
 						trackingId="IntegrationDisconnectSave-Slack"
-						className={styles.modalBtn}
-						type="primary"
-						danger
+						kind="danger"
+						size="medium"
+						emphasis="high"
+						iconLeft={<IconSolidLogout />}
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(false)
 							removeSlackIntegrationFromProject(project_id)
 						}}
 					>
-						<PlugIcon className={styles.modalBtnIcon} />
 						Disconnect Slack
 					</Button>
-				</footer>
-			</>
-		)
-	}
-
-	return (
-		<>
-			<p className={styles.modalSubTitle}>
-				Connect Slack to your Highlight workspace to setup alerts and
-				tag teammates in comments
-			</p>
-			<footer>
-				<Button
-					trackingId="IntegrationConfigurationCancel-Slack"
-					className={styles.modalBtn}
-					onClick={() => {
-						setModalOpen(false)
-						setIntegrationEnabled(false)
-					}}
-				>
-					Cancel
-				</Button>
-				<Button
-					trackingId="IntegrationConfigurationSave-Slack"
-					className={styles.modalBtn}
-					type="primary"
-					href={slackUrl}
-				>
-					<AppsIcon className={styles.modalBtnIcon} /> Connect
-					Highlight with Slack
-				</Button>
-			</footer>
-		</>
+				) : (
+					<Button
+						trackingId="IntegrationConfigurationSave-Slack"
+						kind="primary"
+						size="medium"
+						emphasis="high"
+						iconLeft={<IconSolidSlack />}
+						onClick={() => {
+							if (slackUrl) {
+								window.location.assign(slackUrl)
+							}
+						}}
+					>
+						Connect with Slack
+					</Button>
+				)}
+			</Box>
+		</Stack>
 	)
 }
 

--- a/frontend/src/pages/IntegrationsPage/components/VercelIntegration/VercelIntegrationConfig.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/VercelIntegration/VercelIntegrationConfig.module.css
@@ -1,23 +1,5 @@
-.modalBtn {
-	padding-bottom: 4px !important;
-	padding-top: 4px !important;
-}
-
-.modalBtnIcon {
-	margin-right: 0.5rem;
-}
-
-.modalSubTitle {
-	color: var(--color-gray-500) !important;
-	font-size: 16px;
-	margin-bottom: 20px;
-	margin-top: 0 !important;
-}
-
-.modalBtnText {
-	align-items: center;
-	display: inline-flex !important;
-	height: 100%;
+.container {
+	padding-top: 4px;
 }
 
 .select {

--- a/frontend/src/pages/IntegrationsPage/components/VercelIntegration/VercelIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/VercelIntegration/VercelIntegrationConfig.tsx
@@ -1,4 +1,3 @@
-import Button from '@components/Button/Button/Button'
 import Card from '@components/Card/Card'
 import Input from '@components/Input/Input'
 import Select from '@components/Select/Select'
@@ -10,10 +9,16 @@ import {
 } from '@context/AppLoadingContext'
 import { namedOperations } from '@graph/operations'
 import { VercelProjectMappingInput } from '@graph/schemas'
+import {
+	Box,
+	IconSolidLightningBolt,
+	IconSolidLogout,
+	IconSolidPlus,
+	IconSolidTrash,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
 import SvgHighlightLogoOnLight from '@icons/HighlightLogoOnLight'
-import PlugIcon from '@icons/PlugIcon'
-import Sparkles2Icon from '@icons/Sparkles2Icon'
-import SvgTrashIconSolid from '@icons/TrashIconSolid'
 import {
 	IntegrationAction,
 	IntegrationConfigProps,
@@ -21,8 +26,9 @@ import {
 import { useVercelIntegration } from '@pages/IntegrationsPage/components/VercelIntegration/utils'
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
 import useMap from '@util/useMap'
-import clsx from 'clsx'
 import React, { useEffect, useState } from 'react'
+
+import { Button } from '@/components/Button'
 
 import styles from './VercelIntegrationConfig.module.css'
 
@@ -66,15 +72,22 @@ const VercelIntegrationSetup: React.FC<IntegrationConfigProps> = ({
 	setIntegrationEnabled,
 }) => {
 	return (
-		<>
-			<p className={styles.modalSubTitle}>
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
 				Connect Highlight with Vercel to configure environment variables
 				for source map uploads.
-			</p>
-			<footer>
+			</Text>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
 				<Button
 					trackingId="IntegrationConfigurationCancel-Vercel"
-					className={styles.modalBtn}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(false)
@@ -84,21 +97,22 @@ const VercelIntegrationSetup: React.FC<IntegrationConfigProps> = ({
 				</Button>
 				<Button
 					trackingId="IntegrationConfigurationSave-Vercel"
-					className={styles.modalBtn}
-					type="primary"
-					target="_blank"
-					href="https://vercel.com/integrations/highlight/new"
-					rel="noreferrer"
+					kind="primary"
+					size="medium"
+					emphasis="high"
+					iconLeft={<IconSolidLightningBolt />}
+					onClick={() => {
+						window.open(
+							'https://vercel.com/integrations/highlight/new',
+							'_blank',
+							'noreferrer',
+						)
+					}}
 				>
-					<span className={styles.modalBtnText}>
-						<Sparkles2Icon className={styles.modalBtnIcon} />
-						<span style={{ marginTop: 4 }}>
-							Connect Highlight with Vercel
-						</span>
-					</span>
+					Connect with Vercel
 				</Button>
-			</footer>
-		</>
+			</Box>
+		</Stack>
 	)
 }
 
@@ -109,15 +123,22 @@ const VercelIntegrationDisconnect: React.FC<IntegrationConfigProps> = ({
 	const { removeVercelIntegrationFromProject } = useVercelIntegration()
 
 	return (
-		<>
-			<p className={styles.modalSubTitle}>
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
 				Disconnecting Vercel from Highlight will remove the environment
 				variables for source map uploads.
-			</p>
-			<footer>
+			</Text>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
 				<Button
-					trackingId="IntegrationDisconnectCancel-Slack"
-					className={styles.modalBtn}
+					trackingId="IntegrationDisconnectCancel-Vercel"
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(true)
@@ -126,10 +147,11 @@ const VercelIntegrationDisconnect: React.FC<IntegrationConfigProps> = ({
 					Cancel
 				</Button>
 				<Button
-					trackingId="IntegrationDisconnectSave-Slack"
-					className={styles.modalBtn}
-					type="primary"
-					danger
+					trackingId="IntegrationDisconnectSave-Vercel"
+					kind="danger"
+					size="medium"
+					emphasis="high"
+					iconLeft={<IconSolidLogout />}
 					onClick={() => {
 						removeVercelIntegrationFromProject()
 							.then(() => {
@@ -144,11 +166,10 @@ const VercelIntegrationDisconnect: React.FC<IntegrationConfigProps> = ({
 							})
 					}}
 				>
-					<PlugIcon className={styles.modalBtnIcon} />
 					Disconnect Vercel
 				</Button>
-			</footer>
-		</>
+			</Box>
+		</Stack>
 	)
 }
 
@@ -335,18 +356,16 @@ export const VercelIntegrationSettings: React.FC<
 									}}
 									placeholder="e.g. Frontend"
 								></Input>
-								<div className="h-8 w-8">
-									<Button
-										className="rounded-lg"
-										iconButton
-										trackingId="IntegrationConfiguration-Vercel-DeleteNewProject"
-										onClick={() => {
-											onProjectDelete(row.id)
-										}}
-									>
-										<SvgTrashIconSolid />
-									</Button>
-								</div>
+								<Button
+									trackingId="IntegrationConfiguration-Vercel-DeleteNewProject"
+									kind="secondary"
+									size="small"
+									emphasis="low"
+									iconLeft={<IconSolidTrash />}
+									onClick={() => {
+										onProjectDelete(row.id)
+									}}
+								/>
 							</>
 						) : (
 							<div
@@ -408,63 +427,74 @@ export const VercelIntegrationSettings: React.FC<
 	}
 
 	return (
-		<div>
-			<p className={clsx(styles.modalSubTitle)}>
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
 				Select Vercel projects to link to your Highlight projects.
-			</p>
-			<div className="my-6">
-				<Card noPadding>
-					<Table
-						dataSource={highlightProjects}
-						columns={tableColumns}
-						pagination={false}
-						showHeader={false}
-						rowHasPadding
-						smallPadding
-					></Table>
-					<div className="border-0 border-t border-solid border-[#eaeaea]">
-						<Button
-							trackingId="IntegrationConfiguration-Vercel-NewHighlightProject"
-							className={clsx('m-4 ml-auto', styles.modalBtn)}
-							onClick={() => {
-								const tId = 'new_' + tempId
-								setTempHighlightProjects((cur) =>
-									cur.concat([
-										{
-											name: '',
-											editable: true,
-											id: tId,
-											vercelProjects: [],
-											onUpdateProjectLink: (
-												vercelProjectNames: string[],
-											) => {
-												projectMapSet(
-													tId,
-													vercelProjectNames.map(
-														(n) =>
-															allVercelProjects?.find(
-																(p) =>
-																	p.name ===
-																	n,
-															)?.id ?? '',
-													),
-												)
-											},
+			</Text>
+			<Card noPadding>
+				<Table
+					dataSource={highlightProjects}
+					columns={tableColumns}
+					pagination={false}
+					showHeader={false}
+					rowHasPadding
+					smallPadding
+				></Table>
+				<Box
+					display="flex"
+					justifyContent="flex-end"
+					padding="12"
+					borderTop="divider"
+				>
+					<Button
+						trackingId="IntegrationConfiguration-Vercel-NewHighlightProject"
+						kind="secondary"
+						size="medium"
+						emphasis="medium"
+						iconLeft={<IconSolidPlus />}
+						onClick={() => {
+							const tId = 'new_' + tempId
+							setTempHighlightProjects((cur) =>
+								cur.concat([
+									{
+										name: '',
+										editable: true,
+										id: tId,
+										vercelProjects: [],
+										onUpdateProjectLink: (
+											vercelProjectNames: string[],
+										) => {
+											projectMapSet(
+												tId,
+												vercelProjectNames.map(
+													(n) =>
+														allVercelProjects?.find(
+															(p) => p.name === n,
+														)?.id ?? '',
+												),
+											)
 										},
-									]),
-								)
-								setTempId((cur) => cur + 1)
-							}}
-						>
-							Create New Highlight Project +
-						</Button>
-					</div>
-				</Card>
-			</div>
-			<footer className="flex justify-end gap-2 pt-0">
+									},
+								]),
+							)
+							setTempId((cur) => cur + 1)
+						}}
+					>
+						Create new Highlight project
+					</Button>
+				</Box>
+			</Card>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
 				<Button
 					trackingId="IntegrationConfigurationCancel-Vercel"
-					className={styles.modalBtn}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
 					onClick={() => {
 						onCancel && onCancel()
 						setModalOpen(false)
@@ -474,16 +504,16 @@ export const VercelIntegrationSettings: React.FC<
 				</Button>
 				<Button
 					trackingId="IntegrationConfigurationSave-Vercel"
-					className={styles.modalBtn}
-					type="primary"
-					target="_blank"
+					kind="primary"
+					size="medium"
+					emphasis="high"
+					iconLeft={<IconSolidLightningBolt />}
 					onClick={onSave}
 					disabled={
-						projectMappings.length === 0 || // If no project mappings
-						tempHighlightProjects.find((p) => !p.name) || // If a new project is missing a name
-						tempHighlightProjects.find((p) => {
+						projectMappings.length === 0 ||
+						!!tempHighlightProjects.find((p) => !p.name) ||
+						!!tempHighlightProjects.find((p) => {
 							const vercelProjects = projectMap.get(p.id)
-							// If a new project has no Vercel projects
 							return (
 								vercelProjects === undefined ||
 								vercelProjects.length === 0
@@ -491,13 +521,10 @@ export const VercelIntegrationSettings: React.FC<
 						})
 					}
 				>
-					<span className={styles.modalBtnText}>
-						<Sparkles2Icon className={styles.modalBtnIcon} />
-						<span>Link Projects</span>
-					</span>
+					Link projects
 				</Button>
-			</footer>
-		</div>
+			</Box>
+		</Stack>
 	)
 }
 

--- a/frontend/src/pages/IntegrationsPage/components/ZapierIntegration/ZapierIntegrationConfig.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/ZapierIntegration/ZapierIntegrationConfig.module.css
@@ -1,15 +1,3 @@
-.modalBtn {
-	padding-bottom: 4px !important;
-	padding-top: 4px !important;
-}
-
-.modalBtnIcon {
-	margin-right: 0.5rem;
-}
-
-.modalSubTitle {
-	color: var(--color-gray-500) !important;
-	font-size: 16px;
-	margin-bottom: 20px;
-	margin-top: 0 !important;
+.container {
+	padding-top: 4px;
 }

--- a/frontend/src/pages/IntegrationsPage/components/ZapierIntegration/ZapierIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/ZapierIntegration/ZapierIntegrationConfig.tsx
@@ -1,21 +1,27 @@
-import Button from '@components/Button/Button/Button'
 import { toast } from '@components/Toaster'
-import PlugIcon from '@icons/PlugIcon'
-import Sparkles2Icon from '@icons/Sparkles2Icon'
+import {
+	Box,
+	IconSolidLightningBolt,
+	IconSolidLogout,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
 import {
 	IntegrationAction,
 	IntegrationConfigProps,
 } from '@pages/IntegrationsPage/components/Integration'
 import { useZapierIntegration } from '@pages/IntegrationsPage/components/ZapierIntegration/utils'
-import { CodeBlock } from '@/pages/Connect/CodeBlock'
 import React, { useEffect } from 'react'
 import { coy as lightTheme } from 'react-syntax-highlighter/dist/esm/styles/prism'
+
+import { Button } from '@/components/Button'
+import { CodeBlock } from '@/pages/Connect/CodeBlock'
 
 import styles from './ZapierIntegrationConfig.module.css'
 
 const ZapierIntegrationConfig: React.FC<
 	React.PropsWithChildren<IntegrationConfigProps>
-> = ({ setModalOpen: setModalOpen, setIntegrationEnabled, action }) => {
+> = ({ setModalOpen, setIntegrationEnabled, action }) => {
 	const {
 		generatedJwtToken,
 		removeZapierIntegrationFromProject,
@@ -32,15 +38,22 @@ const ZapierIntegrationConfig: React.FC<
 
 	if (action === IntegrationAction.Disconnect) {
 		return (
-			<>
-				<p className={styles.modalSubTitle}>
+			<Stack gap="16" cssClass={styles.container}>
+				<Text color="moderate" size="small">
 					Disconnecting Zapier from Highlight will cause your Zaps to
 					stop working.
-				</p>
-				<footer>
+				</Text>
+				<Box
+					display="flex"
+					alignItems="center"
+					justifyContent="flex-end"
+					gap="8"
+				>
 					<Button
-						trackingId="IntegrationDisconnectCancel-Slack"
-						className={styles.modalBtn}
+						trackingId="IntegrationDisconnectCancel-Zapier"
+						kind="secondary"
+						size="medium"
+						emphasis="medium"
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(true)
@@ -49,34 +62,35 @@ const ZapierIntegrationConfig: React.FC<
 						Cancel
 					</Button>
 					<Button
-						trackingId="IntegrationDisconnectSave-Slack"
-						className={styles.modalBtn}
-						type="primary"
-						danger
+						trackingId="IntegrationDisconnectSave-Zapier"
+						kind="danger"
+						size="medium"
+						emphasis="high"
+						iconLeft={<IconSolidLogout />}
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(false)
 							removeZapierIntegrationFromProject()
 						}}
 					>
-						<PlugIcon className={styles.modalBtnIcon} />
 						Disconnect Zapier
 					</Button>
-				</footer>
-			</>
+				</Box>
+			</Stack>
 		)
 	}
 
 	return (
-		<>
-			<p className={styles.modalSubTitle}>
+		<Stack gap="16" cssClass={styles.container}>
+			<Text color="moderate" size="small">
 				Connect Highlight with Zapier to use alerts as triggers for your
 				Zaps.
-			</p>
-			<p className={styles.modalSubTitle}>
-				In order to connect, you'll need to create a Zap in Zapier and
-				when prompted, enter the access token from the textbox below.
-			</p>
+			</Text>
+			<Text color="moderate" size="small">
+				In order to connect, you&apos;ll need to create a Zap in Zapier
+				and, when prompted, enter the access token from the textbox
+				below.
+			</Text>
 			<CodeBlock
 				style={lightTheme}
 				showLineNumbers={false}
@@ -84,10 +98,17 @@ const ZapierIntegrationConfig: React.FC<
 				language="text"
 				numberOfLines={2}
 			/>
-			<footer>
+			<Box
+				display="flex"
+				alignItems="center"
+				justifyContent="flex-end"
+				gap="8"
+			>
 				<Button
 					trackingId="IntegrationConfigurationCancel-Zapier"
-					className={styles.modalBtn}
+					kind="secondary"
+					size="medium"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(false)
@@ -97,16 +118,22 @@ const ZapierIntegrationConfig: React.FC<
 				</Button>
 				<Button
 					trackingId="IntegrationConfigurationSave-Zapier"
-					className={styles.modalBtn}
-					type="primary"
-					target="_blank"
-					href="https://zapier.com/app/zaps" // TODO: change to Highlight Zap URL
+					kind="primary"
+					size="medium"
+					emphasis="high"
+					iconLeft={<IconSolidLightningBolt />}
+					onClick={() => {
+						window.open(
+							'https://zapier.com/app/zaps',
+							'_blank',
+							'noreferrer',
+						)
+					}}
 				>
-					<Sparkles2Icon className={styles.modalBtnIcon} /> Create a
-					Zap
+					Create a Zap
 				</Button>
-			</footer>
-		</>
+			</Box>
+		</Stack>
 	)
 }
 


### PR DESCRIPTION
## Summary

Refactored the Integrations sub-pages to use the Highlight UI library and match the new Figma designs. This covers all 14+ provider components. /claim #8614

Every integration modal under `frontend/src/pages/IntegrationsPage/components/` now uses `@highlight-run/ui/components` (`Stack`, `Box`, `Text`, `Button`, and the `IconSolid*` set) in place of the legacy `@components/Button/Button/Button`, `@icons/*` SVGs, and ad-hoc CSS module styles. Connect and disconnect flows were consolidated where possible, Cancel/primary/danger buttons now use `kind` / `emphasis` / `size` props, and each provider's CTA uses the matching `IconSolid*` icon (`IconSolidSlack`, `IconSolidGithub`, `IconSolidDiscord`, `IconSolidLinear`, `IconSolidJira`, `IconSolidGitlab`, `IconSolidClickUp`, `IconSolidHeight`, `IconSolidCloud`, `IconSolidPuzzle`, `IconSolidLightningBolt`, `IconSolidMicrosoftTeams`, `IconSolidSparkles`, `IconSolidLogout`). The shared `Integration.tsx` settings cog was migrated to the new Button + `IconSolidCog` as well.

Providers covered: Slack, Linear, Discord, Clearbit, Zapier, Heroku, Microsoft Teams, Cloudflare, Jira, GitHub, GitLab, ClickUp, Height, Vercel.

## How did you test this change?

- `yarn lint` — clean.
- `yarn types:check` — no new type errors introduced in `IntegrationsPage` (pre-existing errors elsewhere in the tree are unchanged).
- Rendered the refactored modals locally and recorded a short walkthrough showing Slack, GitHub and Discord (connect + disconnect flows).


Slack:
![Slack](https://app.devin.ai/attachments/058273c1-7a86-473a-9802-2fe888f3712d/screenshot_77f385144d074ece9d83eed466dd8eec.png)

GitHub:
![GitHub](https://app.devin.ai/attachments/e246c0dc-9489-49a7-9c08-93c6e623974a/screenshot_5f51db85745244a388317a66e093fa0b.png)

Discord (connect):
![Discord connect](https://app.devin.ai/attachments/7d53265e-fa79-44ef-a2a9-980e46e1a682/screenshot_91d844707c074586be5885516bc9d76c.png)

Discord (disconnect):
![Discord disconnect](https://app.devin.ai/attachments/d02e7e9b-f2e3-4237-8e6b-9e02f2897926/screenshot_f0d3515542ce40a8a8b4d8a905c23ef6.png)

## Are there any deployment considerations?

No — purely a frontend refactor. No schema, migrations, or env changes.

## Does this work require review from our design team?

Yes — flagging for @julian-highlight / the design team to sanity-check alignment with the Figma spec across all 14 provider modals.
