### PR TITLE
chore: remove antd components from workspace and project settings

### DIFF
--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -11,11 +11,11 @@ import {
 	IconSolidTrash,
 	IconSolidX,
 	Text,
+	Select,
 	TextLink,
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -121,7 +121,7 @@ const GithubSettingsForm = ({
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
 				id: repo.key,
-				label: repo.name.split('/').pop(),
+				name: repo.name.split('/').pop() || '',
 				value: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
@@ -155,7 +155,7 @@ const GithubSettingsForm = ({
 							aria-label="GitHub repository"
 							className={styles.repoSelect}
 							placeholder="Search repos..."
-							onSelect={(repo: string) =>
+							onValueChange={(repo: string) =>
 								formStore.setValue(
 									formStore.names.githubRepo,
 									repo,
@@ -165,10 +165,7 @@ const GithubSettingsForm = ({
 								?.split('/')
 								.pop()}
 							options={githubOptions}
-							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
-							filterOption
-							showSearch
+							filterable
 						/>
 						<ButtonIcon
 							kind="secondary"

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -6,9 +6,8 @@ import {
 	useUpdateAllowedEmailOriginsMutation,
 } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
-import { Box, Select, Text } from '@highlight-run/ui/components'
+import { Box, Select, SwitchButton, Text } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React, { useState } from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -61,9 +60,9 @@ export const AutoJoinForm: React.FC = () => {
 		}
 	}
 
-	const handleCheckboxChange = (event: CheckboxChangeEvent) => {
-		const checked = event.target.checked
-		if (checked) {
+	const handleCheckboxChange = () => {
+		const isCurrentlyEnabled = autoJoinDomains.length > 0
+		if (!isCurrentlyEnabled) {
 			onChangeMsg([adminsEmailDomain], 'Successfully enabled auto-join!')
 		} else {
 			onChangeMsg([], 'Successfully disabled auto-join!')
@@ -85,7 +84,7 @@ export const AutoJoinForm: React.FC = () => {
 		>
 			<div className={styles.container}>
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
+					<SwitchButton
 						checked={autoJoinDomains.length > 0}
 						onChange={handleCheckboxChange}
 					/>


### PR DESCRIPTION
## Summary
Removed `antd` dependencies from Workspace and Project Settings, replacing `Checkbox` with `SwitchButton` and `Select` with the native Highlight UI `Select` component.

## How did you test this change?
Validated the replacement components' props and typing logic to ensure the internal filters and state handlers match the new Highlight UI components.

Fixes #8635

