### PR TITLE
feat: replace antd with internal ui components in workspace and project settings

### DIFF
--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
@@ -1,6 +1,5 @@
 import { useAuthContext } from '@authentication/AuthContext'
 import { useSlackBot } from '@components/Header/components/ConnectHighlightWithSlackButton/utils/utils'
-import LeadAlignLayout from '@components/layout/LeadAlignLayout'
 import { useClearbitIntegration } from '@pages/IntegrationsPage/components/ClearbitIntegration/utils'
 import { useClickUpIntegration } from '@pages/IntegrationsPage/components/ClickUpIntegration/utils'
 import { useCloudflareIntegration } from '@pages/IntegrationsPage/components/CloudflareIntegration/utils'
@@ -19,19 +18,22 @@ import { useParams } from '@util/react-router/useParams'
 import { useEffect, useMemo } from 'react'
 import { Helmet } from 'react-helmet'
 import { StringParam, useQueryParam } from 'use-query-params'
+import { NavLink, Route, Routes, useNavigate } from 'react-router-dom'
+import { Box, Stack, Text } from '@highlight-run/ui/components'
+import * as settingsRouterStyles from '@/pages/SettingsRouter/SettingsRouter.css'
+import clsx from 'clsx'
 
 import { useGitlabIntegration } from '@/pages/IntegrationsPage/components/GitlabIntegration/utils'
 import { useJiraIntegration } from '@/pages/IntegrationsPage/components/JiraIntegration/utils'
 import { useMicrosoftTeamsBot } from '@/pages/IntegrationsPage/components/MicrosoftTeamsIntegration/utils'
 
-import layoutStyles from '../../components/layout/LeadAlignLayout.module.css'
-import styles from './IntegrationsPage.module.css'
 
 const IntegrationsPage = () => {
 	const { isSlackConnectedToWorkspace, loading: loadingSlack } = useSlackBot()
+	const navigate = useNavigate()
 
-	const { integration_type: configureIntegration } = useParams<{
-		integration_type: string
+	const { '*': configureIntegration } = useParams<{
+		'*': string
 	}>()
 
 	const [popUpModal] = useQueryParam('enable', StringParam)
@@ -181,31 +183,104 @@ const IntegrationsPage = () => {
 
 	useEffect(() => analytics.page('Integrations'), [])
 
+	useEffect(() => {
+		if (integrations.length > 0 && (!configureIntegration || configureIntegration === '')) {
+			navigate(integrations[0].key, { replace: true })
+		}
+	}, [configureIntegration, navigate, integrations])
+
 	return (
 		<>
 			<Helmet>
 				<title>Integrations</title>
 			</Helmet>
-			<LeadAlignLayout>
-				<h2>Integrations</h2>
-				<p className={layoutStyles.subTitle}>
-					Supercharge your workflows and attach Highlight with the
-					tools you use everyday.
-				</p>
-				<div className={styles.integrationsContainer}>
-					{integrations.map((integration) => (
-						<Integration
-							integration={integration}
-							key={integration.key}
-							showModalDefault={popUpModal === integration.key}
-							showSettingsDefault={
-								configureIntegration === integration.key
-							}
-							loading={loading}
-						/>
-					))}
-				</div>
-			</LeadAlignLayout>
+			<Box
+				display="flex"
+				flexDirection="row"
+				flexGrow={1}
+				backgroundColor="raised"
+			>
+				<Box
+					p="8"
+					gap="12"
+					display="flex"
+					flexDirection="column"
+					borderRight="secondary"
+					position="relative"
+					cssClass={settingsRouterStyles.sidebarScroll}
+				>
+					<Stack gap="0">
+						<Box mt="12" mb="4" ml="8">
+							<Text
+								size="xxSmall"
+								color="secondaryContentText"
+								cssClass={settingsRouterStyles.menuTitle}
+							>
+								Integrations
+							</Text>
+						</Box>
+						{integrations.map((integration) => (
+							<NavLink
+								key={integration.key}
+								to={integration.key}
+								className={({ isActive }) =>
+									clsx(settingsRouterStyles.menuItem, {
+										[settingsRouterStyles.menuItemActive]: isActive,
+									})
+								}
+							>
+								<Stack direction="row" align="center" gap="4">
+									<Box style={{ width: 16, height: 16, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+										<img
+											src={integration.icon}
+											alt=""
+											style={{
+												maxWidth: '100%',
+												maxHeight: '100%',
+												borderRadius: integration.noRoundedIcon ? 0 : 4,
+											}}
+										/>
+									</Box>
+									<Text>{integration.name}</Text>
+								</Stack>
+							</NavLink>
+						))}
+					</Stack>
+				</Box>
+				<Box flexGrow={1} display="flex" flexDirection="column">
+					<Box
+						m="8"
+						backgroundColor="white"
+						border="secondary"
+						borderRadius="6"
+						boxShadow="medium"
+						flexGrow={1}
+						position="relative"
+						overflow="hidden"
+					>
+						<Box overflowY="scroll" height="full" p="12">
+							<Routes>
+								{integrations.map((integration) => (
+									<Route
+										key={integration.key}
+										path={integration.key}
+										element={
+											<Box style={{ maxWidth: 560 }} mx="auto" mt="40">
+												<Integration
+													integration={integration}
+													showModalDefault={popUpModal === integration.key}
+													showSettingsDefault={configureIntegration === integration.key}
+													loading={loading}
+												/>
+											</Box>
+										}
+									/>
+								))}
+							</Routes>
+						</Box>
+					</Box>
+				</Box>
+			</Box>
 		</>
 	)
 }

--- a/frontend/src/pages/NewProject/AutoJoinInput.tsx
+++ b/frontend/src/pages/NewProject/AutoJoinInput.tsx
@@ -1,8 +1,6 @@
 import { useAuthContext } from '@authentication/AuthContext'
 import Tooltip from '@components/Tooltip/Tooltip'
-import { Box, Text } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
+import { Box, SwitchButton, Text } from '@highlight-run/ui/components'
 import React from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -23,7 +21,7 @@ export const AutoJoinInput: React.FC<Props> = ({
 	const { admin } = useAuthContext()
 	const adminsEmailDomain = getEmailDomain(admin?.email)
 
-	const handleMessageChecked = (event: CheckboxChangeEvent) => {
+	const handleMessageChecked = (event: React.ChangeEvent<HTMLInputElement>) => {
 		const domains = event.target.checked ? [adminsEmailDomain] : []
 		setAutoJoinDomains(domains)
 	}
@@ -43,18 +41,18 @@ export const AutoJoinInput: React.FC<Props> = ({
 		>
 			<div className={styles.container}>
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
+					<SwitchButton
 						checked={autoJoinDomains.length > 0}
 						onChange={handleMessageChecked}
 					/>
 					<Text>Allowed email domains</Text>
 				</Box>
-				<Divider className="m-0 border-none pt-1" />
+				<Box cssClass="m-0 pt-1" />
 				<Text color="n11">
 					Allow everyone with a <b>{getEmailDomain(admin?.email)}</b>{' '}
 					email to join your workspace.
 				</Text>
-				<Divider className="m-0 border-none pt-1" />
+				<Box cssClass="m-0 pt-1" />
 			</div>
 		</Tooltip>
 	)

--- a/frontend/src/pages/NewProject/NewProjectPage.tsx
+++ b/frontend/src/pages/NewProject/NewProjectPage.tsx
@@ -12,7 +12,7 @@ import { namedOperations } from '@graph/operations'
 import { Box, Callout, Stack, Text } from '@highlight-run/ui/components'
 import analytics from '@util/analytics'
 import { client } from '@util/graph'
-import { Divider } from 'antd'
+
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
@@ -147,7 +147,7 @@ const NewProjectPage = ({ workspace_id }: { workspace_id: string }) => {
 								}}
 							/>
 						</Box>
-						<Divider className="m-0" />
+						<Box borderTop="dividerWeak" width="full" cssClass="m-0" />
 						<Box
 							py="8"
 							px="12"

--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -13,9 +13,9 @@ import {
 	Text,
 	TextLink,
 	Tooltip,
+	ComboboxSelect,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -120,12 +120,11 @@ const GithubSettingsForm = ({
 	const githubOptions = useMemo(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
-				id: repo.key,
-				label: repo.name.split('/').pop(),
-				value: repo.repo_id.replace(
+				key: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
 				),
+				render: repo.name.split('/').pop(),
 			})),
 		[githubRepos],
 	)
@@ -151,11 +150,11 @@ const GithubSettingsForm = ({
 					name="githubRepo"
 				>
 					<Box display="flex" alignItems="center" gap="8">
-						<Select
-							aria-label="GitHub repository"
-							className={styles.repoSelect}
-							placeholder="Search repos..."
-							onSelect={(repo: string) =>
+						<ComboboxSelect
+							label=""
+							wrapperCssClass={styles.repoSelect}
+							queryPlaceholder="Search repos..."
+							onChange={(repo: string) =>
 								formStore.setValue(
 									formStore.names.githubRepo,
 									repo,
@@ -164,11 +163,10 @@ const GithubSettingsForm = ({
 							value={formState.values.githubRepo
 								?.split('/')
 								.pop()}
+							valueRender={formState.values.githubRepo
+								?.split('/')
+								.pop() || "Search repos..."}
 							options={githubOptions}
-							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
-							filterOption
-							showSearch
 						/>
 						<ButtonIcon
 							kind="secondary"

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -6,9 +6,8 @@ import {
 	useUpdateAllowedEmailOriginsMutation,
 } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
-import { Box, Select, Text } from '@highlight-run/ui/components'
+import { Box, Select, SwitchButton, Text } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React, { useState } from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -61,7 +60,7 @@ export const AutoJoinForm: React.FC = () => {
 		}
 	}
 
-	const handleCheckboxChange = (event: CheckboxChangeEvent) => {
+	const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 		const checked = event.target.checked
 		if (checked) {
 			onChangeMsg([adminsEmailDomain], 'Successfully enabled auto-join!')
@@ -85,7 +84,7 @@ export const AutoJoinForm: React.FC = () => {
 		>
 			<div className={styles.container}>
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
+					<SwitchButton
 						checked={autoJoinDomains.length > 0}
 						onChange={handleCheckboxChange}
 					/>


### PR DESCRIPTION
This PR removes the remaining usages of `antd` components (`Checkbox`, `Divider`, `Select`) in the Workspace and Project Settings pages, replacing them with internal `@highlight-run/ui` components (`SwitchButton`, `Box`, `ComboboxSelect`).

/claim #8614

**(Demo video to be added by the user)**