### PR TITLE
refactor(WorkspaceSettings): replace antd-wrapped Alert with Callout

### DIFF
--- a/.changeset/workspace-settings-callout.md
+++ b/.changeset/workspace-settings-callout.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/frontend': patch
+---
+
+Replace antd-wrapped Alert with Callout in WorkspaceSettings page

--- a/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
@@ -1,7 +1,6 @@
-import Alert from '@components/Alert/Alert'
 import { FieldsBox } from '@components/FieldsBox/FieldsBox'
 import { AdminRole } from '@graph/schemas'
-import { Box } from '@highlight-run/ui/components'
+import { Box, Callout } from '@highlight-run/ui/components'
 import { AutoJoinForm } from '@pages/WorkspaceTeam/components/AutoJoinForm'
 import { Authorization } from '@util/authorization/authorization'
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
@@ -43,12 +42,14 @@ const WorkspaceSettings = () => {
 						<Authorization
 							allowedRoles={[AdminRole.Admin]}
 							forbiddenFallback={
-								<Alert
-									trackingId="AdminNoAccessToAutoJoinDomains"
-									type="info"
-									message="You don't have access to auto-access domains."
-									description={`You don't have permission to configure auto-access domains. Please contact a workspace admin to make changes.`}
-								/>
+								<Callout
+									kind="info"
+									title="You don't have access to auto-access domains."
+								>
+									You don't have permission to configure
+									auto-access domains. Please contact a
+									workspace admin to make changes.
+								</Callout>
 							}
 						>
 							<AutoJoinForm />


### PR DESCRIPTION
## Summary

The `Alert` component imported from `@components/Alert/Alert` wraps antd's Alert. This change replaces its single usage on the Workspace Settings page with `Callout` from `@highlight-run/ui/components`, removing one antd dependency from this page.

Per the issue's note ("feel free to break this up into multiple tickets, perhaps one per page"), this PR is scoped to **only the Workspace Settings page** to keep the diff small and easy to review.

## Changes

- `frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx`:
  - Drop `import Alert from '@components/Alert/Alert'`
  - Add `Callout` to the existing `@highlight-run/ui/components` import
  - Replace the single `<Alert ... />` usage in the auto-join Authorization fallback with `<Callout kind="info" title="...">...</Callout>`

## Notes

- The original `Alert` accepted a `trackingId` for session-based dismissal via `useSessionStorage`. `Callout` doesn't have an equivalent; the message is now always shown when the user lacks admin access, which seems acceptable for an authorization fallback (it's not a transient notification). Happy to add a wrapper if you'd prefer to preserve the dismiss-and-remember behaviour.
- Project Settings has more antd-wrapper usages (Loading, Input, Select, etc.) and is left for a follow-up PR.

Closes #8635