### PR TITLE
fix(ui): standardize session identifier label to 'Fingerprint'

### DIFF
--- a/.changeset/standardize-fingerprint-naming.md
+++ b/.changeset/standardize-fingerprint-naming.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/frontend': patch
+---
+
+standardize session identifier label to "Fingerprint" across player UI (closes #6293)

--- a/frontend/src/components/Comment/SessionComment/SessionCommentHeader.tsx
+++ b/frontend/src/components/Comment/SessionComment/SessionCommentHeader.tsx
@@ -73,7 +73,7 @@ const SessionCommentHeader: React.FC<Props> = ({ comment, isReply }) => {
 			return `Highlight Comment: ${session?.identifier}'s session`
 		}
 		if (session?.fingerprint) {
-			return `Highlight Comment: session with device ID ${session?.fingerprint}`
+			return `Highlight Comment: session with fingerprint ${session?.fingerprint}`
 		}
 		return `Highlight Comment for a session`
 	}, [session])

--- a/frontend/src/pages/Player/MetadataBox/MetadataBox.tsx
+++ b/frontend/src/pages/Player/MetadataBox/MetadataBox.tsx
@@ -90,7 +90,7 @@ export const MetadataBox = React.memo(() => {
 				lines: '1',
 			},
 			{
-				keyDisplayValue: 'UserID',
+				keyDisplayValue: 'Fingerprint',
 				valueDisplayValue: session?.fingerprint?.toString(),
 			},
 			{

--- a/frontend/src/pages/Player/MetadataPanel/MetadataPanel.tsx
+++ b/frontend/src/pages/Player/MetadataPanel/MetadataPanel.tsx
@@ -226,14 +226,14 @@ const MetadataPanel = () => {
 
 	if (session?.fingerprint) {
 		deviceData.push({
-			keyDisplayValue: 'Device ID',
+			keyDisplayValue: 'Fingerprint',
 			valueDisplayValue: (
 				<ButtonLink
 					onClick={(e) => {
 						e.stopPropagation()
 
 						toast.success(
-							`Showing sessions created by device #${session.fingerprint}`,
+							`Showing sessions with fingerprint #${session.fingerprint}`,
 						)
 						onSubmit(`device_id=${session.fingerprint}`)
 					}}


### PR DESCRIPTION
Standardizes the session user-identifier label across the player UI to use **Fingerprint** consistently (per #6293).

The frontend currently uses three different labels for the same generated identifier — `Device ID` in MetadataPanel, `UserID` in MetadataBox, and `device ID` in SessionCommentHeader — while the backend uses `ClientID` and the underlying field is `session.fingerprint`. This PR aligns the visible labels with the field name.

### Changes

| File | Before | After |
|------|--------|-------|
| `frontend/src/pages/Player/MetadataPanel/MetadataPanel.tsx` | `'Device ID'` | `'Fingerprint'` |
| `frontend/src/pages/Player/MetadataPanel/MetadataPanel.tsx` (toast) | `Showing sessions created by device #...` | `Showing sessions with fingerprint #...` |
| `frontend/src/pages/Player/MetadataBox/MetadataBox.tsx` | `'UserID'` | `'Fingerprint'` |
| `frontend/src/components/Comment/SessionComment/SessionCommentHeader.tsx` | `session with device ID ...` | `session with fingerprint ...` |

### What stays unchanged

- Search/query keys (`device_id=...`) and any URL params — those are wire-level identifiers and changing them would break saved searches.
- Backend `ClientID` / GraphQL `client_id` field names — out of scope, backend-only change.

### Notes

- A previous PR (#10339) covered the same three files but is missing a changeset; this PR includes the changeset entry needed for the @highlight-run/frontend release.
- Closes #6293.
