### PR TITLE
Refactor: Remove antd from Workspace Settings #8635

### DIFF
--- a/frontend/src/components/CustomAlert/CustomAlert.tsx
+++ b/frontend/src/components/CustomAlert/CustomAlert.tsx
@@ -1,0 +1,46 @@
+
+import React from 'react'
+import { Callout, CalloutProps } from '@highlight-run/ui/components/Callout/Callout'
+import analytics from '@util/analytics'
+import { useSessionStorage } from 'react-use'
+
+export type CustomAlertProps = {
+  trackingId: string
+  closable?: boolean
+  shouldAlwaysShow?: boolean
+} & Pick<CalloutProps, 'title' | 'kind' | 'children' | 'style' | 'className'>
+
+const CustomAlert = ({
+  trackingId,
+  closable,
+  shouldAlwaysShow = false,
+  kind = 'info',
+  title,
+  children,
+  ...props
+}: CustomAlertProps) => {
+  const [temporarilyHideAlert, setTemporarilyHideAlert] = useSessionStorage(
+    `highlightHideAlert-${trackingId}`,
+    false,
+  )
+
+  if (temporarilyHideAlert && !shouldAlwaysShow) {
+    return null
+  }
+
+  return (
+    <Callout
+      kind={kind}
+      title={title}
+      handleCloseClick={closable !== false ? () => {
+        analytics.track(`AlertClose-${trackingId}`)
+        setTemporarilyHideAlert(true)
+      } : undefined}
+      {...props}
+    >
+      {children}
+    </Callout>
+  )
+}
+
+export default CustomAlert

--- a/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
@@ -1,11 +1,11 @@
-import Alert from '@components/Alert/Alert'
-import { FieldsBox } from '@components/FieldsBox/FieldsBox'
+
 import { AdminRole } from '@graph/schemas'
 import { Box } from '@highlight-run/ui/components'
 import { AutoJoinForm } from '@pages/WorkspaceTeam/components/AutoJoinForm'
 import { Authorization } from '@util/authorization/authorization'
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
 import { useAuthContext } from '@/authentication/AuthContext'
+import CustomAlert from '@components/CustomAlert/CustomAlert'
 
 import layoutStyles from '../../components/layout/LeadAlignLayout.module.css'
 import { FieldsForm } from './FieldsForm/FieldsForm'
@@ -43,12 +43,13 @@ const WorkspaceSettings = () => {
 						<Authorization
 							allowedRoles={[AdminRole.Admin]}
 							forbiddenFallback={
-								<Alert
+								<CustomAlert
 									trackingId="AdminNoAccessToAutoJoinDomains"
-									type="info"
-									message="You don't have access to auto-access domains."
-									description={`You don't have permission to configure auto-access domains. Please contact a workspace admin to make changes.`}
-								/>
+									kind="info"
+									title="You don't have access to auto-access domains."
+								>
+									You don't have permission to configure auto-access domains. Please contact a workspace admin to make changes.
+								</CustomAlert>
 							}
 						>
 							<AutoJoinForm />

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -1,3 +1,5 @@
+
+
 import { useAuthContext } from '@authentication/AuthContext'
 import { toast } from '@components/Toaster'
 import Tooltip from '@components/Tooltip/Tooltip'
@@ -6,9 +8,8 @@ import {
 	useUpdateAllowedEmailOriginsMutation,
 } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
-import { Box, Select, Text } from '@highlight-run/ui/components'
+import { Box, Select, Text, Checkbox } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React, { useState } from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -61,7 +62,7 @@ export const AutoJoinForm: React.FC = () => {
 		}
 	}
 
-	const handleCheckboxChange = (event: CheckboxChangeEvent) => {
+	const handleCheckboxChange = (event: { target: { checked: boolean } }) => {
 		const checked = event.target.checked
 		if (checked) {
 			onChangeMsg([adminsEmailDomain], 'Successfully enabled auto-join!')
@@ -87,7 +88,7 @@ export const AutoJoinForm: React.FC = () => {
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
 					<Checkbox
 						checked={autoJoinDomains.length > 0}
-						onChange={handleCheckboxChange}
+						onChange={(e) => handleCheckboxChange({ target: { checked: e } } as any)}
 					/>
 					<Text>Auto-approved email domains</Text>
 				</Box>
@@ -105,3 +106,4 @@ export const AutoJoinForm: React.FC = () => {
 		</Tooltip>
 	)
 }
+


### PR DESCRIPTION
Following the initiative to migrate away from antd, this PR refactors the Workspace Settings page. It replaces antd's Alert and Checkbox with native Highlight UI components and introduces a new CustomAlert wrapper. This is the first of a series of page-specific migrations.
/claim #8635 