### PR TITLE
Add SvelteKit server instrumentation quickstart

### DIFF
--- a/docs-content/getting-started/4_server/2_js/sveltekit.md
+++ b/docs-content/getting-started/4_server/2_js/sveltekit.md
@@ -1,0 +1,11 @@
+---
+title: SvelteKit
+heading: SvelteKit Server Quick Start
+metaTitle: SvelteKit Server Quick Start
+slug: sveltekit
+createdAt: 2026-05-10T00:00:00.000Z
+updatedAt: 2026-05-10T00:00:00.000Z
+quickstart: true
+---
+
+<QuickStart content={quickStartContent["server"]["js"]["sveltekit"]}/>

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -139,6 +139,7 @@ import { ReactNativeContent } from './frontend/react-native'
 import { siteUrl } from '../../utils/urls'
 import { NextJsTracesReorganizedContent } from './server/js/nextjs'
 import { AWSLambdaTracingSteps } from './server/serverless/shared-snippets-aws-lambda'
+import { JSSvelteKitReorganizedContent } from './server/js/sveltekit'
 
 export type QuickStartContent = {
 	title: string
@@ -209,6 +210,7 @@ export enum QuickStartType {
 	JSWinston = 'winston',
 	JSPino = 'pino',
 	JStRPC = 'trpc',
+	JSSvelteKit = 'sveltekit',
 	HTTPOTLP = 'curl',
 	Syslog = 'syslog',
 	Systemd = 'systemd',
@@ -461,6 +463,7 @@ export const quickStartContent = {
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSManual]: JSManualTracesReorganizedContent,
 			[QuickStartType.JSNextjs]: NextJsTracesReorganizedContent,
+			[QuickStartType.JSSvelteKit]: JSSvelteKitReorganizedContent,
 		},
 		php: {
 			title: 'PHP',
@@ -606,6 +609,7 @@ export const quickStartContentReorganized = {
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSManual]: JSManualTracesReorganizedContent,
 			[QuickStartType.OTLP]: OTLPReorganizedContent,
+			[QuickStartType.JSSvelteKit]: JSSvelteKitReorganizedContent,
 		},
 	},
 	php: {

--- a/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
@@ -1,0 +1,83 @@
+import { QuickStartContent } from '../../QuickstartContent'
+import { verifyLogs } from '../shared-snippets-logging'
+import { frontendInstallSnippet } from '../shared-snippets-monitoring'
+import { verifyTraces } from '../shared-snippets-tracing'
+import {
+	initializeNodeSDK,
+	jsGetSnippet,
+	verifyError,
+} from './shared-snippets-monitoring'
+
+export const JSSvelteKitReorganizedContent: QuickStartContent = {
+	title: 'SvelteKit',
+	subtitle:
+		'Learn how to set up highlight.io server instrumentation in SvelteKit.',
+	logoKey: 'sveltekit',
+	products: ['Errors', 'Logs', 'Traces'],
+	entries: [
+		frontendInstallSnippet,
+		jsGetSnippet(['node']),
+		initializeNodeSDK('node'),
+		{
+			title: 'Wrap SvelteKit server requests.',
+			content:
+				'Use the SvelteKit `handle` hook to wrap each server request with `H.runWithHeaders`. Convert SvelteKit request headers into a plain object before passing them to Highlight.',
+			code: [
+				{
+					text: `// src/hooks.server.ts
+import { H } from '@highlight-run/node'
+import type { Handle } from '@sveltejs/kit'
+
+H.init({
+	projectID: '<YOUR_PROJECT_ID>',
+	serviceName: 'my-sveltekit-app',
+	serviceVersion: 'git-sha',
+	environment: 'production',
+})
+
+export const handle: Handle = async ({ event, resolve }) => {
+	const headers = Object.fromEntries(event.request.headers.entries())
+
+	return H.runWithHeaders('sveltekit.request', headers, () =>
+		resolve(event),
+	)
+}`,
+					language: 'js',
+				},
+			],
+		},
+		{
+			title: 'Report errors from server routes.',
+			content:
+				'When you handle an error manually in a SvelteKit server route, parse the same plain header object so the error can be tied back to the matching Highlight session and request.',
+			code: [
+				{
+					text: `// src/routes/api/example/+server.ts
+import { H } from '@highlight-run/node'
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async ({ request }) => {
+	try {
+		throw new Error('example error!')
+	} catch (error) {
+		const headers = Object.fromEntries(request.headers.entries())
+		const { secureSessionId, requestId } = H.parseHeaders(headers)
+
+		H.consumeError(
+			error as Error,
+			secureSessionId,
+			requestId,
+		)
+	}
+
+	return new Response('ok')
+}`,
+					language: 'js',
+				},
+			],
+		},
+		verifyError('SvelteKit', `throw new Error('example error!')`),
+		verifyLogs,
+		verifyTraces,
+	],
+}


### PR DESCRIPTION
## Summary
- add a SvelteKit server quickstart page under the JavaScript server docs
- document `hooks.server.ts` instrumentation with `H.runWithHeaders`
- show manual server-route error reporting with `H.parseHeaders`
- wire the SvelteKit quickstart into the JS server quickstart maps

/claim #8032

## Verification
- `git diff --check`
- `npx --yes prettier@3.3.3 --check highlight.io/components/QuickstartContent/QuickstartContent.tsx highlight.io/components/QuickstartContent/server/js/sveltekit.tsx docs-content/getting-started/4_server/2_js/sveltekit.md`