### PR TITLE
Add SvelteKit server instrumentation docs

### DIFF
--- a/docs-content/getting-started/4_server/2_js/1_overview.md
+++ b/docs-content/getting-started/4_server/2_js/1_overview.md
@@ -36,6 +36,9 @@ updatedAt: 2022-04-01T19:52:59.000Z
     <DocsCard title="Node.js" href="../js/nodejs">
         {"Get started with Node.js"}
     </DocsCard>
+    <DocsCard title="SvelteKit" href="../js/sveltekit">
+        {"Get started with SvelteKit server instrumentation"}
+    </DocsCard>
     <DocsCard title="Pino" href="../js/pino">
         {"Get started with Pino"}
     </DocsCard>

--- a/docs-content/getting-started/4_server/2_js/sveltekit.md
+++ b/docs-content/getting-started/4_server/2_js/sveltekit.md
@@ -1,0 +1,11 @@
+---
+title: SvelteKit
+heading: SvelteKit Server Quick Start
+metaTitle: SvelteKit Server Quick Start
+slug: sveltekit
+createdAt: 2026-05-12T00:00:00.000Z
+updatedAt: 2026-05-12T00:00:00.000Z
+quickstart: true
+---
+
+<QuickStart content={quickStartContent["server"]["js"]["svelte-kit"]}/>

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -110,6 +110,7 @@ import { JStRPCReorganizedContent } from './server/js/trpc'
 import { JSPinoHTTPJSONLogReorganizedContent } from './server/js/pino'
 import { JSWinstonHTTPJSONLogReorganizedContent } from './server/js/winston'
 import { JSManualTracesReorganizedContent } from './server/js/manual'
+import { JSSvelteKitReorganizedContent } from './server/js/sveltekit'
 import { PHPOtherReorganizedContent } from './server/php/other'
 import { PythonAWSReorganizedContext } from './server/python/aws'
 import { PythonAzureReorganizedContext } from './server/python/azure'
@@ -461,6 +462,7 @@ export const quickStartContent = {
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSManual]: JSManualTracesReorganizedContent,
 			[QuickStartType.JSNextjs]: NextJsTracesReorganizedContent,
+			[QuickStartType.SvelteKit]: JSSvelteKitReorganizedContent,
 		},
 		php: {
 			title: 'PHP',

--- a/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
@@ -1,0 +1,129 @@
+import { QuickStartContent } from '../../QuickstartContent'
+import { verifyLogs } from '../shared-snippets-logging'
+import { frontendInstallSnippet } from '../shared-snippets-monitoring'
+import { verifyTraces } from '../shared-snippets-tracing'
+import {
+	initializeNodeSDK,
+	jsGetSnippet,
+	verifyError,
+} from './shared-snippets-monitoring'
+
+export const JSSvelteKitReorganizedContent: QuickStartContent = {
+	title: 'SvelteKit',
+	subtitle:
+		'Learn how to set up highlight.io server instrumentation for your SvelteKit application.',
+	logoKey: 'sveltekit',
+	products: ['Errors', 'Logs', 'Traces'],
+	entries: [
+		frontendInstallSnippet,
+		jsGetSnippet(['node']),
+		initializeNodeSDK('node'),
+		{
+			title: 'Wrap SvelteKit server requests.',
+			content:
+				'Use the SvelteKit `handle` hook to run each server request inside `H.runWithHeaders`. Convert the SvelteKit `Headers` object into a plain object before passing it to the Node SDK.',
+			code: [
+				{
+					text: `// src/hooks.server.ts
+import { H } from '@highlight-run/node'
+import type { Handle } from '@sveltejs/kit'
+
+H.init({
+	projectID: '<YOUR_PROJECT_ID>',
+	serviceName: 'my-sveltekit-app',
+	environment: 'production',
+})
+
+const headersToObject = (headers: Headers) =>
+	Object.fromEntries(headers.entries())
+
+export const handle: Handle = async ({ event, resolve }) => {
+	return H.runWithHeaders(
+		headersToObject(event.request.headers),
+		async () => resolve(event),
+	)
+}`,
+					language: 'ts',
+				},
+			],
+		},
+		{
+			title: 'Report server-side errors.',
+			content:
+				'When handling errors in SvelteKit, parse the request headers so server errors can be linked back to the frontend session and request.',
+			code: [
+				{
+					text: `// src/hooks.server.ts
+import { H } from '@highlight-run/node'
+import type { HandleServerError } from '@sveltejs/kit'
+
+const headersToObject = (headers: Headers) =>
+	Object.fromEntries(headers.entries())
+
+export const handleError: HandleServerError = ({ error, event }) => {
+	const parsed = H.parseHeaders(headersToObject(event.request.headers))
+	const normalizedError =
+		error instanceof Error ? error : new Error(String(error))
+
+	H.consumeError(normalizedError, parsed.secureSessionId, parsed.requestId)
+
+	return {
+		message: 'An unexpected error occurred.',
+	}
+}`,
+					language: 'ts',
+				},
+			],
+		},
+		verifyError(
+			'SvelteKit',
+			`// src/routes/api/example/+server.ts
+export const GET = async () => {
+	throw new Error('example SvelteKit server error')
+}`,
+		),
+		{
+			title: 'Record server logs.',
+			content:
+				'Logs written with built-in console methods are automatically captured by the Highlight Node SDK. Pass structured metadata as the second argument when useful.',
+			code: [
+				{
+					text: `// src/routes/api/example/+server.ts
+export const GET = async () => {
+	console.info('SvelteKit endpoint called', {
+		route: '/api/example',
+	})
+
+	return new Response('ok')
+}`,
+					language: 'ts',
+				},
+			],
+		},
+		verifyLogs,
+		{
+			title: 'Create custom spans.',
+			content:
+				'After requests are wrapped with `H.runWithHeaders`, spans created with `H.startWithHeaders` are associated with the incoming request context.',
+			code: [
+				{
+					text: `// src/routes/api/work/+server.ts
+import { H } from '@highlight-run/node'
+
+export const GET = async () => {
+	const { span } = H.startWithHeaders('expensive-work', {})
+
+	try {
+		// Run the work you want to trace.
+		return new Response('done')
+	} finally {
+		span.end()
+	}
+}`,
+					language: 'ts',
+				},
+			],
+		},
+		verifyTraces,
+	],
+}


### PR DESCRIPTION
## Summary
- Add a SvelteKit server quickstart page under JavaScript server docs
- Register the SvelteKit server quickstart content in `quickStartContent["server"]["js"]`
- Document `hooks.server.ts` setup with `@highlight-run/node`, `H.runWithHeaders`, `H.parseHeaders`, server error reporting, logs, and custom spans
- Link SvelteKit from the JavaScript server overview

## Verification
- `npx --yes prettier@3.3.3 --check highlight.io/components/QuickstartContent/server/js/sveltekit.tsx highlight.io/components/QuickstartContent/QuickstartContent.tsx docs-content/getting-started/4_server/2_js/sveltekit.md docs-content/getting-started/4_server/2_js/1_overview.md`

## Notes
This is a docs-only PR. I used Codex/OpenAI assistance to draft and review the docs, and I manually checked the existing quickstart wiring and final diff before submitting.

/claim #8032