### PR TITLE
fix(rrweb): reduce Safari canvas snapshot defaults

### DIFF
--- a/sdk/highlight-run/src/client/index.tsx
+++ b/sdk/highlight-run/src/client/index.tsx
@@ -378,9 +378,15 @@ export class Highlight {
 		this.inlineImages = options.inlineImages ?? this._isOnLocalHost
 		this.inlineVideos = options.inlineVideos ?? this._isOnLocalHost
 		this.inlineStylesheet = options.inlineStylesheet ?? this._isOnLocalHost
+		const isSafari =
+			typeof navigator !== 'undefined' &&
+			/^((?!chrome|android).)*safari/i.test(navigator.userAgent)
+		const canvasDefaults = isSafari
+			? { canvasFactor: 0.25, canvasMaxSnapshotDimension: 180 }
+			: { canvasFactor: 0.5, canvasMaxSnapshotDimension: 360 }
+
 		this.samplingStrategy = {
-			canvasFactor: 0.5,
-			canvasMaxSnapshotDimension: 360,
+			...canvasDefaults,
 			canvasClearWebGLBuffer: true,
 			dataUrlOptions: getDefaultDataURLOptions(),
 			...(options.samplingStrategy ?? {


### PR DESCRIPTION
/claim #6775

## Summary

Reduces default canvas snapshot overhead on Safari by lowering the canvas resize factor and max snapshot dimension only when Safari is detected.

## Why

Safari 16/17 has significantly slower canvas snapshotting than Chromium. The existing defaults (`canvasFactor: 0.5`, `canvasMaxSnapshotDimension: 360`) are safe for Chrome, but can still be expensive on Safari for retina canvases. This change applies conservative Safari-only defaults while keeping Chrome and user overrides unchanged.

## Changes

- Detect Safari via `navigator.userAgent`
- Use Safari-specific canvas defaults:
  - `canvasFactor: 0.25`
  - `canvasMaxSnapshotDimension: 180`
- Preserve existing defaults for non-Safari browsers
- Preserve any user-supplied `samplingStrategy` override

Closes #6775
