### PR TITLE
feat(integrations): refresh integrations page design

### DIFF
--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
@@ -1,9 +1,39 @@
+.pageHeader {
+	align-items: flex-start;
+	display: flex;
+	gap: var(--size-large);
+	justify-content: space-between;
+	margin-bottom: var(--size-large);
+}
+
+.integrationCount {
+	background: var(--color-neutral-100);
+	border: 1px solid var(--color-neutral-200);
+	border-radius: var(--size-small);
+	color: var(--color-neutral-500);
+	font-size: 13px;
+	font-weight: 500;
+	padding: 6px 10px;
+	white-space: nowrap;
+}
+
 .integrationsContainer {
 	display: grid;
-	grid-gap: var(--size-large);
-	grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+	gap: var(--size-large);
+	grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
 }
+
 .modalBtn {
 	padding-bottom: 4px !important;
 	padding-top: 4px !important;
+}
+
+@media (max-width: 768px) {
+	.pageHeader {
+		flex-direction: column;
+	}
+
+	.integrationCount {
+		width: fit-content;
+	}
 }

--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
@@ -187,11 +187,18 @@ const IntegrationsPage = () => {
 				<title>Integrations</title>
 			</Helmet>
 			<LeadAlignLayout>
-				<h2>Integrations</h2>
-				<p className={layoutStyles.subTitle}>
-					Supercharge your workflows and attach Highlight with the
-					tools you use everyday.
-				</p>
+				<div className={styles.pageHeader}>
+					<div>
+						<h2>Integrations</h2>
+						<p className={layoutStyles.subTitle}>
+							Supercharge your workflows and attach Highlight with the
+							tools you use everyday.
+						</p>
+					</div>
+					<div className={styles.integrationCount}>
+						{integrations.length} integrations
+					</div>
+				</div>
 				<div className={styles.integrationsContainer}>
 					{integrations.map((integration) => (
 						<Integration

--- a/frontend/src/pages/IntegrationsPage/components/Integration.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.module.css
@@ -1,15 +1,31 @@
 .integration {
+	height: 100%;
+	transition:
+		border-color 120ms ease,
+		box-shadow 120ms ease,
+		transform 120ms ease;
+
+	&:hover {
+		box-shadow: 0 6px 18px rgb(0 0 0 / 8%);
+		transform: translateY(-1px);
+	}
+
 	& .logo {
+		background: var(--color-neutral-100);
+		border: 1px solid var(--color-neutral-200);
 		border-radius: 50%;
-		height: var(--size-xxLarge);
-		width: var(--size-xxLarge);
+		height: 44px;
+		object-fit: contain;
+		padding: 6px;
+		width: 44px;
 	}
 
 	& .header {
 		align-items: flex-start;
 		display: flex;
+		gap: var(--size-medium);
 		justify-content: space-between;
-		padding-bottom: var(--size-small);
+		padding-bottom: var(--size-medium);
 	}
 
 	& .connectButton {
@@ -17,10 +33,14 @@
 	}
 
 	& .title {
+		font-size: 16px !important;
+		font-weight: 600 !important;
 		margin-bottom: var(--size-small) !important;
 	}
 
 	& .description {
+		color: var(--color-neutral-500) !important;
+		line-height: 1.45;
 		margin-bottom: 0 !important;
 	}
 }


### PR DESCRIPTION
/claim #8614

## Summary

Refreshes the integrations page design with a cleaner header and more polished integration cards.

## Changes

- Adds a page header wrapper with an integration count badge
- Updates the integrations grid to use `auto-fill` with wider cards for better balance
- Improves mobile layout for the header
- Updates integration cards with:
  - equal-height cards
  - subtle hover elevation
  - larger, padded logo container
  - improved spacing and typography
  - muted description text

Closes #8614
