### PR TITLE
Document SvelteKit backend instrumentation

### DIFF
--- a/.changeset/spotty-parents-tan.md
+++ b/.changeset/spotty-parents-tan.md
@@ -1,0 +1,6 @@
+---
+"docs-content": patch
+"highlight.io": patch
+---
+
+Document SvelteKit backend instrumentation.

--- a/.changeset/tough-steaks-lay.md
+++ b/.changeset/tough-steaks-lay.md
@@ -1,0 +1,6 @@
+---
+"docs-content": patch
+"highlight.io": patch
+---
+
+Document SvelteKit backend instrumentation

--- a/.changeset/tough-steaks-lay.md
+++ b/.changeset/tough-steaks-lay.md
@@ -1,6 +1,0 @@
----
-"docs-content": patch
-"highlight.io": patch
----
-
-Document SvelteKit backend instrumentation

--- a/docs-content/getting-started/4_server/2_js/1_overview.md
+++ b/docs-content/getting-started/4_server/2_js/1_overview.md
@@ -36,6 +36,9 @@ updatedAt: 2022-04-01T19:52:59.000Z
     <DocsCard title="Node.js" href="../js/nodejs">
         {"Get started with Node.js"}
     </DocsCard>
+    <DocsCard title="SvelteKit" href="../js/sveltekit">
+        {"Get started with SvelteKit server hooks"}
+    </DocsCard>
     <DocsCard title="Pino" href="../js/pino">
         {"Get started with Pino"}
     </DocsCard>

--- a/docs-content/getting-started/4_server/2_js/sveltekit.md
+++ b/docs-content/getting-started/4_server/2_js/sveltekit.md
@@ -1,0 +1,8 @@
+---
+toc: SvelteKit
+title: SvelteKit Quick Start
+slug: sveltekit
+quickstart: true
+---
+
+<QuickStart content={quickStartContent["server"]["js"]["svelte-kit"]}/>

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -12,6 +12,7 @@ import { JSExpressContent } from './backend/js/express'
 import { JSFirebaseContent } from './backend/js/firebase'
 import { JSNestContent } from './backend/js/nestjs'
 import { JSNodeContent } from './backend/js/nodejs'
+import { JSSvelteKitContent } from './backend/js/sveltekit'
 import { JStRPCContent } from './backend/js/trpc'
 import { OTLPErrorMonitoringContent } from './backend/otlp'
 import { PHPOtherContent } from './backend/php/other'
@@ -273,6 +274,7 @@ export const quickStartContent = {
 			[QuickStartType.JSHono]: JSHonoContent,
 			[QuickStartType.JSNodejs]: JSNodeContent,
 			[QuickStartType.JSNestjs]: JSNestContent,
+			[QuickStartType.SvelteKit]: JSSvelteKitContent,
 			[QuickStartType.JStRPC]: JStRPCContent,
 		},
 		ruby: {
@@ -456,6 +458,7 @@ export const quickStartContent = {
 			[QuickStartType.JSHono]: JSHonoReorganizedContent,
 			[QuickStartType.JSNodejs]: JSNodeReorganizedContent,
 			[QuickStartType.JSNestjs]: JSNestReorganizedContent,
+			[QuickStartType.SvelteKit]: JSSvelteKitContent,
 			[QuickStartType.JStRPC]: JStRPCReorganizedContent,
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,

--- a/highlight.io/components/QuickstartContent/backend/js/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/backend/js/sveltekit.tsx
@@ -1,0 +1,58 @@
+import { QuickStartContent } from '../../QuickstartContent'
+import { frontendInstallSnippet } from '../shared-snippets'
+import { initializeNodeSDK, jsGetSnippet, verifyError } from './shared-snippets'
+
+const svelteKitServerHookSnippet = `// src/hooks.server.ts
+import { H } from '@highlight-run/node'
+import type { Handle, HandleServerError } from '@sveltejs/kit'
+
+H.init({
+	projectID: '<YOUR_PROJECT_ID>',
+	serviceName: 'sveltekit-backend',
+	environment: 'production',
+})
+
+export const handle: Handle = async ({ event, resolve }) => {
+	return H.runWithHeaders(
+		'sveltekit.server',
+		event.request.headers,
+		() => resolve(event),
+	)
+}
+
+export const handleError: HandleServerError = ({ error, event }) => {
+	const parsed = H.parseHeaders(event.request.headers)
+	const errorObject =
+		error instanceof Error ? error : new Error(String(error))
+
+	H.consumeError(errorObject, parsed.secureSessionId, parsed.requestId)
+}`
+
+export const JSSvelteKitContent: QuickStartContent = {
+	title: 'SvelteKit',
+	subtitle: 'Learn how to set up highlight.io in your SvelteKit backend.',
+	logoKey: 'sveltekit',
+	products: ['Errors', 'Logs', 'Traces'],
+	entries: [
+		frontendInstallSnippet,
+		jsGetSnippet(['node']),
+		initializeNodeSDK('node'),
+		{
+			title: 'Add Highlight to your SvelteKit server hooks.',
+			content:
+				'Initialize the Node.js SDK in `hooks.server.ts`, wrap SvelteKit requests with `H.runWithHeaders`, and report unexpected server errors from `handleError`. This keeps backend errors and traces linked to the frontend session through the `x-highlight-request` header.',
+			code: [
+				{
+					text: svelteKitServerHookSnippet,
+					language: 'ts',
+				},
+			],
+		},
+		{
+			title: 'Keep frontend-to-backend mapping enabled.',
+			content:
+				'Make sure your SvelteKit frontend Highlight setup includes `tracingOrigins: true` or an explicit origin list for your server routes. That allows Highlight to attach the request header that `H.runWithHeaders` reads on the backend.',
+		},
+		verifyError('SvelteKit', svelteKitServerHookSnippet),
+	],
+}


### PR DESCRIPTION
## Summary
- Improves the SvelteKit backend instrumentation docs requested in #8032.
- Adds a focused server-side quickstart for wiring Highlight into SvelteKit server hooks.

## How did you test this change?
- `git diff --check`
- Result: passed
- `node .yarn/releases/yarn-4.6.0.cjs dlx prettier@3.3.3 --check docs-content/getting-started/4_server/2_js/1_overview.md docs-content/getting-started/4_server/2_js/sveltekit.md highlight.io/components/QuickstartContent/QuickstartContent.tsx highlight.io/components/QuickstartContent/backend/js/sveltekit.tsx`
- Result: passed
- Full docs build not run because this checkout does not have node_modules installed.

## Are there any deployment considerations?
No authentication, payment, database, deployment, or security-sensitive configuration changes were made. No secrets, credentials, production data, or security-sensitive information were accessed.

## Does this work require review from our design team?
No.

## Algora
/claim #8032