### PR TITLE
docs(sveltekit): add backend instrumentation in hooks.server.ts

### DIFF
--- a/.changeset/gold-terms-whisper.md
+++ b/.changeset/gold-terms-whisper.md
@@ -1,0 +1,5 @@
+---
+'highlight.io': patch
+---
+
+docs(sveltekit): add backend instrumentation in hooks.server.ts

--- a/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
@@ -1,9 +1,9 @@
 import {
+	backendInstrumentationLink,
 	configureSourcemapsCI,
 	identifySnippet,
 	initializeSnippet,
 	packageInstallSnippet,
-	setupBackendSnippet,
 	verifySnippet,
 } from './shared-snippets'
 
@@ -32,14 +32,34 @@ H.init('<YOUR_PROJECT_ID>', {
 ...
 `
 
+const svelteKitBackendCodeSnippet = `// hooks.server.ts
+import type { Handle, HandleServerError } from '@sveltejs/kit'
+import { H } from '@highlight-run/node'
+
+H.init('<YOUR_PROJECT_ID>', {
+	serviceName: 'sveltekit-backend',
+	environment: 'production',
+})
+
+export const handle: Handle = async ({ event, resolve }) => {
+	return H.runWithHeaders('sveltekit-request', event.request.headers, async () => {
+		return resolve(event)
+	})
+}
+
+export const handleError: HandleServerError = ({ error }) => {
+	H.consumeError(error)
+}
+`
+
 export const SvelteKitContent: QuickStartContent = {
 	title: 'SvelteKit',
 	subtitle:
 		'Learn how to set up highlight.io with your SvelteKit application.',
 	logoKey: 'sveltekit',
 	products: ['Sessions', 'Errors', 'Logs', 'Traces'],
-	entries: [
-		packageInstallSnippet,
+		entries: [
+			packageInstallSnippet,
 		{
 			...initializeSnippet,
 			content:
@@ -76,9 +96,21 @@ export default config;`,
 				},
 			],
 		},
-		identifySnippet,
-		verifySnippet,
-		configureSourcemapsCI(),
-		setupBackendSnippet,
-	],
+			identifySnippet,
+			verifySnippet,
+			configureSourcemapsCI(),
+			{
+				title: 'Instrument SvelteKit backend requests.',
+				content:
+					'Start a Node SDK context in `hooks.server.ts` so server errors, logs, and traces are mapped to frontend sessions. See the full [backend instrumentation guide](' +
+					backendInstrumentationLink +
+					') for advanced server setup options.',
+				code: [
+					{
+						language: 'ts',
+						text: svelteKitBackendCodeSnippet,
+					},
+				],
+			},
+		],
 }


### PR DESCRIPTION
/claim #8032

This PR adds concrete backend instrumentation guidance for the SvelteKit quickstart.

## What changed
- Updated `highlight.io/components/QuickstartContent/frontend/sveltekit.tsx`
- Replaced the generic backend step with a SvelteKit-specific `hooks.server.ts` example using `@highlight-run/node`
- Added guidance for:
  - `H.init(...)` on the server
  - `H.runWithHeaders(...)` inside `handle`
  - `H.consumeError(...)` inside `handleError`
- Kept frontend setup and sourcemap flow unchanged

## Why
The previous SvelteKit quickstart ended with a generic backend pointer. This makes backend instrumentation explicit and copy/paste-ready for SvelteKit users so frontend sessions can be mapped to backend traces/errors.

## Validation
- Docs-only change.
- Confirmed quickstart structure remains intact and all existing SvelteKit steps are preserved.

## Demo
I cannot record a desktop video from this headless environment, but this is a docs-only PR with a concrete server snippet and no runtime code-path changes.
