### PR TITLE
fix(highlight-node): safeStringify must not mutate the caller's object

### DIFF
--- a/sdk/highlight-node/src/hooks.test.ts
+++ b/sdk/highlight-node/src/hooks.test.ts
@@ -22,4 +22,22 @@ describe('safeStringify', () => {
 			hello: 'world',
 		})
 	})
+
+	it('does not mutate the original object', () => {
+		const original = BigInt(42)
+		const obj = { value: original, nested: { count: BigInt(7) } }
+		safeStringify(obj)
+		expect(obj.value).toBe(original)
+		expect(typeof obj.value).toBe('bigint')
+		expect(obj.nested.count).toBe(BigInt(7))
+		expect(typeof obj.nested.count).toBe('bigint')
+	})
+
+	it('does not mutate arrays in the original object', () => {
+		const arr = [BigInt(1), BigInt(2)]
+		const obj = { items: arr }
+		safeStringify(obj)
+		expect(typeof obj.items[0]).toBe('bigint')
+		expect(typeof obj.items[1]).toBe('bigint')
+	})
 })

--- a/sdk/highlight-node/src/hooks.ts
+++ b/sdk/highlight-node/src/hooks.ts
@@ -46,22 +46,6 @@ type ConsoleFn = (...data: any) => void
 let consoleHooked = false
 
 export function safeStringify(obj: any): string {
-	function replacer(input: any, depth?: number): any {
-		if ((depth ?? 0) > MAX_RECURSION) {
-			throw new Error('max recursion exceeded')
-		}
-		if (input && typeof input === 'object') {
-			for (let k in input) {
-				if (typeof input[k] === 'object') {
-					replacer(input[k], (depth ?? 0) + 1)
-				} else if (!canStringify(input[k])) {
-					input[k] = input[k].toString()
-				}
-			}
-		}
-		return input
-	}
-
 	function canStringify(value: any): boolean {
 		try {
 			JSON.stringify(value)
@@ -71,10 +55,31 @@ export function safeStringify(obj: any): string {
 		}
 	}
 
+	function replacer(input: any, depth?: number): any {
+		if ((depth ?? 0) > MAX_RECURSION) {
+			throw new Error('max recursion exceeded')
+		}
+		if (Array.isArray(input)) {
+			return input.map((item) => replacer(item, (depth ?? 0) + 1))
+		}
+		if (input && typeof input === 'object') {
+			const result: { [key: string]: any } = {}
+			for (let k in input) {
+				result[k] = replacer(input[k], (depth ?? 0) + 1)
+			}
+			return result
+		}
+		// primitive: convert to string if not JSON-serialisable (e.g. BigInt, Symbol)
+		if (!canStringify(input)) {
+			return String(input)
+		}
+		return input
+	}
+
 	try {
 		return JSON.stringify(replacer(obj))
 	} catch (e) {
-		return obj.toString()
+		return String(obj)
 	}
 }
 


### PR DESCRIPTION
## Problem

`safeStringify` in `sdk/highlight-node/src/hooks.ts` modifies the caller's object in-place. When `hookConsole` intercepts a `console.log()` call with `serializeConsoleAttributes: true`, any BigInt or Symbol values in the logged object are silently converted to strings on the **original object** — a surprising side effect for users.

Example:
```ts
const req = { id: BigInt(42) }
console.log('request', req)
// After the log call, typeof req.id === 'string'  ← bug
```

A secondary issue: non-serialisable primitives (BigInt, Symbol) inside **arrays** were passed through `replacer` unchanged and later caused `JSON.stringify` to throw, falling back to `obj.toString()` (i.e. `"[object Object]"`).

## Fix

- `replacer` now builds a **fresh** plain object / array at every level instead of modifying `input` in-place.
- Primitive handling is unified: any non-JSON-serialisable scalar (BigInt, Symbol) is converted with `String()` in one place, covering both object properties and array elements.
- `obj.toString()` fallback replaced with `String(obj)` to avoid throwing on null/undefined.

## Tests

Two regression tests added to `hooks.test.ts`:
- `does not mutate the original object` — verifies BigInt properties stay BigInt after `safeStringify`.
- `does not mutate arrays in the original object` — same check for array elements.

The existing BigInt/Symbol round-trip test continues to pass.