### PR TITLE
docs: document SvelteKit server instrumentation

### DIFF
--- a/docs-content/general/6_product-features/99_frequently-asked-questions.md
+++ b/docs-content/general/6_product-features/99_frequently-asked-questions.md
@@ -30,7 +30,7 @@ This documentation provides solutions and guidance for common issues encountered
 
 **Question:** How can I set up tracing with SvelteKit as I am not seeing any traces despite having logs and errors?
 
-**Answer:** Ensure that your `H.init` configuration is correctly set up in both `hooks.client.ts` and `hooks.server.ts`. Use `H.runWithHeaders` in your server-side handle function to ensure that headers are correctly passed and handled. If issues persist, please provide the Highlight traces page URL and check the version of the `@highlight-run/node` SDK you are using. For detailed guidance, refer to the [Highlight.io SvelteKit Documentation](https://www.highlight.io/docs/getting-started/client-sdk/sveltekit).
+**Answer:** Make sure Highlight is set up in both `src/hooks.client.ts` and `src/hooks.server.ts`. On the server side, wrap your request handler with `H.runWithHeaders(...)` so Highlight can carry the session context into traces and errors. If you still are not seeing traces, confirm that the browser SDK has `tracingOrigins` and `networkRecording.enabled` turned on. For a full example, see the [SvelteKit walkthrough](https://www.highlight.io/docs/getting-started/fullstack-frameworks/sveltekit).
 
 ## Session Recording Issues
 

--- a/docs-content/getting-started/fullstack-frameworks/sveltekit.md
+++ b/docs-content/getting-started/fullstack-frameworks/sveltekit.md
@@ -1,0 +1,190 @@
+---
+title: SvelteKit Walkthrough
+slug: sveltekit
+heading: SvelteKit Walkthrough
+createdAt: 2026-05-12T00:00:00.000Z
+updatedAt: 2026-05-12T00:00:00.000Z
+---
+
+## Overview
+
+Highlight works well with SvelteKit once both halves are wired up:
+
+1. `highlight.run` in `src/hooks.client.ts` for session replay and browser errors
+2. `@highlight-run/node` in `src/hooks.server.ts` for server errors, logs, and traces
+
+If you already have auth, redirects, or other request logic in `hooks.server.ts`, keep it there. You are just wrapping the request lifecycle with Highlight, not replacing it.
+
+## Install
+
+```bash
+# with yarn
+yarn add highlight.run @highlight-run/node
+
+# with npm
+npm install highlight.run @highlight-run/node
+
+# with pnpm
+pnpm add highlight.run @highlight-run/node
+```
+
+## Client instrumentation
+
+Start in `src/hooks.client.ts`:
+
+```ts
+// src/hooks.client.ts
+import { H } from 'highlight.run'
+
+H.init('<YOUR_PROJECT_ID>', {
+	environment: 'production',
+	version: 'commit:abcdefg12345',
+	tracingOrigins: true,
+	networkRecording: {
+		enabled: true,
+		recordHeadersAndBody: true,
+		urlBlocklist: [
+			'https://www.googleapis.com/identitytoolkit',
+			'https://securetoken.googleapis.com',
+		],
+	},
+})
+```
+
+`tracingOrigins` and `networkRecording` matter here because they let Highlight attach the `x-highlight-request` header. That is what ties a browser session to the work your SvelteKit server does for that request.
+
+If you want a longer explanation of that flow, see [Fullstack Mapping](../2_frontend-backend-mapping.md).
+
+## Server instrumentation
+
+If your app runs on a server adapter, add Highlight to `src/hooks.server.ts`.
+
+```ts
+// src/hooks.server.ts
+import { H, type NodeOptions } from '@highlight-run/node'
+import type { Handle, HandleServerError } from '@sveltejs/kit'
+
+const highlightConfig: NodeOptions = {
+	projectID: '<YOUR_PROJECT_ID>',
+	serviceName: 'my-sveltekit-backend',
+	environment: 'production',
+}
+
+if (!H.isInitialized()) {
+	H.init(highlightConfig)
+}
+
+export const handle: Handle = async ({ event, resolve }) => {
+	return H.runWithHeaders(
+		`${event.request.method} ${event.url.pathname}`,
+		event.request.headers,
+		() => resolve(event),
+		{
+			attributes: {
+				route: event.route.id ?? event.url.pathname,
+			},
+		},
+	)
+}
+
+export const handleError: HandleServerError = async ({
+	error,
+	event,
+	status,
+	message,
+}) => {
+	const { secureSessionId, requestId } = H.parseHeaders(event.request.headers)
+	const reportedError =
+		error instanceof Error ? error : new Error(message)
+
+	H.consumeError(reportedError, secureSessionId, requestId, {
+		route: event.route.id ?? event.url.pathname,
+		status,
+	})
+}
+```
+
+This does two useful things:
+
+1. Every server request gets a parent span through `H.runWithHeaders(...)`
+2. Unexpected server errors still show up in Highlight with the same session and request IDs
+
+If you already export `handle`, just wrap your existing `resolve(event)` call the same way. If you already export `handleError`, keep your current logic and add `H.consumeError(...)` inside it.
+
+If your site is fully prerendered with `adapter-static`, there is no long-running server process to instrument, so this section does not apply.
+
+## CSS paths in SvelteKit
+
+SvelteKit can emit relative stylesheet URLs, which can get in the way of Highlight fetching stylesheets for replay. If you see missing styling in recordings, set `kit.paths.relative = false` in `svelte.config.js`.
+
+```js
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	kit: {
+		paths: {
+			relative: false,
+		},
+	},
+}
+
+export default config
+```
+
+## Identify users
+
+If your app has login or signup flows, identify the signed-in user after auth finishes:
+
+```ts
+import { H } from 'highlight.run'
+
+H.identify('jay@highlight.io', {
+	id: 'very-secure-id',
+	plan: 'pro',
+})
+```
+
+That makes session search much more useful when you are trying to connect a backend failure to one specific customer.
+
+## Verifying installation
+
+1. Open your app and confirm a new session shows up in [Highlight Sessions](https://app.highlight.io/sessions)
+2. Trigger a server-side exception and confirm it appears in [Highlight Errors](https://app.highlight.io/errors)
+3. Visit the [Traces page](https://app.highlight.io/traces) and look for the `serviceName` you used in `hooks.server.ts`
+
+If you only see browser sessions but no traces, the usual culprit is that `src/hooks.server.ts` was never added, or your app is deployed with a static adapter.
+
+## Sourcemaps
+
+Readable stack traces are much nicer than minified ones. If you upload sourcemaps in CI, Highlight can show the original source in browser error stacks.
+
+See the [sourcemap docs](../3_browser/7_replay-configuration/sourcemaps.md) for the full setup.
+
+## Troubleshooting
+
+### I see sessions, but not server traces
+
+Check that your app is actually using a server adapter, and make sure `H.runWithHeaders(...)` wraps the request in `src/hooks.server.ts`.
+
+### I already have auth logic in `handle`
+
+That is fine. Keep your existing logic. Just wrap the part that calls `resolve(event)`:
+
+```ts
+export const handle: Handle = async ({ event, resolve }) => {
+	// your existing auth or locals logic here
+
+	return H.runWithHeaders(
+		`${event.request.method} ${event.url.pathname}`,
+		event.request.headers,
+		() => resolve(event),
+	)
+}
+```
+
+### My server errors still are not linked to the session
+
+Double-check that the browser SDK has both `tracingOrigins` and `networkRecording.enabled` turned on. Without those, the request header that ties frontend and backend together will never be sent.
+
+### I only want to capture server errors
+
+You can do that, but most teams get the most value when they keep both the browser SDK and the server SDK on. The whole point is seeing the failing request together with the replay that led up to it.

--- a/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
@@ -2,14 +2,15 @@ import {
 	configureSourcemapsCI,
 	identifySnippet,
 	initializeSnippet,
-	packageInstallSnippet,
-	setupBackendSnippet,
 	verifySnippet,
 } from './shared-snippets'
 
+import { siteUrl } from '../../../utils/urls'
 import { QuickStartContent } from '../QuickstartContent'
 
-const svelteKitInitCodeSnippet = `// hooks.client.ts
+const GUIDE_URL = siteUrl('/docs/getting-started/fullstack-frameworks/sveltekit')
+
+const svelteKitInitCodeSnippet = `// src/hooks.client.ts
 ...
 
 import { H } from 'highlight.run';
@@ -32,6 +33,50 @@ H.init('<YOUR_PROJECT_ID>', {
 ...
 `
 
+const svelteKitServerCodeSnippet = `// src/hooks.server.ts
+import { H, type NodeOptions } from '@highlight-run/node'
+import type { Handle, HandleServerError } from '@sveltejs/kit'
+
+const highlightConfig: NodeOptions = {
+\tprojectID: '<YOUR_PROJECT_ID>',
+\tserviceName: 'my-sveltekit-backend',
+\tenvironment: 'production',
+}
+
+if (!H.isInitialized()) {
+\tH.init(highlightConfig)
+}
+
+export const handle: Handle = async ({ event, resolve }) => {
+\treturn H.runWithHeaders(
+\t\t\`\${event.request.method} \${event.url.pathname}\`,
+\t\tevent.request.headers,
+\t\t() => resolve(event),
+\t\t{
+\t\t\tattributes: {
+\t\t\t\troute: event.route.id ?? event.url.pathname,
+\t\t\t},
+\t\t},
+\t)
+}
+
+export const handleError: HandleServerError = async ({
+\terror,
+\tevent,
+\tstatus,
+\tmessage,
+}) => {
+\tconst { secureSessionId, requestId } = H.parseHeaders(event.request.headers)
+\tconst reportedError =
+\t\terror instanceof Error ? error : new Error(message)
+
+\tH.consumeError(reportedError, secureSessionId, requestId, {
+\t\troute: event.route.id ?? event.url.pathname,
+\t\tstatus,
+\t})
+}
+`
+
 export const SvelteKitContent: QuickStartContent = {
 	title: 'SvelteKit',
 	subtitle:
@@ -39,17 +84,49 @@ export const SvelteKitContent: QuickStartContent = {
 	logoKey: 'sveltekit',
 	products: ['Sessions', 'Errors', 'Logs', 'Traces'],
 	entries: [
-		packageInstallSnippet,
+		{
+			title: 'Install the client and server SDKs.',
+			content:
+				'Install `highlight.run` for the browser side of your app, plus `@highlight-run/node` for the SvelteKit server runtime.',
+			code: [
+				{
+					key: 'npm',
+					text: `npm install highlight.run @highlight-run/node`,
+					language: 'bash',
+				},
+				{
+					key: 'yarn',
+					text: `yarn add highlight.run @highlight-run/node`,
+					language: 'bash',
+				},
+				{
+					key: 'pnpm',
+					text: `pnpm add highlight.run @highlight-run/node`,
+					language: 'bash',
+				},
+			],
+		},
 		{
 			...initializeSnippet,
 			content:
-				'In SvelteKit, we recommend initializing highlight.io in the `hooks.client.js` or `hooks.client.ts` file. You can find more details about this file in the SvelteKit docs [here](https://kit.svelte.dev/docs/hooks). To get started, we recommend setting `tracingOrigins` and `networkRecording` so that we can pass a header to pair frontend and backend errors. \n\n\n' +
+				'In SvelteKit, we recommend initializing highlight.io in `src/hooks.client.js` or `src/hooks.client.ts`. You can find more details about this file in the SvelteKit docs [here](https://kit.svelte.dev/docs/hooks). To get started, we recommend setting `tracingOrigins` and `networkRecording` so that we can pass a header to pair frontend and backend errors. \n\n\n' +
 				`Grab your project ID from [app.highlight.io/setup](https://app.highlight.io/setup), and pass it as the first parameter of the \`H.init()\` method.`,
 			code: [
 				{
-					...initializeSnippet.code,
+					...(initializeSnippet.code?.[0] ?? {}),
 					text: svelteKitInitCodeSnippet,
 					language: initializeSnippet.code?.[0]?.language ?? 'js',
+				},
+			],
+		},
+		{
+			title: 'Instrument the SvelteKit server.',
+			content:
+				'If your app has a real server runtime, add Highlight to `src/hooks.server.ts` so each request carries the frontend session context into server logs, errors, and traces. If you are fully static with `adapter-static`, you can skip this step.',
+			code: [
+				{
+					language: 'ts',
+					text: svelteKitServerCodeSnippet,
 				},
 			],
 		},
@@ -79,6 +156,9 @@ export default config;`,
 		identifySnippet,
 		verifySnippet,
 		configureSourcemapsCI(),
-		setupBackendSnippet,
+		{
+			title: 'More SvelteKit setup details?',
+			content: `See our [full SvelteKit guide](${GUIDE_URL}) for a longer walkthrough, troubleshooting tips, and a few notes on how to fit Highlight into an existing \`hooks.server.ts\` file.`,
+		},
 	],
 }


### PR DESCRIPTION
Adds SvelteKit server-side instrumentation docs.

The current SvelteKit quickstart only covers the client setup, so this adds an example for wiring `@highlight-run/node` into `src/hooks.server.ts` with `H.runWithHeaders` and `handleError`.

Also adds a longer walkthrough with troubleshooting notes for static adapters, existing `handle` hooks, and missing trace context.
