### PR TITLE
Refine integrations page cards

### DIFF
--- a/.changeset/forty-masks-talk.md
+++ b/.changeset/forty-masks-talk.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+Refine integrations page cards

--- a/.changeset/forty-masks-talk.md
+++ b/.changeset/forty-masks-talk.md
@@ -1,5 +1,0 @@
----
-"@highlight-run/frontend": patch
----
-
-Refine integrations page cards

--- a/.changeset/six-badgers-kneel.md
+++ b/.changeset/six-badgers-kneel.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+Refine integrations page cards.

--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
@@ -1,7 +1,7 @@
 .integrationsContainer {
 	display: grid;
-	grid-gap: var(--size-large);
-	grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+	gap: var(--size-large);
+	grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
 }
 .modalBtn {
 	padding-bottom: 4px !important;

--- a/frontend/src/pages/IntegrationsPage/components/Integration.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.module.css
@@ -1,26 +1,62 @@
 .integration {
+	display: flex;
+	flex-direction: column;
+	gap: var(--size-medium);
+	height: 100%;
+
 	& .logo {
+		background: var(--color-gray-100);
 		border-radius: 50%;
+		border: 1px solid var(--color-gray-300);
+		flex: 0 0 var(--size-xxLarge);
 		height: var(--size-xxLarge);
+		object-fit: contain;
+		padding: var(--size-xxSmall);
 		width: var(--size-xxLarge);
 	}
 
 	& .header {
 		align-items: flex-start;
 		display: flex;
+		gap: var(--size-medium);
 		justify-content: space-between;
-		padding-bottom: var(--size-small);
 	}
 
 	& .connectButton {
 		text-transform: uppercase;
 	}
 
+	& .actions {
+		align-items: center;
+		display: flex;
+		flex-shrink: 0;
+		gap: var(--size-small);
+	}
+
+	& .settingsButton {
+		flex-shrink: 0;
+	}
+
+	& .content {
+		display: flex;
+		flex: 1;
+		flex-direction: column;
+		gap: var(--size-xSmall);
+	}
+
 	& .title {
-		margin-bottom: var(--size-small) !important;
+		margin: 0 !important;
 	}
 
 	& .description {
+		line-height: 1.5;
 		margin-bottom: 0 !important;
+	}
+
+	& .docsLink {
+		color: var(--color-purple);
+		font-weight: 500;
+		line-height: 1.5;
+		margin-top: auto;
 	}
 }

--- a/frontend/src/pages/IntegrationsPage/components/Integration.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.tsx
@@ -75,7 +75,7 @@ const Integration = ({
 
 	return (
 		<>
-			<Card className={styles.integration} interactable>
+			<Card className={styles.integration} interactable full>
 				<div className={styles.header}>
 					<img
 						src={icon}
@@ -84,7 +84,7 @@ const Integration = ({
 							['rounded-none']: noRoundedIcon,
 						})}
 					/>
-					<div className="flex flex-col gap-2">
+					<div className={styles.actions}>
 						{isGated ? (
 							<EnterpriseFeatureButton
 								setting={enterpriseSetting}
@@ -144,27 +144,26 @@ const Integration = ({
 							/>
 						)}
 						{hasSettings && (
-							<div className="flex h-[18px] w-full justify-end">
-								<Button
-									trackingId="IntegrationSettings"
-									iconButton
-									onClick={() => {
-										setShowUpdateSettings(true)
-									}}
-									disabled={!integrationEnabled}
-								>
-									<SettingsIcon />
-								</Button>
-							</div>
+							<Button
+								trackingId="IntegrationSettings"
+								iconButton
+								className={styles.settingsButton}
+								onClick={() => {
+									setShowUpdateSettings(true)
+								}}
+								disabled={!integrationEnabled}
+							>
+								<SettingsIcon />
+							</Button>
 						)}
 					</div>
 				</div>
-				<div>
-					<h2 className={styles.title}>{name}</h2>
+				<div className={styles.content}>
+					<h3 className={styles.title}>{name}</h3>
 					<p className={styles.description}>{description}</p>
 					{docs && (
 						<a
-							className={styles.description}
+							className={styles.docsLink}
 							href={docs}
 							target="_blank"
 							rel="noopener noreferrer"


### PR DESCRIPTION
## Summary
- Improves the integrations page card layout described in #8614.
- Keeps the change focused on card spacing, alignment, and link presentation.

## Changes
- Uses a slightly wider responsive grid so integration cards have less cramped content.
- Makes each integration card fill its grid row and align logos, toggles, and settings actions consistently.
- Separates the docs link styling from body description text and keeps it anchored to the bottom of each card.

## Testing
- `node .yarn/releases/yarn-4.6.0.cjs prettier --check frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css frontend/src/pages/IntegrationsPage/components/Integration.tsx frontend/src/pages/IntegrationsPage/components/Integration.module.css`
- Result: passed
- `node_modules/.bin/eslint.cmd frontend/src/pages/IntegrationsPage/components/Integration.tsx`
- Result: passed
- `git diff --check`
- Result: passed
- `node .yarn/releases/yarn-4.6.0.cjs workspace @highlight-run/frontend lint`
- Result: failed due existing repo-wide CRLF Prettier diagnostics in unrelated files
- `node .yarn/releases/yarn-4.6.0.cjs workspace @highlight-run/frontend types:check`
- Result: failed due existing workspace UI package/module resolution errors unrelated to this focused change

## Notes
- No authentication, payment, database, deployment, or security-sensitive configuration changes were made.
- No secrets, credentials, production data, or security-sensitive information were accessed.

## Algora
/claim #8614