### PR TITLE
Reduce Safari canvas snapshot defaults

### DIFF
--- a/.changeset/quiet-lamps-dance.md
+++ b/.changeset/quiet-lamps-dance.md
@@ -1,0 +1,5 @@
+---
+"highlight.run": patch
+---
+
+reduce Safari canvas snapshot defaults

--- a/sdk/highlight-run/src/client/index.tsx
+++ b/sdk/highlight-run/src/client/index.tsx
@@ -102,6 +102,7 @@ import {
 	setItem,
 	setStorageMode,
 } from './utils/storage'
+import { getCanvasSamplingDefaults } from './utils/canvas-sampling'
 import { getDefaultDataURLOptions } from './utils/utils'
 import type { HighlightClientRequestWorker } from './workers/highlight-client-worker'
 import HighlightClientWorker from './workers/highlight-client-worker?worker&inline'
@@ -379,8 +380,7 @@ export class Highlight {
 		this.inlineVideos = options.inlineVideos ?? this._isOnLocalHost
 		this.inlineStylesheet = options.inlineStylesheet ?? this._isOnLocalHost
 		this.samplingStrategy = {
-			canvasFactor: 0.5,
-			canvasMaxSnapshotDimension: 360,
+			...getCanvasSamplingDefaults(navigator.userAgent),
 			canvasClearWebGLBuffer: true,
 			dataUrlOptions: getDefaultDataURLOptions(),
 			...(options.samplingStrategy ?? {

--- a/sdk/highlight-run/src/client/utils/canvas-sampling.test.ts
+++ b/sdk/highlight-run/src/client/utils/canvas-sampling.test.ts
@@ -1,0 +1,37 @@
+import {
+	getCanvasSamplingDefaults,
+	isSafariCanvasSnapshotBrowser,
+} from './canvas-sampling'
+
+const DESKTOP_SAFARI_USER_AGENT =
+	'Mozilla/5.0 (Macintosh; Intel Mac OS X 13_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Safari/605.1.15'
+const DESKTOP_CHROME_USER_AGENT =
+	'Mozilla/5.0 (Macintosh; Intel Mac OS X 13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36'
+const IOS_CHROME_USER_AGENT =
+	'Mozilla/5.0 (iPhone; CPU iPhone OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/117.0.0.0 Mobile/15E148 Safari/604.1'
+
+describe('canvas sampling defaults', () => {
+	it('uses lower canvas snapshot defaults for Safari', () => {
+		expect(isSafariCanvasSnapshotBrowser(DESKTOP_SAFARI_USER_AGENT)).toBe(
+			true,
+		)
+		expect(getCanvasSamplingDefaults(DESKTOP_SAFARI_USER_AGENT)).toEqual({
+			canvasFactor: 0.25,
+			canvasMaxSnapshotDimension: 180,
+		})
+	})
+
+	it('keeps existing canvas snapshot defaults for non-Safari browsers', () => {
+		expect(isSafariCanvasSnapshotBrowser(DESKTOP_CHROME_USER_AGENT)).toBe(
+			false,
+		)
+		expect(getCanvasSamplingDefaults(DESKTOP_CHROME_USER_AGENT)).toEqual({
+			canvasFactor: 0.5,
+			canvasMaxSnapshotDimension: 360,
+		})
+	})
+
+	it('treats iOS Safari-based browsers as affected', () => {
+		expect(isSafariCanvasSnapshotBrowser(IOS_CHROME_USER_AGENT)).toBe(true)
+	})
+})

--- a/sdk/highlight-run/src/client/utils/canvas-sampling.ts
+++ b/sdk/highlight-run/src/client/utils/canvas-sampling.ts
@@ -1,0 +1,29 @@
+import type { SamplingStrategy } from '../types/types'
+
+export const isSafariCanvasSnapshotBrowser = (userAgent: string) => {
+	if (!/safari/i.test(userAgent) || /android/i.test(userAgent)) {
+		return false
+	}
+
+	if (/ipad|iphone|ipod/i.test(userAgent)) {
+		return true
+	}
+
+	return !/chrome|chromium|crios|edg|opr|opera|firefox|fxios/i.test(userAgent)
+}
+
+export const getCanvasSamplingDefaults = (
+	userAgent: string,
+): Pick<SamplingStrategy, 'canvasFactor' | 'canvasMaxSnapshotDimension'> => {
+	if (isSafariCanvasSnapshotBrowser(userAgent)) {
+		return {
+			canvasFactor: 0.25,
+			canvasMaxSnapshotDimension: 180,
+		}
+	}
+
+	return {
+		canvasFactor: 0.5,
+		canvasMaxSnapshotDimension: 360,
+	}
+}


### PR DESCRIPTION
## Summary
- Improves the Safari canvas snapshot performance issue described in #6775.
- Keeps the change focused on Highlight SDK canvas snapshot defaults and adds focused coverage for browser detection.

## Changes
- Adds a small canvas sampling helper that detects Safari and iOS Safari-based browsers.
- Uses lower canvas snapshot defaults for affected Safari runtimes while preserving existing defaults for non-Safari browsers.
- Adds focused tests for Safari, Chrome, and iOS Safari-based user agents.

## Testing
- `node .yarn/releases/yarn-4.6.0.cjs prettier --check sdk/highlight-run/src/client/index.tsx sdk/highlight-run/src/client/utils/canvas-sampling.ts sdk/highlight-run/src/client/utils/canvas-sampling.test.ts`
- Result: passed
- `node .yarn/releases/yarn-4.6.0.cjs workspace highlight.run test src/client/utils/canvas-sampling.test.ts`
- Result: passed, 3 passed / 0 failed
- `git diff --check`
- Result: passed
- `node .yarn/releases/yarn-4.6.0.cjs workspace highlight.run typegen`
- Result: failed in this checkout because local workspace packages such as `rrweb` and `@rrweb/types` could not be resolved before reaching this change.

## Notes
- No authentication, payment, database, deployment, or security-sensitive configuration changes were made.
- No secrets, credentials, production data, or security-sensitive information were accessed.

## Algora
/claim #6775