### PR TITLE
docs: add SvelteKit backend instrumentation quickstart

### DIFF
--- a/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
@@ -3,7 +3,6 @@ import {
 	identifySnippet,
 	initializeSnippet,
 	packageInstallSnippet,
-	setupBackendSnippet,
 	verifySnippet,
 } from './shared-snippets'
 
@@ -31,6 +30,72 @@ H.init('<YOUR_PROJECT_ID>', {
 });
 ...
 `
+
+const svelteKitBackendInstallSnippet = {
+	title: 'Install the server SDK.',
+	content:
+		'To instrument your SvelteKit backend on Node.js, install `@highlight-run/node`.',
+	code: [
+		{
+			key: 'npm',
+			text: `# with npm
+npm install @highlight-run/node`,
+			language: 'bash',
+		},
+		{
+			key: 'yarn',
+			text: `# with yarn
+yarn add @highlight-run/node`,
+			language: 'bash',
+		},
+		{
+			key: 'pnpm',
+			text: `# with pnpm
+pnpm add @highlight-run/node`,
+			language: 'bash',
+		},
+	],
+}
+
+const svelteKitBackendInstrumentationSnippet = {
+	title: 'Instrument your SvelteKit backend.',
+	content:
+		'Initialize the Node.js SDK in `hooks.server.ts` and wrap your `handle` hook with `H.runWithHeaders()` so Highlight can correlate backend errors/logs/traces with frontend sessions.\n\n' +
+		'If you are deploying to an edge/worker runtime (e.g. Cloudflare Workers), use the appropriate SDK for that runtime instead of `@highlight-run/node`.',
+	code: [
+		{
+			language: 'ts',
+			text: `// src/hooks.server.ts
+import type { Handle, HandleServerError } from '@sveltejs/kit'
+import { H, type NodeOptions } from '@highlight-run/node'
+
+const highlightConfig: NodeOptions = {
+	projectID: process.env.HIGHLIGHT_PROJECT_ID ?? '<YOUR_PROJECT_ID>',
+	serviceName: 'my-sveltekit-backend',
+	environment: process.env.NODE_ENV,
+}
+
+if (!H.isInitialized()) {
+	H.init(highlightConfig)
+}
+
+export const handle: Handle = async ({ event, resolve }) => {
+	const headers = Object.fromEntries(event.request.headers.entries())
+	return await H.runWithHeaders(headers, async () => resolve(event))
+}
+
+export const handleError: HandleServerError = ({ error, event }) => {
+	const headers = Object.fromEntries(event.request.headers.entries())
+	const parsed = H.parseHeaders(headers)
+	if (parsed) {
+		H.consumeError(error, parsed.secureSessionId, parsed.requestId)
+	} else {
+		H.consumeError(error)
+	}
+}`,
+		},
+	],
+}
 
 export const SvelteKitContent: QuickStartContent = {
 	title: 'SvelteKit',
@@ -77,8 +142,9 @@ export default config;`,
 			],
 		},
 		identifySnippet,
+		svelteKitBackendInstallSnippet,
+		svelteKitBackendInstrumentationSnippet,
 		verifySnippet,
 		configureSourcemapsCI(),
-		setupBackendSnippet,
 	],
 }


### PR DESCRIPTION
Fixes #8032.

Adds SvelteKit backend (Node.js) instrumentation steps to the SvelteKit quickstart, including installing `@highlight-run/node`, initializing the SDK, wrapping `handle` with `H.runWithHeaders`, and an optional `handleError` example.

Verification:
- yarn workspace @highlight-run/next build
- yarn workspace @highlight-run/sourcemap-uploader build
- yarn workspace highlight.io lint