### PR TITLE
Support GraphQL contexts in NestJS interceptor

### DIFF
--- a/.changeset/graphql-nest-interceptor.md
+++ b/.changeset/graphql-nest-interceptor.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/nest": patch
+---
+
+Support GraphQL request contexts in the NestJS interceptor.

--- a/sdk/highlight-nest/src/index.test.ts
+++ b/sdk/highlight-nest/src/index.test.ts
@@ -1,0 +1,98 @@
+import api from '@opentelemetry/api'
+import { H as NodeH } from '@highlight-run/node'
+import { lastValueFrom, of } from 'rxjs'
+import { HighlightInterceptor } from './index'
+
+jest.mock(
+	'@highlight-run/node',
+	() => ({
+		H: {
+			_debug: jest.fn(),
+			consumeError: jest.fn(),
+			flush: jest.fn(),
+			init: jest.fn(),
+			isInitialized: jest.fn(() => true),
+			log: jest.fn(),
+			startWithHeaders: jest.fn(),
+		},
+	}),
+	{ virtual: true },
+)
+
+const mockNodeH = NodeH as jest.Mocked<typeof NodeH>
+
+describe('HighlightInterceptor', () => {
+	beforeEach(() => {
+		jest.clearAllMocks()
+		mockNodeH.isInitialized.mockReturnValue(true)
+		mockNodeH.startWithHeaders.mockReturnValue({
+			ctx: api.context.active(),
+			span: {
+				end: jest.fn(),
+			} as any,
+		})
+	})
+
+	it('uses the GraphQL request when the HTTP request is not available', async () => {
+		const interceptor = new HighlightInterceptor({ projectID: '1' } as any)
+		const request = {
+			headers: { 'x-test-header': 'test' },
+			method: 'POST',
+			url: '/graphql',
+		}
+		const context = {
+			getArgByIndex: jest.fn((index: number) =>
+				index === 2 ? { req: request } : undefined,
+			),
+			getClass: () => function AppResolver() {},
+			getHandler: () => function getUser() {},
+			getType: () => 'graphql',
+			switchToHttp: () => ({
+				getRequest: () => undefined,
+			}),
+		}
+
+		await lastValueFrom(
+			interceptor.intercept(context as any, { handle: () => of('ok') }),
+		)
+
+		expect(mockNodeH.startWithHeaders).toHaveBeenCalledWith(
+			'POST /graphql',
+			request.headers,
+			{
+				attributes: {
+					'http.method': 'POST',
+					'http.url': '/graphql',
+				},
+			},
+		)
+	})
+
+	it('falls back to resolver metadata when no request object is available', async () => {
+		const interceptor = new HighlightInterceptor({ projectID: '1' } as any)
+		const context = {
+			getArgByIndex: jest.fn(() => undefined),
+			getClass: () => function AppResolver() {},
+			getHandler: () => function getUser() {},
+			getType: () => 'graphql',
+			switchToHttp: () => ({
+				getRequest: () => undefined,
+			}),
+		}
+
+		await lastValueFrom(
+			interceptor.intercept(context as any, { handle: () => of('ok') }),
+		)
+
+		expect(mockNodeH.startWithHeaders).toHaveBeenCalledWith(
+			'GRAPHQL AppResolver.getUser',
+			{},
+			{
+				attributes: {
+					'http.method': 'GRAPHQL',
+					'http.url': 'AppResolver.getUser',
+				},
+			},
+		)
+	})
+})

--- a/sdk/highlight-nest/src/index.ts
+++ b/sdk/highlight-nest/src/index.ts
@@ -9,8 +9,47 @@ import {
 	NestInterceptor,
 } from '@nestjs/common'
 import api from '@opentelemetry/api'
+import type { IncomingHttpHeaders } from 'http'
 import { finalize, Observable, throwError } from 'rxjs'
 import { catchError } from 'rxjs/operators'
+
+type RequestHeaders = Headers | IncomingHttpHeaders
+
+type RequestLike = {
+	headers?: RequestHeaders
+	method?: string
+	originalUrl?: string
+	url?: string
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null
+
+const getRequestFromContext = (context: ExecutionContext): RequestLike => {
+	const httpRequest = context
+		.switchToHttp()
+		.getRequest<RequestLike | undefined>()
+	if (isObject(httpRequest)) {
+		return httpRequest
+	}
+
+	const gqlContext = context.getArgByIndex<unknown>(2)
+	if (isObject(gqlContext)) {
+		const request = gqlContext.req ?? gqlContext.request
+		if (isObject(request)) {
+			return request
+		}
+	}
+
+	return {}
+}
+
+const getFallbackUrl = (context: ExecutionContext) => {
+	const className = context.getClass()?.name
+	const handlerName = context.getHandler()?.name
+
+	return [className, handlerName].filter(Boolean).join('.') || 'unknown'
+}
 
 @Injectable()
 export class HighlightLogger
@@ -95,16 +134,19 @@ export class HighlightInterceptor
 	}
 
 	intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
-		const ctx = context.switchToHttp()
-		const request = ctx.getRequest()
+		const request = getRequestFromContext(context)
+		const method =
+			request.method ?? context.getType<string>()?.toUpperCase()
+		const url =
+			request.originalUrl ?? request.url ?? getFallbackUrl(context)
 
 		const { span: requestSpan, ctx: spanCtx } = NodeH.startWithHeaders(
-			`${request.method} ${request.url}`,
-			request.headers,
+			[method, url].filter(Boolean).join(' '),
+			request.headers ?? {},
 			{
 				attributes: {
-					'http.method': request.method,
-					'http.url': request.url,
+					'http.method': method,
+					'http.url': url,
 				},
 			},
 		)


### PR DESCRIPTION
## Summary
- Resolve GraphQL execution contexts in `HighlightInterceptor` by reading `context.getArgByIndex(2).req` or `.request` when no HTTP request is available.
- Fall back to resolver metadata instead of reading `headers` from `undefined`.
- Add focused Jest coverage for GraphQL request and no-request fallback paths.
- Add a patch changeset for `@highlight-run/nest`.

/claim #7157

## Validation
- `node .yarn/releases/yarn-4.6.0.cjs workspace @highlight-run/node build`
- `node .yarn/releases/yarn-4.6.0.cjs prettier --check sdk/highlight-nest/src/index.ts sdk/highlight-nest/src/index.test.ts .changeset/graphql-nest-interceptor.md`
- `..\..\node_modules\.bin\jest.cmd --config jest.config.js --runInBand` from `sdk/highlight-nest`
- `node .yarn/releases/yarn-4.6.0.cjs workspace @highlight-run/nest build`
- `git diff --check`