### PR TITLE
Refactor: Replace legacy BorderBox with native UI Box in ProjectSettings (#8635)

### DIFF
--- a/frontend/src/pages/ProjectSettings/ProjectSettings.tsx
+++ b/frontend/src/pages/ProjectSettings/ProjectSettings.tsx
@@ -16,7 +16,6 @@ import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { useNavigate } from 'react-router-dom'
 
-import BorderBox from '@/components/BorderBox/BorderBox'
 import { Button } from '@/components/Button'
 import {
 	CircularSpinner,
@@ -226,13 +225,13 @@ const ProjectSettings = () => {
 												)}
 											</Button>
 										</Box>
-										<BorderBox>
-											<Stack gap="8">
-												<ErrorSettingsForm />
-												<Box borderTop="dividerWeak" />
-												<ErrorFiltersForm />
-											</Stack>
-										</BorderBox>
+										<Box border="dividerWeak" borderRadius="6" p="12">
+	<Stack gap="8">
+		<ErrorSettingsForm />
+		<Box borderTop="dividerWeak" />
+		<ErrorFiltersForm />
+	</Stack>
+</Box>
 										<FilterExtensionForm />
 										<SourcemapSettings />
 										<AutoresolveStaleErrorsForm />


### PR DESCRIPTION
This PR replaces the legacy BorderBox component with the standardized @highlight-run/ui Box component in the Project Settings page. This reduces tech debt and aligns the implementation with the modern design system as requested.

/claim #8635