### PR TITLE
refactor(settings): remove direct antd Select from GitHub settings modal

### DIFF
--- a/.changeset/chilled-rocks-obey.md
+++ b/.changeset/chilled-rocks-obey.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+refactor(settings): remove direct antd Select from GitHub settings modal

--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -2,6 +2,7 @@ import { Button } from '@components/Button'
 import { LinkButton } from '@components/LinkButton'
 import Modal from '@components/Modal/Modal'
 import ModalBody from '@components/ModalBody/ModalBody'
+import Select from '@components/Select/Select'
 import {
 	Box,
 	ButtonIcon,
@@ -15,7 +16,6 @@ import {
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -121,7 +121,7 @@ const GithubSettingsForm = ({
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
 				id: repo.key,
-				label: repo.name.split('/').pop(),
+				displayValue: repo.name.split('/').pop(),
 				value: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
@@ -161,9 +161,7 @@ const GithubSettingsForm = ({
 									repo,
 								)
 							}
-							value={formState.values.githubRepo
-								?.split('/')
-								.pop()}
+							value={formState.values.githubRepo ?? undefined}
 							options={githubOptions}
 							notFoundContent={<span>No repos found</span>}
 							optionFilterProp="label"


### PR DESCRIPTION
/claim #8635

## Summary
- replace direct `antd` `Select` import in `ProjectSettings/GitHubSettingsModal` with the shared `@components/Select/Select` component
- migrate option shape from `{ label, value }` to shared Select option shape `{ displayValue, value, id }`
- keep search/filter behavior (`showSearch`, `filterOption`, `optionFilterProp="label"`) and preserve existing save/clear flows

## Validation
- code is scoped to project settings modal only
- local lint/type checks were not run in this environment because workspace dependencies are not installed (`node_modules state file` missing for Yarn PnP)
