### PR TITLE
refactor(settings): remove antd from ErrorSettingsForm

### DIFF
--- a/frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx
@@ -1,6 +1,5 @@
 import { LoadingBar } from '@components/Loading/Loading'
-import Select from '@components/Select/Select'
-import { Stack } from '@highlight-run/ui/components'
+import { Select, Stack } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
 
 import BoxLabel from '@/components/BoxLabel/BoxLabel'
@@ -20,6 +19,8 @@ export const ErrorSettingsForm = () => {
 		return <LoadingBar />
 	}
 
+	const errorJsonPaths = data?.projectSettings?.error_json_paths || []
+
 	return (
 		<form key={project_id}>
 			<Stack gap="8">
@@ -28,16 +29,23 @@ export const ErrorSettingsForm = () => {
 					info="Enter JSON expressions to use for grouping your errors."
 				/>
 				<Select
-					mode="tags"
+					creatable
+					filterable
+					displayMode="tags"
 					placeholder="$.context.messages[0]"
-					value={data?.projectSettings?.error_json_paths || []}
-					onChange={(paths: string[]) => {
+					options={errorJsonPaths}
+					value={errorJsonPaths}
+					onValueChange={(
+						paths: { name: string; value: string }[],
+					) => {
 						setAllProjectSettings((currentProjectSettings) =>
 							currentProjectSettings?.projectSettings
 								? {
 										projectSettings: {
 											...currentProjectSettings.projectSettings,
-											error_json_paths: paths,
+											error_json_paths: paths.map(
+												(path) => path.value,
+											),
 										},
 									}
 								: currentProjectSettings,


### PR DESCRIPTION
/claim #8635

## Summary
- Removes antd usage from `ErrorSettingsForm`.
- Replaces it with existing Highlight/internal UI components.
- Keeps the scope intentionally small as part of the broader settings antd cleanup.

## Validation
- `corepack yarn prettier --check --ignore-unknown frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx` ✅
- `corepack yarn lint` ⚠️ fails before linting due to repo script/workspace issue: `No package found with name 'react-native' in workspace`
- `corepack yarn workspace @highlight-run/frontend eslint ./src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx` ✅
- `corepack yarn workspace @highlight-run/frontend types:check` ⚠️ fails with unrelated pre-existing `@highlight-run/ui` export/type errors across many frontend files on `upstream/main`
- `git diff --check` ✅

## Demo
Attached in PR comments.

