### PR TITLE
docs: add SvelteKit server-side quickstart for backend instrumentation

### DIFF
--- a/docs-content/getting-started/4_server/2_js/sveltekit.md
+++ b/docs-content/getting-started/4_server/2_js/sveltekit.md
@@ -1,0 +1,10 @@
+---
+toc: SvelteKit
+title: SvelteKit Quick Start
+slug: sveltekit
+createdAt: 2022-03-28T20:31:15.000Z
+updatedAt: 2024-01-01T00:00:00.000Z
+quickstart: true
+---
+
+<QuickStart content={quickStartContent["server"]["js"]["sveltekit"]}/>

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -107,6 +107,7 @@ import { JSHonoReorganizedContent } from './server/js/hono'
 import { JSNodeReorganizedContent } from './server/js/nodejs'
 import { JSNestReorganizedContent } from './server/js/nestjs'
 import { JStRPCReorganizedContent } from './server/js/trpc'
+import { JSSvelteKitReorganizedContent } from './server/js/sveltekit'
 import { JSPinoHTTPJSONLogReorganizedContent } from './server/js/pino'
 import { JSWinstonHTTPJSONLogReorganizedContent } from './server/js/winston'
 import { JSManualTracesReorganizedContent } from './server/js/manual'
@@ -209,6 +210,7 @@ export enum QuickStartType {
 	JSWinston = 'winston',
 	JSPino = 'pino',
 	JStRPC = 'trpc',
+	JSSvelteKit = 'sveltekit',
 	HTTPOTLP = 'curl',
 	Syslog = 'syslog',
 	Systemd = 'systemd',
@@ -457,6 +459,7 @@ export const quickStartContent = {
 			[QuickStartType.JSNodejs]: JSNodeReorganizedContent,
 			[QuickStartType.JSNestjs]: JSNestReorganizedContent,
 			[QuickStartType.JStRPC]: JStRPCReorganizedContent,
+			[QuickStartType.JSSvelteKit]: JSSvelteKitReorganizedContent,
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSManual]: JSManualTracesReorganizedContent,
@@ -602,6 +605,7 @@ export const quickStartContentReorganized = {
 			[QuickStartType.JSNodejs]: JSNodeReorganizedContent,
 			[QuickStartType.JSNestjs]: JSNestReorganizedContent,
 			[QuickStartType.JStRPC]: JStRPCReorganizedContent,
+			[QuickStartType.JSSvelteKit]: JSSvelteKitReorganizedContent,
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSManual]: JSManualTracesReorganizedContent,

--- a/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
@@ -1,0 +1,88 @@
+import { QuickStartContent } from '../../QuickstartContent'
+import { frontendInstallSnippet } from '../shared-snippets-monitoring'
+import { jsGetSnippet } from './shared-snippets-monitoring'
+import { verifyTraces } from '../shared-snippets-tracing'
+
+const svelteKitInitCode = `// src/hooks.server.ts
+import { H } from '@highlight-run/node'
+
+H.init({
+	projectID: '<YOUR_PROJECT_ID>',
+	serviceName: 'my-sveltekit-backend',
+	environment: 'production',
+})`
+
+const svelteKitHandleCode = `// src/hooks.server.ts
+import type { Handle } from '@sveltejs/kit'
+import { H } from '@highlight-run/node'
+
+export const handle: Handle = async ({ event, resolve }) => {
+	return H.runWithHeaders(
+		\`\${event.request.method} \${event.url.pathname}\`,
+		event.request.headers,
+		() => resolve(event),
+	)
+}`
+
+const svelteKitErrorCode = `// src/hooks.server.ts
+import type { HandleServerError } from '@sveltejs/kit'
+import { H } from '@highlight-run/node'
+
+export const handleError: HandleServerError = ({ error, event }) => {
+	const parsed = H.parseHeaders(event.request.headers)
+	H.consumeError(
+		error instanceof Error ? error : new Error(String(error)),
+		parsed?.secureSessionId,
+		parsed?.requestId,
+	)
+}`
+
+export const JSSvelteKitReorganizedContent: QuickStartContent = {
+	title: 'SvelteKit',
+	subtitle: 'Set up highlight.io server-side error monitoring in SvelteKit.',
+	logoKey: 'sveltekit',
+	products: ['Errors', 'Traces'],
+	entries: [
+		frontendInstallSnippet,
+		jsGetSnippet(['node']),
+		{
+			title: 'Initialize the SDK in hooks.server.ts.',
+			content:
+				'Import `@highlight-run/node` and call `H.init()` once in `src/hooks.server.ts`. ' +
+				'Set `serviceName` so your SvelteKit server spans show up with a clear name in the Traces view. ' +
+				'See [tracingOrigins](../2_frontend-backend-mapping.md) for how to connect server spans to frontend sessions.',
+			code: [
+				{
+					text: svelteKitInitCode,
+					language: 'ts',
+				},
+			],
+		},
+		{
+			title: 'Wrap requests with H.runWithHeaders.',
+			content:
+				'Export a `handle` hook that wraps every request through `H.runWithHeaders(...)`. ' +
+				'This creates a parent span for every server request and links it to the session ID from the browser. ' +
+				'If you already have a `handle` function, wrap just the `resolve(event)` call.',
+			code: [
+				{
+					text: svelteKitHandleCode,
+					language: 'ts',
+				},
+			],
+		},
+		{
+			title: 'Report server errors.',
+			content:
+				'Export `handleError` to send uncaught exceptions to Highlight. ' +
+				'`H.parseHeaders(...)` extracts the session and request IDs so the error is linked to the right browser session.',
+			code: [
+				{
+					text: svelteKitErrorCode,
+					language: 'ts',
+				},
+			],
+		},
+		verifyTraces,
+	],
+}


### PR DESCRIPTION
## Overview
This PR adds server-side instrumentation documentation for SvelteKit as part of issue #8032.

### Changes

1. **New file: `highlight.io/components/QuickstartContent/server/js/sveltekit.tsx`**
   Interactive QuickStart component covering:
   - Install `@highlight-run/node` SDK
   - Initialize in `hooks.server.ts` with `H.init()`
   - Wrap requests with `H.runWithHeaders()` to link server spans to frontend sessions
   - Export `handleError` to report server exceptions
   - Verify traces in the Highlight dashboard

2. **New file: `docs-content/getting-started/4_server/2_js/sveltekit.md`**
   Markdown doc page that renders the QuickStart component

3. **Modified: `highlight.io/components/QuickstartContent/QuickstartContent.tsx`**
   - Added `JSSvelteKit = 'sveltekit'` to `QuickStartType` enum
   - Imported `JSSvelteKitReorganizedContent` from `./server/js/sveltekit`
   - Registered `[QuickStartType.JSSvelteKit]: JSSvelteKitReorganizedContent` in the `server.js` content map

### Notes
- Does **not** modify `frontend/sveltekit.tsx` (already heavily contested by other PRs)
- Does **not** modify `1_overview.md` to avoid conflicts
- Focuses on the server-side/backend integration for SvelteKit, complementing the existing client-side frontend docs

Closes #8032