### PR TITLE
Refactor: Remove BorderBox from HaroldAISettings (#8635)

### DIFF
--- a/frontend/src/pages/Auth/JoinWorkspace.tsx
+++ b/frontend/src/pages/Auth/JoinWorkspace.tsx
@@ -1,5 +1,5 @@
 import { toast } from '@components/Toaster'
-import { Form, Select, Stack, Text } from '@highlight-run/ui/components'
+import { Form, Stack, Text } from '@highlight-run/ui/components'
 import useLocalStorage from '@rehooks/local-storage'
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -20,6 +20,7 @@ import { ABOUT_YOU_ROUTE } from '@/routers/AppRouter/AppRouter'
 import { getEmailDomain } from '@/util/email'
 import { showSupportMessage } from '@/util/window'
 
+import * as styles from './AdminForm.css'
 import * as authRouterStyles from './AuthRouter.css'
 
 export const DISMISS_JOIN_WORKSPACE_LOCAL_STORAGE_KEY =
@@ -34,12 +35,10 @@ export const JoinWorkspace = () => {
 			)
 		},
 	})
-
 	const { data: adminData } = useGetAdminQuery()
 	const navigate = useNavigate()
 	const { setLoadingState } = useAppLoadingContext()
 	const [joinWorkspace, { loading: joinLoading }] = useJoinWorkspaceMutation()
-
 	const [_, setDismissedJoinWorkspace] = useLocalStorage(
 		DISMISS_JOIN_WORKSPACE_LOCAL_STORAGE_KEY,
 		false,
@@ -50,7 +49,6 @@ export const JoinWorkspace = () => {
 			workspaceId: '',
 		},
 	})
-
 	const workspaceId = formStore.useValue('workspaceId')
 
 	formStore.useSubmit(async (formState) => {
@@ -66,8 +64,7 @@ export const JoinWorkspace = () => {
 			navigate(ABOUT_YOU_ROUTE, { replace: true })
 		} else if (response.errors?.length) {
 			const error = response.errors[0].message
-
-			toast.error(error, { duration: 1000 })
+			toast.error(response.errors[0].message, { duration: 1000 })
 
 			showSupportMessage(
 				`I can't join a workspace. This is the error I'm getting: "${error}"`,
@@ -95,21 +92,20 @@ export const JoinWorkspace = () => {
 				<AuthHeader>
 					<Text color="moderate">Join Workspace</Text>
 				</AuthHeader>
-
 				<AuthBody>
 					<Stack gap="16" direction="column">
 						{noJoinableWorkspaces ? (
 							<Stack>
 								<Text>
 									Creating new workspaces is disabled.{' '}
-									<a href="https://highlight.io">
+									<a href="https://highlight.io/blog/launchdarkly-migration">
 										Learn more on our blog.
 									</a>
 								</Text>
-
 								<Text>
-									If you are trying to join an existing workspace,
-									please ask your admin for an invite link.
+									If you are trying to join an existing
+									workspace, please ask your admin for an
+									invite link.
 								</Text>
 							</Stack>
 						) : (
@@ -117,20 +113,19 @@ export const JoinWorkspace = () => {
 								<Stack>
 									<Text>
 										Creating new workspaces is disabled.{' '}
-										<a href="https://highlight.io">
+										<a href="https://highlight.io/blog/launchdarkly-migration">
 											Learn more on our blog.
 										</a>
 									</Text>
-
 									<Text>
-										Based on your <b>@{emailDomain}</b> email
-										address you are able to join the following
-										workspaces.
+										Based on your <b>@{emailDomain}</b>{' '}
+										email address you are able to join the
+										following workspaces.
 									</Text>
 								</Stack>
 
-								<Select
-									value={workspaceId}
+								<select
+									className={styles.select}
 									onChange={(e) => {
 										const selectedWorkspace =
 											data?.joinable_workspaces?.find(
@@ -149,20 +144,21 @@ export const JoinWorkspace = () => {
 										Select a workspace
 									</option>
 
-									{data?.joinable_workspaces?.map((workspace) => (
-										<option
-											key={workspace?.id}
-											value={workspace?.id}
-										>
-											{workspace?.name}
-										</option>
-									))}
-								</Select>
+									{data?.joinable_workspaces?.map(
+										(workspace) => (
+											<option
+												key={workspace?.id}
+												value={workspace?.id}
+											>
+												{workspace?.name}
+											</option>
+										),
+									)}
+								</select>
 							</>
 						)}
 					</Stack>
 				</AuthBody>
-
 				<AuthFooter>
 					<Button
 						type="submit"

--- a/frontend/src/pages/Auth/JoinWorkspace.tsx
+++ b/frontend/src/pages/Auth/JoinWorkspace.tsx
@@ -97,7 +97,7 @@ export const JoinWorkspace = () => {
 							<Stack>
 								<Text>
 									Creating new workspaces is disabled.{' '}
-									<a href="https://highlight.io/blog/launchdarkly-migration">
+									<a href="https://highlight.io">
 										Learn more on our blog.
 									</a>
 								</Text>
@@ -112,7 +112,7 @@ export const JoinWorkspace = () => {
 								<Stack>
 									<Text>
 										Creating new workspaces is disabled.{' '}
-										<a href="https://highlight.io/blog/launchdarkly-migration">
+										<a href="https://highlight.io">
 											Learn more on our blog.
 										</a>
 									</Text>

--- a/frontend/src/pages/Auth/JoinWorkspace.tsx
+++ b/frontend/src/pages/Auth/JoinWorkspace.tsx
@@ -1,5 +1,5 @@
 import { toast } from '@components/Toaster'
-import { Form, Stack, Text, Select } from '@highlight-run/ui/components'
+import { Form, Select, Stack, Text } from '@highlight-run/ui/components'
 import useLocalStorage from '@rehooks/local-storage'
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -34,10 +34,12 @@ export const JoinWorkspace = () => {
 			)
 		},
 	})
+
 	const { data: adminData } = useGetAdminQuery()
 	const navigate = useNavigate()
 	const { setLoadingState } = useAppLoadingContext()
 	const [joinWorkspace, { loading: joinLoading }] = useJoinWorkspaceMutation()
+
 	const [_, setDismissedJoinWorkspace] = useLocalStorage(
 		DISMISS_JOIN_WORKSPACE_LOCAL_STORAGE_KEY,
 		false,
@@ -48,6 +50,7 @@ export const JoinWorkspace = () => {
 			workspaceId: '',
 		},
 	})
+
 	const workspaceId = formStore.useValue('workspaceId')
 
 	formStore.useSubmit(async (formState) => {
@@ -63,7 +66,8 @@ export const JoinWorkspace = () => {
 			navigate(ABOUT_YOU_ROUTE, { replace: true })
 		} else if (response.errors?.length) {
 			const error = response.errors[0].message
-			toast.error(response.errors[0].message, { duration: 1000 })
+
+			toast.error(error, { duration: 1000 })
 
 			showSupportMessage(
 				`I can't join a workspace. This is the error I'm getting: "${error}"`,
@@ -91,6 +95,7 @@ export const JoinWorkspace = () => {
 				<AuthHeader>
 					<Text color="moderate">Join Workspace</Text>
 				</AuthHeader>
+
 				<AuthBody>
 					<Stack gap="16" direction="column">
 						{noJoinableWorkspaces ? (
@@ -101,10 +106,10 @@ export const JoinWorkspace = () => {
 										Learn more on our blog.
 									</a>
 								</Text>
+
 								<Text>
-									If you are trying to join an existing
-									workspace, please ask your admin for an
-									invite link.
+									If you are trying to join an existing workspace,
+									please ask your admin for an invite link.
 								</Text>
 							</Stack>
 						) : (
@@ -116,10 +121,11 @@ export const JoinWorkspace = () => {
 											Learn more on our blog.
 										</a>
 									</Text>
+
 									<Text>
-										Based on your <b>@{emailDomain}</b>{' '}
-										email address you are able to join the
-										following workspaces.
+										Based on your <b>@{emailDomain}</b> email
+										address you are able to join the following
+										workspaces.
 									</Text>
 								</Stack>
 
@@ -143,21 +149,20 @@ export const JoinWorkspace = () => {
 										Select a workspace
 									</option>
 
-									{data?.joinable_workspaces?.map(
-										(workspace) => (
-											<option
-												key={workspace?.id}
-												value={workspace?.id}
-											>
-												{workspace?.name}
-											</option>
-										),
-									)}
+									{data?.joinable_workspaces?.map((workspace) => (
+										<option
+											key={workspace?.id}
+											value={workspace?.id}
+										>
+											{workspace?.name}
+										</option>
+									))}
 								</Select>
 							</>
 						)}
 					</Stack>
 				</AuthBody>
+
 				<AuthFooter>
 					<Button
 						type="submit"
@@ -174,3 +179,5 @@ export const JoinWorkspace = () => {
 		</Landing>
 	)
 }
+
+export default JoinWorkspace

--- a/frontend/src/pages/Auth/JoinWorkspace.tsx
+++ b/frontend/src/pages/Auth/JoinWorkspace.tsx
@@ -1,5 +1,5 @@
 import { toast } from '@components/Toaster'
-import { Form, Stack, Text } from '@highlight-run/ui/components'
+import { Form, Stack, Text, Select } from '@highlight-run/ui/components'
 import useLocalStorage from '@rehooks/local-storage'
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -20,7 +20,6 @@ import { ABOUT_YOU_ROUTE } from '@/routers/AppRouter/AppRouter'
 import { getEmailDomain } from '@/util/email'
 import { showSupportMessage } from '@/util/window'
 
-import * as styles from './AdminForm.css'
 import * as authRouterStyles from './AuthRouter.css'
 
 export const DISMISS_JOIN_WORKSPACE_LOCAL_STORAGE_KEY =
@@ -124,8 +123,8 @@ export const JoinWorkspace = () => {
 									</Text>
 								</Stack>
 
-								<select
-									className={styles.select}
+								<Select
+									value={workspaceId}
 									onChange={(e) => {
 										const selectedWorkspace =
 											data?.joinable_workspaces?.find(
@@ -154,7 +153,7 @@ export const JoinWorkspace = () => {
 											</option>
 										),
 									)}
-								</select>
+								</Select>
 							</>
 						)}
 					</Stack>

--- a/frontend/src/pages/HaroldAISettings/HaroldAISettings.tsx
+++ b/frontend/src/pages/HaroldAISettings/HaroldAISettings.tsx
@@ -1,5 +1,11 @@
 import { toast } from '@components/Toaster'
-import { Box, Heading, Stack, Text } from '@highlight-run/ui/components'
+import {
+	Box,
+	Heading,
+	IconSolidExternalLink,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
 import { useAuthorization } from '@util/authorization/authorization'
 import { POLICY_NAMES } from '@util/authorization/authorizationPolicies'
 
@@ -82,11 +88,13 @@ export const HaroldAISettings = () => {
 	}
 
 	return (
-		<Box border="secondary" borderRadius="6" p="16">
-			<Stack gap="24">
-				<Stack direction="column" gap="8">
-					<Heading level="h3">Harold AI</Heading>
-					<Text color="moderate">
+		<Box style={{ maxWidth: 560 }} my="40" mx="auto">
+			<Stack gap="24" direction="column">
+				<Stack gap="16" direction="column">
+					<Heading mt="16" level="h4">
+						Harold AI
+					</Heading>
+					<Text weight="medium" size="small" color="default">
 						Highlight&apos;s Harold is an AI assistant helping you better
 						understand the context around your data. Harold is based on OpenAI
 						GPT-3.5.
@@ -94,53 +102,56 @@ export const HaroldAISettings = () => {
 				</Stack>
 
 				<Box border="secondary" borderRadius="6" p="16">
-					<Stack direction="column" gap="12">
-						<Stack direction="column" gap="4">
-							<Heading level="h4">Learn more about Highlight&apos;s AI</Heading>
+					<Box pt="4">
+						<Stack gap="12" direction="column" pb="12">
+							<Text weight="bold" size="small" color="strong">
+								Learn more about Highlight&apos;s AI
+							</Text>
 							<Text color="moderate">
 								Curious about how we use OpenAI&apos;s GPT-3.5 to power our AI
 								services? Read the blog post!
 							</Text>
 						</Stack>
 
-						<Box>
-							<Button
-								onClick={() => {
-									window.open(
-										'https://highlight.io/blog/introducing-harold',
-										'_blank',
-									)
-								}}
-								trackingId="settings_ai-learn-more"
-							>
-								Read the blog post
-							</Button>
-						</Box>
-					</Stack>
+						<Button
+							kind="secondary"
+							emphasis="high"
+							iconRight={<IconSolidExternalLink size={14} />}
+							onClick={() => {
+								window.open(
+									'https://highlight.io/blog/introducing-harold',
+									'_blank',
+								)
+							}}
+							trackingId="settings_ai-learn-more"
+						>
+							Read the blog post
+						</Button>
+					</Box>
 				</Box>
 
-				<Stack direction="column" gap="12">
-					<Heading level="h4">Harold Features</Heading>
+				<Stack gap="12" direction="column" paddingTop="24">
+					<Text weight="bold" size="small" color="default">
+						Harold Features
+					</Text>
 
-					<Stack direction="column" gap="8">
-						{AI_FEATURES.map((setting) => (
-							<Box
-								key={setting.key}
-								border="secondary"
-								borderRadius="6"
-								p="12"
-							>
-								{ToggleRow(
-									setting.label,
-									setting.info,
-									data?.workspaceSettings?.[setting.key] ?? false,
-									handleSwitch(setting),
-									loading || !canEdit,
-									canEdit ? '' : 'Please contact your admin to update',
-								)}
-							</Box>
-						))}
-					</Stack>
+					{AI_FEATURES.map((setting) => (
+						<Box
+							key={setting.key}
+							border="secondary"
+							borderRadius="6"
+							p="12"
+						>
+							{ToggleRow(
+								setting.label,
+								setting.info,
+								data?.workspaceSettings?.[setting.key] ?? false,
+								handleSwitch(setting),
+								loading || !canEdit,
+								canEdit ? '' : 'Please contact your admin to update',
+							)}
+						</Box>
+					))}
 				</Stack>
 			</Stack>
 		</Box>

--- a/frontend/src/pages/HaroldAISettings/HaroldAISettings.tsx
+++ b/frontend/src/pages/HaroldAISettings/HaroldAISettings.tsx
@@ -59,6 +59,7 @@ export const HaroldAISettings = () => {
 	})
 
 	const { checkPolicyAccess } = useAuthorization()
+
 	const canEdit = checkPolicyAccess({
 		policyName: POLICY_NAMES.HaroldSettingsUpdate,
 	})
@@ -77,9 +78,7 @@ export const HaroldAISettings = () => {
 		})
 			.then(() => {
 				toast.success(
-					`${isOptIn ? 'Enabled' : 'Disabled'} Harold for your ${
-						setting.feature
-					}.`,
+					`${isOptIn ? 'Enabled' : 'Disabled'} Harold for your ${setting.feature}.`,
 				)
 			})
 			.catch((reason: any) => {
@@ -94,6 +93,7 @@ export const HaroldAISettings = () => {
 					<Heading mt="16" level="h4">
 						Harold AI
 					</Heading>
+
 					<Text weight="medium" size="small" color="default">
 						Highlight&apos;s Harold is an AI assistant helping you better
 						understand the context around your data. Harold is based on OpenAI
@@ -107,6 +107,7 @@ export const HaroldAISettings = () => {
 							<Text weight="bold" size="small" color="strong">
 								Learn more about Highlight&apos;s AI
 							</Text>
+
 							<Text color="moderate">
 								Curious about how we use OpenAI&apos;s GPT-3.5 to power our AI
 								services? Read the blog post!
@@ -157,3 +158,5 @@ export const HaroldAISettings = () => {
 		</Box>
 	)
 }
+
+export default HaroldAISettings

--- a/frontend/src/pages/HaroldAISettings/HaroldAISettings.tsx
+++ b/frontend/src/pages/HaroldAISettings/HaroldAISettings.tsx
@@ -1,15 +1,8 @@
 import { toast } from '@components/Toaster'
-import {
-	Box,
-	Heading,
-	IconSolidExternalLink,
-	Stack,
-	Text,
-} from '@highlight-run/ui/components'
+import { Box, Heading, Stack, Text } from '@highlight-run/ui/components'
 import { useAuthorization } from '@util/authorization/authorization'
 import { POLICY_NAMES } from '@util/authorization/authorizationPolicies'
 
-import BorderBox from '@/components/BorderBox/BorderBox'
 import { Button } from '@/components/Button'
 import { ToggleRow } from '@/components/ToggleRow/ToggleRow'
 import {
@@ -53,6 +46,7 @@ export const HaroldAISettings = () => {
 	const [editWorkspaceSettings] = useEditWorkspaceSettingsMutation({
 		refetchQueries: [namedOperations.Query.GetWorkspaceSettings],
 	})
+
 	const { data, loading } = useGetWorkspaceSettingsQuery({
 		variables: { workspace_id: String(currentWorkspace?.id) },
 		skip: !currentWorkspace?.id,
@@ -67,6 +61,7 @@ export const HaroldAISettings = () => {
 		if (!currentWorkspace?.id) {
 			return
 		}
+
 		editWorkspaceSettings({
 			variables: {
 				...data?.workspaceSettings,
@@ -87,34 +82,29 @@ export const HaroldAISettings = () => {
 	}
 
 	return (
-		<Box>
-			<Box style={{ maxWidth: 560 }} my="40" mx="auto">
-				<Stack gap="24" direction="column">
-					<Stack gap="16" direction="column">
-						<Heading mt="16" level="h4">
-							Harold AI
-						</Heading>
-						<Text weight="medium" size="small" color="default">
-							Highlight's Harold is an AI assistant helping you
-							better understand the context around your data.
-							Harold is based on OpenAI GPT-3.5.
-						</Text>
-					</Stack>
-					<BorderBox>
-						<Box pt="4">
-							<Stack gap="12" direction="column" pb="12">
-								<Text weight="bold" size="small" color="strong">
-									Learn more about Highlight's AI
-								</Text>
-								<Text color="moderate">
-									Curious about how we use OpenAI's GPT-3.5 to
-									power our AI services? Read the blog post!
-								</Text>
-							</Stack>
+		<Box border="secondary" borderRadius="6" p="16">
+			<Stack gap="24">
+				<Stack direction="column" gap="8">
+					<Heading level="h3">Harold AI</Heading>
+					<Text color="moderate">
+						Highlight&apos;s Harold is an AI assistant helping you better
+						understand the context around your data. Harold is based on OpenAI
+						GPT-3.5.
+					</Text>
+				</Stack>
+
+				<Box border="secondary" borderRadius="6" p="16">
+					<Stack direction="column" gap="12">
+						<Stack direction="column" gap="4">
+							<Heading level="h4">Learn more about Highlight&apos;s AI</Heading>
+							<Text color="moderate">
+								Curious about how we use OpenAI&apos;s GPT-3.5 to power our AI
+								services? Read the blog post!
+							</Text>
+						</Stack>
+
+						<Box>
 							<Button
-								kind="secondary"
-								emphasis="high"
-								iconRight={<IconSolidExternalLink size={14} />}
 								onClick={() => {
 									window.open(
 										'https://highlight.io/blog/introducing-harold',
@@ -126,28 +116,33 @@ export const HaroldAISettings = () => {
 								Read the blog post
 							</Button>
 						</Box>
-					</BorderBox>
-					<Stack gap="12" direction="column" paddingTop="24">
-						<Text weight="bold" size="small" color="default">
-							Harold Features
-						</Text>
-						{AI_FEATURES.map((c) => (
-							<BorderBox key={c.key}>
+					</Stack>
+				</Box>
+
+				<Stack direction="column" gap="12">
+					<Heading level="h4">Harold Features</Heading>
+
+					<Stack direction="column" gap="8">
+						{AI_FEATURES.map((setting) => (
+							<Box
+								key={setting.key}
+								border="secondary"
+								borderRadius="6"
+								p="12"
+							>
 								{ToggleRow(
-									c.label,
-									c.info,
-									data?.workspaceSettings?.[c.key] ?? false,
-									handleSwitch(c),
+									setting.label,
+									setting.info,
+									data?.workspaceSettings?.[setting.key] ?? false,
+									handleSwitch(setting),
 									loading || !canEdit,
-									canEdit
-										? ''
-										: 'Please contact your admin to update',
+									canEdit ? '' : 'Please contact your admin to update',
 								)}
-							</BorderBox>
+							</Box>
 						))}
 					</Stack>
 				</Stack>
-			</Box>
+			</Stack>
 		</Box>
 	)
 }

--- a/frontend/src/pages/HaroldAISettings/HaroldAISettings.tsx
+++ b/frontend/src/pages/HaroldAISettings/HaroldAISettings.tsx
@@ -71,7 +71,7 @@ export const HaroldAISettings = () => {
 		editWorkspaceSettings({
 			variables: {
 				...data?.workspaceSettings,
-				workspace_id: currentWorkspace?.id,
+				workspace_id: currentWorkspace.id,
 				[setting.key]: isOptIn,
 			},
 		})

--- a/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
@@ -1,15 +1,13 @@
 import Alert from '@components/Alert/Alert'
 import { FieldsBox } from '@components/FieldsBox/FieldsBox'
 import { AdminRole } from '@graph/schemas'
-import { Box } from '@highlight-run/ui/components'
+import { Box, Heading, Text } from '@highlight-run/ui/components'
 import { AutoJoinForm } from '@pages/WorkspaceTeam/components/AutoJoinForm'
 import { Authorization } from '@util/authorization/authorization'
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
 import { useAuthContext } from '@/authentication/AuthContext'
 
-import layoutStyles from '../../components/layout/LeadAlignLayout.module.css'
 import { FieldsForm } from './FieldsForm/FieldsForm'
-import styles from './WorkspaceSettings.module.css'
 
 const WorkspaceSettings = () => {
 	const { currentWorkspace } = useApplicationContext()
@@ -17,44 +15,45 @@ const WorkspaceSettings = () => {
 	const isAdminRole = workspaceRole === AdminRole.Admin
 
 	return (
-		<Box>
-			<Box style={{ maxWidth: 560 }} my="40" mx="auto">
-				<div className={styles.container}>
-					<div className={styles.titleContainer}>
-						<div>
-							<h3>Properties</h3>
-							<p className={layoutStyles.subTitle}>
-								Manage your workspace details.
-							</p>
-						</div>
-					</div>
-					<FieldsBox id="workspace">
-						<FieldsForm
-							defaultName={currentWorkspace?.name}
-							disabled={!isAdminRole}
-						/>
-					</FieldsBox>
-					<FieldsBox id="autojoin">
-						<h3>Auto Join</h3>
-						<p>
+		<Box style={{ maxWidth: 560 }} my="40" mx="auto">
+			<Box display="flex" flexDirection="column" gap="32">
+				<Box display="flex" flexDirection="column" gap="8">
+					<Heading level="h3">Properties</Heading>
+					<Text size="large" color="moderate">
+						Manage your workspace details.
+					</Text>
+				</Box>
+
+				<FieldsBox id="workspace">
+					<FieldsForm
+						defaultName={currentWorkspace?.name}
+						disabled={!isAdminRole}
+					/>
+				</FieldsBox>
+
+				<FieldsBox id="autojoin">
+					<Box display="flex" flexDirection="column" gap="16" mb="16">
+						<Heading level="h3">Auto Join</Heading>
+						<Text color="moderate">
 							Enable auto join to allow anyone with an approved
 							email origin join.
-						</p>
-						<Authorization
-							allowedRoles={[AdminRole.Admin]}
-							forbiddenFallback={
-								<Alert
-									trackingId="AdminNoAccessToAutoJoinDomains"
-									type="info"
-									message="You don't have access to auto-access domains."
-									description={`You don't have permission to configure auto-access domains. Please contact a workspace admin to make changes.`}
-								/>
-							}
-						>
-							<AutoJoinForm />
-						</Authorization>
-					</FieldsBox>
-				</div>
+						</Text>
+					</Box>
+					
+					<Authorization
+						allowedRoles={[AdminRole.Admin]}
+						forbiddenFallback={
+							<Alert
+								trackingId="AdminNoAccessToAutoJoinDomains"
+								type="info"
+								message="You don't have access to auto-access domains."
+								description={`You don't have permission to configure auto-access domains. Please contact a workspace admin to make changes.`}
+							/>
+						}
+					>
+						<AutoJoinForm />
+					</Authorization>
+				</FieldsBox>
 			</Box>
 		</Box>
 	)

--- a/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
@@ -1,13 +1,15 @@
 import Alert from '@components/Alert/Alert'
 import { FieldsBox } from '@components/FieldsBox/FieldsBox'
 import { AdminRole } from '@graph/schemas'
-import { Box, Heading, Text } from '@highlight-run/ui/components'
+import { Box } from '@highlight-run/ui/components'
 import { AutoJoinForm } from '@pages/WorkspaceTeam/components/AutoJoinForm'
 import { Authorization } from '@util/authorization/authorization'
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
 import { useAuthContext } from '@/authentication/AuthContext'
 
+import layoutStyles from '../../components/layout/LeadAlignLayout.module.css'
 import { FieldsForm } from './FieldsForm/FieldsForm'
+import styles from './WorkspaceSettings.module.css'
 
 const WorkspaceSettings = () => {
 	const { currentWorkspace } = useApplicationContext()
@@ -15,45 +17,44 @@ const WorkspaceSettings = () => {
 	const isAdminRole = workspaceRole === AdminRole.Admin
 
 	return (
-		<Box style={{ maxWidth: 560 }} my="40" mx="auto">
-			<Box display="flex" flexDirection="column" gap="32">
-				<Box display="flex" flexDirection="column" gap="8">
-					<Heading level="h3">Properties</Heading>
-					<Text size="large" color="moderate">
-						Manage your workspace details.
-					</Text>
-				</Box>
-
-				<FieldsBox id="workspace">
-					<FieldsForm
-						defaultName={currentWorkspace?.name}
-						disabled={!isAdminRole}
-					/>
-				</FieldsBox>
-
-				<FieldsBox id="autojoin">
-					<Box display="flex" flexDirection="column" gap="16" mb="16">
-						<Heading level="h3">Auto Join</Heading>
-						<Text color="moderate">
+		<Box>
+			<Box style={{ maxWidth: 560 }} my="40" mx="auto">
+				<div className={styles.container}>
+					<div className={styles.titleContainer}>
+						<div>
+							<h3>Properties</h3>
+							<p className={layoutStyles.subTitle}>
+								Manage your workspace details.
+							</p>
+						</div>
+					</div>
+					<FieldsBox id="workspace">
+						<FieldsForm
+							defaultName={currentWorkspace?.name}
+							disabled={!isAdminRole}
+						/>
+					</FieldsBox>
+					<FieldsBox id="autojoin">
+						<h3>Auto Join</h3>
+						<p>
 							Enable auto join to allow anyone with an approved
 							email origin join.
-						</Text>
-					</Box>
-
-					<Authorization
-						allowedRoles={[AdminRole.Admin]}
-						forbiddenFallback={
-							<Alert
-								trackingId="AdminNoAccessToAutoJoinDomains"
-								type="info"
-								message="You don't have access to auto-access domains."
-								description={`You don't have permission to configure auto-access domains. Please contact a workspace admin to make changes.`}
-							/>
-						}
-					>
-						<AutoJoinForm />
-					</Authorization>
-				</FieldsBox>
+						</p>
+						<Authorization
+							allowedRoles={[AdminRole.Admin]}
+							forbiddenFallback={
+								<Alert
+									trackingId="AdminNoAccessToAutoJoinDomains"
+									type="info"
+									message="You don't have access to auto-access domains."
+									description={`You don't have permission to configure auto-access domains. Please contact a workspace admin to make changes.`}
+								/>
+							}
+						>
+							<AutoJoinForm />
+						</Authorization>
+					</FieldsBox>
+				</div>
 			</Box>
 		</Box>
 	)

--- a/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
@@ -39,7 +39,7 @@ const WorkspaceSettings = () => {
 							email origin join.
 						</Text>
 					</Box>
-					
+
 					<Authorization
 						allowedRoles={[AdminRole.Admin]}
 						forbiddenFallback={


### PR DESCRIPTION
## Summary

Replaces the legacy BorderBox usage in HaroldAISettings with Highlight UI Box components.

## Changes

- Removes the BorderBox import from HaroldAISettings.tsx
- Wraps the Harold AI settings layout in native Highlight UI Box components
- Keeps the existing toggle behavior and workspace settings mutation logic unchanged

## Issue

Part of #8635