### PR TITLE
Remove antd Select from GitHub settings modal

### DIFF
--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -10,12 +10,13 @@ import {
 	IconSolidQuestionMarkCircle,
 	IconSolidTrash,
 	IconSolidX,
+	Select,
 	Text,
 	TextLink,
 	Tooltip,
+	type SelectOption,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -121,7 +122,7 @@ const GithubSettingsForm = ({
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
 				id: repo.key,
-				label: repo.name.split('/').pop(),
+				name: repo.name.split('/').pop() ?? repo.name,
 				value: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
@@ -155,20 +156,15 @@ const GithubSettingsForm = ({
 							aria-label="GitHub repository"
 							className={styles.repoSelect}
 							placeholder="Search repos..."
-							onSelect={(repo: string) =>
+							filterable
+							onValueChange={(option: SelectOption) =>
 								formStore.setValue(
 									formStore.names.githubRepo,
-									repo,
+									String(option.value),
 								)
 							}
-							value={formState.values.githubRepo
-								?.split('/')
-								.pop()}
+							value={formState.values.githubRepo ?? undefined}
 							options={githubOptions}
-							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
-							filterOption
-							showSearch
 						/>
 						<ButtonIcon
 							kind="secondary"


### PR DESCRIPTION
## Summary
- Replace the Project Settings GitHub repository selector with the shared @highlight-run/ui Select component.
- Keep storing the full owner/repo value while displaying repository names in the selector.
- Remove the direct antd Select usage from this settings modal.

## Testing
- corepack yarn prettier --check frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
- corepack yarn workspace @highlight-run/frontend eslint src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx

/claim #8635

## Reviewer notes
- The changeset warning should be non-blocking for this PR: `@highlight-run/frontend` is listed under `ignore` in `.changeset/config.json`, and this change is an internal UI tech-debt cleanup with no package release expected.
- The Vercel failure points to Vercel/GitHub authorization, not a code-level failure. Local formatting and eslint checks are listed above.
