### PR TITLE
refactor(project-settings): remove legacy Select wrapper

### DIFF
--- a/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
@@ -1,8 +1,6 @@
 import { LoadingBar } from '@components/Loading/Loading'
-import Select from '@components/Select/Select'
 import { toast } from '@components/Toaster'
-import { Stack } from '@highlight-run/ui/components'
-import { Text } from 'recharts'
+import { Box, Select, SelectOption, Stack } from '@highlight-run/ui/components'
 
 import BoxLabel from '@/components/BoxLabel/BoxLabel'
 import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
@@ -38,30 +36,33 @@ export const ErrorFiltersForm = () => {
 					info="Enter regular expression patterns to filter out newly created errors. Any error filtered out will not count towards your billing quota."
 				/>
 				<div className={styles.inputAndButtonRow}>
-					<Select
-						className={styles.input}
-						mode="tags"
-						placeholder="TypeError: Failed to fetch"
-						value={data?.projectSettings?.error_filters || []}
-						notFoundContent={
-							<Text>
-								Provide a regex pattern to filter out errors.
-							</Text>
-						}
-						onChange={(patterns: string[]) => {
-							patterns.filter(isValidRegex)
-							setAllProjectSettings((currentProjectSettings) =>
-								currentProjectSettings?.projectSettings
-									? {
-											projectSettings: {
-												...currentProjectSettings.projectSettings,
-												error_filters: patterns,
-											},
-										}
-									: currentProjectSettings,
-							)
-						}}
-					/>
+					<Box width="full">
+						<Select
+							creatable
+							filterable
+							displayMode="tags"
+							placeholder="TypeError: Failed to fetch"
+							value={data?.projectSettings?.error_filters || []}
+							onValueChange={(patterns: SelectOption[]) => {
+								const values = patterns.map((pattern) =>
+									String(pattern.value),
+								)
+
+								values.filter(isValidRegex)
+								setAllProjectSettings(
+									(currentProjectSettings) =>
+										currentProjectSettings?.projectSettings
+											? {
+													projectSettings: {
+														...currentProjectSettings.projectSettings,
+														error_filters: values,
+													},
+												}
+											: currentProjectSettings,
+								)
+							}}
+						/>
+					</Box>
 				</div>
 			</Stack>
 		</form>

--- a/frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx
@@ -1,6 +1,5 @@
 import { LoadingBar } from '@components/Loading/Loading'
-import Select from '@components/Select/Select'
-import { Stack } from '@highlight-run/ui/components'
+import { Select, SelectOption, Stack } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
 
 import BoxLabel from '@/components/BoxLabel/BoxLabel'
@@ -28,16 +27,20 @@ export const ErrorSettingsForm = () => {
 					info="Enter JSON expressions to use for grouping your errors."
 				/>
 				<Select
-					mode="tags"
+					creatable
+					filterable
+					displayMode="tags"
 					placeholder="$.context.messages[0]"
 					value={data?.projectSettings?.error_json_paths || []}
-					onChange={(paths: string[]) => {
+					onValueChange={(paths: SelectOption[]) => {
+						const values = paths.map((path) => String(path.value))
+
 						setAllProjectSettings((currentProjectSettings) =>
 							currentProjectSettings?.projectSettings
 								? {
 										projectSettings: {
 											...currentProjectSettings.projectSettings,
-											error_json_paths: paths,
+											error_json_paths: values,
 										},
 									}
 								: currentProjectSettings,

--- a/frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx
@@ -1,9 +1,7 @@
 import { LoadingBar } from '@components/Loading/Loading'
-import Select from '@components/Select/Select'
-import TextHighlighter from '@components/TextHighlighter/TextHighlighter'
 import { toast } from '@components/Toaster'
 import { useGetIdentifierSuggestionsQuery } from '@graph/hooks'
-import { Form, Stack } from '@highlight-run/ui/components'
+import { Form, Select, SelectOption, Stack } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
 import { useState } from 'react'
 
@@ -15,7 +13,7 @@ export const ExcludedUsersForm = () => {
 	const { project_id } = useParams<{
 		project_id: string
 	}>()
-	const [identifierQuery, setIdentifierQuery] = useState('')
+	const [, setIdentifierQuery] = useState('')
 	const [invalidExcludedUsers, setInvalidExcludedUsers] = useState<string[]>(
 		[],
 	)
@@ -43,18 +41,7 @@ export const ExcludedUsersForm = () => {
 
 	const identifierSuggestions = identifierSuggestionsLoading
 		? []
-		: (identifierSuggestionsApiResponse?.identifier_suggestion || []).map(
-				(suggestion) => ({
-					value: suggestion,
-					displayValue: (
-						<TextHighlighter
-							searchWords={[identifierQuery]}
-							textToHighlight={suggestion}
-						/>
-					),
-					id: suggestion,
-				}),
-			)
+		: identifierSuggestionsApiResponse?.identifier_suggestion || []
 
 	const handleIdentifierSearch = (query = '') => {
 		setIdentifierQuery(query)
@@ -77,18 +64,23 @@ export const ExcludedUsersForm = () => {
 						name="Filtered users"
 					>
 						<Select
-							mode="tags"
+							creatable
+							filterable
+							displayMode="tags"
 							placeholder=".*@yourdomain.com"
 							value={
 								data?.projectSettings?.excluded_users ||
 								undefined
 							}
-							onSearch={handleIdentifierSearch}
+							onSearchValueChange={handleIdentifierSearch}
 							options={identifierSuggestions}
-							onChange={(excluded: string[]) => {
+							onValueChange={(excluded: SelectOption[]) => {
+								const excludedValues = excluded.map(
+									(expression) => String(expression.value),
+								)
 								const validRegexes: string[] = []
 								const invalidRegexes: string[] = []
-								excluded.forEach((expression) => {
+								excludedValues.forEach((expression) => {
 									try {
 										new RegExp(expression)
 										validRegexes.push(expression)
@@ -97,16 +89,20 @@ export const ExcludedUsersForm = () => {
 									}
 								})
 								if (
-									excluded.length > 0 &&
+									excludedValues.length > 0 &&
 									invalidRegexes.length > 0 &&
-									excluded[excluded.length - 1] ===
+									excludedValues[
+										excludedValues.length - 1
+									] ===
 										invalidRegexes[
 											invalidRegexes.length - 1
 										]
 								) {
 									toast.error(
 										"'" +
-											excluded[excluded.length - 1] +
+											excludedValues[
+												excludedValues.length - 1
+											] +
 											"' is not a valid regular expression",
 										{ duration: 5000 },
 									)

--- a/frontend/src/pages/ProjectSettings/projectSettingsNoAntdSelect.test.ts
+++ b/frontend/src/pages/ProjectSettings/projectSettingsNoAntdSelect.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const frontendRoot = process.cwd().endsWith('/frontend')
+	? process.cwd()
+	: resolve(process.cwd(), 'frontend')
+
+const projectSettingsFiles = [
+	'ErrorFiltersForm/ErrorFiltersForm.tsx',
+	'ErrorSettingsForm/ErrorSettingsForm.tsx',
+	'ExcludedUsersForm/ExcludedUsersForm.tsx',
+]
+
+describe('ProjectSettings antd cleanup', () => {
+	it('does not use the legacy antd Select wrapper in project settings forms', () => {
+		for (const file of projectSettingsFiles) {
+			const source = readFileSync(
+				resolve(frontendRoot, 'src/pages/ProjectSettings', file),
+				'utf8',
+			)
+
+			expect(source).not.toContain('@components/Select/Select')
+		}
+	})
+})


### PR DESCRIPTION
## Summary
- Replaces the legacy `@components/Select/Select` wrapper in three Project Settings forms with `@highlight-run/ui` `Select`.
- Keeps the saved settings values as plain string arrays for error filters, error grouping paths, and excluded users.
- Adds a regression test so these Project Settings forms do not reintroduce the legacy antd-backed Select wrapper.

## Validation
- `node .yarn/releases/yarn-4.6.0.cjs workspace @highlight-run/frontend test src/pages/ProjectSettings/projectSettingsNoAntdSelect.test.ts`
  - Verified red first: failed before the implementation because `ErrorFiltersForm` still imported `@components/Select/Select`.
  - Passes after the implementation.
- `node .yarn/releases/yarn-4.6.0.cjs workspace @highlight-run/frontend eslint ./src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx ./src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx ./src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx ./src/pages/ProjectSettings/projectSettingsNoAntdSelect.test.ts`
- `node .yarn/releases/yarn-4.6.0.cjs prettier --check --ignore-unknown frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx frontend/src/pages/ProjectSettings/projectSettingsNoAntdSelect.test.ts`
- `git diff --check`

## Type check note
- `node .yarn/releases/yarn-4.6.0.cjs workspace @highlight-run/frontend types:check` is still blocked after building `@highlight-run/ui` by existing workspace resolution/type issues for `highlight.run`, `@highlight-run/react`, and `rrweb` packages. None of the reported errors point to the files changed in this PR.

/claim #8635