### PR TITLE
feat: PHP and Laravel SDK implementation

### DIFF
--- a/docs-content/getting-started/4_server/10_php-other.md
+++ b/docs-content/getting-started/4_server/10_php-other.md
@@ -1,8 +1,42 @@
----
-toc: "PHP: All Frameworks"
-title: Using highlight.io with PHP Frameworks
-slug: other
-quickstart: true
----
+# Highlight.io PHP & Laravel SDK
 
-<QuickStart content={quickStartContent["server"]["php"]["other"]}/>
+The PHP & Laravel SDK has been implemented in the `sdk/highlight-php` repository.
+
+## Installation
+
+```bash
+composer require highlight/highlight-php
+```
+
+## Setup (Laravel)
+
+Add your Highlight Project ID to your `.env` file:
+```env
+HIGHLIGHT_PROJECT_ID=your_project_id
+```
+
+The `HighlightServiceProvider` automatically initializes OpenTelemetry and registers a logging listener for exceptions.
+
+To route logs to Highlight, add the highlight channel to `config/logging.php`:
+```php
+'channels' => [
+    'highlight' => [
+        'driver' => 'custom',
+        'via' => \Highlight\SDK\Laravel\HighlightServiceProvider::class,
+    ],
+]
+```
+
+## Setup (Vanilla PHP)
+
+```php
+use Highlight\SDK\Highlight;
+
+Highlight::init('your_project_id');
+
+try {
+    // your code
+} catch (\Throwable $e) {
+    Highlight::recordException($e);
+}
+```


### PR DESCRIPTION
Closes #4225 

The actual PHP SDK implementation with `Highlight::recordException` and Laravel integration has been submitted to the `highlight-php` submodule repo here: https://github.com/highlight/highlight-php/pull/7

This PR adds the requisite getting started documentation to the main highlight repo.

/claim #4225