### PR TITLE
docs: add SvelteKit backend instrumentation guide

### DIFF
--- a/docs-content/general/6_product-features/99_frequently-asked-questions.md
+++ b/docs-content/general/6_product-features/99_frequently-asked-questions.md
@@ -30,7 +30,7 @@ This documentation provides solutions and guidance for common issues encountered
 
 **Question:** How can I set up tracing with SvelteKit as I am not seeing any traces despite having logs and errors?
 
-**Answer:** Ensure that your `H.init` configuration is correctly set up in both `hooks.client.ts` and `hooks.server.ts`. Use `H.runWithHeaders` in your server-side handle function to ensure that headers are correctly passed and handled. If issues persist, please provide the Highlight traces page URL and check the version of the `@highlight-run/node` SDK you are using. For detailed guidance, refer to the [Highlight.io SvelteKit Documentation](https://www.highlight.io/docs/getting-started/client-sdk/sveltekit).
+**Answer:** Ensure that your `H.init` configuration is correctly set up in both `hooks.client.ts` and `hooks.server.ts`. Use `H.runWithHeaders` in your server-side handle function to ensure that headers are correctly passed and handled. If issues persist, please provide the Highlight traces page URL and check the version of the `@highlight-run/node` SDK you are using. For detailed guidance, refer to the [SvelteKit frontend setup](../../getting-started/3_browser/6_sveltekit.md) and [SvelteKit backend instrumentation](../../getting-started/4_server/2_js/sveltekit.md) guides.
 
 ## Session Recording Issues
 

--- a/docs-content/getting-started/4_server/2_js/1_overview.md
+++ b/docs-content/getting-started/4_server/2_js/1_overview.md
@@ -36,6 +36,9 @@ updatedAt: 2022-04-01T19:52:59.000Z
     <DocsCard title="Node.js" href="../js/nodejs">
         {"Get started with Node.js"}
     </DocsCard>
+    <DocsCard title="SvelteKit" href="../js/sveltekit">
+        {"Get started with SvelteKit"}
+    </DocsCard>
     <DocsCard title="Pino" href="../js/pino">
         {"Get started with Pino"}
     </DocsCard>

--- a/docs-content/getting-started/4_server/2_js/sveltekit.md
+++ b/docs-content/getting-started/4_server/2_js/sveltekit.md
@@ -1,0 +1,11 @@
+---
+title: SvelteKit
+heading: SvelteKit Backend Quick Start
+metaTitle: SvelteKit Backend Quick Start
+slug: sveltekit
+createdAt: 2026-05-20T00:00:00.000Z
+updatedAt: 2026-05-20T00:00:00.000Z
+quickstart: true
+---
+
+<QuickStart content={quickStartContent["server"]["js"]["svelte-kit"]}/>

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -108,6 +108,7 @@ import { JSNodeReorganizedContent } from './server/js/nodejs'
 import { JSNestReorganizedContent } from './server/js/nestjs'
 import { JStRPCReorganizedContent } from './server/js/trpc'
 import { JSPinoHTTPJSONLogReorganizedContent } from './server/js/pino'
+import { JSSvelteKitReorganizedContent } from './server/js/sveltekit'
 import { JSWinstonHTTPJSONLogReorganizedContent } from './server/js/winston'
 import { JSManualTracesReorganizedContent } from './server/js/manual'
 import { PHPOtherReorganizedContent } from './server/php/other'
@@ -456,6 +457,7 @@ export const quickStartContent = {
 			[QuickStartType.JSHono]: JSHonoReorganizedContent,
 			[QuickStartType.JSNodejs]: JSNodeReorganizedContent,
 			[QuickStartType.JSNestjs]: JSNestReorganizedContent,
+			[QuickStartType.SvelteKit]: JSSvelteKitReorganizedContent,
 			[QuickStartType.JStRPC]: JStRPCReorganizedContent,
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,
@@ -601,6 +603,7 @@ export const quickStartContentReorganized = {
 			[QuickStartType.JSHono]: JSHonoReorganizedContent,
 			[QuickStartType.JSNodejs]: JSNodeReorganizedContent,
 			[QuickStartType.JSNestjs]: JSNestReorganizedContent,
+			[QuickStartType.SvelteKit]: JSSvelteKitReorganizedContent,
 			[QuickStartType.JStRPC]: JStRPCReorganizedContent,
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,

--- a/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
@@ -1,0 +1,102 @@
+import { QuickStartContent } from '../../QuickstartContent'
+import { verifyLogs } from '../shared-snippets-logging'
+import {
+	frontendInstallSnippet,
+	verifyErrors,
+} from '../shared-snippets-monitoring'
+import { verifyTraces } from '../shared-snippets-tracing'
+import { jsGetSnippet } from './shared-snippets-monitoring'
+
+export const JSSvelteKitReorganizedContent: QuickStartContent = {
+	title: 'SvelteKit',
+	subtitle:
+		'Learn how to set up highlight.io backend monitoring for your SvelteKit application.',
+	logoKey: 'sveltekit',
+	products: ['Errors', 'Logs', 'Traces'],
+	entries: [
+		frontendInstallSnippet,
+		jsGetSnippet(['node']),
+		{
+			title: 'Initialize Highlight and wrap SvelteKit server requests.',
+			content:
+				'Use the SvelteKit `handle` hook to create a Highlight trace for each server-side request. Copy the incoming request headers before passing them to `H.runWithHeaders` so Highlight can read the `x-highlight-request` header without mutating SvelteKit request headers.',
+			code: [
+				{
+					text: `// src/hooks.server.ts
+import { H } from '@highlight-run/node'
+import type { Handle } from '@sveltejs/kit'
+
+H.init({
+	projectID: '<YOUR_PROJECT_ID>',
+	serviceName: 'sveltekit-backend',
+	environment: 'production',
+})
+
+export const handle: Handle = async ({ event, resolve }) => {
+	const headers = new Headers(event.request.headers)
+
+	return H.runWithHeaders('sveltekit.request', headers, async () => {
+		return resolve(event)
+	})
+}`,
+					language: 'js',
+				},
+			],
+		},
+		{
+			title: 'Report unexpected server errors.',
+			content:
+				'SvelteKit calls `handleError` for unexpected server-side errors during request handling, loading, or rendering. Parse the Highlight request header from the original request and report the error so it can be connected to the related session and request.',
+			code: [
+				{
+					text: `// src/hooks.server.ts
+import { H } from '@highlight-run/node'
+import type { HandleServerError } from '@sveltejs/kit'
+
+export const handleError: HandleServerError = async ({
+	error,
+	event,
+	status,
+}) => {
+	const { secureSessionId, requestId } = H.parseHeaders(event.request.headers)
+	const highlightError =
+		error instanceof Error ? error : new Error(String(error))
+
+	H.consumeError(highlightError, secureSessionId, requestId, {
+		route: event.route.id ?? 'unknown',
+		status,
+	})
+}`,
+					language: 'js',
+				},
+			],
+		},
+		{
+			title: 'Add custom spans inside server handlers.',
+			content:
+				'After the `handle` hook is installed, spans created in server routes, actions, and server load functions are tied to the current request context.',
+			code: [
+				{
+					text: `// src/routes/api/ping/+server.ts
+import { H } from '@highlight-run/node'
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async () => {
+	const { span } = H.startWithHeaders('sveltekit.api.ping', {})
+
+	try {
+		console.info('checking API health')
+		return new Response('ok')
+	} finally {
+		span.end()
+	}
+}`,
+					language: 'js',
+				},
+			],
+		},
+		verifyErrors,
+		verifyLogs,
+		verifyTraces,
+	],
+}


### PR DESCRIPTION
## Summary
- add a SvelteKit backend quickstart for @highlight-run/node
- link the new guide from the JavaScript server docs index
- update the SvelteKit tracing FAQ to point to both frontend and backend guides

## Verification
- git show --check
- git status --short

Resolves #8032
/claim #8032