### PR TITLE
Remove antd Select from GitHub settings modal

### DIFF
--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -10,12 +10,12 @@ import {
 	IconSolidQuestionMarkCircle,
 	IconSolidTrash,
 	IconSolidX,
+	Select,
 	Text,
 	TextLink,
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -120,8 +120,7 @@ const GithubSettingsForm = ({
 	const githubOptions = useMemo(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
-				id: repo.key,
-				label: repo.name.split('/').pop(),
+				name: repo.name.split('/').pop() ?? repo.name,
 				value: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
@@ -155,20 +154,15 @@ const GithubSettingsForm = ({
 							aria-label="GitHub repository"
 							className={styles.repoSelect}
 							placeholder="Search repos..."
-							onSelect={(repo: string) =>
+							onValueChange={(repo) =>
 								formStore.setValue(
 									formStore.names.githubRepo,
-									repo,
+									String(repo.value),
 								)
 							}
-							value={formState.values.githubRepo
-								?.split('/')
-								.pop()}
+							value={formState.values.githubRepo ?? undefined}
 							options={githubOptions}
-							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
-							filterOption
-							showSearch
+							filterable
 						/>
 						<ButtonIcon
 							kind="secondary"


### PR DESCRIPTION
## Summary

- Replaced the Ant Design `Select` usage in the GitHub settings modal with Highlight's internal UI `Select`
- Converted repository options to the internal select option shape
- Preserved searchable repo selection and the stored GitHub repository path value

## Testing

- `YARN_ENABLE_GLOBAL_CACHE=false YARN_CACHE_FOLDER=.yarn/cache YARN_GLOBAL_FOLDER=.yarn/global node .yarn/releases/yarn-4.6.0.cjs workspace @highlight-run/frontend lint --quiet --no-error-on-unmatched-pattern src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx`
- `YARN_ENABLE_GLOBAL_CACHE=false YARN_CACHE_FOLDER=.yarn/cache YARN_GLOBAL_FOLDER=.yarn/global node .yarn/releases/yarn-4.6.0.cjs workspace @highlight-run/ui build`
- Confirmed no `antd` imports remain under `frontend/src/pages/ProjectSettings` or `frontend/src/pages/WorkspaceSettings`

## Notes

I could not complete a full local frontend typecheck in this environment. The repo install hit unrelated postinstall failures for Cypress/Puppeteer/Sharp/RRVideo, and the later frontend typecheck failed on existing workspace/module resolution issues outside this file.
