### PR TITLE
refactor(new-project): remove antd Divider and Checkbox from NewProje…

### DIFF
--- a/frontend/src/pages/NewProject/AutoJoinInput.module.css
+++ b/frontend/src/pages/NewProject/AutoJoinInput.module.css
@@ -7,15 +7,3 @@
 	max-height: fit-content;
 	min-height: var(--size-xxLarge);
 }
-
-.select {
-	&:global(.ant-select-disabled .ant-select-selector) {
-		background-color: transparent !important;
-	}
-
-	:global(.ant-select-selector) {
-		padding: 0 !important;
-		border: 0px solid var(--color-gray-300) !important;
-		background-color: transparent !important;
-	}
-}

--- a/frontend/src/pages/NewProject/AutoJoinInput.tsx
+++ b/frontend/src/pages/NewProject/AutoJoinInput.tsx
@@ -1,8 +1,6 @@
 import { useAuthContext } from '@authentication/AuthContext'
 import Tooltip from '@components/Tooltip/Tooltip'
 import { Box, Text } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -23,7 +21,7 @@ export const AutoJoinInput: React.FC<Props> = ({
 	const { admin } = useAuthContext()
 	const adminsEmailDomain = getEmailDomain(admin?.email)
 
-	const handleMessageChecked = (event: CheckboxChangeEvent) => {
+	const handleMessageChecked = (event: React.ChangeEvent<HTMLInputElement>) => {
 		const domains = event.target.checked ? [adminsEmailDomain] : []
 		setAutoJoinDomains(domains)
 	}
@@ -43,18 +41,19 @@ export const AutoJoinInput: React.FC<Props> = ({
 		>
 			<div className={styles.container}>
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
+					<input
+						type="checkbox"
 						checked={autoJoinDomains.length > 0}
 						onChange={handleMessageChecked}
 					/>
 					<Text>Allowed email domains</Text>
 				</Box>
-				<Divider className="m-0 border-none pt-1" />
+				<Box my="4" />
 				<Text color="n11">
 					Allow everyone with a <b>{getEmailDomain(admin?.email)}</b>{' '}
 					email to join your workspace.
 				</Text>
-				<Divider className="m-0 border-none pt-1" />
+				<Box my="4" />
 			</div>
 		</Tooltip>
 	)

--- a/frontend/src/pages/NewProject/NewProjectPage.tsx
+++ b/frontend/src/pages/NewProject/NewProjectPage.tsx
@@ -12,7 +12,6 @@ import { namedOperations } from '@graph/operations'
 import { Box, Callout, Stack, Text } from '@highlight-run/ui/components'
 import analytics from '@util/analytics'
 import { client } from '@util/graph'
-import { Divider } from 'antd'
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
@@ -147,7 +146,7 @@ const NewProjectPage = ({ workspace_id }: { workspace_id: string }) => {
 								}}
 							/>
 						</Box>
-						<Divider className="m-0" />
+						<Box borderBottom="divider" width="full" />
 						<Box
 							py="8"
 							px="12"
@@ -242,16 +241,3 @@ const NewProjectPage = ({ workspace_id }: { workspace_id: string }) => {
 											color: 'var(--text-primary-inverted)',
 										}}
 									/>
-								) : (
-									`Create ${pageTypeCaps}`
-								)}
-							</Button>
-						</Box>
-					</CardForm>
-				</Box>
-			</Box>
-		</>
-	) : null
-}
-
-export default NewProjectPage


### PR DESCRIPTION
Removes `antd` imports from the `NewProject` pages as part of #8635.

## Changes
- `NewProjectPage.tsx`: replaced antd `Divider` with `<Box borderBottom="divider" width="full" />` from `@highlight-run/ui/components`
- `AutoJoinInput.tsx`: replaced antd `Divider` with `<Box my="4" />` spacers, replaced antd `Checkbox` with native `<input type="checkbox">`
- `AutoJoinInput.module.css`: removed dead antd-specific CSS (`.select` block with `ant-select` class overrides)

/claim #8635