### PR TITLE
docs: add SvelteKit server quickstart

### DIFF
--- a/docs-content/getting-started/4_server/2_js/1_overview.md
+++ b/docs-content/getting-started/4_server/2_js/1_overview.md
@@ -36,6 +36,9 @@ updatedAt: 2022-04-01T19:52:59.000Z
     <DocsCard title="Node.js" href="../js/nodejs">
         {"Get started with Node.js"}
     </DocsCard>
+    <DocsCard title="SvelteKit" href="../js/sveltekit">
+        {"Get started with SvelteKit"}
+    </DocsCard>
     <DocsCard title="Pino" href="../js/pino">
         {"Get started with Pino"}
     </DocsCard>

--- a/docs-content/getting-started/4_server/2_js/sveltekit.md
+++ b/docs-content/getting-started/4_server/2_js/sveltekit.md
@@ -1,0 +1,8 @@
+---
+toc: SvelteKit
+title: SvelteKit Quick Start
+slug: sveltekit
+quickstart: true
+---
+
+<QuickStart content={quickStartContent["server"]["js"]["svelte-kit"]}/>

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -106,6 +106,7 @@ import { JSFirebaseReorganizedContent } from './server/js/firebase'
 import { JSHonoReorganizedContent } from './server/js/hono'
 import { JSNodeReorganizedContent } from './server/js/nodejs'
 import { JSNestReorganizedContent } from './server/js/nestjs'
+import { JSSvelteKitReorganizedContent } from './server/js/sveltekit'
 import { JStRPCReorganizedContent } from './server/js/trpc'
 import { JSPinoHTTPJSONLogReorganizedContent } from './server/js/pino'
 import { JSWinstonHTTPJSONLogReorganizedContent } from './server/js/winston'
@@ -455,6 +456,7 @@ export const quickStartContent = {
 			[QuickStartType.JSFirebase]: JSFirebaseReorganizedContent,
 			[QuickStartType.JSHono]: JSHonoReorganizedContent,
 			[QuickStartType.JSNodejs]: JSNodeReorganizedContent,
+			[QuickStartType.SvelteKit]: JSSvelteKitReorganizedContent,
 			[QuickStartType.JSNestjs]: JSNestReorganizedContent,
 			[QuickStartType.JStRPC]: JStRPCReorganizedContent,
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,
@@ -600,6 +602,7 @@ export const quickStartContentReorganized = {
 			[QuickStartType.JSFirebase]: JSFirebaseReorganizedContent,
 			[QuickStartType.JSHono]: JSHonoReorganizedContent,
 			[QuickStartType.JSNodejs]: JSNodeReorganizedContent,
+			[QuickStartType.SvelteKit]: JSSvelteKitReorganizedContent,
 			[QuickStartType.JSNestjs]: JSNestReorganizedContent,
 			[QuickStartType.JStRPC]: JStRPCReorganizedContent,
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,

--- a/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
@@ -1,0 +1,109 @@
+import { QuickStartContent } from '../../QuickstartContent'
+import { verifyLogs } from '../shared-snippets-logging'
+import { frontendInstallSnippet } from '../shared-snippets-monitoring'
+import { verifyTraces } from '../shared-snippets-tracing'
+import {
+	initializeNodeSDK,
+	jsGetSnippet,
+	verifyError,
+} from './shared-snippets-monitoring'
+
+export const JSSvelteKitReorganizedContent: QuickStartContent = {
+	title: 'SvelteKit',
+	subtitle: 'Learn how to set up highlight.io in a SvelteKit server.',
+	logoKey: 'sveltekit',
+	products: ['Errors', 'Logs', 'Traces'],
+	entries: [
+		frontendInstallSnippet,
+		jsGetSnippet(['node']),
+		initializeNodeSDK('node'),
+		{
+			title: 'Initialize Highlight for server requests.',
+			content:
+				'Initialize the Node.js SDK from `hooks.server.ts`, then wrap each request with `H.runWithHeaders`. Convert SvelteKit `Headers` to a plain object before passing them to Highlight.',
+			code: [
+				{
+					language: 'ts',
+					text: `// src/hooks.server.ts
+import type { Handle } from '@sveltejs/kit'
+import { H } from '@highlight-run/node'
+
+H.init({
+	projectID: '<YOUR_PROJECT_ID>',
+	serviceName: 'sveltekit-server',
+	environment: 'production',
+})
+
+const headersToObject = (headers: Headers) =>
+	Object.fromEntries(headers.entries())
+
+export const handle: Handle = async ({ event, resolve }) => {
+	return H.runWithHeaders(headersToObject(event.request.headers), async () => {
+		return resolve(event)
+	})
+}`,
+				},
+			],
+		},
+		verifyError(
+			'SvelteKit',
+			`// src/hooks.server.ts
+import type { HandleServerError } from '@sveltejs/kit'
+import { H } from '@highlight-run/node'
+
+const headersToObject = (headers: Headers) =>
+	Object.fromEntries(headers.entries())
+
+export const handleError: HandleServerError = ({ error, event }) => {
+	const parsed = H.parseHeaders(headersToObject(event.request.headers))
+	H.consumeError(error as Error, parsed.secureSessionId, parsed.requestId)
+
+	return {
+		message: 'An unexpected error occurred.',
+	}
+}`,
+		),
+		{
+			title: 'Call built-in console methods.',
+			content:
+				'Logs written during server requests are recorded by the Node.js SDK. Pass an object as the second argument to attach searchable fields.',
+			code: [
+				{
+					language: 'ts',
+					text: `// src/routes/api/example/+server.ts
+export const GET = async () => {
+	console.info('sveltekit server route called', {
+		route: '/api/example',
+	})
+
+	return new Response('ok')
+}`,
+				},
+			],
+		},
+		verifyLogs,
+		{
+			title: 'Create custom spans in server routes.',
+			content:
+				'Use `H.startWithHeaders` inside a server route or load function when you need an explicit span for a backend operation.',
+			code: [
+				{
+					language: 'ts',
+					text: `// src/routes/api/example/+server.ts
+import { H } from '@highlight-run/node'
+
+export const GET = async () => {
+	const { span } = H.startWithHeaders('sveltekit-api-example', {})
+
+	try {
+		return new Response('ok')
+	} finally {
+		span.end()
+	}
+}`,
+				},
+			],
+		},
+		verifyTraces,
+	],
+}


### PR DESCRIPTION
## Summary
- add a SvelteKit server quickstart page under JavaScript server docs
- register SvelteKit in the server quickstart content map
- document hooks.server.ts request wrapping, handleError error capture, logs, and custom spans

## Validation
- npx prettier --check highlight.io/components/QuickstartContent/QuickstartContent.tsx highlight.io/components/QuickstartContent/server/js/sveltekit.tsx docs-content/getting-started/4_server/2_js/1_overview.md docs-content/getting-started/4_server/2_js/sveltekit.md

/claim #8032