### PR TITLE
Document SvelteKit server instrumentation

### DIFF
--- a/docs-content/getting-started/4_server/2_js/1_overview.md
+++ b/docs-content/getting-started/4_server/2_js/1_overview.md
@@ -36,6 +36,9 @@ updatedAt: 2022-04-01T19:52:59.000Z
     <DocsCard title="Node.js" href="../js/nodejs">
         {"Get started with Node.js"}
     </DocsCard>
+    <DocsCard title="SvelteKit" href="../js/sveltekit">
+        {"Get started with SvelteKit server instrumentation"}
+    </DocsCard>
     <DocsCard title="Pino" href="../js/pino">
         {"Get started with Pino"}
     </DocsCard>

--- a/docs-content/getting-started/4_server/2_js/sveltekit.md
+++ b/docs-content/getting-started/4_server/2_js/sveltekit.md
@@ -1,0 +1,8 @@
+---
+toc: SvelteKit
+title: SvelteKit Server Quick Start
+slug: sveltekit
+quickstart: true
+---
+
+<QuickStart content={quickStartContent["server"]["js"]["svelte-kit"]}/>

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -106,6 +106,7 @@ import { JSFirebaseReorganizedContent } from './server/js/firebase'
 import { JSHonoReorganizedContent } from './server/js/hono'
 import { JSNodeReorganizedContent } from './server/js/nodejs'
 import { JSNestReorganizedContent } from './server/js/nestjs'
+import { JSSvelteKitReorganizedContent } from './server/js/sveltekit'
 import { JStRPCReorganizedContent } from './server/js/trpc'
 import { JSPinoHTTPJSONLogReorganizedContent } from './server/js/pino'
 import { JSWinstonHTTPJSONLogReorganizedContent } from './server/js/winston'
@@ -456,6 +457,7 @@ export const quickStartContent = {
 			[QuickStartType.JSHono]: JSHonoReorganizedContent,
 			[QuickStartType.JSNodejs]: JSNodeReorganizedContent,
 			[QuickStartType.JSNestjs]: JSNestReorganizedContent,
+			[QuickStartType.SvelteKit]: JSSvelteKitReorganizedContent,
 			[QuickStartType.JStRPC]: JStRPCReorganizedContent,
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,
@@ -601,6 +603,7 @@ export const quickStartContentReorganized = {
 			[QuickStartType.JSHono]: JSHonoReorganizedContent,
 			[QuickStartType.JSNodejs]: JSNodeReorganizedContent,
 			[QuickStartType.JSNestjs]: JSNestReorganizedContent,
+			[QuickStartType.SvelteKit]: JSSvelteKitReorganizedContent,
 			[QuickStartType.JStRPC]: JStRPCReorganizedContent,
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,

--- a/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
@@ -3,7 +3,6 @@ import {
 	identifySnippet,
 	initializeSnippet,
 	packageInstallSnippet,
-	setupBackendSnippet,
 	verifySnippet,
 } from './shared-snippets'
 
@@ -79,6 +78,10 @@ export default config;`,
 		identifySnippet,
 		verifySnippet,
 		configureSourcemapsCI(),
-		setupBackendSnippet,
+		{
+			title: 'Instrument your SvelteKit backend.',
+			content:
+				'If your SvelteKit app has server routes or server load functions, use the [SvelteKit server quickstart](/docs/getting-started/server/js/sveltekit) to connect backend errors, logs, and traces to your frontend sessions.',
+		},
 	],
 }

--- a/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
@@ -1,0 +1,127 @@
+import { QuickStartContent } from '../../QuickstartContent'
+import { verifyLogs } from '../shared-snippets-logging'
+import { frontendInstallSnippet } from '../shared-snippets-monitoring'
+import { verifyTraces } from '../shared-snippets-tracing'
+import { jsGetSnippet, verifyError } from './shared-snippets-monitoring'
+
+const hooksServerSnippet = `// src/hooks.server.ts
+import { env } from '$env/dynamic/private'
+import { H } from '@highlight-run/node'
+import type { Handle, HandleServerError } from '@sveltejs/kit'
+
+const projectID = env.HIGHLIGHT_PROJECT_ID
+
+if (!projectID) {
+	throw new Error('HIGHLIGHT_PROJECT_ID is required')
+}
+
+H.init({
+	projectID,
+	serviceName: env.HIGHLIGHT_SERVICE_NAME ?? 'sveltekit',
+	environment: env.HIGHLIGHT_ENVIRONMENT ?? 'production',
+})
+
+const headersToObject = (headers: Headers): Record<string, string> =>
+	Object.fromEntries(headers.entries())
+
+export const handle: Handle = async ({ event, resolve }) => {
+	const headers = headersToObject(event.request.headers)
+
+	return H.runWithHeaders(headers, () => resolve(event))
+}
+
+export const handleError: HandleServerError = ({ error, event }) => {
+	const headers = headersToObject(event.request.headers)
+	const { secureSessionId, requestId } = H.parseHeaders(headers)
+	const reportedError =
+		error instanceof Error ? error : new Error(String(error))
+
+	H.consumeError(reportedError, secureSessionId, requestId)
+
+	return {
+		message: 'Internal server error',
+	}
+}
+`
+
+const routeSnippet = `// src/routes/api/highlight-test/+server.ts
+import { H } from '@highlight-run/node'
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async () => {
+	const { span } = H.startWithHeaders('sveltekit.server.route', {})
+
+	try {
+		console.info('Highlight captured this server log from SvelteKit')
+		return new Response('ok')
+	} finally {
+		span.end()
+	}
+}
+`
+
+export const JSSvelteKitReorganizedContent: QuickStartContent = {
+	title: 'SvelteKit',
+	subtitle:
+		'Learn how to set up highlight.io backend instrumentation in SvelteKit.',
+	logoKey: 'sveltekit',
+	products: ['Errors', 'Logs', 'Traces'],
+	entries: [
+		frontendInstallSnippet,
+		jsGetSnippet(['node']),
+		{
+			title: 'Add private Highlight environment variables.',
+			content:
+				'Configure your SvelteKit server runtime with `HIGHLIGHT_PROJECT_ID`. ' +
+				'You can also set `HIGHLIGHT_SERVICE_NAME` and `HIGHLIGHT_ENVIRONMENT` to control how backend telemetry is grouped in Highlight.',
+			code: [
+				{
+					text: `HIGHLIGHT_PROJECT_ID=<YOUR_PROJECT_ID>
+HIGHLIGHT_SERVICE_NAME=sveltekit
+HIGHLIGHT_ENVIRONMENT=production`,
+					language: 'bash',
+				},
+			],
+		},
+		{
+			title: 'Initialize Highlight in the SvelteKit server hook.',
+			content:
+				'Use `src/hooks.server.ts` so every server request is wrapped before it reaches your load functions or endpoint handlers. ' +
+				'SvelteKit exposes request headers as a Web `Headers` object, so convert them to a plain object before calling `H.runWithHeaders` or `H.parseHeaders`.',
+			code: [
+				{
+					text: hooksServerSnippet,
+					language: 'ts',
+				},
+			],
+		},
+		verifyError(
+			'SvelteKit',
+			`// src/routes/api/highlight-error/+server.ts
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async () => {
+	throw new Error('Highlight SvelteKit server test')
+}
+`,
+		),
+		{
+			title: 'Verify server logs and traces.',
+			content:
+				'Call a SvelteKit endpoint that logs and creates a span. The request is already wrapped by `hooks.server.ts`, so logs and child spans are linked to the incoming Highlight headers.',
+			code: [
+				{
+					text: routeSnippet,
+					language: 'ts',
+				},
+			],
+		},
+		verifyLogs,
+		verifyTraces,
+		{
+			title: 'Confirm your adapter runs on Node.js.',
+			content:
+				'The `@highlight-run/node` SDK must run in a Node-compatible SvelteKit adapter. If a route is deployed to an edge runtime, use the Cloudflare or OpenTelemetry setup for that edge target instead.',
+		},
+	],
+}


### PR DESCRIPTION
## Summary
- add a SvelteKit server quickstart under the JavaScript server docs
- wire the new quickstart into the JS server docs overview and quickstart content maps
- link the existing SvelteKit browser quickstart to the new server-side guide
- document `hooks.server.ts` setup for `@highlight-run/node`, including `H.runWithHeaders`, `H.parseHeaders`, `handleError`, server logs, traces, and Node-compatible adapter guidance

/claim #8032

## Demo / docs route
- New docs page: `/docs/getting-started/server/js/sveltekit`
- Existing SvelteKit browser quickstart now links to that server page for backend instrumentation
- Docs-only change; the diff includes the full rendered quickstart source and route wiring

## Validation
- `npx --yes prettier@3.3.3 --check docs-content/getting-started/4_server/2_js/1_overview.md docs-content/getting-started/4_server/2_js/sveltekit.md highlight.io/components/QuickstartContent/QuickstartContent.tsx highlight.io/components/QuickstartContent/frontend/sveltekit.tsx highlight.io/components/QuickstartContent/server/js/sveltekit.tsx` -> passed
- `git diff --check` -> passed
- reference check for `quickStartContent["server"]["js"]["svelte-kit"]`, JS server overview card, and frontend quickstart link -> passed
- touched-file secret-pattern scan -> clean
