### PR TITLE
refactor(project-settings): replace legacy BorderBox wrappers

### DIFF
--- a/frontend/src/pages/ProjectSettings/AutoresolveStaleErrorsForm/AutoresolveStaleErrorsForm.tsx
+++ b/frontend/src/pages/ProjectSettings/AutoresolveStaleErrorsForm/AutoresolveStaleErrorsForm.tsx
@@ -2,7 +2,6 @@ import { LoadingBar } from '@components/Loading/Loading'
 import { Box, Callout, Form, Label, Stack } from '@highlight-run/ui/components'
 import { useEffect, useState } from 'react'
 
-import BorderBox from '@/components/BorderBox/BorderBox'
 import { ToggleRow } from '@/components/ToggleRow/ToggleRow'
 import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
 
@@ -58,7 +57,13 @@ export const AutoresolveStaleErrorsForm = () => {
 	return (
 		<Form>
 			{categories.map((c) => (
-				<BorderBox key={c.key}>
+				<Box
+					key={c.key}
+					border="dividerWeak"
+					borderRadius="8"
+					px="8"
+					py="12"
+				>
 					<Box py="8">
 						{ToggleRow(
 							c.key,
@@ -117,7 +122,7 @@ export const AutoresolveStaleErrorsForm = () => {
 							time period.
 						</Callout>
 					)}
-				</BorderBox>
+				</Box>
 			))}
 		</Form>
 	)

--- a/frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx
@@ -3,11 +3,10 @@ import Select from '@components/Select/Select'
 import TextHighlighter from '@components/TextHighlighter/TextHighlighter'
 import { toast } from '@components/Toaster'
 import { useGetIdentifierSuggestionsQuery } from '@graph/hooks'
-import { Form, Stack } from '@highlight-run/ui/components'
+import { Box, Form, Stack } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
 import { useState } from 'react'
 
-import BorderBox from '@/components/BorderBox/BorderBox'
 import BoxLabel from '@/components/BoxLabel/BoxLabel'
 import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
 
@@ -62,7 +61,7 @@ export const ExcludedUsersForm = () => {
 	}
 
 	return (
-		<BorderBox>
+		<Box border="dividerWeak" borderRadius="8" px="8" py="12">
 			<Form>
 				<Stack gap="8">
 					<BoxLabel
@@ -131,6 +130,6 @@ export const ExcludedUsersForm = () => {
 					{invalidExcludedUsers.length > 0 && <div></div>}
 				</Stack>
 			</Form>
-		</BorderBox>
+		</Box>
 	)
 }

--- a/frontend/src/pages/ProjectSettings/FilterExtensionForm/FilterExtensionForm.tsx
+++ b/frontend/src/pages/ProjectSettings/FilterExtensionForm/FilterExtensionForm.tsx
@@ -1,7 +1,7 @@
 import { LoadingBar } from '@components/Loading/Loading'
+import { Box } from '@highlight-run/ui/components'
 import { useEffect, useState } from 'react'
 
-import BorderBox from '@/components/BorderBox/BorderBox'
 import { ToggleRow } from '@/components/ToggleRow/ToggleRow'
 import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
 
@@ -38,7 +38,13 @@ export const FilterExtensionForm = () => {
 	return (
 		<>
 			{categories.map((c) => (
-				<BorderBox key={c.key}>
+				<Box
+					key={c.key}
+					border="dividerWeak"
+					borderRadius="8"
+					px="8"
+					py="12"
+				>
 					{ToggleRow(
 						c.key,
 						c.message,
@@ -59,7 +65,7 @@ export const FilterExtensionForm = () => {
 						},
 						false,
 					)}
-				</BorderBox>
+				</Box>
 			))}
 		</>
 	)

--- a/frontend/src/pages/ProjectSettings/ProjectSettings.tsx
+++ b/frontend/src/pages/ProjectSettings/ProjectSettings.tsx
@@ -16,7 +16,6 @@ import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { useNavigate } from 'react-router-dom'
 
-import BorderBox from '@/components/BorderBox/BorderBox'
 import { Button } from '@/components/Button'
 import {
 	CircularSpinner,
@@ -226,13 +225,18 @@ const ProjectSettings = () => {
 												)}
 											</Button>
 										</Box>
-										<BorderBox>
+										<Box
+											border="dividerWeak"
+											borderRadius="8"
+											px="8"
+											py="12"
+										>
 											<Stack gap="8">
 												<ErrorSettingsForm />
 												<Box borderTop="dividerWeak" />
 												<ErrorFiltersForm />
 											</Stack>
-										</BorderBox>
+										</Box>
 										<FilterExtensionForm />
 										<SourcemapSettings />
 										<AutoresolveStaleErrorsForm />

--- a/frontend/src/pages/ProjectSettings/RageClicksForm/RageClicksForm.tsx
+++ b/frontend/src/pages/ProjectSettings/RageClicksForm/RageClicksForm.tsx
@@ -4,7 +4,6 @@ import { Box, Form, Stack } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
 import { useEffect, useState } from 'react'
 
-import BorderBox from '@/components/BorderBox/BorderBox'
 import BoxLabel from '@/components/BoxLabel/BoxLabel'
 import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
 
@@ -45,7 +44,7 @@ export const RageClicksForm = () => {
 	}
 
 	return (
-		<BorderBox>
+		<Box border="dividerWeak" borderRadius="8" px="8" py="12">
 			<Form key={project_id}>
 				<Stack gap="8">
 					<BoxLabel
@@ -143,6 +142,6 @@ export const RageClicksForm = () => {
 					</Box>
 				</Stack>
 			</Form>
-		</BorderBox>
+		</Box>
 	)
 }

--- a/frontend/src/pages/ProjectSettings/SessionExportForm/SessionExportForm.tsx
+++ b/frontend/src/pages/ProjectSettings/SessionExportForm/SessionExportForm.tsx
@@ -1,4 +1,3 @@
-import BorderBox from '@components/BorderBox/BorderBox'
 import BoxLabel from '@components/BoxLabel/BoxLabel'
 import { IconAnimatedLoading, LoadingBar } from '@components/Loading/Loading'
 import { useGetSessionExportsQuery } from '@graph/hooks'
@@ -47,7 +46,7 @@ export const SessionExportForm = () => {
 	const gridColumns = ['120px', '120px', '1fr', '124px']
 	return (
 		<Box ref={ref}>
-			<BorderBox noPadding>
+			<Box border="dividerWeak" borderRadius="8">
 				<Stack gap="8">
 					<Box paddingTop="12" px="8">
 						<BoxLabel
@@ -155,7 +154,7 @@ export const SessionExportForm = () => {
 						</Table.Body>
 					</Table>
 				</Stack>
-			</BorderBox>
+			</Box>
 		</Box>
 	)
 }


### PR DESCRIPTION
## Summary

- remove the legacy `BorderBox` wrapper from Project Settings forms and the remaining local Project Settings wrappers
- replace it with direct `@highlight-run/ui` `Box` usage using the same border, radius, and padding behavior
- keep the diff limited to source files; no generated file churn and no changeset because this is a private frontend refactor

## Validation

- `git diff --check`
- `yarn dlx prettier@3.3.3 --check frontend/src/pages/ProjectSettings/FilterExtensionForm/FilterExtensionForm.tsx frontend/src/pages/ProjectSettings/AutoresolveStaleErrorsForm/AutoresolveStaleErrorsForm.tsx frontend/src/pages/ProjectSettings/RageClicksForm/RageClicksForm.tsx frontend/src/pages/ProjectSettings/SessionExportForm/SessionExportForm.tsx frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx frontend/src/pages/ProjectSettings/ProjectSettings.tsx`
- `rg -n -F 'BorderBox' frontend/src/pages/ProjectSettings -g '*.tsx'` returns no matches

/claim #8635
