### PR TITLE
Remove antd Select from GitHub settings modal

### DIFF
--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -10,12 +10,12 @@ import {
 	IconSolidQuestionMarkCircle,
 	IconSolidTrash,
 	IconSolidX,
+	Select,
 	Text,
 	TextLink,
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -121,7 +121,7 @@ const GithubSettingsForm = ({
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
 				id: repo.key,
-				label: repo.name.split('/').pop(),
+				name: repo.name.split('/').pop() ?? repo.name,
 				value: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
@@ -152,23 +152,24 @@ const GithubSettingsForm = ({
 				>
 					<Box display="flex" alignItems="center" gap="8">
 						<Select
+							key={
+								formState.values.githubRepo ??
+								'empty-github-repo'
+							}
 							aria-label="GitHub repository"
 							className={styles.repoSelect}
 							placeholder="Search repos..."
-							onSelect={(repo: string) =>
+							filterable
+							defaultValue={
+								formState.values.githubRepo ?? undefined
+							}
+							onValueChange={(repo) =>
 								formStore.setValue(
 									formStore.names.githubRepo,
-									repo,
+									repo?.value ? String(repo.value) : null,
 								)
 							}
-							value={formState.values.githubRepo
-								?.split('/')
-								.pop()}
 							options={githubOptions}
-							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
-							filterOption
-							showSearch
 						/>
 						<ButtonIcon
 							kind="secondary"


### PR DESCRIPTION
/claim #8635

## Summary

- Replace the direct antd `Select` in `GitHubSettingsModal` with the Highlight UI `Select`.
- Preserve searchable repository selection using the existing `owner/repo` value shape.
- Preserve the reset/trash flow by remounting the selector when the stored repo value is cleared.

## Validation

- `node .yarn/releases/yarn-4.6.0.cjs exec prettier --check frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx`
- `node .yarn/releases/yarn-4.6.0.cjs workspace @highlight-run/frontend exec eslint src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx`
- `git diff --check`
- `node .yarn/releases/yarn-4.6.0.cjs workspace @highlight-run/ui build:vite`

## Notes

I did not use the full frontend `tsc` result as a clean signal locally. After a partial workspace install, it was still blocked by broader missing built workspace packages/modules such as `highlight.run`, `@highlight-run/react`, and rrweb-related packages. The touched file passed targeted format/lint checks, and the UI package build completed successfully.
