### PR TITLE
Add SvelteKit server quickstart docs

### DIFF
--- a/docs-content/getting-started/4_server/2_js/1_overview.md
+++ b/docs-content/getting-started/4_server/2_js/1_overview.md
@@ -39,6 +39,9 @@ updatedAt: 2022-04-01T19:52:59.000Z
     <DocsCard title="Pino" href="../js/pino">
         {"Get started with Pino"}
     </DocsCard>
+    <DocsCard title="SvelteKit" href="../js/sveltekit">
+        {"Get started with SvelteKit"}
+    </DocsCard>
     <DocsCard title="tRPC" href="../js/trpc">
         {"Get started with tRPC"}
     </DocsCard>

--- a/docs-content/getting-started/4_server/2_js/sveltekit.md
+++ b/docs-content/getting-started/4_server/2_js/sveltekit.md
@@ -1,0 +1,11 @@
+---
+title: SvelteKit
+heading: SvelteKit Server Quick Start
+metaTitle: SvelteKit Server Quick Start
+slug: sveltekit
+createdAt: 2026-05-25T00:00:00.000Z
+updatedAt: 2026-05-25T00:00:00.000Z
+quickstart: true
+---
+
+<QuickStart content={quickStartContent["server"]["js"]["svelte-kit"]}/>

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -110,6 +110,7 @@ import { JStRPCReorganizedContent } from './server/js/trpc'
 import { JSPinoHTTPJSONLogReorganizedContent } from './server/js/pino'
 import { JSWinstonHTTPJSONLogReorganizedContent } from './server/js/winston'
 import { JSManualTracesReorganizedContent } from './server/js/manual'
+import { JSSvelteKitReorganizedContent } from './server/js/sveltekit'
 import { PHPOtherReorganizedContent } from './server/php/other'
 import { PythonAWSReorganizedContext } from './server/python/aws'
 import { PythonAzureReorganizedContext } from './server/python/azure'
@@ -461,6 +462,7 @@ export const quickStartContent = {
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSManual]: JSManualTracesReorganizedContent,
 			[QuickStartType.JSNextjs]: NextJsTracesReorganizedContent,
+			[QuickStartType.SvelteKit]: JSSvelteKitReorganizedContent,
 		},
 		php: {
 			title: 'PHP',
@@ -605,6 +607,7 @@ export const quickStartContentReorganized = {
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSManual]: JSManualTracesReorganizedContent,
+			[QuickStartType.SvelteKit]: JSSvelteKitReorganizedContent,
 			[QuickStartType.OTLP]: OTLPReorganizedContent,
 		},
 	},

--- a/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
@@ -1,0 +1,104 @@
+import { QuickStartContent } from '../../QuickstartContent'
+import { verifyLogs } from '../shared-snippets-logging'
+import { frontendInstallSnippet } from '../shared-snippets-monitoring'
+import { verifyTraces } from '../shared-snippets-tracing'
+import {
+	initializeNodeSDK,
+	jsGetSnippet,
+	verifyError,
+} from './shared-snippets-monitoring'
+
+export const JSSvelteKitReorganizedContent: QuickStartContent = {
+	title: 'SvelteKit',
+	subtitle:
+		'Learn how to set up highlight.io server instrumentation in SvelteKit.',
+	logoKey: 'sveltekit',
+	products: ['Errors', 'Logs', 'Traces'],
+	entries: [
+		frontendInstallSnippet,
+		jsGetSnippet(['node']),
+		initializeNodeSDK('node'),
+		{
+			title: 'Add Highlight to your server hooks.',
+			content:
+				'Initialize `@highlight-run/node` from `src/hooks.server.ts`, then wrap each request with `H.runWithHeaders()` so server errors, logs, and traces can be correlated with the frontend session. Use a Node-compatible SvelteKit adapter for this setup; edge-only runtimes should use the runtime-specific server guide instead.',
+			code: [
+				{
+					text: `// src/hooks.server.ts
+import type { Handle, HandleServerError } from '@sveltejs/kit'
+import { H } from '@highlight-run/node'
+
+H.init({
+	projectID: '<YOUR_PROJECT_ID>',
+	serviceName: 'my-sveltekit-app',
+	environment: 'production',
+})
+
+const headersToRecord = (headers: Headers): Record<string, string> =>
+	Object.fromEntries(headers.entries())
+
+export const handle: Handle = async ({ event, resolve }) => {
+	return H.runWithHeaders(headersToRecord(event.request.headers), () =>
+		resolve(event),
+	)
+}
+
+export const handleError: HandleServerError = ({ error, event }) => {
+	const parsed = H.parseHeaders(headersToRecord(event.request.headers))
+
+	if (error instanceof Error) {
+		H.consumeError(error, parsed?.secureSessionId, parsed?.requestId)
+	} else {
+		H.consumeError(
+			new Error(String(error)),
+			parsed?.secureSessionId,
+			parsed?.requestId,
+		)
+	}
+
+	console.error(error)
+}`,
+					language: 'ts',
+				},
+			],
+		},
+		{
+			title: 'Trace a server route.',
+			content:
+				'For endpoint-specific spans, pass the SvelteKit request headers to `H.runWithHeaders()` inside the route handler before starting child spans or writing logs.',
+			code: [
+				{
+					text: `// src/routes/api/highlight-check/+server.ts
+import { json, type RequestHandler } from '@sveltejs/kit'
+import { H } from '@highlight-run/node'
+
+const headersToRecord = (headers: Headers): Record<string, string> =>
+	Object.fromEntries(headers.entries())
+
+export const GET: RequestHandler = async ({ request }) => {
+	return H.runWithHeaders(headersToRecord(request.headers), () => {
+		const { span } = H.startWithHeaders('sveltekit-server-route', {})
+
+		console.info('Sending a SvelteKit backend trace to Highlight')
+		span.end()
+
+		return json({ ok: true })
+	})
+}`,
+					language: 'ts',
+				},
+			],
+		},
+		verifyError(
+			'SvelteKit',
+			`// src/routes/api/highlight-error/+server.ts
+import type { RequestHandler } from '@sveltejs/kit'
+
+export const GET: RequestHandler = async () => {
+	throw new Error('Highlight SvelteKit backend test')
+}`,
+		),
+		verifyLogs,
+		verifyTraces,
+	],
+}


### PR DESCRIPTION
## Summary
- Add a SvelteKit JavaScript server quickstart page.
- Register the SvelteKit server quickstart in `quickStartContent["server"]["js"]` and `quickStartContentReorganized.js.sdks`.
- Add a SvelteKit card to the JavaScript server docs overview.

/claim #8032

## Details
The new quickstart documents `src/hooks.server.ts` setup with `@highlight-run/node`, request wrapping through `H.runWithHeaders()`, server error reporting through `handleError`, route-level trace setup, and the Node-compatible adapter caveat.

## Validation
- `safe-env-run -- npm exec --yes prettier@3.3.3 -- --check docs-content/getting-started/4_server/2_js/1_overview.md docs-content/getting-started/4_server/2_js/sveltekit.md highlight.io/components/QuickstartContent/QuickstartContent.tsx highlight.io/components/QuickstartContent/server/js/sveltekit.tsx`
- `git diff --check`
- Reference checks for the new docs page, overview card, and QuickStartContent mapping

## Demo Note
This is a documentation-only quickstart wiring change. I do not have a running Highlight docs environment in this sparse checkout, so no runtime demo video is included.

## AI assistance disclosure
I used AI assistance to inspect the existing quickstart patterns, draft the documentation snippets, and run validation. I reviewed the final diff before submitting.