### PR TITLE
Remove legacy select from sourcemap settings

### DIFF
--- a/frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.tsx
@@ -2,13 +2,12 @@ import Card from '@components/Card/Card'
 import CopyText from '@components/CopyText/CopyText'
 import Input from '@components/Input/Input'
 import ProgressBarTable from '@components/ProgressBarTable/ProgressBarTable'
-import Select from '@components/Select/Select'
 import {
 	useGetProjectQuery,
 	useGetSourcemapFilesLazyQuery,
 	useGetSourcemapVersionsQuery,
 } from '@graph/hooks'
-import { Box, Stack } from '@highlight-run/ui/components'
+import { Box, Select, Stack } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
 import { debounce } from 'lodash'
 import React, { useEffect } from 'react'
@@ -78,6 +77,10 @@ const SourcemapSettings = () => {
 	const visibleFileKeys = query.length
 		? fileKeys.filter((key) => key && key.indexOf(query) > -1)
 		: fileKeys
+	const versionOptions = versions.map((version) => ({
+		name: version,
+		value: version,
+	}))
 
 	const filterResults = debounce((query: string) => {
 		setQuery(query)
@@ -128,16 +131,13 @@ const SourcemapSettings = () => {
 										aria-label="Sourcemap app version"
 										className={styles.versionSelect}
 										placeholder="Select a version of your app"
-										options={versions.map((v) => ({
-											id: v,
-											value: v,
-											displayValue: v,
-										}))}
-										onChange={setSelectedVersion}
+										options={versionOptions}
+										onValueChange={(version) => {
+											setSelectedVersion(
+												version.value.toString(),
+											)
+										}}
 										value={selectedVersion}
-										notFoundContent={
-											<p>No sourcemaps found</p>
-										}
 									/>
 								</div>
 							)}


### PR DESCRIPTION
/claim #8635

## Summary
- Replaced the remaining legacy `@components/Select/Select` usage in `WorkspaceSettings/SourcemapSettings` with the `@highlight-run/ui` `Select`.
- Converted the sourcemap app-version options to the UI Select `{ name, value }` shape.
- Preserved the existing selected-version state behavior and kept the change scoped to one remaining Workspace Settings page slice.

## Duplicate check
- Searched existing PRs for `SourcemapSettings 8635`; no matching PRs were returned.
- This intentionally avoids the already-crowded GitHubSettingsModal, ProjectSettings, AutoJoin, and NewProject slices.

## Validation
- `git diff --check`
- `corepack yarn prettier --check frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.tsx`
- `corepack yarn workspace @highlight-run/frontend exec eslint src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.tsx`
- `corepack yarn workspace @highlight-run/ui build`
- `corepack yarn workspace @highlight-run/frontend types:check` was attempted after building `@highlight-run/ui`; it still fails on pre-existing missing workspace package declarations for `highlight.run`, `@highlight-run/react`, `rrweb`, and `@rrweb/types`, but no `SourcemapSettings` errors remain.

AI-assisted with OpenAI Codex; I reviewed and verified the diff.