### PR TITLE
Remove legacy settings input wrappers

### DIFF
--- a/frontend/src/pages/ProjectSettings/DangerForm/DangerForm.tsx
+++ b/frontend/src/pages/ProjectSettings/DangerForm/DangerForm.tsx
@@ -1,6 +1,7 @@
 import { FieldsBox } from '@components/FieldsBox/FieldsBox'
-import Input from '@components/Input/Input'
+import { Button } from '@components/Button'
 import LoadingBox from '@components/LoadingBox'
+import { Form } from '@highlight-run/ui/components'
 import { useDeleteProjectMutation, useGetProjectQuery } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
 import { FieldsForm } from '@pages/WorkspaceSettings/FieldsForm/FieldsForm'
@@ -12,7 +13,6 @@ import { useAuthContext } from '@/authentication/AuthContext'
 import { AdminRole } from '@/graph/generated/schemas'
 
 import commonStyles from '../../../Common.module.css'
-import Button from '../../../components/Button/Button/Button'
 import styles from './DangerForm.module.css'
 
 export const DangerForm = () => {
@@ -52,7 +52,7 @@ export const DangerForm = () => {
 				<FieldsBox id="danger">
 					<h3>Danger Zone</h3>
 
-					<form onSubmit={onSubmit}>
+					<Form onSubmit={onSubmit}>
 						{loading ? (
 							<LoadingBox />
 						) : (
@@ -63,7 +63,7 @@ export const DangerForm = () => {
 									{`${data?.project?.name}`}' to confirm.
 								</p>
 								<div className={styles.dangerRow}>
-									<Input
+									<Form.Input
 										placeholder={`${data?.project?.name}`}
 										name="text"
 										value={confirmationText}
@@ -73,8 +73,7 @@ export const DangerForm = () => {
 									/>
 									<Button
 										trackingId="DeleteProject"
-										danger
-										type="primary"
+										kind="danger"
 										className={clsx(
 											commonStyles.submitButton,
 											styles.deleteButton,
@@ -83,7 +82,7 @@ export const DangerForm = () => {
 											confirmationText !==
 											data?.project?.name
 										}
-										htmlType="submit"
+										type="submit"
 										loading={deleteLoading}
 									>
 										Delete
@@ -91,7 +90,7 @@ export const DangerForm = () => {
 								</div>
 							</>
 						)}
-					</form>
+					</Form>
 				</FieldsBox>
 			)}
 		</>

--- a/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx
+++ b/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx
@@ -1,5 +1,5 @@
-import Input from '@components/Input/Input'
-import { Tooltip } from '@highlight-run/ui/components'
+import { Button } from '@components/Button'
+import { Form, Tooltip } from '@highlight-run/ui/components'
 import { toast } from '@components/Toaster'
 import { useEditProjectMutation, useEditWorkspaceMutation } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
@@ -7,8 +7,6 @@ import { useParams } from '@util/react-router/useParams'
 import React, { useState } from 'react'
 
 import commonStyles from '../../../Common.module.css'
-import Button from '../../../components/Button/Button/Button'
-import { CircularSpinner } from '../../../components/Loading/Loading'
 import styles from './FieldsForm.module.css'
 
 type Props = {
@@ -66,10 +64,10 @@ export const FieldsForm: React.FC<Props> = ({
 	}
 
 	return (
-		<form onSubmit={onSubmit} key={project_id}>
+		<Form onSubmit={onSubmit} key={project_id}>
 			<div className={styles.fieldRow}>
 				<label className={styles.fieldKey}>Name</label>
-				<Input
+				<Form.Input
 					name="name"
 					value={name}
 					onChange={(e) => {
@@ -83,7 +81,7 @@ export const FieldsForm: React.FC<Props> = ({
 					{' '}
 					<div className={styles.fieldRow}>
 						<label className={styles.fieldKey}>Billing Email</label>
-						<Input
+						<Form.Input
 							placeholder="Billing Email"
 							type="email"
 							name="email"
@@ -104,21 +102,14 @@ export const FieldsForm: React.FC<Props> = ({
 							trackingId={`${
 								isWorkspace ? 'Workspace' : 'Project'
 							}Update`}
-							htmlType="submit"
-							type="primary"
+							type="submit"
+							kind="primary"
+							emphasis="high"
 							className={commonStyles.submitButton}
 							disabled={formDisabled}
+							loading={editProjectLoading || editWorkspaceLoading}
 						>
-							{editProjectLoading || editWorkspaceLoading ? (
-								<CircularSpinner
-									style={{
-										fontSize: 18,
-										color: 'var(--text-primary-inverted)',
-									}}
-								/>
-							) : (
-								'Save changes'
-							)}
+							Save changes
 						</Button>
 					}
 				>
@@ -126,6 +117,6 @@ export const FieldsForm: React.FC<Props> = ({
 					contact your workspace admin.
 				</Tooltip>
 			</div>
-		</form>
+		</Form>
 	)
 }

--- a/frontend/src/pages/WorkspaceSettings/legacySettingsInputs.test.tsx
+++ b/frontend/src/pages/WorkspaceSettings/legacySettingsInputs.test.tsx
@@ -1,0 +1,250 @@
+import { readFileSync } from 'node:fs'
+import React, { act } from 'react'
+import { createRoot, Root } from 'react-dom/client'
+import { vi } from 'vitest'
+;(
+	globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+const readSource = (path: string) =>
+	readFileSync(new URL(path, import.meta.url), 'utf8')
+
+const mocks = vi.hoisted(() => ({
+	routeParams: { project_id: 'project-1' } as Record<string, string>,
+	editProject: vi.fn(() => Promise.resolve()),
+	editWorkspace: vi.fn(() => Promise.resolve()),
+	deleteProject: vi.fn(),
+}))
+
+vi.mock('@util/react-router/useParams', () => ({
+	useParams: () => mocks.routeParams,
+}))
+
+vi.mock('@graph/hooks', () => ({
+	useEditProjectMutation: () => [
+		mocks.editProject,
+		{
+			loading: false,
+		},
+	],
+	useEditWorkspaceMutation: () => [
+		mocks.editWorkspace,
+		{
+			loading: false,
+		},
+	],
+	useGetProjectQuery: () => ({
+		loading: false,
+		data: {
+			project: {
+				name: 'Apollo',
+				billing_email: 'billing@example.com',
+			},
+		},
+	}),
+	useDeleteProjectMutation: () => [
+		mocks.deleteProject,
+		{
+			loading: false,
+			data: undefined,
+		},
+	],
+}))
+
+vi.mock('@graph/operations', () => ({
+	namedOperations: {
+		Query: {
+			GetProjects: 'GetProjects',
+			GetProject: 'GetProject',
+		},
+	},
+}))
+
+vi.mock('@components/Toaster', () => ({
+	toast: {
+		success: vi.fn(),
+	},
+}))
+
+vi.mock('@util/analytics', () => ({
+	default: {
+		track: vi.fn(),
+	},
+}))
+
+vi.mock('@/authentication/AuthContext', () => ({
+	useAuthContext: () => ({
+		workspaceRole: 'ADMIN',
+	}),
+}))
+
+vi.mock('@/graph/generated/schemas', () => ({
+	AdminRole: {
+		Admin: 'ADMIN',
+	},
+}))
+
+vi.mock('react-router-dom', () => ({
+	Navigate: () => null,
+	useLocation: () => ({
+		hash: '',
+		pathname: '/',
+		search: '',
+	}),
+}))
+
+import { DangerForm } from '../ProjectSettings/DangerForm/DangerForm'
+import { FieldsForm } from './FieldsForm/FieldsForm'
+
+const roots: Root[] = []
+
+const renderComponent = async (component: React.ReactElement) => {
+	const container = document.createElement('div')
+	document.body.appendChild(container)
+	const root = createRoot(container)
+	roots.push(root)
+
+	await act(async () => {
+		root.render(component)
+	})
+
+	return container
+}
+
+const updateInput = async (input: HTMLInputElement, value: string) => {
+	const valueSetter = Object.getOwnPropertyDescriptor(
+		HTMLInputElement.prototype,
+		'value',
+	)?.set
+
+	valueSetter?.call(input, value)
+
+	await act(async () => {
+		input.dispatchEvent(new Event('input', { bubbles: true }))
+	})
+}
+
+const submitForm = async (form: HTMLFormElement | null) => {
+	expect(form).not.toBeNull()
+
+	await act(async () => {
+		form?.dispatchEvent(
+			new Event('submit', { bubbles: true, cancelable: true }),
+		)
+	})
+}
+
+const getButtonByText = (container: HTMLElement, text: string) => {
+	const button = Array.from(container.querySelectorAll('button')).find(
+		(candidate) => candidate.textContent === text,
+	)
+
+	expect(button).toBeDefined()
+
+	return button as HTMLButtonElement
+}
+
+beforeEach(() => {
+	mocks.routeParams = { project_id: 'project-1' }
+	mocks.editProject.mockClear()
+	mocks.editWorkspace.mockClear()
+	mocks.deleteProject.mockClear()
+})
+
+afterEach(() => {
+	roots.splice(0).forEach((root) => {
+		act(() => {
+			root.unmount()
+		})
+	})
+	document.body.innerHTML = ''
+})
+
+describe('settings forms legacy UI migration', () => {
+	it('keeps FieldsForm off the Ant Design-backed legacy wrappers', () => {
+		const source = readSource('./FieldsForm/FieldsForm.tsx')
+
+		expect(source).not.toContain('@components/Input/Input')
+		expect(source).not.toContain('components/Button/Button/Button')
+		expect(source).toContain('@highlight-run/ui/components')
+	})
+
+	it('submits edited project fields through the existing mutation', async () => {
+		const container = await renderComponent(
+			<FieldsForm
+				defaultName="Apollo"
+				defaultEmail="billing@example.com"
+			/>,
+		)
+
+		const nameInput =
+			container.querySelector<HTMLInputElement>('input[name="name"]')
+		const emailInput = container.querySelector<HTMLInputElement>(
+			'input[name="email"]',
+		)
+		expect(nameInput).not.toBeNull()
+		expect(emailInput).not.toBeNull()
+
+		await updateInput(nameInput!, 'Hermes')
+		await updateInput(emailInput!, 'finance@example.com')
+		await submitForm(container.querySelector('form'))
+
+		expect(mocks.editProject).toHaveBeenCalledWith({
+			variables: {
+				id: 'project-1',
+				name: 'Hermes',
+				billing_email: 'finance@example.com',
+			},
+		})
+	})
+
+	it('keeps workspace fields disabled when editing is forbidden', async () => {
+		mocks.routeParams = { workspace_id: 'workspace-1' }
+
+		const container = await renderComponent(
+			<FieldsForm defaultName="Workspace" disabled />,
+		)
+		const nameInput =
+			container.querySelector<HTMLInputElement>('input[name="name"]')
+		const emailInput = container.querySelector<HTMLInputElement>(
+			'input[name="email"]',
+		)
+
+		expect(nameInput).not.toBeNull()
+		expect(nameInput?.disabled).toBe(true)
+		expect(emailInput).toBeNull()
+		expect(getButtonByText(container, 'Save changes').disabled).toBe(true)
+	})
+
+	it('keeps DangerForm off the Ant Design-backed legacy wrappers', () => {
+		const source = readSource(
+			'../ProjectSettings/DangerForm/DangerForm.tsx',
+		)
+
+		expect(source).not.toContain('@components/Input/Input')
+		expect(source).not.toContain('components/Button/Button/Button')
+		expect(source).toContain('@highlight-run/ui/components')
+	})
+
+	it('requires the project name before delete can submit', async () => {
+		const container = await renderComponent(<DangerForm />)
+
+		const confirmationInput =
+			container.querySelector<HTMLInputElement>('input[name="text"]')
+		const deleteButton = getButtonByText(container, 'Delete')
+
+		expect(confirmationInput).not.toBeNull()
+		expect(deleteButton.disabled).toBe(true)
+
+		await updateInput(confirmationInput!, 'Apollo')
+		expect(deleteButton.disabled).toBe(false)
+
+		await submitForm(deleteButton.closest('form'))
+
+		expect(mocks.deleteProject).toHaveBeenCalledWith({
+			variables: {
+				id: 'project-1',
+			},
+		})
+	})
+})


### PR DESCRIPTION
/claim #8635

## Summary
- Replaced the Ant Design-backed `@components/Input/Input` wrapper in `FieldsForm` and `DangerForm` with `@highlight-run/ui` `Form.Input`.
- Swapped the old AntD button wrapper for the tracking-aware `@components/Button` wrapper while preserving submit, loading, disabled, and danger-button behavior.
- Added focused regression coverage for source guards, project field submission, workspace disabled state, and delete confirmation behavior.

## Demo
https://github.com/justusaugust/highlight/releases/download/highlight-8635-demo-2026-05-25/highlight-8635-demo.mp4

## Verification
- `node .yarn/releases/yarn-4.6.0.cjs workspace @highlight-run/frontend test src/pages/WorkspaceSettings/legacySettingsInputs.test.tsx` -> 5 tests passed
- `node .yarn/releases/yarn-4.6.0.cjs workspace @highlight-run/frontend lint --quiet --no-error-on-unmatched-pattern src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx src/pages/ProjectSettings/DangerForm/DangerForm.tsx src/pages/WorkspaceSettings/legacySettingsInputs.test.tsx` -> passed
- `node .yarn/releases/yarn-4.6.0.cjs prettier --check frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx frontend/src/pages/ProjectSettings/DangerForm/DangerForm.tsx frontend/src/pages/WorkspaceSettings/legacySettingsInputs.test.tsx` -> passed
- `node .yarn/releases/yarn-4.6.0.cjs workspace @highlight-run/frontend build` -> passed
- `git diff --check` -> passed

Full frontend Vitest also ran 76 passing tests across 12 files before the existing `src/pages/Player/PlayerHook/utils/utils.test.ts` suite failed during collection with `TypeError: localStorage.getItem is not a function`; that suite did not touch these settings forms.
