### PR TITLE
Replace workspace auto-join Alert with Highlight Callout

### DIFF
--- a/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
@@ -1,15 +1,46 @@
-import Alert from '@components/Alert/Alert'
 import { FieldsBox } from '@components/FieldsBox/FieldsBox'
 import { AdminRole } from '@graph/schemas'
-import { Box } from '@highlight-run/ui/components'
+import { Box, Callout, Text } from '@highlight-run/ui/components'
 import { AutoJoinForm } from '@pages/WorkspaceTeam/components/AutoJoinForm'
 import { Authorization } from '@util/authorization/authorization'
+import analytics from '@util/analytics'
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
 import { useAuthContext } from '@/authentication/AuthContext'
+import { useSessionStorage } from 'react-use'
 
 import layoutStyles from '../../components/layout/LeadAlignLayout.module.css'
 import { FieldsForm } from './FieldsForm/FieldsForm'
 import styles from './WorkspaceSettings.module.css'
+
+const AUTO_JOIN_ADMIN_CALLOUT_STORAGE_KEY =
+	'highlightHideAlert-AdminNoAccessToAutoJoinDomains'
+const AUTO_JOIN_ADMIN_CALLOUT_TRACKING_ID =
+	'AlertClose-AdminNoAccessToAutoJoinDomains'
+
+const AutoJoinAdminFallback = () => {
+	const [temporarilyHideCallout, setTemporarilyHideCallout] =
+		useSessionStorage(AUTO_JOIN_ADMIN_CALLOUT_STORAGE_KEY, false)
+
+	if (temporarilyHideCallout) {
+		return null
+	}
+
+	return (
+		<Callout
+			kind="info"
+			title="You don't have access to auto-access domains."
+			handleCloseClick={() => {
+				analytics.track(AUTO_JOIN_ADMIN_CALLOUT_TRACKING_ID)
+				setTemporarilyHideCallout(true)
+			}}
+		>
+			<Text color="moderate">
+				You don't have permission to configure auto-access domains.
+				Please contact a workspace admin to make changes.
+			</Text>
+		</Callout>
+	)
+}
 
 const WorkspaceSettings = () => {
 	const { currentWorkspace } = useApplicationContext()
@@ -42,14 +73,7 @@ const WorkspaceSettings = () => {
 						</p>
 						<Authorization
 							allowedRoles={[AdminRole.Admin]}
-							forbiddenFallback={
-								<Alert
-									trackingId="AdminNoAccessToAutoJoinDomains"
-									type="info"
-									message="You don't have access to auto-access domains."
-									description={`You don't have permission to configure auto-access domains. Please contact a workspace admin to make changes.`}
-								/>
-							}
+							forbiddenFallback={<AutoJoinAdminFallback />}
 						>
 							<AutoJoinForm />
 						</Authorization>


### PR DESCRIPTION
/claim #8635

## Proposed Changes
- Replaced the Workspace Settings auto-join admin fallback from the legacy `@components/Alert/Alert` wrapper to `@highlight-run/ui` `Callout` + `Text`.
- Kept the old dismiss behavior by preserving the same session-storage key: `highlightHideAlert-AdminNoAccessToAutoJoinDomains`.
- Kept the existing analytics close event: `AlertClose-AdminNoAccessToAutoJoinDomains`.
- Scoped this PR to `WorkspaceSettings.tsx` only to avoid overlapping the recent ProjectSettings, SourcemapSettings, GitHubSettingsModal, and integrations slices on #8635.

## Proof
Before this PR, `WorkspaceSettings.tsx` imported the legacy Alert wrapper, which imports Ant Design's Alert component. After this PR, the file uses the Highlight UI Callout directly and no longer imports or renders the legacy Alert wrapper.

## Security
- UI-only change; no workspace role checks, authorization rules, or auto-join settings mutations were changed.
- The fallback still renders only through the existing `Authorization` boundary for non-admin users.
- No user input, network calls, persistence schema, or secrets handling were added.

## Verification
- `bunx prettier@3.3.3 --check frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx`
- `bunx esbuild@0.19.5 frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx --bundle --external:* --loader:.tsx=tsx --format=esm --outfile=<temp> --log-level=error`
- `rg @components/Alert/Alert|<Alert frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx` -> no matches
- `git diff --check`

Note: full Yarn workspace typecheck was attempted, but `yarn install --immutable` timed out after 10 minutes on this fresh Windows clone after initializing submodules. I kept the validation evidence to the touched file and syntax parse path instead of overstating full-repo checks.

Prepared with AI assistance and manually reviewed before submission.