### PR TITLE
Replace excluded users select with Highlight UI

### DIFF
--- a/frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx
@@ -1,9 +1,7 @@
 import { LoadingBar } from '@components/Loading/Loading'
-import Select from '@components/Select/Select'
-import TextHighlighter from '@components/TextHighlighter/TextHighlighter'
 import { toast } from '@components/Toaster'
 import { useGetIdentifierSuggestionsQuery } from '@graph/hooks'
-import { Form, Stack } from '@highlight-run/ui/components'
+import { Form, Select, Stack } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
 import { useState } from 'react'
 
@@ -11,11 +9,12 @@ import BorderBox from '@/components/BorderBox/BorderBox'
 import BoxLabel from '@/components/BoxLabel/BoxLabel'
 import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
 
+type ExcludedUserOption = string | { value: string | number }
+
 export const ExcludedUsersForm = () => {
 	const { project_id } = useParams<{
 		project_id: string
 	}>()
-	const [identifierQuery, setIdentifierQuery] = useState('')
 	const [invalidExcludedUsers, setInvalidExcludedUsers] = useState<string[]>(
 		[],
 	)
@@ -45,21 +44,17 @@ export const ExcludedUsersForm = () => {
 		? []
 		: (identifierSuggestionsApiResponse?.identifier_suggestion || []).map(
 				(suggestion) => ({
+					name: suggestion,
 					value: suggestion,
-					displayValue: (
-						<TextHighlighter
-							searchWords={[identifierQuery]}
-							textToHighlight={suggestion}
-						/>
-					),
-					id: suggestion,
 				}),
 			)
 
 	const handleIdentifierSearch = (query = '') => {
-		setIdentifierQuery(query)
 		refetchIdentifierSuggestions({ query, project_id })
 	}
+
+	const getExcludedUserValue = (option: ExcludedUserOption) =>
+		typeof option === 'string' ? option : String(option.value)
 
 	return (
 		<BorderBox>
@@ -77,15 +72,22 @@ export const ExcludedUsersForm = () => {
 						name="Filtered users"
 					>
 						<Select
-							mode="tags"
+							aria-label="Filtered users"
+							creatable
+							filterable
+							displayMode="tags"
 							placeholder=".*@yourdomain.com"
-							value={
-								data?.projectSettings?.excluded_users ||
-								undefined
-							}
-							onSearch={handleIdentifierSearch}
+							value={data?.projectSettings?.excluded_users || []}
+							onSearchValueChange={handleIdentifierSearch}
 							options={identifierSuggestions}
-							onChange={(excluded: string[]) => {
+							resultsLoading={identifierSuggestionsLoading}
+							onValueChange={(
+								selectedExcludedUsers: ExcludedUserOption[],
+							) => {
+								const excluded =
+									selectedExcludedUsers.map(
+										getExcludedUserValue,
+									)
 								const validRegexes: string[] = []
 								const invalidRegexes: string[] = []
 								excluded.forEach((expression) => {


### PR DESCRIPTION
/claim #8635

## Summary
- Replaced the remaining legacy `@components/Select/Select` usage in `ExcludedUsersForm` with `@highlight-run/ui` `Select`.
- Kept the excluded-user field as creatable/filterable tags and preserved async identifier suggestions.
- Preserved regex validation, invalid-regex toast behavior, clearing the identifier search after change, and the existing project settings update path.

## Security
- UI-only settings change.
- No auth, project permission, GraphQL mutation, or backend behavior changes.
- User-provided regex strings are still validated before being persisted into `excluded_users`.

## Verification
- `bunx prettier@3.3.3 --check frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx`
- `bunx esbuild@0.19.5 frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx --bundle --external:* --loader:.tsx=tsx --format=esm --outfile=<temp> --log-level=error`
- `rg '@components/Select/Select|TextHighlighter|mode="tags"|onSearch=' frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx` -> no matches
- `git diff --check`

Prepared with AI assistance and manually reviewed before submission.