### PR TITLE
Replace Heroku token select with Highlight UI

### DIFF
--- a/frontend/src/pages/IntegrationsPage/components/HerokuIntegration/HerokuIntegration.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/HerokuIntegration/HerokuIntegration.tsx
@@ -1,5 +1,5 @@
 import Button from '@components/Button/Button/Button'
-import { Form } from '@highlight-run/ui/components'
+import { Form, Select } from '@highlight-run/ui/components'
 import AppsIcon from '@icons/AppsIcon'
 import PlugIcon from '@icons/PlugIcon'
 import {
@@ -11,7 +11,11 @@ import React from 'react'
 
 import styles from './HerokuIntegration.module.css'
 import { useHerokuIntegration } from './utils'
-import Select from '@components/Select/Select'
+
+type TokenOption = string | { value: string | number }
+
+const getTokenValue = (option: TokenOption) =>
+	typeof option === 'string' ? option : String(option.value)
 
 const HerokuIntegration: React.FC<
 	React.PropsWithChildren<IntegrationConfigProps>
@@ -86,13 +90,18 @@ const HerokuIntegration: React.FC<
 				>
 					<Select
 						aria-label="Log Drain Token(s)"
+						creatable
+						filterable
+						displayMode="tags"
 						placeholder="d.9173ea1f-6f14-4976-9cf0-deadbeef1234"
-						onChange={(values: any): any =>
-							formStore.setValue(formStore.names.tokens, values)
-						}
+						onValueChange={(values: TokenOption[]) => {
+							formStore.setValue(
+								formStore.names.tokens,
+								values.map(getTokenValue),
+							)
+						}}
 						className={styles.selectContainer}
-						mode="tags"
-						value={formStore.getValue(formStore.names.tokens)}
+						value={tokens}
 					/>
 				</Form.NamedSection>
 			</Form>


### PR DESCRIPTION
/claim #8635

## Summary
- Replaced the legacy `@components/Select/Select` log-drain token field in `HerokuIntegration` with `@highlight-run/ui` `Select`.
- Kept the field as creatable/filterable tags and normalized selected options back into the existing `tokens: string[]` Form store value.
- Preserved the existing minimum token-length gate, cancel/save behavior, and `addHerokuToProject(tokens, project_id)` submission path.

## Security
- UI-only integration setup change.
- No Heroku token submission endpoint, token storage, auth, or API behavior changes.
- The existing save button token-length guard remains unchanged.

## Verification
- `bunx prettier@3.3.3 --check frontend/src/pages/IntegrationsPage/components/HerokuIntegration/HerokuIntegration.tsx`
- `bunx esbuild@0.19.5 frontend/src/pages/IntegrationsPage/components/HerokuIntegration/HerokuIntegration.tsx --bundle --external:* --loader:.tsx=tsx --format=esm --outfile=<temp> --log-level=error`
- `rg '@components/Select/Select|mode="tags"|onChange=' frontend/src/pages/IntegrationsPage/components/HerokuIntegration/HerokuIntegration.tsx` -> no matches
- `git diff --check`

Prepared with AI assistance and manually reviewed before submission.