### PR TITLE
Replace error alert regex select with Highlight UI

### DIFF
--- a/frontend/src/pages/Alerts/ErrorAlert/ErrorAlertPage.tsx
+++ b/frontend/src/pages/Alerts/ErrorAlert/ErrorAlertPage.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@components/Button'
-import Select from '@components/Select/Select'
 import { toast } from '@components/Toaster'
 import {
 	useDeleteErrorAlertMutation,
@@ -17,6 +16,7 @@ import {
 	IconSolidCheveronUp,
 	IconSolidBell,
 	Menu,
+	Select,
 	Stack,
 	Tag,
 	Text,
@@ -48,6 +48,13 @@ import AlertTitleField from '@/pages/Alerts/components/AlertTitleField/AlertTitl
 import analytics from '@/util/analytics'
 
 import * as styles from './styles.css'
+
+type RegexGroupValue = string | { value: string | number }
+
+const selectValuesToStrings = (values: RegexGroupValue[] = []) =>
+	values.map((value) =>
+		typeof value === 'string' ? value : String(value.value),
+	)
 
 export const ErrorAlertPage = () => {
 	const [queryParam] = useQueryParam('query', StringParam)
@@ -388,6 +395,7 @@ type ErrorAlertFormProps = {
 const ErrorAlertForm = ({ hideRegexExpression }: ErrorAlertFormProps) => {
 	const formStore = Form.useContext() as FormState<ErrorAlertFormItem>
 	const errors = formStore.useState('errors')
+	const regexGroups = formStore.getValue(formStore.names.regex_groups) ?? []
 
 	const { presets } = useRetentionPresets(ProductType.Errors)
 	const initialPreset = presets?.at(5) ?? presets?.at(-1)
@@ -437,17 +445,17 @@ const ErrorAlertForm = ({ hideRegexExpression }: ErrorAlertFormProps) => {
 							<Select
 								aria-label="Regex Patterns to Ignore list"
 								placeholder={`Input any valid regex, like: \\d{5}(-\\d{4})?, Hello\\nworld, [b-chm-pP]at|ot`}
-								onChange={(values: any): any =>
+								creatable
+								displayMode="tags"
+								filterable
+								options={regexGroups}
+								onValueChange={(values: RegexGroupValue[]) =>
 									formStore.setValue(
 										formStore.names.regex_groups,
-										values,
+										selectValuesToStrings(values),
 									)
 								}
-								className={styles.selectContainer}
-								mode="tags"
-								value={formStore.getValue(
-									formStore.names.regex_groups,
-								)}
+								value={regexGroups}
 							/>
 						</Form.NamedSection>
 					)}

--- a/frontend/src/pages/Alerts/ErrorAlert/styles.css.ts
+++ b/frontend/src/pages/Alerts/ErrorAlert/styles.css.ts
@@ -1,6 +1,6 @@
 import { sprinkles } from '@highlight-run/ui/sprinkles'
 import { vars } from '@highlight-run/ui/vars'
-import { globalStyle, style } from '@vanilla-extract/css'
+import { style } from '@vanilla-extract/css'
 
 export const header = style({
 	height: 40,
@@ -66,28 +66,3 @@ export const thresholdTypeButton = style([
 		height: 20,
 	},
 ])
-
-export const selectContainer = style({
-	color: `${vars.theme.static.content.default} !important`,
-	selectors: {
-		'&:hover': {
-			background: vars.theme.interactive.overlay.secondary.hover,
-		},
-	},
-})
-
-globalStyle(`${selectContainer} .ant-select-selector`, {
-	padding: `0 6px !important`,
-	borderRadius: `6px !important`,
-	border: `${vars.border.secondary} !important`,
-	boxShadow: 'none !important',
-})
-
-globalStyle(`${selectContainer} .ant-select-selector:hover`, {
-	background: `${vars.theme.interactive.overlay.secondary.hover} !important`,
-})
-
-globalStyle(`${selectContainer} .ant-select-selection-item`, {
-	display: 'flex',
-	alignItems: 'center',
-})


### PR DESCRIPTION
/claim #8635

## Summary
- Replace the Error Alert "Regex Patterns to Ignore" tag input with `@highlight-run/ui` `Select` in creatable/filterable tag mode.
- Normalize selected option values back to `string[]` before writing `regex_groups`, preserving the existing update payload shape.
- Remove the ErrorAlert stylesheet rules that only targeted Ant Design `.ant-select` DOM.

## Demo / walkthrough
- Error alert configuration still exposes the same regex tag input.
- Existing regex groups are passed as the controlled value and options so they render as tags.
- Newly-created tags are converted back to plain strings before save, matching the old `regex_groups` form state.

## Verification
- `npx -y prettier@3.3.3 --check frontend/src/pages/Alerts/ErrorAlert/ErrorAlertPage.tsx frontend/src/pages/Alerts/ErrorAlert/styles.css.ts`
- `npx -y esbuild@0.19.5 frontend/src/pages/Alerts/ErrorAlert/ErrorAlertPage.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=/tmp/highlight-error-alert-check.mjs --log-level=error`
- `grep -R -n "@components/Select/Select\|ant-select\|selectContainer\|mode=\"tags\"" frontend/src/pages/Alerts/ErrorAlert` -> no matches
- `git diff --check`

Security: UI-only alert configuration change; no auth, alert mutation, query, threshold, notification destination, or backend behavior changed.

Prepared with AI assistance and manually reviewed before submission.