### PR TITLE
Replace log alert legacy selects

### DIFF
--- a/.changeset/rich-heads-matter.md
+++ b/.changeset/rich-heads-matter.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+Replace log alert legacy selects.

--- a/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
+++ b/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@components/Button'
-import Select from '@components/Select/Select'
 import { toast } from '@components/Toaster'
 import {
 	useDeleteLogAlertMutation,
@@ -22,10 +21,12 @@ import {
 	IconSolidBell,
 	Menu,
 	presetStartDate,
+	Select,
 	Stack,
 	Tag,
 	Text,
 } from '@highlight-run/ui/components'
+import type { SelectOption } from '@highlight-run/ui/components'
 import { useProjectId } from '@hooks/useProjectId'
 import { useSlackSync } from '@hooks/useSlackSync'
 import {
@@ -57,6 +58,43 @@ import analytics from '@/util/analytics'
 import * as styles from './styles.css'
 
 const LOG_ALERT_MINIMUM_FREQUENCY = 15
+
+type ExistingChannel = {
+	id?: string
+	value?: string
+	name?: string
+	displayValue?: string
+	webhook_channel?: string
+	webhook_channel_id?: string
+	webhook_channel_name?: string
+}
+
+type ChannelOption = SelectOption & {
+	id: string
+	displayValue?: string
+	webhook_channel_id?: string
+	webhook_channel_name?: string
+}
+
+const channelValue = (channel: ExistingChannel) =>
+	channel.webhook_channel_id ?? channel.value ?? channel.id ?? ''
+
+const channelName = (channel: ExistingChannel) =>
+	channel.webhook_channel_name ??
+	channel.webhook_channel ??
+	channel.name ??
+	channel.displayValue ??
+	channelValue(channel)
+
+const toSelectedOptions = (channels: ExistingChannel[] = []) =>
+	channels.map((channel) => ({
+		name: channelName(channel),
+		value: channelValue(channel),
+		...channel,
+	}))
+
+const toStringOptions = (values: string[] = []) =>
+	values.map((value) => ({ name: value, value }))
 
 export const LogAlertPage = () => {
 	const { startDate, endDate, selectedPreset, updateSearchTime } =
@@ -487,8 +525,11 @@ const LogAlertForm = () => {
 	const slackChannels = (alertsPayload?.slack_channel_suggestion ?? []).map(
 		({ webhook_channel, webhook_channel_id }) => ({
 			displayValue: webhook_channel!,
+			name: webhook_channel!,
 			value: webhook_channel_id!,
 			id: webhook_channel_id!,
+			webhook_channel_id: webhook_channel_id!,
+			webhook_channel_name: webhook_channel!,
 		}),
 	)
 
@@ -496,25 +537,44 @@ const LogAlertForm = () => {
 		alertsPayload?.discord_channel_suggestions ?? []
 	).map(({ name, id }) => ({
 		displayValue: name,
+		name,
 		value: id,
-		id: id,
+		id,
 	}))
 
 	const microsoftTeamsChannels = (
 		alertsPayload?.microsoft_teams_channel_suggestions ?? []
 	).map(({ name, id }) => ({
 		displayValue: name,
+		name,
 		value: id,
-		id: id,
+		id,
 	}))
 
 	const emails = (alertsPayload?.admins ?? [])
 		.map((wa) => wa.admin!.email)
 		.map((email) => ({
 			displayValue: email,
+			name: email,
 			value: email,
 			id: email,
 		}))
+
+	const selectedSlackChannels = toSelectedOptions(
+		formStore.getValue(formStore.names.slackChannels),
+	)
+	const selectedDiscordChannels = toSelectedOptions(
+		formStore.getValue(formStore.names.discordChannels),
+	)
+	const selectedMicrosoftTeamsChannels = toSelectedOptions(
+		formStore.getValue(formStore.names.microsoftTeamsChannels),
+	)
+	const selectedEmails = toStringOptions(
+		formStore.getValue(formStore.names.emails),
+	)
+	const selectedWebhooks = toStringOptions(
+		formStore.getValue(formStore.names.webhookDestinations),
+	)
 
 	return (
 		<Box cssClass={styles.grid}>
@@ -584,22 +644,26 @@ const LogAlertForm = () => {
 							aria-label="Slack channels to notify"
 							placeholder="Select Slack channels"
 							options={slackChannels}
-							optionFilterProp="label"
+							filterable
+							displayMode="tags"
+							checkType="checkbox"
 							onFocus={syncSlack}
-							onSearch={(value) => {
-								setSlackSearchQuery(value)
-							}}
-							onChange={(values) => {
+							onSearchValueChange={setSlackSearchQuery}
+							onValueChange={(values: ChannelOption[]) => {
 								formStore.setValue(
 									formStore.names.slackChannels,
-									values.map((v: any) => ({
-										webhook_channel_name: v.label,
-										webhook_channel_id: v.value,
+									values.map((v) => ({
+										webhook_channel_name: v.name,
+										webhook_channel_id: String(v.value),
 										...v,
 									})),
 								)
 							}}
-							notFoundContent={
+							className={styles.selectContainer}
+							value={selectedSlackChannels}
+						/>
+						{slackChannels.length === 0 && (
+							<Box mt="4">
 								<SlackLoadOrConnect
 									isLoading={slackLoading}
 									searchQuery={slackSearchQuery}
@@ -609,14 +673,8 @@ const LogAlertForm = () => {
 										false
 									}
 								/>
-							}
-							className={styles.selectContainer}
-							mode="multiple"
-							labelInValue
-							value={formStore.getValue(
-								formStore.names.slackChannels,
-							)}
-						/>
+							</Box>
+						)}
 					</Form.NamedSection>
 
 					<Form.NamedSection
@@ -627,33 +685,29 @@ const LogAlertForm = () => {
 							aria-label="Discord channels to notify"
 							placeholder="Select Discord channels"
 							options={discordChannels}
-							optionFilterProp="label"
-							onChange={(values) => {
+							filterable
+							displayMode="tags"
+							checkType="checkbox"
+							onValueChange={(values: ChannelOption[]) => {
 								formStore.setValue(
 									formStore.names.discordChannels,
-									values.map((v: any) => ({
-										name: v.label,
-										id: v.value,
+									values.map((v) => ({
+										name: v.name,
+										id: String(v.value),
 										...v,
 									})),
 								)
 							}}
-							notFoundContent={
-								discordChannels.length === 0 ? (
-									<Link to="/integrations">
-										Connect Highlight with Discord
-									</Link>
-								) : (
-									'Discord channel not found'
-								)
-							}
 							className={styles.selectContainer}
-							mode="multiple"
-							labelInValue
-							value={formStore.getValue(
-								formStore.names.discordChannels,
-							)}
+							value={selectedDiscordChannels}
 						/>
+						{discordChannels.length === 0 && (
+							<Box mt="4">
+								<Link to="/integrations">
+									Connect Highlight with Discord
+								</Link>
+							</Box>
+						)}
 					</Form.NamedSection>
 
 					<Form.NamedSection
@@ -664,33 +718,29 @@ const LogAlertForm = () => {
 							aria-label="Microsoft Teams channels to notify"
 							placeholder="Select Microsoft Teams channels"
 							options={microsoftTeamsChannels}
-							optionFilterProp="label"
-							onChange={(values) => {
+							filterable
+							displayMode="tags"
+							checkType="checkbox"
+							onValueChange={(values: ChannelOption[]) => {
 								formStore.setValue(
 									formStore.names.microsoftTeamsChannels,
-									values.map((v: any) => ({
-										name: v.label,
-										id: v.value,
+									values.map((v) => ({
+										name: v.name,
+										id: String(v.value),
 										...v,
 									})),
 								)
 							}}
-							notFoundContent={
-								microsoftTeamsChannels.length === 0 ? (
-									<Link to="/integrations">
-										Connect Highlight with Microsoft Teams
-									</Link>
-								) : (
-									'Microsoft Teams channel not found'
-								)
-							}
 							className={styles.selectContainer}
-							mode="multiple"
-							labelInValue
-							value={formStore.getValue(
-								formStore.names.microsoftTeamsChannels,
-							)}
+							value={selectedMicrosoftTeamsChannels}
 						/>
+						{microsoftTeamsChannels.length === 0 && (
+							<Box mt="4">
+								<Link to="/integrations">
+									Connect Highlight with Microsoft Teams
+								</Link>
+							</Box>
+						)}
 					</Form.NamedSection>
 
 					<Form.NamedSection
@@ -701,16 +751,18 @@ const LogAlertForm = () => {
 							aria-label="Emails to notify"
 							placeholder="Select emails"
 							options={emails}
-							onChange={(values: any): any =>
+							filterable
+							creatable
+							displayMode="tags"
+							checkType="checkbox"
+							onValueChange={(values: SelectOption[]) =>
 								formStore.setValue(
 									formStore.names.emails,
-									values,
+									values.map(({ value }) => String(value)),
 								)
 							}
-							notFoundContent={<p>No email suggestions</p>}
 							className={styles.selectContainer}
-							mode="tags"
-							value={formStore.getValue(formStore.names.emails)}
+							value={selectedEmails}
 						/>
 					</Form.NamedSection>
 
@@ -721,18 +773,18 @@ const LogAlertForm = () => {
 						<Select
 							aria-label="Webhooks to notify"
 							placeholder="Enter webhook addresses"
-							onChange={(values: any): any =>
+							filterable
+							creatable
+							displayMode="tags"
+							checkType="checkbox"
+							onValueChange={(values: SelectOption[]) =>
 								formStore.setValue(
 									formStore.names.webhookDestinations,
-									values,
+									values.map(({ value }) => String(value)),
 								)
 							}
-							notFoundContent={null}
 							className={styles.selectContainer}
-							mode="tags"
-							value={formStore.getValue(
-								formStore.names.webhookDestinations,
-							)}
+							value={selectedWebhooks}
 						/>
 					</Form.NamedSection>
 				</Stack>

--- a/frontend/src/pages/Alerts/LogAlert/styles.css.ts
+++ b/frontend/src/pages/Alerts/LogAlert/styles.css.ts
@@ -1,6 +1,5 @@
 import { sprinkles } from '@highlight-run/ui/sprinkles'
-import { vars } from '@highlight-run/ui/vars'
-import { globalStyle, style } from '@vanilla-extract/css'
+import { style } from '@vanilla-extract/css'
 
 export const header = style({
 	height: 40,
@@ -45,26 +44,5 @@ export const thresholdTypeButton = style([
 ])
 
 export const selectContainer = style({
-	color: `${vars.theme.static.content.default} !important`,
-	selectors: {
-		'&:hover': {
-			background: vars.theme.interactive.overlay.secondary.hover,
-		},
-	},
-})
-
-globalStyle(`${selectContainer} .ant-select-selector`, {
-	padding: `0 6px !important`,
-	borderRadius: `6px !important`,
-	border: `${vars.border.secondary} !important`,
-	boxShadow: 'none !important',
-})
-
-globalStyle(`${selectContainer} .ant-select-selector:hover`, {
-	background: `${vars.theme.interactive.overlay.secondary.hover} !important`,
-})
-
-globalStyle(`${selectContainer} .ant-select-selection-item`, {
-	display: 'flex',
-	alignItems: 'center',
+	width: '100%',
 })


### PR DESCRIPTION
## Summary

/claim #8635

- Replace the Log Alert notification selectors with `@highlight-run/ui` `Select`.
- Preserve Slack, Discord, Microsoft Teams, email, and webhook form value shapes used by the existing alert mutation payload.
- Remove the LogAlert-only Ant Design `.ant-select` style overrides that are no longer needed.

## Validation

- `npx -y prettier@3.3.3 --check frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx frontend/src/pages/Alerts/LogAlert/styles.css.ts`
- `npx -y esbuild@0.19.5 frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx --bundle '--external:*' --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=/tmp/highlight-log-alert-check.mjs --log-level=error`
- `rg -n "@components/Select/Select|ant-select|notFoundContent|mode=|labelInValue|optionFilterProp|onSearch=|onChange=" frontend/src/pages/Alerts/LogAlert` -> no matches
- `git diff --check`

## Security

UI-only alert configuration refactor. No auth, alert mutation, notification destination payload, query, threshold, or backend behavior changes.

## Demo

I could not run an authenticated local Log Alert settings page in this environment. The change is scoped to the existing selector UI and was validated with the focused checks above.
