### PR TITLE
Replace session alert legacy selects

### DIFF
--- a/frontend/src/pages/Alerts/SessionAlert/SessionAlertPage.tsx
+++ b/frontend/src/pages/Alerts/SessionAlert/SessionAlertPage.tsx
@@ -51,28 +51,10 @@ import AlertNotifyForm from '@/pages/Alerts/components/AlertNotifyForm/AlertNoti
 import AlertTitleField from '@/pages/Alerts/components/AlertTitleField/AlertTitleField'
 import analytics from '@/util/analytics'
 
+import { selectValuesToStrings } from './selectUtils'
 import * as styles from './styles.css'
 
 const SEPARATOR = ':$&'
-
-const selectValuesToStrings = (values: unknown): string[] => {
-	if (!Array.isArray(values)) {
-		return []
-	}
-
-	return values.map((value) => {
-		if (
-			value &&
-			typeof value === 'object' &&
-			'value' in value &&
-			value.value !== undefined
-		) {
-			return String(value.value)
-		}
-
-		return String(value)
-	})
-}
 
 const SessionAlertOptions = [
 	{ title: 'New Session', value: SessionAlertType.NewSessionAlert },
@@ -130,7 +112,7 @@ export const SessionAlertPage = () => {
 			formStore.setValues({
 				name: alert.Name ?? '',
 				belowThreshold: false,
-				excludedEnvironments: alert.ExcludedEnvironments,
+				excludedEnvironments: alert.ExcludedEnvironments ?? [],
 				slackChannels: alert.ChannelsToNotify.map((c: any) => ({
 					...c,
 					webhook_channel_name: c.webhook_channel,
@@ -160,15 +142,17 @@ export const SessionAlertPage = () => {
 				threshold: alert.CountThreshold,
 				frequency: getFrequencyOption(alert.Frequency).value,
 				threshold_window: alert.ThresholdWindow,
-				userProperties: alert.UserProperties?.map(
-					(userProperty: any) =>
-						getPropertiesOption(userProperty).value,
-				),
-				trackProperties: alert.TrackProperties?.map(
-					(trackProperty: any) =>
-						getPropertiesOption(trackProperty).value,
-				),
-				excludeRules: alert.ExcludeRules,
+				userProperties:
+					alert.UserProperties?.map(
+						(userProperty: any) =>
+							getPropertiesOption(userProperty).value,
+					) ?? [],
+				trackProperties:
+					alert.TrackProperties?.map(
+						(trackProperty: any) =>
+							getPropertiesOption(trackProperty).value,
+					) ?? [],
+				excludeRules: alert.ExcludeRules ?? [],
 				type: alertType,
 				loaded: true,
 			})
@@ -617,9 +601,11 @@ const SessionAlertForm = ({
 											selectValuesToStrings(values),
 										)
 									}}
-									value={formStore.getValue(
-										formStore.names.excludeRules,
-									)}
+									value={
+										formStore.getValue(
+											formStore.names.excludeRules,
+										) ?? []
+									}
 								/>
 							</Form.NamedSection>
 						)}
@@ -638,9 +624,11 @@ const SessionAlertForm = ({
 											selectValuesToStrings(values),
 										)
 									}
-									value={formStore.getValue(
-										formStore.names.userProperties,
-									)}
+									value={
+										formStore.getValue(
+											formStore.names.userProperties,
+										) ?? []
+									}
 								/>
 							</Form.NamedSection>
 						)}
@@ -658,9 +646,11 @@ const SessionAlertForm = ({
 											selectValuesToStrings(values),
 										)
 									}
-									value={formStore.getValue(
-										formStore.names.trackProperties,
-									)}
+									value={
+										formStore.getValue(
+											formStore.names.trackProperties,
+										) ?? []
+									}
 								/>
 							</Form.NamedSection>
 						)}
@@ -692,9 +682,11 @@ const SessionAlertForm = ({
 									selectValuesToStrings(values),
 								)
 							}
-							value={formStore.getValue(
-								formStore.names.excludedEnvironments,
-							)}
+							value={
+								formStore.getValue(
+									formStore.names.excludedEnvironments,
+								) ?? []
+							}
 						/>
 					</Form.NamedSection>
 				</Stack>

--- a/frontend/src/pages/Alerts/SessionAlert/SessionAlertPage.tsx
+++ b/frontend/src/pages/Alerts/SessionAlert/SessionAlertPage.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@components/Button'
-import Select from '@components/Select/Select'
 import { toast } from '@components/Toaster'
 import {
 	useDeleteSessionAlertMutation,
@@ -18,6 +17,7 @@ import {
 	IconSolidCheveronUp,
 	IconSolidBell,
 	Menu,
+	Select,
 	Stack,
 	SwitchButton,
 	Tag,
@@ -39,7 +39,6 @@ import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import LoadingBox from '@/components/LoadingBox'
-import TextHighlighter from '@/components/TextHighlighter/TextHighlighter'
 import { namedOperations } from '@/graph/generated/operations'
 import { SessionAlertInput, SessionAlertType } from '@/graph/generated/schemas'
 import {
@@ -55,6 +54,25 @@ import analytics from '@/util/analytics'
 import * as styles from './styles.css'
 
 const SEPARATOR = ':$&'
+
+const selectValuesToStrings = (values: unknown): string[] => {
+	if (!Array.isArray(values)) {
+		return []
+	}
+
+	return values.map((value) => {
+		if (
+			value &&
+			typeof value === 'object' &&
+			'value' in value &&
+			value.value !== undefined
+		) {
+			return String(value.value)
+		}
+
+		return String(value)
+	})
+}
 
 const SessionAlertOptions = [
 	{ title: 'New Session', value: SessionAlertType.NewSessionAlert },
@@ -498,12 +516,9 @@ const SessionAlertForm = ({
 		(alertsPayload?.environment_suggestion ??
 			[]) as EnvironmentSuggestion[],
 	).map((environmentSuggestion) => ({
-		displayValue: environmentSuggestion,
+		name: environmentSuggestion,
 		value: environmentSuggestion,
-		id: environmentSuggestion,
 	}))
-
-	const [identifierQuery, setIdentifierQuery] = useState('')
 
 	const {
 		refetch: refetchIdentifierSuggestions,
@@ -522,18 +537,11 @@ const SessionAlertForm = ({
 		: (identifierSuggestionsApiResponse?.identifier_suggestion || []).map(
 				(suggestion) => ({
 					value: suggestion,
-					displayValue: (
-						<TextHighlighter
-							searchWords={[identifierQuery]}
-							textToHighlight={suggestion}
-						/>
-					),
-					id: suggestion,
+					name: suggestion,
 				}),
 			)
 
 	const handleIdentifierSearch = (query = '') => {
-		setIdentifierQuery(query)
 		refetchIdentifierSuggestions({ query, project_id: project_id })
 	}
 
@@ -593,21 +601,22 @@ const SessionAlertForm = ({
 							>
 								<Select
 									aria-label="Excluded identifiers list"
-									notFoundContent={
-										<p>No identifier suggestions</p>
-									}
-									onSearch={handleIdentifierSearch}
+									creatable
+									displayMode="tags"
+									filterable
+									onSearchValueChange={handleIdentifierSearch}
 									options={identifierSuggestions}
-									mode="tags"
 									placeholder="Select a identifier(s) that should not trigger alerts."
-									onChange={(values: any): any => {
+									resultsLoading={
+										identifierSuggestionsLoading
+									}
+									onValueChange={(values) => {
 										handleIdentifierSearch('')
 										formStore.setValue(
 											formStore.names.excludeRules,
-											values,
+											selectValuesToStrings(values),
 										)
 									}}
-									className={styles.selectContainer}
 									value={formStore.getValue(
 										formStore.names.excludeRules,
 									)}
@@ -621,13 +630,12 @@ const SessionAlertForm = ({
 								name={formStore.names.userProperties}
 							>
 								<Select
-									className={styles.selectContainer}
-									mode="multiple"
+									displayMode="tags"
 									placeholder="Pick the user properties that you would like to get alerted for."
-									onChange={(values: any): any =>
+									onValueChange={(values) =>
 										formStore.setValue(
 											formStore.names.userProperties,
-											values,
+											selectValuesToStrings(values),
 										)
 									}
 									value={formStore.getValue(
@@ -642,13 +650,12 @@ const SessionAlertForm = ({
 								name={formStore.names.trackProperties}
 							>
 								<Select
-									className={styles.selectContainer}
-									mode="multiple"
+									displayMode="tags"
 									placeholder="Pick the track properties that you would like to get alerted for."
-									onChange={(values: any): any =>
+									onValueChange={(values) =>
 										formStore.setValue(
 											formStore.names.trackProperties,
-											values,
+											selectValuesToStrings(values),
 										)
 									}
 									value={formStore.getValue(
@@ -677,15 +684,14 @@ const SessionAlertForm = ({
 							aria-label="Excluded environments list"
 							placeholder="Select excluded environments"
 							options={environments}
-							onChange={(values: any): any =>
+							displayMode="tags"
+							filterable
+							onValueChange={(values) =>
 								formStore.setValue(
 									formStore.names.excludedEnvironments,
-									values,
+									selectValuesToStrings(values),
 								)
 							}
-							notFoundContent={<p>No environment suggestions</p>}
-							className={styles.selectContainer}
-							mode="multiple"
 							value={formStore.getValue(
 								formStore.names.excludedEnvironments,
 							)}

--- a/frontend/src/pages/Alerts/SessionAlert/selectUtils.test.ts
+++ b/frontend/src/pages/Alerts/SessionAlert/selectUtils.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { selectValuesToStrings } from './selectUtils'
+
+describe('selectValuesToStrings', () => {
+	it('preserves plain string array values', () => {
+		expect(selectValuesToStrings(['production', 'staging'])).toEqual([
+			'production',
+			'staging',
+		])
+	})
+
+	it('normalizes UI Select option values back to strings', () => {
+		expect(
+			selectValuesToStrings([
+				{ name: 'Production', value: 'production' },
+				{ name: 'Staging', value: 'staging' },
+			]),
+		).toEqual(['production', 'staging'])
+	})
+
+	it('normalizes generated creatable values emitted by UI Select', () => {
+		expect(
+			selectValuesToStrings([
+				{ name: 'user.email', value: 'user.email' },
+			]),
+		).toEqual(['user.email'])
+	})
+
+	it('preserves encoded property values emitted by UI Select', () => {
+		const propertyValue = 'property-id:$&browser:$&chrome'
+
+		expect(
+			selectValuesToStrings([
+				{ name: 'browser: chrome', value: propertyValue },
+			]),
+		).toEqual([propertyValue])
+	})
+
+	it('normalizes numeric option values to strings', () => {
+		expect(selectValuesToStrings([{ name: 'One', value: 1 }])).toEqual([
+			'1',
+		])
+	})
+
+	it('falls back to an empty array for non-array values', () => {
+		expect(selectValuesToStrings(undefined)).toEqual([])
+		expect(selectValuesToStrings(null)).toEqual([])
+	})
+})

--- a/frontend/src/pages/Alerts/SessionAlert/selectUtils.ts
+++ b/frontend/src/pages/Alerts/SessionAlert/selectUtils.ts
@@ -1,0 +1,18 @@
+export const selectValuesToStrings = (values: unknown): string[] => {
+	if (!Array.isArray(values)) {
+		return []
+	}
+
+	return values.map((value) => {
+		if (
+			value &&
+			typeof value === 'object' &&
+			'value' in value &&
+			value.value !== undefined
+		) {
+			return String(value.value)
+		}
+
+		return String(value)
+	})
+}

--- a/frontend/src/pages/Alerts/SessionAlert/styles.css.ts
+++ b/frontend/src/pages/Alerts/SessionAlert/styles.css.ts
@@ -1,6 +1,6 @@
 import { sprinkles } from '@highlight-run/ui/sprinkles'
 import { vars } from '@highlight-run/ui/vars'
-import { globalStyle, style } from '@vanilla-extract/css'
+import { style } from '@vanilla-extract/css'
 
 export const header = style({
 	height: 40,
@@ -66,28 +66,3 @@ export const thresholdTypeButton = style([
 		height: 20,
 	},
 ])
-
-export const selectContainer = style({
-	color: `${vars.theme.static.content.default} !important`,
-	selectors: {
-		'&:hover': {
-			background: vars.theme.interactive.overlay.secondary.hover,
-		},
-	},
-})
-
-globalStyle(`${selectContainer} .ant-select-selector`, {
-	padding: `0 6px !important`,
-	borderRadius: `6px !important`,
-	border: `${vars.border.secondary} !important`,
-	boxShadow: 'none !important',
-})
-
-globalStyle(`${selectContainer} .ant-select-selector:hover`, {
-	background: `${vars.theme.interactive.overlay.secondary.hover} !important`,
-})
-
-globalStyle(`${selectContainer} .ant-select-selection-item`, {
-	display: 'flex',
-	alignItems: 'center',
-})


### PR DESCRIPTION
/claim #8635

## Summary
- Replaced the Session Alert page's legacy Ant Design-backed `@components/Select/Select` import with `@highlight-run/ui` `Select`.
- Preserved the existing `string[]` form state shape by normalizing selected UI Select option objects back to string values before save.
- Guarded loaded multi-select form values with empty-array fallbacks so the UI Select stays in multi-select mode when optional API fields are absent.
- Removed SessionAlert-only `.ant-select` CSS overrides that are no longer used after the migration.
- Added targeted regression coverage for the select value normalization helper.

## Validation
- `npx -y prettier@3.3.3 --check frontend/src/pages/Alerts/SessionAlert/SessionAlertPage.tsx frontend/src/pages/Alerts/SessionAlert/styles.css.ts frontend/src/pages/Alerts/SessionAlert/selectUtils.ts frontend/src/pages/Alerts/SessionAlert/selectUtils.test.ts`
- `npx -y esbuild@0.19.5 frontend/src/pages/Alerts/SessionAlert/SessionAlertPage.tsx --bundle '--external:*' --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=/tmp/highlight-session-alert-check.mjs --log-level=error`
- `npx -y tsx@4.19.2 -e "<selectValuesToStrings assertions>"`
- `rg -n "@components/Select/Select|TextHighlighter|notFoundContent|mode=|onSearch=|optionFilterProp|labelInValue|ant-select|selectContainer" frontend/src/pages/Alerts/SessionAlert` -> no matches
- `git diff --check`

## Security
UI-only alert configuration refactor. No auth, alert mutation, notification destination payload, threshold, or backend behavior changes.

## Demo
I could not run an authenticated local Session Alert settings page in this environment. The change is scoped to the existing selector UI and was validated with focused format, parse, legacy-pattern, helper-regression, and diff checks.

Prepared with AI assistance and manually reviewed before submission.
