### PR TITLE
refactor(workspace-settings): remove antd Checkbox from AutoJoinForm (#8635)

### DIFF
--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.module.css
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.module.css
@@ -7,11 +7,3 @@
 	max-height: fit-content;
 	min-height: var(--size-xxLarge);
 }
-
-.select {
-	width: 100%;
-
-	&:global(.ant-select-disabled .ant-select-selector) {
-		background-color: var(--color-primary-background) !important;
-	}
-}

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -8,7 +8,6 @@ import {
 import { namedOperations } from '@graph/operations'
 import { Box, Select, Text } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React, { useState } from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -61,7 +60,9 @@ export const AutoJoinForm: React.FC = () => {
 		}
 	}
 
-	const handleCheckboxChange = (event: CheckboxChangeEvent) => {
+	const handleCheckboxChange = (
+		event: React.ChangeEvent<HTMLInputElement>,
+	) => {
 		const checked = event.target.checked
 		if (checked) {
 			onChangeMsg([adminsEmailDomain], 'Successfully enabled auto-join!')
@@ -85,7 +86,8 @@ export const AutoJoinForm: React.FC = () => {
 		>
 			<div className={styles.container}>
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
+					<input
+						type="checkbox"
 						checked={autoJoinDomains.length > 0}
 						onChange={handleCheckboxChange}
 					/>


### PR DESCRIPTION
## Summary

One narrow Workspace Settings slice for #8635: removes the direct `antd/es/checkbox` import from `frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx` (rendered inside `WorkspaceSettings.tsx`).

The auto-approved-email-domains toggle now uses a native `<input type="checkbox">` with `React.ChangeEvent<HTMLInputElement>` typing. This matches the precedent set by PR #10460, which used the same native input pattern when removing antd `Checkbox` from `NewProject/AutoJoinInput.tsx`.

## Changes

- `frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx`
  - Removed `import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'`.
  - Replaced `<Checkbox checked onChange={handleCheckboxChange} />` with `<input type="checkbox" checked onChange={handleCheckboxChange} />`.
  - Re-typed `handleCheckboxChange` from `CheckboxChangeEvent` to `React.ChangeEvent<HTMLInputElement>`.
- `frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.module.css`
  - Removed the dead `.select` rule. It only set `width: 100%` and a `:global(.ant-select-disabled .ant-select-selector)` background override, neither of which apply to the highlight-ui Ariakit-based `Select` already in use. `styles.select` was never referenced by the component (only `styles.container` is used).

## Component swap

| antd component | Replacement |
| --- | --- |
| `antd/es/checkbox` (`Checkbox`) | Native `<input type="checkbox">` |
| `CheckboxChangeEvent` type | `React.ChangeEvent<HTMLInputElement>` |

## Behavior preserved

- Checking the box still seeds `autoJoinDomains` with the admin's email domain via `onChangeMsg([adminsEmailDomain], 'Successfully enabled auto-join!')`.
- Unchecking still clears the list via `onChangeMsg([], 'Successfully disabled auto-join!')`.
- The `updateAllowedEmailOrigins` GraphQL mutation, refetch behavior, and success toast paths are unchanged.
- The `@highlight-run/ui` `Select` rendering the editable domain tag list is untouched.
- `<Tooltip>`, `<Box>`, `<Text>`, and the surrounding container styles are unchanged.

## Visual notes

The native `<input type="checkbox">` renders using the platform-default UA style instead of antd's themed checkbox. This is consistent with how PR #10460 handled `AutoJoinInput.tsx` in `NewProject`. If a styled token-themed checkbox component lands in `@highlight-run/ui` later, both sites can adopt it together in a follow-up.

## Scope

- This PR stays single-file (plus its CSS module). It does not overlap with the other open slices for #8635 (e.g. `SourcemapSettings`, `FieldsForm`/`DangerForm` `Input`, `GitHubSettingsModal` `Select`, `ExcludedUsersForm`, `WorkspaceSettings` `Alert`, integrations).
- `@components/Tooltip/Tooltip` (the antd-wrapped tooltip used by `AutoJoinForm`) is intentionally not migrated here. It is a shared wrapper and is better swapped in a dedicated PR.

## Verification

Performed against the working branch:

- `cd packages/ui && yarn build:vite` — UI library built so `@highlight-run/ui/components` declarations are present.
- `cd sdk/highlight-run && yarn build` and `cd sdk/highlight-react && yarn build` — SDK declarations available for the frontend's TS resolution.
- `cd rrweb && yarn build:all` — submodule packages built (17/19 succeed; `@rrweb/web-extension` fail is unrelated to this PR).
- `cd frontend && yarn types:check` — exits 0 on the branch; no new TypeScript errors.
- `cd frontend && yarn eslint src/pages/WorkspaceTeam/components/AutoJoinForm.tsx` — clean, no warnings.
- `yarn dlx prettier@3 --check frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.module.css` — "All matched files use Prettier code style!".
- `grep -n "antd" frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.*` — no matches.

## Test plan

- [ ] Open Workspace Settings → "Auto-join" section.
- [ ] Toggle the checkbox on: expect the admin's email domain to populate the tag list and "Successfully enabled auto-join!" toast.
- [ ] Toggle off: expect the list cleared and "Successfully disabled auto-join!" toast.
- [ ] Manually add/remove a domain via the `@highlight-run/ui` `Select` and confirm "Successfully updated auto-join email domains!" toast.
- [ ] As a non-admin (Authorization-blocked) user, confirm the surrounding `Authorization` boundary still renders the existing fallback.

Refs: #8635
