### PR TITLE
[codex] Redesign integrations page

### DIFF
--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
@@ -1,9 +1,261 @@
-.integrationsContainer {
-	display: grid;
-	grid-gap: var(--size-large);
-	grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+.page {
+	max-width: 1180px !important;
 }
+
+.header {
+	align-items: flex-start;
+	display: flex;
+	gap: var(--size-large);
+	justify-content: space-between;
+	margin-bottom: var(--size-xLarge);
+}
+
+.title {
+	margin-bottom: var(--size-xSmall) !important;
+}
+
+.subTitle {
+	color: var(--color-gray-500);
+	font-size: 18px;
+	margin-bottom: 0 !important;
+	max-width: 620px;
+}
+
+.summary {
+	border: 1px solid var(--color-gray-300);
+	border-radius: var(--border-radius);
+	display: grid;
+	grid-template-columns: repeat(2, minmax(96px, 1fr));
+	overflow: hidden;
+}
+
+.summaryItem {
+	background: var(--color-primary-background);
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	padding: var(--size-small) var(--size-medium);
+}
+
+.summaryItem + .summaryItem {
+	border-left: 1px solid var(--color-gray-300);
+}
+
+.summaryValue {
+	color: var(--text-primary);
+	font-size: 20px;
+	font-weight: 600;
+	line-height: 1;
+}
+
+.summaryLabel {
+	color: var(--color-gray-500);
+	font-size: 12px;
+	line-height: 1;
+}
+
+.layout {
+	align-items: stretch;
+	display: grid;
+	gap: var(--size-large);
+	grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
+	min-height: 520px;
+}
+
+.sidebar {
+	background: var(--color-primary-background);
+	border: 1px solid var(--color-gray-300);
+	border-radius: var(--border-radius);
+	display: flex;
+	flex-direction: column;
+	max-height: calc(100vh - 220px);
+	overflow-y: auto;
+	padding: var(--size-small);
+}
+
+.integrationNavSection + .integrationNavSection {
+	border-top: 1px solid var(--color-gray-300);
+	margin-top: var(--size-small);
+	padding-top: var(--size-small);
+}
+
+.integrationNavHeading {
+	color: var(--color-gray-500);
+	font-size: 11px !important;
+	font-weight: 600;
+	letter-spacing: 0.05em;
+	margin: 0 0 var(--size-xSmall) !important;
+	padding: 0 var(--size-xSmall);
+	text-transform: uppercase;
+}
+
+.integrationNavItem {
+	align-items: center;
+	background: transparent;
+	border: 0;
+	border-radius: var(--border-radius);
+	color: var(--text-primary);
+	cursor: pointer;
+	display: grid;
+	font-family: inherit;
+	gap: var(--size-small);
+	grid-template-columns: 34px minmax(0, 1fr) auto;
+	padding: var(--size-xSmall);
+	text-align: left;
+	transition:
+		background-color 120ms ease,
+		box-shadow 120ms ease;
+	width: 100%;
+}
+
+.integrationNavItem:hover {
+	background: var(--color-gray-200);
+}
+
+.integrationNavItemSelected {
+	background: var(--color-gray-200);
+	box-shadow: inset 0 0 0 1px var(--color-gray-300);
+}
+
+.integrationNavIconWrap {
+	align-items: center;
+	background: var(--color-primary-background);
+	border: 1px solid var(--color-gray-300);
+	border-radius: var(--border-radius);
+	display: flex;
+	height: 34px;
+	justify-content: center;
+	width: 34px;
+}
+
+.integrationNavIcon {
+	border-radius: 50%;
+	height: 22px;
+	object-fit: contain;
+	width: 22px;
+}
+
+.integrationNavCopy {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+}
+
+.integrationNavName {
+	color: var(--text-primary);
+	font-size: 14px;
+	font-weight: 600;
+	line-height: 1.2;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.integrationNavDescription {
+	color: var(--color-gray-500);
+	font-size: 12px;
+	line-height: 1.25;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.integrationNavStatus {
+	background: var(--color-green-100);
+	border-radius: 999px;
+	color: var(--color-green-700);
+	font-size: 11px;
+	font-weight: 600;
+	padding: 3px 7px;
+}
+
+.detailPanel {
+	background: var(--color-primary-background);
+	border: 1px solid var(--color-gray-300);
+	border-radius: var(--border-radius);
+	display: flex;
+	flex-direction: column;
+	gap: var(--size-large);
+	min-width: 0;
+	padding: var(--size-large);
+}
+
+.detailHeader {
+	align-items: center;
+	border-bottom: 1px solid var(--color-gray-300);
+	display: flex;
+	gap: var(--size-medium);
+	padding-bottom: var(--size-large);
+}
+
+.detailIconWrap {
+	align-items: center;
+	background: var(--color-gray-200);
+	border: 1px solid var(--color-gray-300);
+	border-radius: var(--border-radius);
+	display: flex;
+	flex-shrink: 0;
+	height: 54px;
+	justify-content: center;
+	width: 54px;
+}
+
+.detailIcon {
+	border-radius: 50%;
+	height: 34px;
+	object-fit: contain;
+	width: 34px;
+}
+
+.detailTitle {
+	font-size: 20px !important;
+	font-weight: 600;
+	line-height: 1.2;
+	margin: 0 0 4px !important;
+}
+
+.detailDescription {
+	color: var(--color-gray-500);
+	font-size: 14px;
+	line-height: 1.4;
+	margin: 0 !important;
+}
+
 .modalBtn {
 	padding-bottom: 4px !important;
 	padding-top: 4px !important;
+}
+
+@media (max-width: 900px) {
+	.header {
+		flex-direction: column;
+	}
+
+	.summary {
+		width: 100%;
+	}
+
+	.layout {
+		grid-template-columns: 1fr;
+	}
+
+	.sidebar {
+		max-height: 360px;
+	}
+}
+
+@media (max-width: 540px) {
+	.integrationNavItem {
+		grid-template-columns: 34px minmax(0, 1fr);
+	}
+
+	.integrationNavStatus {
+		grid-column: 2;
+		justify-self: start;
+	}
+
+	.detailHeader {
+		align-items: flex-start;
+	}
 }

--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
@@ -12,11 +12,14 @@ import Integration from '@pages/IntegrationsPage/components/Integration'
 import { useLinearIntegration } from '@pages/IntegrationsPage/components/LinearIntegration/utils'
 import { useVercelIntegration } from '@pages/IntegrationsPage/components/VercelIntegration/utils'
 import { useZapierIntegration } from '@pages/IntegrationsPage/components/ZapierIntegration/utils'
-import INTEGRATIONS from '@pages/IntegrationsPage/Integrations'
+import INTEGRATIONS, {
+	Integration as IntegrationType,
+} from '@pages/IntegrationsPage/Integrations'
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
 import analytics from '@util/analytics'
 import { useParams } from '@util/react-router/useParams'
-import { useEffect, useMemo } from 'react'
+import clsx from 'clsx'
+import { useEffect, useMemo, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { StringParam, useQueryParam } from 'use-query-params'
 
@@ -24,14 +27,54 @@ import { useGitlabIntegration } from '@/pages/IntegrationsPage/components/Gitlab
 import { useJiraIntegration } from '@/pages/IntegrationsPage/components/JiraIntegration/utils'
 import { useMicrosoftTeamsBot } from '@/pages/IntegrationsPage/components/MicrosoftTeamsIntegration/utils'
 
-import layoutStyles from '../../components/layout/LeadAlignLayout.module.css'
 import styles from './IntegrationsPage.module.css'
+
+const getIntegrationRouteKey = (routePath?: string) =>
+	routePath?.split('/').filter(Boolean)[0]
+
+const IntegrationNavItem = ({
+	integration,
+	isSelected,
+	onSelect,
+}: {
+	integration: IntegrationType
+	isSelected: boolean
+	onSelect: (key: string) => void
+}) => (
+	<button
+		type="button"
+		className={clsx(styles.integrationNavItem, {
+			[styles.integrationNavItemSelected]: isSelected,
+		})}
+		onClick={() => onSelect(integration.key)}
+		aria-pressed={isSelected}
+	>
+		<span className={styles.integrationNavIconWrap}>
+			<img
+				src={integration.icon}
+				alt=""
+				className={clsx(styles.integrationNavIcon, {
+					['rounded-none']: integration.noRoundedIcon,
+				})}
+			/>
+		</span>
+		<span className={styles.integrationNavCopy}>
+			<span className={styles.integrationNavName}>{integration.name}</span>
+			<span className={styles.integrationNavDescription}>
+				{integration.description}
+			</span>
+		</span>
+		{integration.defaultEnable && (
+			<span className={styles.integrationNavStatus}>Connected</span>
+		)}
+	</button>
+)
 
 const IntegrationsPage = () => {
 	const { isSlackConnectedToWorkspace, loading: loadingSlack } = useSlackBot()
 
-	const { integration_type: configureIntegration } = useParams<{
-		integration_type: string
+	const { '*': integrationRoutePath } = useParams<{
+		'*': string
 	}>()
 
 	const [popUpModal] = useQueryParam('enable', StringParam)
@@ -179,6 +222,41 @@ const IntegrationsPage = () => {
 		isCloudflareConnectedToWorkspace,
 	])
 
+	const connectedIntegrations = useMemo(
+		() => integrations.filter((integration) => integration.defaultEnable),
+		[integrations],
+	)
+
+	const availableIntegrations = useMemo(
+		() => integrations.filter((integration) => !integration.defaultEnable),
+		[integrations],
+	)
+
+	const routedIntegrationKey = getIntegrationRouteKey(integrationRoutePath)
+	const defaultIntegrationKey =
+		routedIntegrationKey ||
+		popUpModal ||
+		connectedIntegrations[0]?.key ||
+		integrations[0]?.key
+
+	const [selectedIntegrationKey, setSelectedIntegrationKey] = useState<
+		string | undefined
+	>(defaultIntegrationKey ?? undefined)
+
+	useEffect(() => {
+		if (defaultIntegrationKey) {
+			setSelectedIntegrationKey(defaultIntegrationKey)
+		}
+	}, [defaultIntegrationKey])
+
+	const selectedIntegration =
+		integrations.find(
+			(integration) => integration.key === selectedIntegrationKey,
+		) ?? integrations[0]
+	const handleSelectIntegration = (key: string) => {
+		setSelectedIntegrationKey(key)
+	}
+
 	useEffect(() => analytics.page('Integrations'), [])
 
 	return (
@@ -186,24 +264,124 @@ const IntegrationsPage = () => {
 			<Helmet>
 				<title>Integrations</title>
 			</Helmet>
-			<LeadAlignLayout>
-				<h2>Integrations</h2>
-				<p className={layoutStyles.subTitle}>
-					Supercharge your workflows and attach Highlight with the
-					tools you use everyday.
-				</p>
-				<div className={styles.integrationsContainer}>
-					{integrations.map((integration) => (
-						<Integration
-							integration={integration}
-							key={integration.key}
-							showModalDefault={popUpModal === integration.key}
-							showSettingsDefault={
-								configureIntegration === integration.key
-							}
-							loading={loading}
-						/>
-					))}
+			<LeadAlignLayout fullWidth className={styles.page}>
+				<div className={styles.header}>
+					<div>
+						<h2 className={styles.title}>Integrations</h2>
+						<p className={styles.subTitle}>
+							Supercharge your workflows and attach Highlight with
+							the tools you use everyday.
+						</p>
+					</div>
+					<div className={styles.summary}>
+						<div className={styles.summaryItem}>
+							<span className={styles.summaryValue}>
+								{connectedIntegrations.length}
+							</span>
+							<span className={styles.summaryLabel}>
+								Connected
+							</span>
+						</div>
+						<div className={styles.summaryItem}>
+							<span className={styles.summaryValue}>
+								{availableIntegrations.length}
+							</span>
+							<span className={styles.summaryLabel}>
+								Available
+							</span>
+						</div>
+					</div>
+				</div>
+				<div className={styles.layout}>
+					<aside
+						className={styles.sidebar}
+						aria-label="Integrations"
+					>
+						{connectedIntegrations.length > 0 && (
+							<section className={styles.integrationNavSection}>
+								<h3 className={styles.integrationNavHeading}>
+									Connected
+								</h3>
+								{connectedIntegrations.map((integration) => (
+									<IntegrationNavItem
+										key={integration.key}
+										integration={integration}
+										isSelected={
+											selectedIntegration?.key ===
+											integration.key
+										}
+										onSelect={handleSelectIntegration}
+									/>
+								))}
+							</section>
+						)}
+						{availableIntegrations.length > 0 && (
+							<section className={styles.integrationNavSection}>
+								<h3 className={styles.integrationNavHeading}>
+									Available
+								</h3>
+								{availableIntegrations.map((integration) => (
+									<IntegrationNavItem
+										key={integration.key}
+										integration={integration}
+										isSelected={
+											selectedIntegration?.key ===
+											integration.key
+										}
+										onSelect={handleSelectIntegration}
+									/>
+								))}
+							</section>
+						)}
+					</aside>
+					<section className={styles.detailPanel}>
+						{selectedIntegration && (
+							<>
+								<div className={styles.detailHeader}>
+									<div
+										className={styles.detailIconWrap}
+										aria-hidden="true"
+									>
+										<img
+											src={selectedIntegration.icon}
+											alt=""
+											className={clsx(
+												styles.detailIcon,
+												{
+													['rounded-none']:
+														selectedIntegration.noRoundedIcon,
+												},
+											)}
+										/>
+									</div>
+									<div>
+										<h3 className={styles.detailTitle}>
+											{selectedIntegration.name}
+										</h3>
+										<p
+											className={
+												styles.detailDescription
+											}
+										>
+											{selectedIntegration.description}
+										</p>
+									</div>
+								</div>
+								<Integration
+									integration={selectedIntegration}
+									key={selectedIntegration.key}
+									showModalDefault={
+										popUpModal === selectedIntegration.key
+									}
+									showSettingsDefault={
+										routedIntegrationKey ===
+										selectedIntegration.key
+									}
+									loading={loading}
+								/>
+							</>
+						)}
+					</section>
 				</div>
 			</LeadAlignLayout>
 		</>

--- a/frontend/src/pages/IntegrationsPage/components/Integration.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.module.css
@@ -1,26 +1,77 @@
 .integration {
+	display: flex;
+	flex-direction: column;
+	gap: var(--size-medium);
+	min-height: 190px;
+
 	& .logo {
+		background: var(--color-gray-200);
+		border: 1px solid var(--color-gray-300);
 		border-radius: 50%;
 		height: var(--size-xxLarge);
+		object-fit: contain;
+		padding: 4px;
 		width: var(--size-xxLarge);
 	}
 
 	& .header {
 		align-items: flex-start;
+		border-bottom: 1px solid var(--color-gray-300);
 		display: flex;
+		gap: var(--size-medium);
 		justify-content: space-between;
-		padding-bottom: var(--size-small);
+		padding-bottom: var(--size-medium);
 	}
 
-	& .connectButton {
-		text-transform: uppercase;
+	& .controls {
+		align-items: flex-end;
+		display: flex;
+		flex-direction: column;
+		flex-shrink: 0;
+		gap: var(--size-small);
+		min-width: 112px;
+	}
+
+	& .body {
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-xSmall);
+	}
+
+	& .statusBadge {
+		align-self: flex-start;
+		background: var(--color-green-100);
+		border-radius: 999px;
+		color: var(--color-green-700);
+		font-size: 11px;
+		font-weight: 600;
+		line-height: 1;
+		padding: 4px 8px;
 	}
 
 	& .title {
-		margin-bottom: var(--size-small) !important;
+		font-size: 18px;
+		font-weight: 600;
+		line-height: 1.25;
+		margin: 0 !important;
 	}
 
 	& .description {
+		color: var(--color-gray-500);
+		font-size: 14px;
+		line-height: 1.45;
 		margin-bottom: 0 !important;
+	}
+
+	& .docsLink {
+		color: var(--color-purple);
+		font-size: 14px;
+		font-weight: 600;
+		margin-top: var(--size-xSmall);
+		text-decoration: none;
+	}
+
+	& .docsLink:hover {
+		text-decoration: underline;
 	}
 }

--- a/frontend/src/pages/IntegrationsPage/components/Integration.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.tsx
@@ -84,7 +84,7 @@ const Integration = ({
 							['rounded-none']: noRoundedIcon,
 						})}
 					/>
-					<div className="flex flex-col gap-2">
+					<div className={styles.controls}>
 						{isGated ? (
 							<EnterpriseFeatureButton
 								setting={enterpriseSetting}
@@ -159,12 +159,15 @@ const Integration = ({
 						)}
 					</div>
 				</div>
-				<div>
+				<div className={styles.body}>
+					{integrationEnabled && (
+						<span className={styles.statusBadge}>Connected</span>
+					)}
 					<h2 className={styles.title}>{name}</h2>
 					<p className={styles.description}>{description}</p>
 					{docs && (
 						<a
-							className={styles.description}
+							className={styles.docsLink}
 							href={docs}
 							target="_blank"
 							rel="noopener noreferrer"


### PR DESCRIPTION
## Summary

Redesigns the integrations page around a focused two-pane workflow:

- adds connected/available summary counts
- replaces the flat grid with a sidebar grouped by connection state
- shows the selected integration in a detail panel
- keeps existing connect/disconnect switches, settings modals, enterprise gating, and configuration components intact
- reads the `integrations/*` route segment so OAuth callback deep links still select/open the intended integration
- refreshes integration card spacing, status treatment, docs link styling, and mobile behavior

/claim #8614

## Validation

- Ran `git diff --check` successfully.
- Attempted `corepack yarn workspace @highlight-run/frontend types:check`, but the checkout had no `node_modules` state.
- Attempted `corepack yarn install --immutable`; install could not complete in this environment because the sparse checkout was missing workspace packages and expanding the full workspace timed out.

## Demo

I could not capture a local demo video in this environment because the frontend dependency install did not complete. The change is limited to the integrations page presentation/components and should be straightforward to verify locally at the integrations page once dependencies are installed.