### PR TITLE
fix(project-settings): replace antd Select with ComboboxSelect in GitHubSettingsModal

### DIFF
--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -5,6 +5,7 @@ import ModalBody from '@components/ModalBody/ModalBody'
 import {
 	Box,
 	ButtonIcon,
+	ComboboxSelect,
 	Form,
 	IconSolidInformationCircle,
 	IconSolidQuestionMarkCircle,
@@ -15,7 +16,6 @@ import {
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -120,12 +120,11 @@ const GithubSettingsForm = ({
 	const githubOptions = useMemo(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
-				id: repo.key,
-				label: repo.name.split('/').pop(),
-				value: repo.repo_id.replace(
+				key: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
 				),
+				render: repo.name.split('/').pop() ?? repo.name,
 			})),
 		[githubRepos],
 	)
@@ -151,24 +150,26 @@ const GithubSettingsForm = ({
 					name="githubRepo"
 				>
 					<Box display="flex" alignItems="center" gap="8">
-						<Select
-							aria-label="GitHub repository"
-							className={styles.repoSelect}
-							placeholder="Search repos..."
-							onSelect={(repo: string) =>
+						<ComboboxSelect
+							label="GitHub repository"
+							queryPlaceholder="Search repos..."
+							value={formState.values.githubRepo ?? undefined}
+							valueRender={
+								formState.values.githubRepo
+									?.split('/')
+									.pop() ?? undefined
+							}
+							options={githubOptions}
+							onChange={(repo: string) =>
 								formStore.setValue(
 									formStore.names.githubRepo,
 									repo,
 								)
 							}
-							value={formState.values.githubRepo
-								?.split('/')
-								.pop()}
-							options={githubOptions}
-							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
-							filterOption
-							showSearch
+							emptyStateRender={
+								<Text>No repos found</Text>
+							}
+							cssClass={styles.repoSelect}
 						/>
 						<ButtonIcon
 							kind="secondary"


### PR DESCRIPTION
## Summary

Removes the antd `Select` import from `GitHubSettingsModal.tsx` and replaces it with `ComboboxSelect` from `@highlight-run/ui/components`.

**Before:** `GitHubSettingsModal` imported `Select` from `antd`
**After:** Uses `ComboboxSelect` from the existing `@highlight-run/ui` design system

The replacement keeps identical behaviour:
- Searchable repo list via `queryPlaceholder`
- Displays repo name in the trigger button via `valueRender`
- Clears on trash button click
- Binds to the same form field

## Bounty claim

/claim #8635