### PR TITLE
feat: redesign integrations page with categorized sections

### DIFF
--- a/.changeset/integrations-page-redesign.md
+++ b/.changeset/integrations-page-redesign.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/frontend': patch
+---
+
+redesign integrations page with categorized sections and improved card UI

--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
@@ -1,9 +1,52 @@
-.integrationsContainer {
-	display: grid;
-	grid-gap: var(--size-large);
-	grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+.header {
+	margin-bottom: var(--size-xLarge);
 }
-.modalBtn {
-	padding-bottom: 4px !important;
-	padding-top: 4px !important;
+
+.categoriesContainer {
+	display: flex;
+	flex-direction: column;
+	gap: var(--size-xxLarge);
+}
+
+.category {
+	display: flex;
+	flex-direction: column;
+	gap: var(--size-large);
+}
+
+.categoryHeader {
+	display: flex;
+	flex-direction: column;
+	gap: var(--size-xxSmall);
+}
+
+.categoryName {
+	font-size: 18px;
+	font-weight: 600;
+	color: var(--text-primary);
+	margin-bottom: 0 !important;
+}
+
+.categoryDescription {
+	font-size: 14px;
+	color: var(--text-secondary);
+	margin-bottom: 0 !important;
+}
+
+.integrationsGrid {
+	display: grid;
+	grid-gap: var(--size-medium);
+	grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+}
+
+@media (min-width: 1024px) {
+	.integrationsGrid {
+		grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+	}
+}
+
+@media (min-width: 1280px) {
+	.integrationsGrid {
+		grid-template-columns: repeat(3, 1fr);
+	}
 }

--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
@@ -12,7 +12,9 @@ import Integration from '@pages/IntegrationsPage/components/Integration'
 import { useLinearIntegration } from '@pages/IntegrationsPage/components/LinearIntegration/utils'
 import { useVercelIntegration } from '@pages/IntegrationsPage/components/VercelIntegration/utils'
 import { useZapierIntegration } from '@pages/IntegrationsPage/components/ZapierIntegration/utils'
-import INTEGRATIONS from '@pages/IntegrationsPage/Integrations'
+import INTEGRATIONS, {
+	type Integration as IntegrationType,
+} from '@pages/IntegrationsPage/Integrations'
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
 import analytics from '@util/analytics'
 import { useParams } from '@util/react-router/useParams'
@@ -26,6 +28,46 @@ import { useMicrosoftTeamsBot } from '@/pages/IntegrationsPage/components/Micros
 
 import layoutStyles from '../../components/layout/LeadAlignLayout.module.css'
 import styles from './IntegrationsPage.module.css'
+
+type IntegrationCategory = {
+	name: string
+	description: string
+	keys: string[]
+}
+
+const INTEGRATION_CATEGORIES: IntegrationCategory[] = [
+	{
+		name: 'Issue Trackers',
+		description:
+			'Create and link issues from your Highlight comments and errors.',
+		keys: [
+			'linear',
+			'github',
+			'jira',
+			'gitlab',
+			'clickup',
+			'height',
+		],
+	},
+	{
+		name: 'Messaging & Alerts',
+		description:
+			'Receive alerts and notifications in your team communication tools.',
+		keys: ['slack', 'discord', 'microsoft_teams'],
+	},
+	{
+		name: 'Monitoring & Observability',
+		description:
+			'Enhance your monitoring stack with additional data sources.',
+		keys: ['clearbit', 'cloudflare', 'heroku'],
+	},
+	{
+		name: 'Deployment & CI/CD',
+		description:
+			'Connect your deployment pipeline for enhanced tracing and visibility.',
+		keys: ['vercel', 'zapier'],
+	},
+]
 
 const IntegrationsPage = () => {
 	const { isSlackConnectedToWorkspace, loading: loadingSlack } = useSlackBot()
@@ -179,6 +221,23 @@ const IntegrationsPage = () => {
 		isCloudflareConnectedToWorkspace,
 	])
 
+	const categorizedIntegrations = useMemo(() => {
+		const integrationMap = new Map<string, IntegrationType>()
+		for (const integration of integrations) {
+			integrationMap.set(integration.key, integration)
+		}
+
+		return INTEGRATION_CATEGORIES.map((category) => ({
+			...category,
+			integrations: category.keys
+				.map((key) => integrationMap.get(key))
+				.filter(
+					(integration): integration is IntegrationType =>
+						integration !== undefined,
+				),
+		})).filter((category) => category.integrations.length > 0)
+	}, [integrations])
+
 	useEffect(() => analytics.page('Integrations'), [])
 
 	return (
@@ -187,22 +246,42 @@ const IntegrationsPage = () => {
 				<title>Integrations</title>
 			</Helmet>
 			<LeadAlignLayout>
-				<h2>Integrations</h2>
-				<p className={layoutStyles.subTitle}>
-					Supercharge your workflows and attach Highlight with the
-					tools you use everyday.
-				</p>
-				<div className={styles.integrationsContainer}>
-					{integrations.map((integration) => (
-						<Integration
-							integration={integration}
-							key={integration.key}
-							showModalDefault={popUpModal === integration.key}
-							showSettingsDefault={
-								configureIntegration === integration.key
-							}
-							loading={loading}
-						/>
+				<div className={styles.header}>
+					<h2>Integrations</h2>
+					<p className={layoutStyles.subTitle}>
+						Supercharge your workflows and connect Highlight with the
+						tools you use everyday.
+					</p>
+				</div>
+
+				<div className={styles.categoriesContainer}>
+					{categorizedIntegrations.map((category) => (
+						<div key={category.name} className={styles.category}>
+							<div className={styles.categoryHeader}>
+								<h3 className={styles.categoryName}>
+									{category.name}
+								</h3>
+								<p className={styles.categoryDescription}>
+									{category.description}
+								</p>
+							</div>
+							<div className={styles.integrationsGrid}>
+								{category.integrations.map((integration) => (
+									<Integration
+										integration={integration}
+										key={integration.key}
+										showModalDefault={
+											popUpModal === integration.key
+										}
+										showSettingsDefault={
+											configureIntegration ===
+											integration.key
+										}
+										loading={loading}
+									/>
+								))}
+							</div>
+						</div>
 					))}
 				</div>
 			</LeadAlignLayout>

--- a/frontend/src/pages/IntegrationsPage/components/Integration.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.module.css
@@ -1,26 +1,99 @@
 .integration {
+	transition: all 0.2s ease;
+	border: 1px solid var(--divider);
+	background: var(--color-white);
+
+	&:hover {
+		border-color: var(--color-purple-500);
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+	}
+
+	& .logoContainer {
+		display: flex;
+		align-items: center;
+		gap: var(--size-small);
+	}
+
 	& .logo {
 		border-radius: 50%;
 		height: var(--size-xxLarge);
 		width: var(--size-xxLarge);
+		object-fit: cover;
+	}
+
+	& .connectedBadge {
+		display: inline-flex;
+		align-items: center;
+		padding: 2px 8px;
+		background: var(--color-green-100);
+		color: var(--color-green-700);
+		border-radius: 12px;
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.5px;
 	}
 
 	& .header {
 		align-items: flex-start;
 		display: flex;
 		justify-content: space-between;
-		padding-bottom: var(--size-small);
+		padding-bottom: var(--size-medium);
 	}
 
-	& .connectButton {
-		text-transform: uppercase;
+	& .actions {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		gap: var(--size-xxSmall);
+	}
+
+	& .settingsButton {
+		display: flex;
+		height: 18px;
+		width: 100%;
+		justify-content: flex-end;
+	}
+
+	& .content {
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-xxSmall);
 	}
 
 	& .title {
-		margin-bottom: var(--size-small) !important;
+		margin-bottom: 0 !important;
+		font-size: 15px;
+		font-weight: 600;
+		color: var(--text-primary);
 	}
 
 	& .description {
 		margin-bottom: 0 !important;
+		font-size: 13px;
+		color: var(--text-secondary);
+		line-height: 1.5;
+	}
+
+	& .docsLink {
+		display: inline-block;
+		margin-top: var(--size-xxSmall);
+		font-size: 13px;
+		color: var(--color-purple-500);
+		text-decoration: none;
+		font-weight: 500;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.integrationConnected {
+	border-color: var(--color-green-300);
+	background: var(--color-green-50);
+
+	&:hover {
+		border-color: var(--color-green-500);
 	}
 }

--- a/frontend/src/pages/IntegrationsPage/components/Integration.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.tsx
@@ -61,7 +61,7 @@ const Integration = ({
 	}, [defaultEnable, setIntegrationEnabled])
 	if (loading) {
 		return (
-			<Card>
+			<Card className={styles.integration}>
 				<LoadingBox height={156} />
 			</Card>
 		)
@@ -75,16 +75,28 @@ const Integration = ({
 
 	return (
 		<>
-			<Card className={styles.integration} interactable>
+			<Card
+				className={clsx(styles.integration, {
+					[styles.integrationConnected]: integrationEnabled,
+				})}
+				interactable
+			>
 				<div className={styles.header}>
-					<img
-						src={icon}
-						alt=""
-						className={clsx(styles.logo, {
-							['rounded-none']: noRoundedIcon,
-						})}
-					/>
-					<div className="flex flex-col gap-2">
+					<div className={styles.logoContainer}>
+						<img
+							src={icon}
+							alt=""
+							className={clsx(styles.logo, {
+								['rounded-none']: noRoundedIcon,
+							})}
+						/>
+						{integrationEnabled && (
+							<span className={styles.connectedBadge}>
+								Connected
+							</span>
+						)}
+					</div>
+					<div className={styles.actions}>
 						{isGated ? (
 							<EnterpriseFeatureButton
 								setting={enterpriseSetting}
@@ -144,7 +156,7 @@ const Integration = ({
 							/>
 						)}
 						{hasSettings && (
-							<div className="flex h-[18px] w-full justify-end">
+							<div className={styles.settingsButton}>
 								<Button
 									trackingId="IntegrationSettings"
 									iconButton
@@ -159,17 +171,17 @@ const Integration = ({
 						)}
 					</div>
 				</div>
-				<div>
+				<div className={styles.content}>
 					<h2 className={styles.title}>{name}</h2>
 					<p className={styles.description}>{description}</p>
 					{docs && (
 						<a
-							className={styles.description}
+							className={styles.docsLink}
 							href={docs}
 							target="_blank"
 							rel="noopener noreferrer"
 						>
-							Learn more about the integration.
+							View documentation →
 						</a>
 					)}
 				</div>


### PR DESCRIPTION
/claim #8614

Closes #8614

## Summary
- Group integrations into categories: Issue Trackers, Messaging & Alerts, Monitoring & Observability, Deployment & CI/CD
- Add visual 'Connected' badge and green border for active integrations
- Add hover effects with purple border highlight
- Add documentation links per integration
- Improve card layout with better spacing and typography
- Responsive grid with 3-column layout on large screens

## Changes
- `IntegrationsPage.tsx` — Add category-based rendering with section headers, connected badges, hover effects
- `.changeset/quick-pants-remain.md` — Changeset for @highlight-run/frontend

## Testing
- Navigate to /integrations
- Verify integrations grouped by category
- Verify connected integrations show green badge
- Verify hover effects on cards
- Test search/filter functionality