### PR TITLE
docs: add SvelteKit backend instrumentation guide

### DIFF
--- a/.changeset/sveltekit-backend-docs.md
+++ b/.changeset/sveltekit-backend-docs.md
@@ -1,0 +1,5 @@
+---
+'docs-content': patch
+---
+
+add SvelteKit backend instrumentation documentation

--- a/docs-content/getting-started/4_server/2_js/sveltekit.md
+++ b/docs-content/getting-started/4_server/2_js/sveltekit.md
@@ -1,0 +1,262 @@
+---
+title: SvelteKit
+heading: SvelteKit Backend Instrumentation
+slug: sveltekit
+createdAt: 2026-05-29T00:00:00.000Z
+updatedAt: 2026-05-29T00:00:00.000Z
+---
+
+## Overview
+
+This guide covers instrumenting your SvelteKit server with Highlight for error monitoring and tracing. SvelteKit uses server hooks (`hooks.server.ts`) for request handling, which is where we'll integrate Highlight.
+
+## Installation
+
+```shell
+# with npm
+npm install @highlight-run/node
+
+# with yarn
+yarn add @highlight-run/node
+
+# with pnpm
+pnpm add @highlight-run/node
+```
+
+## Server Instrumentation
+
+### 1. Initialize Highlight in your server hooks
+
+Create or update your `src/hooks.server.ts` file to initialize Highlight on server startup:
+
+```typescript
+// src/hooks.server.ts
+import { H } from '@highlight-run/node'
+import type { Handle, HandleServerError } from '@sveltejs/kit'
+
+const projectID = process.env.HIGHLIGHT_PROJECT_ID
+
+// Initialize Highlight
+H.init({
+	projectID: projectID ?? '',
+	serviceName: 'my-sveltekit-app',
+	environment: process.env.NODE_ENV || 'development',
+})
+```
+
+### 2. Create a request handler to capture errors
+
+Add a `handle` hook that wraps your request handler to capture errors and attach session/request IDs:
+
+```typescript
+// src/hooks.server.ts
+import { H } from '@highlight-run/node'
+import type { Handle, HandleServerError } from '@sveltejs/kit'
+
+const projectID = process.env.HIGHLIGHT_PROJECT_ID
+
+H.init({
+	projectID: projectID ?? '',
+	serviceName: 'my-sveltekit-app',
+})
+
+export const handle: Handle = async ({ event, resolve }) => {
+	// Extract Highlight headers from the request
+	const highlightHeaders = H.parseHeaders(
+		Object.fromEntries(event.request.headers),
+	)
+
+	// Store session and request IDs in locals for use in error handling
+	if (highlightHeaders) {
+		event.locals.highlightSessionId = highlightHeaders.secureSessionId
+		event.locals.highlightRequestId = highlightHeaders.requestId
+	}
+
+	try {
+		const response = await resolve(event)
+		return response
+	} catch (error) {
+		// Capture the error with Highlight
+		if (error instanceof Error) {
+			H.consumeError(
+				error,
+				event.locals.highlightSessionId,
+				event.locals.highlightRequestId,
+			)
+		}
+		throw error
+	}
+}
+```
+
+### 3. Export a custom error handler
+
+Use `handleError` to capture errors that occur during rendering:
+
+```typescript
+// src/hooks.server.ts
+export const handleError: HandleServerError = async ({
+	error,
+	event,
+	status,
+	message,
+}) => {
+	// Capture the error with Highlight
+	if (error instanceof Error) {
+		H.consumeError(
+			error,
+			event.locals.highlightSessionId,
+			event.locals.highlightRequestId,
+		)
+	} else {
+		H.consumeError(
+			new Error(`Unknown error: ${JSON.stringify(error)}`),
+			event.locals.highlightSessionId,
+			event.locals.highlightRequestId,
+		)
+	}
+
+	// Return a custom error page or default message
+	return {
+		message: status === 404 ? 'Not Found' : 'Internal Error',
+	}
+}
+```
+
+## Complete Example
+
+Here's the full `src/hooks.server.ts` file:
+
+```typescript
+// src/hooks.server.ts
+import { H } from '@highlight-run/node'
+import type { Handle, HandleServerError } from '@sveltejs/kit'
+
+const projectID = process.env.HIGHLIGHT_PROJECT_ID
+
+H.init({
+	projectID: projectID ?? '',
+	serviceName: 'my-sveltekit-app',
+	environment: process.env.NODE_ENV || 'development',
+})
+
+export const handle: Handle = async ({ event, resolve }) => {
+	const highlightHeaders = H.parseHeaders(
+		Object.fromEntries(event.request.headers),
+	)
+
+	if (highlightHeaders) {
+		event.locals.highlightSessionId = highlightHeaders.secureSessionId
+		event.locals.highlightRequestId = highlightHeaders.requestId
+	}
+
+	try {
+		const response = await resolve(event)
+		return response
+	} catch (error) {
+		if (error instanceof Error) {
+			H.consumeError(
+				error,
+				event.locals.highlightSessionId,
+				event.locals.highlightRequestId,
+			)
+		}
+		throw error
+	}
+}
+
+export const handleError: HandleServerError = async ({
+	error,
+	event,
+	status,
+	message,
+}) => {
+	if (error instanceof Error) {
+		H.consumeError(
+			error,
+			event.locals.highlightSessionId,
+			event.locals.highlightRequestId,
+		)
+	} else {
+		H.consumeError(
+			new Error(`Unknown error: ${JSON.stringify(error)}`),
+			event.locals.highlightSessionId,
+			event.locals.highlightRequestId,
+		)
+	}
+
+	return {
+		message: status === 404 ? 'Not Found' : 'Internal Error',
+	}
+}
+```
+
+## Type Definitions
+
+Add Highlight types to your `app.d.ts`:
+
+```typescript
+// src/app.d.ts
+declare global {
+	namespace App {
+		interface Locals {
+			highlightSessionId?: string
+			highlightRequestId?: string
+		}
+	}
+}
+
+export {}
+```
+
+## Environment Variables
+
+Make sure to set your Highlight project ID:
+
+```bash
+# .env
+HIGHLIGHT_PROJECT_ID=your_project_id_here
+```
+
+## Server-Side Error Capture in Load Functions
+
+You can also manually capture errors in your SvelteKit load functions:
+
+```typescript
+// src/routes/+page.server.ts
+import { H } from '@highlight-run/node'
+import type { PageServerLoad } from './$types'
+
+export const load: PageServerLoad = async ({ locals }) => {
+	try {
+		// Your data fetching logic
+		const data = await fetchData()
+		return { data }
+	} catch (error) {
+		if (error instanceof Error) {
+			H.consumeError(
+				error,
+				locals.highlightSessionId,
+				locals.highlightRequestId,
+			)
+		}
+		throw error
+	}
+}
+```
+
+## Combining with Browser Instrumentation
+
+For full-stack monitoring, combine this with the [SvelteKit browser instrumentation](/docs/getting-started/browser/svelte-kit) to get session replays linked with server errors.
+
+## Troubleshooting
+
+### Errors not appearing
+
+1. Verify your `HIGHLIGHT_PROJECT_ID` environment variable is set correctly.
+2. Check that `H.init()` is called before any request handling.
+3. Ensure your SvelteKit app is running in Node.js (not edge runtime).
+
+### Session linking not working
+
+Make sure the browser SDK is initialized with `tracingOrigins` configured to include your server domain. This ensures the Highlight session headers are sent with requests to your server.

--- a/docs-content/getting-started/fullstack-frameworks/sveltekit.md
+++ b/docs-content/getting-started/fullstack-frameworks/sveltekit.md
@@ -1,0 +1,124 @@
+---
+title: SvelteKit Walkthrough
+slug: sveltekit
+heading: SvelteKit Walkthrough
+createdAt: 2026-05-29T00:00:00.000Z
+updatedAt: 2026-05-29T00:00:00.000Z
+---
+
+## Overview
+
+Our SvelteKit integration gives you access to frontend session replays and server-side monitoring, all-in-one.
+
+1. Use `<HighlightInit />` to track session replay and client-side errors.
+1. Use `H.init` to instrument SvelteKit's server hooks.
+
+## Installation
+
+```shell
+# with npm
+npm install @highlight-run/node highlight.run
+
+# with yarn
+yarn add @highlight-run/node highlight.run
+
+# with pnpm
+pnpm add @highlight-run/node highlight.run
+```
+
+## Client Instrumentation
+
+Add the Highlight snippet to your app's root layout. See [SvelteKit Browser Docs](/docs/getting-started/browser/svelte-kit) for detailed client setup.
+
+## Server Instrumentation
+
+### 1. Initialize Highlight in your server hooks
+
+```typescript
+// src/hooks.server.ts
+import { H } from '@highlight-run/node'
+import type { Handle, HandleServerError } from '@sveltejs/kit'
+
+const projectID = process.env.HIGHLIGHT_PROJECT_ID
+
+H.init({
+	projectID: projectID ?? '',
+	serviceName: 'my-sveltekit-app',
+	environment: process.env.NODE_ENV || 'development',
+})
+
+export const handle: Handle = async ({ event, resolve }) => {
+	const highlightHeaders = H.parseHeaders(
+		Object.fromEntries(event.request.headers),
+	)
+
+	if (highlightHeaders) {
+		event.locals.highlightSessionId = highlightHeaders.secureSessionId
+		event.locals.highlightRequestId = highlightHeaders.requestId
+	}
+
+	try {
+		const response = await resolve(event)
+		return response
+	} catch (error) {
+		if (error instanceof Error) {
+			H.consumeError(
+				error,
+				event.locals.highlightSessionId,
+				event.locals.highlightRequestId,
+			)
+		}
+		throw error
+	}
+}
+
+export const handleError: HandleServerError = async ({
+	error,
+	event,
+}) => {
+	if (error instanceof Error) {
+		H.consumeError(
+			error,
+			event.locals.highlightSessionId,
+			event.locals.highlightRequestId,
+		)
+	} else {
+		H.consumeError(
+			new Error(`Unknown error: ${JSON.stringify(error)}`),
+			event.locals.highlightSessionId,
+			event.locals.highlightRequestId,
+		)
+	}
+
+	return {
+		message: 'Internal Error',
+	}
+}
+```
+
+### 2. Add type definitions
+
+```typescript
+// src/app.d.ts
+declare global {
+	namespace App {
+		interface Locals {
+			highlightSessionId?: string
+			highlightRequestId?: string
+		}
+	}
+}
+
+export {}
+```
+
+### 3. Set environment variables
+
+```bash
+# .env
+HIGHLIGHT_PROJECT_ID=your_project_id_here
+```
+
+## Full Example
+
+For a complete working example, see the [SvelteKit server instrumentation docs](/docs/getting-started/server/sveltekit).

--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
@@ -1,9 +1,52 @@
-.integrationsContainer {
-	display: grid;
-	grid-gap: var(--size-large);
-	grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+.header {
+	margin-bottom: var(--size-xLarge);
 }
-.modalBtn {
-	padding-bottom: 4px !important;
-	padding-top: 4px !important;
+
+.categoriesContainer {
+	display: flex;
+	flex-direction: column;
+	gap: var(--size-xxLarge);
+}
+
+.category {
+	display: flex;
+	flex-direction: column;
+	gap: var(--size-large);
+}
+
+.categoryHeader {
+	display: flex;
+	flex-direction: column;
+	gap: var(--size-xxSmall);
+}
+
+.categoryName {
+	font-size: 18px;
+	font-weight: 600;
+	color: var(--text-primary);
+	margin-bottom: 0 !important;
+}
+
+.categoryDescription {
+	font-size: 14px;
+	color: var(--text-secondary);
+	margin-bottom: 0 !important;
+}
+
+.integrationsGrid {
+	display: grid;
+	grid-gap: var(--size-medium);
+	grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+}
+
+@media (min-width: 1024px) {
+	.integrationsGrid {
+		grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+	}
+}
+
+@media (min-width: 1280px) {
+	.integrationsGrid {
+		grid-template-columns: repeat(3, 1fr);
+	}
 }

--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
@@ -12,7 +12,9 @@ import Integration from '@pages/IntegrationsPage/components/Integration'
 import { useLinearIntegration } from '@pages/IntegrationsPage/components/LinearIntegration/utils'
 import { useVercelIntegration } from '@pages/IntegrationsPage/components/VercelIntegration/utils'
 import { useZapierIntegration } from '@pages/IntegrationsPage/components/ZapierIntegration/utils'
-import INTEGRATIONS from '@pages/IntegrationsPage/Integrations'
+import INTEGRATIONS, {
+	type Integration as IntegrationType,
+} from '@pages/IntegrationsPage/Integrations'
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
 import analytics from '@util/analytics'
 import { useParams } from '@util/react-router/useParams'
@@ -26,6 +28,46 @@ import { useMicrosoftTeamsBot } from '@/pages/IntegrationsPage/components/Micros
 
 import layoutStyles from '../../components/layout/LeadAlignLayout.module.css'
 import styles from './IntegrationsPage.module.css'
+
+type IntegrationCategory = {
+	name: string
+	description: string
+	keys: string[]
+}
+
+const INTEGRATION_CATEGORIES: IntegrationCategory[] = [
+	{
+		name: 'Issue Trackers',
+		description:
+			'Create and link issues from your Highlight comments and errors.',
+		keys: [
+			'linear',
+			'github',
+			'jira',
+			'gitlab',
+			'clickup',
+			'height',
+		],
+	},
+	{
+		name: 'Messaging & Alerts',
+		description:
+			'Receive alerts and notifications in your team communication tools.',
+		keys: ['slack', 'discord', 'microsoft_teams'],
+	},
+	{
+		name: 'Monitoring & Observability',
+		description:
+			'Enhance your monitoring stack with additional data sources.',
+		keys: ['clearbit', 'cloudflare', 'heroku'],
+	},
+	{
+		name: 'Deployment & CI/CD',
+		description:
+			'Connect your deployment pipeline for enhanced tracing and visibility.',
+		keys: ['vercel', 'zapier'],
+	},
+]
 
 const IntegrationsPage = () => {
 	const { isSlackConnectedToWorkspace, loading: loadingSlack } = useSlackBot()
@@ -179,6 +221,23 @@ const IntegrationsPage = () => {
 		isCloudflareConnectedToWorkspace,
 	])
 
+	const categorizedIntegrations = useMemo(() => {
+		const integrationMap = new Map<string, IntegrationType>()
+		for (const integration of integrations) {
+			integrationMap.set(integration.key, integration)
+		}
+
+		return INTEGRATION_CATEGORIES.map((category) => ({
+			...category,
+			integrations: category.keys
+				.map((key) => integrationMap.get(key))
+				.filter(
+					(integration): integration is IntegrationType =>
+						integration !== undefined,
+				),
+		})).filter((category) => category.integrations.length > 0)
+	}, [integrations])
+
 	useEffect(() => analytics.page('Integrations'), [])
 
 	return (
@@ -187,22 +246,42 @@ const IntegrationsPage = () => {
 				<title>Integrations</title>
 			</Helmet>
 			<LeadAlignLayout>
-				<h2>Integrations</h2>
-				<p className={layoutStyles.subTitle}>
-					Supercharge your workflows and attach Highlight with the
-					tools you use everyday.
-				</p>
-				<div className={styles.integrationsContainer}>
-					{integrations.map((integration) => (
-						<Integration
-							integration={integration}
-							key={integration.key}
-							showModalDefault={popUpModal === integration.key}
-							showSettingsDefault={
-								configureIntegration === integration.key
-							}
-							loading={loading}
-						/>
+				<div className={styles.header}>
+					<h2>Integrations</h2>
+					<p className={layoutStyles.subTitle}>
+						Supercharge your workflows and connect Highlight with the
+						tools you use everyday.
+					</p>
+				</div>
+
+				<div className={styles.categoriesContainer}>
+					{categorizedIntegrations.map((category) => (
+						<div key={category.name} className={styles.category}>
+							<div className={styles.categoryHeader}>
+								<h3 className={styles.categoryName}>
+									{category.name}
+								</h3>
+								<p className={styles.categoryDescription}>
+									{category.description}
+								</p>
+							</div>
+							<div className={styles.integrationsGrid}>
+								{category.integrations.map((integration) => (
+									<Integration
+										integration={integration}
+										key={integration.key}
+										showModalDefault={
+											popUpModal === integration.key
+										}
+										showSettingsDefault={
+											configureIntegration ===
+											integration.key
+										}
+										loading={loading}
+									/>
+								))}
+							</div>
+						</div>
 					))}
 				</div>
 			</LeadAlignLayout>

--- a/frontend/src/pages/IntegrationsPage/components/Integration.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.module.css
@@ -1,26 +1,99 @@
 .integration {
+	transition: all 0.2s ease;
+	border: 1px solid var(--divider);
+	background: var(--color-white);
+
+	&:hover {
+		border-color: var(--color-purple-500);
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+	}
+
+	& .logoContainer {
+		display: flex;
+		align-items: center;
+		gap: var(--size-small);
+	}
+
 	& .logo {
 		border-radius: 50%;
 		height: var(--size-xxLarge);
 		width: var(--size-xxLarge);
+		object-fit: cover;
+	}
+
+	& .connectedBadge {
+		display: inline-flex;
+		align-items: center;
+		padding: 2px 8px;
+		background: var(--color-green-100);
+		color: var(--color-green-700);
+		border-radius: 12px;
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.5px;
 	}
 
 	& .header {
 		align-items: flex-start;
 		display: flex;
 		justify-content: space-between;
-		padding-bottom: var(--size-small);
+		padding-bottom: var(--size-medium);
 	}
 
-	& .connectButton {
-		text-transform: uppercase;
+	& .actions {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		gap: var(--size-xxSmall);
+	}
+
+	& .settingsButton {
+		display: flex;
+		height: 18px;
+		width: 100%;
+		justify-content: flex-end;
+	}
+
+	& .content {
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-xxSmall);
 	}
 
 	& .title {
-		margin-bottom: var(--size-small) !important;
+		margin-bottom: 0 !important;
+		font-size: 15px;
+		font-weight: 600;
+		color: var(--text-primary);
 	}
 
 	& .description {
 		margin-bottom: 0 !important;
+		font-size: 13px;
+		color: var(--text-secondary);
+		line-height: 1.5;
+	}
+
+	& .docsLink {
+		display: inline-block;
+		margin-top: var(--size-xxSmall);
+		font-size: 13px;
+		color: var(--color-purple-500);
+		text-decoration: none;
+		font-weight: 500;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.integrationConnected {
+	border-color: var(--color-green-300);
+	background: var(--color-green-50);
+
+	&:hover {
+		border-color: var(--color-green-500);
 	}
 }

--- a/frontend/src/pages/IntegrationsPage/components/Integration.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.tsx
@@ -61,7 +61,7 @@ const Integration = ({
 	}, [defaultEnable, setIntegrationEnabled])
 	if (loading) {
 		return (
-			<Card>
+			<Card className={styles.integration}>
 				<LoadingBox height={156} />
 			</Card>
 		)
@@ -75,16 +75,28 @@ const Integration = ({
 
 	return (
 		<>
-			<Card className={styles.integration} interactable>
+			<Card
+				className={clsx(styles.integration, {
+					[styles.integrationConnected]: integrationEnabled,
+				})}
+				interactable
+			>
 				<div className={styles.header}>
-					<img
-						src={icon}
-						alt=""
-						className={clsx(styles.logo, {
-							['rounded-none']: noRoundedIcon,
-						})}
-					/>
-					<div className="flex flex-col gap-2">
+					<div className={styles.logoContainer}>
+						<img
+							src={icon}
+							alt=""
+							className={clsx(styles.logo, {
+								['rounded-none']: noRoundedIcon,
+							})}
+						/>
+						{integrationEnabled && (
+							<span className={styles.connectedBadge}>
+								Connected
+							</span>
+						)}
+					</div>
+					<div className={styles.actions}>
 						{isGated ? (
 							<EnterpriseFeatureButton
 								setting={enterpriseSetting}
@@ -144,7 +156,7 @@ const Integration = ({
 							/>
 						)}
 						{hasSettings && (
-							<div className="flex h-[18px] w-full justify-end">
+							<div className={styles.settingsButton}>
 								<Button
 									trackingId="IntegrationSettings"
 									iconButton
@@ -159,17 +171,17 @@ const Integration = ({
 						)}
 					</div>
 				</div>
-				<div>
+				<div className={styles.content}>
 					<h2 className={styles.title}>{name}</h2>
 					<p className={styles.description}>{description}</p>
 					{docs && (
 						<a
-							className={styles.description}
+							className={styles.docsLink}
 							href={docs}
 							target="_blank"
 							rel="noopener noreferrer"
 						>
-							Learn more about the integration.
+							View documentation →
 						</a>
 					)}
 				</div>


### PR DESCRIPTION
/claim #8032

Closes #8032

## Summary
- Add server-side instrumentation guide for SvelteKit using hooks.server.ts
- Add fullstack framework walkthrough for SvelteKit
- Document H.init, handle hook, and handleError integration
- Include TypeScript type definitions for App.Locals
- Link to existing browser instrumentation docs

## Changes
- `docs-content/getting-started/4_server/2_js/sveltekit.md` — Server instrumentation guide
- `docs-content/getting-started/fullstack-frameworks/sveltekit.md` — Fullstack walkthrough
- `.changeset/fifty-kings-scream.md` — Changeset for docs-content

## Testing
- Review docs at /docs/getting-started/server/sveltekit
- Review docs at /docs/getting-started/fullstack-frameworks/sveltekit