### PR TITLE
Replace SwitchProject select with Highlight UI

### DIFF
--- a/.changeset/green-pandas-switch.md
+++ b/.changeset/green-pandas-switch.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+Replace the SwitchProject select with the shared Highlight UI select.

--- a/frontend/src/pages/SwitchProject/SwitchProject.tsx
+++ b/frontend/src/pages/SwitchProject/SwitchProject.tsx
@@ -1,11 +1,11 @@
 import Button from '@components/Button/Button/Button'
 import ButtonLink from '@components/Button/ButtonLink/ButtonLink'
-import Select from '@components/Select/Select'
 import {
 	AppLoadingState,
 	useAppLoadingContext,
 } from '@context/AppLoadingContext'
 import { useGetWorkspaceQuery } from '@graph/hooks'
+import { Select, type SelectOption } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
 import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
@@ -33,8 +33,7 @@ const SwitchProject = () => {
 	const projectOptions = (data?.workspace?.projects || [])?.map(
 		(projects) => ({
 			value: projects?.id || '',
-			displayValue: projects?.name || '',
-			id: projects?.id || '',
+			name: projects?.name || '',
 		}),
 	)
 
@@ -44,7 +43,7 @@ const SwitchProject = () => {
 	}
 
 	const currentProject = projectOptions?.find(
-		(project) => project.id === selectedProject,
+		(project) => project.value === selectedProject,
 	)
 
 	if (shouldRedirect) {
@@ -70,10 +69,10 @@ const SwitchProject = () => {
 					<Select
 						className={styles.fullWidth}
 						options={projectOptions}
-						onChange={(projectId) => {
-							setSelectedProject(projectId)
+						onValueChange={(project: SelectOption) => {
+							setSelectedProject(String(project.value))
 						}}
-						value={currentProject?.id}
+						value={currentProject}
 						placeholder="Enter a Project"
 					/>
 					<Button


### PR DESCRIPTION
Summary:
- Replace the SwitchProject page legacy Ant Design-backed Select wrapper with @highlight-run/ui Select.
- Preserve selected project id handling, submit redirect behavior, loading state, and create-project link behavior.
- Keep this scoped to one project switcher UI page.

Validation:
- `npx.cmd -y prettier@3.3.3 --check frontend/src/pages/SwitchProject/SwitchProject.tsx`
- `npx.cmd -y esbuild@0.19.5 frontend/src/pages/SwitchProject/SwitchProject.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --format=esm --outfile=%TEMP%/switch-project-check.js --log-level=error`
- `git diff --check`
- `rg "@components/Select/Select" frontend/src/pages/SwitchProject/SwitchProject.tsx` -> no matches

Security:
- UI-only change. No auth, project permission, mutation, billing, or backend behavior changed.

/claim #8635
