### PR TITLE
docs: add SvelteKit backend instrumentation

### DIFF
--- a/docs-content/general/6_product-features/99_frequently-asked-questions.md
+++ b/docs-content/general/6_product-features/99_frequently-asked-questions.md
@@ -30,7 +30,7 @@ This documentation provides solutions and guidance for common issues encountered
 
 **Question:** How can I set up tracing with SvelteKit as I am not seeing any traces despite having logs and errors?
 
-**Answer:** Ensure that your `H.init` configuration is correctly set up in both `hooks.client.ts` and `hooks.server.ts`. Use `H.runWithHeaders` in your server-side handle function to ensure that headers are correctly passed and handled. If issues persist, please provide the Highlight traces page URL and check the version of the `@highlight-run/node` SDK you are using. For detailed guidance, refer to the [Highlight.io SvelteKit Documentation](https://www.highlight.io/docs/getting-started/client-sdk/sveltekit).
+**Answer:** Ensure that your `H.init` configuration is correctly set up in both `hooks.client.ts` and `hooks.server.ts`. Use `H.runWithHeaders` in your server-side handle function to ensure that headers are correctly passed and handled. If issues persist, please provide the Highlight traces page URL and check the version of the `@highlight-run/node` SDK you are using. For detailed guidance, refer to the [Highlight.io SvelteKit backend instrumentation documentation](https://www.highlight.io/docs/getting-started/browser/sveltekit#backend-instrumentation).
 
 ## Session Recording Issues
 

--- a/docs-content/getting-started/3_browser/6_sveltekit.md
+++ b/docs-content/getting-started/3_browser/6_sveltekit.md
@@ -6,3 +6,79 @@ quickstart: true
 ---
 
 <QuickStart content={quickStartContent["client"]["js"]["svelte-kit"]}/>
+
+## Backend instrumentation
+
+SvelteKit runs server hooks in `hooks.server.ts`. Initialize the Highlight Node
+SDK once in that file, then wrap each request with `H.runWithHeaders()` so
+backend traces are linked to the same Highlight session and request as the
+browser SDK.
+
+```typescript
+// hooks.server.ts
+import type { Handle, HandleServerError } from '@sveltejs/kit'
+import { H } from '@highlight-run/node'
+
+if (!H.isInitialized()) {
+	H.init({
+		projectID: '<YOUR_PROJECT_ID>',
+		serviceName: 'my-sveltekit-backend',
+		serviceVersion: 'git-sha',
+	})
+}
+
+const headersToObject = (headers: Headers) =>
+	Object.fromEntries(headers.entries())
+
+export const handle: Handle = async ({ event, resolve }) => {
+	return H.runWithHeaders(headersToObject(event.request.headers), async () => {
+		return resolve(event)
+	})
+}
+
+export const handleError: HandleServerError = ({ error, event }) => {
+	const parsed = H.parseHeaders(headersToObject(event.request.headers))
+
+	if (parsed && error instanceof Error) {
+		H.consumeError(error, parsed.secureSessionId, parsed.requestId, {
+			url: event.url.pathname,
+		})
+	}
+}
+```
+
+If you already have a `handle` hook, keep your existing logic inside the
+`H.runWithHeaders()` callback. For example, authentication, locals setup, and
+custom response headers should remain in the callback before or after
+`resolve(event)`.
+
+```typescript
+export const handle: Handle = async ({ event, resolve }) => {
+	return H.runWithHeaders(headersToObject(event.request.headers), async () => {
+		event.locals.user = await getUser(event)
+
+		const response = await resolve(event)
+		response.headers.set('x-service-name', 'my-sveltekit-backend')
+
+		return response
+	})
+}
+```
+
+## Validate backend instrumentation
+
+Create a test route that throws on the server, then request it after starting
+your SvelteKit app.
+
+```typescript
+// src/routes/highlight-server-test/+server.ts
+export const GET = () => {
+	throw new Error('Highlight SvelteKit backend test error')
+}
+```
+
+Run your app and visit `/highlight-server-test`. The error should appear in
+Highlight with `serviceName` set to `my-sveltekit-backend`. When the browser
+SDK is also initialized with `tracingOrigins` and network recording enabled,
+the backend error and trace will be associated with the originating frontend
+session.


### PR DESCRIPTION
## Summary
- document SvelteKit backend instrumentation in `hooks.server.ts`
- show `@highlight-run/node` initialization, `H.runWithHeaders`, and `handleError` wiring
- add a validation route example and update the FAQ link to point at the new backend section

## Validation
- `git diff --check`

/claim #8032
