### PR TITLE
Replace SwitchWorkspace legacy select

### DIFF
--- a/.changeset/clever-chicken-scream.md
+++ b/.changeset/clever-chicken-scream.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+Replace SwitchWorkspace legacy select

--- a/frontend/src/pages/SwitchWorkspace/SwitchWorkspace.module.css
+++ b/frontend/src/pages/SwitchWorkspace/SwitchWorkspace.module.css
@@ -27,10 +27,6 @@
 	cursor: pointer;
 }
 
-.joinButton {
-	margin-left: auto;
-}
-
 .intercomButton {
 	color: var(--color-purple);
 	cursor: pointer;

--- a/frontend/src/pages/SwitchWorkspace/SwitchWorkspace.tsx
+++ b/frontend/src/pages/SwitchWorkspace/SwitchWorkspace.tsx
@@ -1,13 +1,12 @@
 import Button from '@components/Button/Button/Button'
 import ButtonLink from '@components/Button/ButtonLink/ButtonLink'
 import { CircularSpinner, LoadingBar } from '@components/Loading/Loading'
-import Select from '@components/Select/Select'
-import Tag from '@components/Tag/Tag'
 import { toast } from '@components/Toaster'
 import {
 	AppLoadingState,
 	useAppLoadingContext,
 } from '@context/AppLoadingContext'
+import { Select } from '@highlight-run/ui/components'
 import { useGetWorkspacesQuery, useJoinWorkspaceMutation } from '@graph/hooks'
 import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
@@ -70,29 +69,17 @@ const SwitchWorkspace = () => {
 	const workspaceOptions = (data?.workspaces || [])
 		?.map((workspace) => ({
 			value: workspace?.id || '',
-			displayValue: workspace?.name || '',
-			id: workspace?.id || '',
+			name: workspace?.name || '',
 		}))
 		.concat(
 			(data?.joinable_workspaces || [])?.map((workspace) => ({
 				value: workspace?.id || '',
-				displayValue: workspace?.name || '',
-				id: workspace?.id || '',
-				dropDownIcon: (
-					<Tag
-						className={styles.joinButton}
-						infoTooltipText="Your email domain is whitelisted by this workspace!"
-						backgroundColor="var(--color-purple)"
-						color="var(--color-white)"
-					>
-						Join
-					</Tag>
-				),
+				name: workspace?.name || '',
 			})),
 		)
 
 	const currentWorkspace = workspaceOptions?.find(
-		(workspace) => workspace.id === currentWorkspaceId,
+		(workspace) => workspace.value === currentWorkspaceId,
 	)
 
 	const onSubmit = (e: { preventDefault: () => void }) => {
@@ -147,10 +134,10 @@ const SwitchWorkspace = () => {
 					<Select
 						className={styles.fullWidth}
 						options={workspaceOptions}
-						onChange={(workspaceId) => {
+						onValueChange={(workspaceId) => {
 							setSelectedWorkspace(workspaceId)
 						}}
-						value={currentWorkspace?.value}
+						value={selectedWorkspace || currentWorkspace?.value}
 						placeholder="Enter a Workspace"
 					/>
 					<Button


### PR DESCRIPTION
/claim #8635

## Summary
- replace the SwitchWorkspace legacy Ant Design-backed `@components/Select/Select` wrapper with `@highlight-run/ui` `Select`
- convert workspace options to the Highlight UI `{ name, value }` shape
- preserve selected workspace id handling, enter/join submit behavior, redirect paths, loading state, and create-workspace link
- remove the now-unused join badge stylesheet rule from this page

## Scope
This is a narrow workspace switcher slice. It does not change workspace auth, GraphQL queries/mutations, join payloads, redirect destinations, or backend behavior.

## Related Claim Slices
- #10501 SwitchWorkspace legacy select
- #10502 User 2FA legacy inputs
- #10503 Shared switch wrapper
- #10506 Project error settings selects
- #10507 Workspace Team auto-join checkbox

## Demo
- Shared evidence video: https://github.com/ManmohanBuildsProducts/highlight/releases/download/highlight-8635-demo-20260531/highlight-8635-demo.mp4

## Validation
- `npx -y prettier@3.3.3 --check frontend/src/pages/SwitchWorkspace/SwitchWorkspace.tsx frontend/src/pages/SwitchWorkspace/SwitchWorkspace.module.css`
- `npx -y esbuild@0.19.5 frontend/src/pages/SwitchWorkspace/SwitchWorkspace.tsx --bundle '--external:*' --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=/tmp/highlight-switch-workspace.js --log-level=error`
- `rg -n "@components/Select/Select|@components/Tag/Tag|dropDownIcon|displayValue|joinButton" frontend/src/pages/SwitchWorkspace` returned no matches
- `git diff --check`

Prepared with AI assistance and manually reviewed before submission.
