### PR TITLE
Replace user 2FA legacy inputs

### DIFF
--- a/.changeset/pink-friends-peel.md
+++ b/.changeset/pink-friends-peel.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+Replace user 2FA legacy inputs

--- a/frontend/src/pages/UserSettings/Auth/Auth.tsx
+++ b/frontend/src/pages/UserSettings/Auth/Auth.tsx
@@ -1,9 +1,9 @@
 import Alert from '@components/Alert/Alert'
 import Button from '@components/Button/Button/Button'
 import { FieldsBox } from '@components/FieldsBox/FieldsBox'
-import Input from '@components/Input/Input'
 import Space from '@components/Space/Space'
 import { toast } from '@components/Toaster'
+import { Form } from '@highlight-run/ui/components'
 import { auth } from '@util/auth'
 import firebase from 'firebase/compat/app'
 import moment from 'moment'
@@ -168,14 +168,15 @@ const Enroll: React.FC<Props> = ({ setError, setStatus }) => {
 	return (
 		<>
 			{!verificationId ? (
-				<form onSubmit={handleSubmit}>
+				<Form onSubmit={handleSubmit}>
 					<Space size="medium" direction="vertical">
 						<p>
 							Add an additional layer of security for your account
 							by enabling SMS-based two-factor authentication.
 						</p>
 
-						<Input
+						<Form.Input
+							name="phoneNumber"
 							value={phoneNumber}
 							onChange={(e) => setPhoneNumber(e.target.value)}
 							placeholder="+1 123-456-7890"
@@ -191,7 +192,7 @@ const Enroll: React.FC<Props> = ({ setError, setStatus }) => {
 							Setup 2FA
 						</Button>
 					</Space>
-				</form>
+				</Form>
 			) : (
 				<VerifyPhone
 					phoneNumber={phoneNumber}
@@ -272,9 +273,10 @@ export const VerifyPhone: React.FC<VerifyPhoneProps> = ({
 
 			<p>Enter the code sent to your phone to verify your device.</p>
 
-			<form onSubmit={handleCodeSubmit}>
+			<Form onSubmit={handleCodeSubmit}>
 				<Space direction="vertical" size="medium">
-					<Input
+					<Form.Input
+						name="verificationCode"
 						value={verificationCode}
 						onChange={(e) => setVerificationCode(e.target.value)}
 						placeholder="Verification code"
@@ -289,7 +291,7 @@ export const VerifyPhone: React.FC<VerifyPhoneProps> = ({
 						Submit
 					</Button>
 				</Space>
-			</form>
+			</Form>
 		</>
 	)
 }


### PR DESCRIPTION
## Summary
- Replace the user settings 2FA phone-number and verification-code fields with Highlight UI `Form.Input`.
- Remove the legacy Ant Design-backed `@components/Input/Input` wrapper import from `UserSettings/Auth/Auth.tsx`.
- Preserve the existing Firebase enrollment and verification flow.

/claim #8635

## Demo
- Shared evidence video: https://github.com/ManmohanBuildsProducts/highlight/releases/download/highlight-8635-demo-20260531/highlight-8635-demo.mp4

## Validation
- `npx -y prettier@3.3.3 --check frontend/src/pages/UserSettings/Auth/Auth.tsx`
- `npx -y esbuild@0.19.5 frontend/src/pages/UserSettings/Auth/Auth.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=/tmp/highlight-user-auth.js --log-level=error`
- `rg -n "@components/Input/Input|<Input" frontend/src/pages/UserSettings/Auth/Auth.tsx` returned no matches
- `git diff --check`

## AI assistance
Implemented with Codex; I reviewed the diff and ran the validation above.
