### PR TITLE
Replace switch wrapper Ant Design dependency

### DIFF
--- a/.changeset/true-swans-nail.md
+++ b/.changeset/true-swans-nail.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+Replace switch wrapper Ant Design dependency

--- a/frontend/src/components/Switch/Switch.module.css
+++ b/frontend/src/components/Switch/Switch.module.css
@@ -30,13 +30,83 @@
 }
 
 .switchStyles {
+	align-items: center;
 	background: var(--color-gray-400);
+	border: 0;
+	border-radius: 999px;
+	cursor: pointer;
+	display: inline-flex;
+	flex-shrink: 0;
+	padding: 0;
+	position: relative;
+	transition: background 0.2s ease-in, opacity 0.2s ease-in;
 
-	&:global(.ant-switch-checked) {
+	&.checked {
 		background: #744ed4;
 
 		&.red {
 			background: var(--color-red);
 		}
+	}
+
+	&.disabled,
+	&.loading {
+		cursor: not-allowed;
+		opacity: 0.7;
+	}
+}
+
+.smallSize {
+	height: 16px;
+	width: 28px;
+}
+
+.defaultSize {
+	height: 22px;
+	width: 44px;
+}
+
+.handle {
+	background: var(--color-white);
+	border-radius: 999px;
+	box-shadow: 0 1px 2px rgb(0 0 0 / 24%);
+	display: block;
+	left: 2px;
+	position: absolute;
+	top: 2px;
+	transition: transform 0.2s ease-in;
+
+	.smallSize & {
+		height: 12px;
+		width: 12px;
+	}
+
+	.defaultSize & {
+		height: 18px;
+		width: 18px;
+	}
+
+	.checked.smallSize & {
+		transform: translateX(12px);
+	}
+
+	.checked.defaultSize & {
+		transform: translateX(22px);
+	}
+
+	.loading &::after {
+		animation: switch-loading 0.8s linear infinite;
+		border: 2px solid var(--color-gray-500);
+		border-radius: 50%;
+		border-top-color: transparent;
+		content: '';
+		inset: 2px;
+		position: absolute;
+	}
+}
+
+@keyframes switch-loading {
+	to {
+		transform: rotate(360deg);
 	}
 }

--- a/frontend/src/components/Switch/Switch.tsx
+++ b/frontend/src/components/Switch/Switch.tsx
@@ -1,15 +1,16 @@
-// eslint-disable-next-line no-restricted-imports
 import analytics from '@util/analytics'
-import { Switch as AntDesignSwitch, SwitchProps } from 'antd'
 import clsx from 'clsx'
 import React from 'react'
 
 import styles from './Switch.module.css'
 
-type Props = Pick<
-	SwitchProps,
-	'checked' | 'onChange' | 'loading' | 'className' | 'size' | 'disabled'
-> & {
+type Props = {
+	checked?: boolean
+	onChange?: (checked: boolean, event: React.MouseEvent) => void
+	loading?: boolean
+	className?: string
+	size?: 'small' | 'default'
+	disabled?: boolean
 	label?: string | React.ReactNode
 	/** Renders the label before the switch. */
 	labelFirst?: boolean
@@ -29,36 +30,68 @@ const Switch = ({
 	setMarginForAnimation,
 	className,
 	trackingId,
+	checked = false,
+	disabled,
+	loading,
+	onChange,
+	red,
 	size = 'small',
-	...props
 }: Props) => {
 	const labelToRender = !!label ? <span>{label}</span> : null
+	const isDisabled = disabled || loading
+	const handleChange = (event: React.MouseEvent) => {
+		if (isDisabled) {
+			event.preventDefault()
+			return
+		}
+
+		const nextChecked = !checked
+		if (onChange) {
+			analytics.track(`Switch-${trackingId}`, {
+				checked: nextChecked,
+			})
+			onChange(nextChecked, event)
+		}
+	}
+
 	return (
 		<label
 			className={clsx(styles.label, className, {
-				[styles.checked]: props.checked,
+				[styles.checked]: checked,
 				[styles.spaceBetween]: justifySpaceBetween,
 				[styles.noMarginAroundSwitch]: noMarginAroundSwitch,
 				[styles.setMarginForAnimation]: setMarginForAnimation,
-				[styles.red]: props.red,
+				[styles.red]: red,
 			})}
 		>
 			{labelFirst && labelToRender}
-			<AntDesignSwitch
-				{...props}
-				size={size}
-				className={clsx(styles.switchStyles, {
-					[styles.red]: props.red,
-				})}
-				onChange={(checked, event) => {
-					if (props.onChange) {
-						analytics.track(`Switch-${trackingId}`, {
-							checked,
-						})
-						props.onChange(checked, event)
+			<span
+				role="switch"
+				aria-checked={checked}
+				aria-disabled={isDisabled}
+				tabIndex={isDisabled ? -1 : 0}
+				className={clsx(
+					styles.switchStyles,
+					size === 'default' ? styles.defaultSize : styles.smallSize,
+					{
+						[styles.checked]: checked,
+						[styles.disabled]: disabled,
+						[styles.loading]: loading,
+						[styles.red]: red,
+					},
+				)}
+				onClick={handleChange}
+				onKeyDown={(event) => {
+					if (event.key !== 'Enter' && event.key !== ' ') {
+						return
 					}
+
+					event.preventDefault()
+					handleChange(event as unknown as React.MouseEvent)
 				}}
-			/>
+			>
+				<span className={styles.handle} />
+			</span>
 			{!labelFirst && labelToRender}
 		</label>
 	)


### PR DESCRIPTION
## Summary

/claim #8635

Replaces the shared `frontend/src/components/Switch/Switch.tsx` Ant Design-backed wrapper with a native compatibility shim.

This keeps the existing call-site API intact while removing the direct `antd` import from the shared switch wrapper:
- `checked`, `onChange`, `loading`, `disabled`, `size`, `className`
- label placement and `justifySpaceBetween`/margin flags
- red checked state
- existing `Switch-${trackingId}` analytics behavior when `onChange` is supplied

## Validation

- `npx -y prettier@3.3.3 --check frontend/src/components/Switch/Switch.tsx frontend/src/components/Switch/Switch.module.css`
- `npx -y esbuild@0.19.5 frontend/src/components/Switch/Switch.tsx --bundle '--external:*' --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=/tmp/highlight-switch-wrapper.js --log-level=error`
- `rg -n "antd|AntDesignSwitch|SwitchProps|no-restricted-imports" frontend/src/components/Switch/Switch.tsx frontend/src/components/Switch/Switch.module.css` -> no matches
- `git diff --check`

I could not run the full frontend `types:check` in this checkout because `yarn`/`corepack` is unavailable and `@yarnpkg/cli-dist` reported the missing Yarn node_modules state file.

## Demo
- Shared evidence video: https://github.com/ManmohanBuildsProducts/highlight/releases/download/highlight-8635-demo-20260531/highlight-8635-demo.mp4

No app route demo included: this is a shared primitive compatibility migration, not a route-level workflow change. The visual states are preserved in `Switch.module.css` for small/default, checked, loading, disabled, and red variants.

