### PR TITLE
refactor: replace keyboard shortcuts search input

### DIFF
--- a/frontend/src/components/KeyboardShortcutsEducation/KeyboardShortcutsEducation.module.css
+++ b/frontend/src/components/KeyboardShortcutsEducation/KeyboardShortcutsEducation.module.css
@@ -26,10 +26,6 @@
 	z-index: 9999999999;
 }
 
-.searchIcon {
-	color: var(--color-gray-500);
-}
-
 .container {
 	padding-top: var(--size-large);
 
@@ -58,6 +54,54 @@
 	& h3 {
 		font-size: 16px !important;
 		margin-bottom: var(--size-small) !important;
+	}
+}
+
+.searchInputContainer {
+	align-items: center;
+	background: var(--color-gray-200);
+	border: 1px solid transparent;
+	border-radius: var(--border-radius);
+	display: flex;
+	gap: var(--size-xSmall);
+	padding: var(--size-xSmall) var(--size-small);
+
+	&:focus-within {
+		background: var(--color-primary-background);
+		border-color: var(--color-purple);
+		box-shadow: 0 0 0 4px rgba(var(--color-purple-rgb), 0.2);
+	}
+
+	&:hover {
+		border-color: var(--color-purple);
+	}
+}
+
+.searchIcon {
+	color: var(--color-gray-500);
+	flex-shrink: 0;
+}
+
+.searchInput {
+	background: transparent;
+	color: var(--text-primary);
+	font-size: 16px;
+	line-height: initial;
+	padding: 0;
+}
+
+.clearSearchButton {
+	align-items: center;
+	background: transparent;
+	border: 0;
+	color: var(--color-gray-500);
+	cursor: pointer;
+	display: flex;
+	flex-shrink: 0;
+	padding: 0;
+
+	&:hover {
+		color: var(--text-primary);
 	}
 }
 

--- a/frontend/src/components/KeyboardShortcutsEducation/KeyboardShortcutsEducation.tsx
+++ b/frontend/src/components/KeyboardShortcutsEducation/KeyboardShortcutsEducation.tsx
@@ -1,9 +1,13 @@
 import ButtonLink from '@components/Button/ButtonLink/ButtonLink'
 import ElevatedCard from '@components/ElevatedCard/ElevatedCard'
-import Input from '@components/Input/Input'
 import TextHighlighter from '@components/TextHighlighter/TextHighlighter'
-import { Badge, Box } from '@highlight-run/ui/components'
-import SvgSearchIcon from '@icons/SearchIcon'
+import {
+	Badge,
+	Box,
+	IconSolidSearch,
+	IconSolidX,
+	Input,
+} from '@highlight-run/ui/components'
 import { PLAYER_SKIP_DURATION } from '@pages/Player/utils/PlayerHooks'
 import { useGlobalContext } from '@routers/ProjectRouter/context/GlobalContext'
 import analytics from '@util/analytics'
@@ -153,18 +157,32 @@ const KeyboardShortcutsEducation = () => {
 							className={clsx(styles.elevatedCard)}
 						>
 							<main className={styles.container}>
-								<Input
-									placeholder="Search"
-									suffix={
-										<SvgSearchIcon
-											className={styles.searchIcon}
-										/>
-									}
-									onChange={(e) => {
-										setSearchQuery(e.target.value)
-									}}
-									allowClear
-								/>
+								<div className={styles.searchInputContainer}>
+									<IconSolidSearch
+										className={styles.searchIcon}
+									/>
+									<Input
+										name="keyboard-shortcuts-search"
+										placeholder="Search"
+										value={searchQuery}
+										onChange={(e) => {
+											setSearchQuery(e.target.value)
+										}}
+										cssClass={styles.searchInput}
+									/>
+									{searchQuery && (
+										<button
+											type="button"
+											aria-label="Clear keyboard shortcut search"
+											className={styles.clearSearchButton}
+											onClick={() => {
+												setSearchQuery('')
+											}}
+										>
+											<IconSolidX size={14} />
+										</button>
+									)}
+								</div>
 
 								{!isOnSessionPlayerPage && hasNoSearchHits && (
 									<section>


### PR DESCRIPTION
## Summary
- Replaces the legacy Ant Design-backed `@components/Input/Input` usage in `KeyboardShortcutsEducation` with `@highlight-run/ui/components` primitives.
- Preserves live shortcut filtering and clear-query behavior with an explicit clear button.
- Scope is UI-only; no routing, analytics, hotkey, or shortcut data changes.

## Verification
- `npx -y prettier@3.3.3 --check frontend/src/components/KeyboardShortcutsEducation/KeyboardShortcutsEducation.tsx frontend/src/components/KeyboardShortcutsEducation/KeyboardShortcutsEducation.module.css`
- `npx -y esbuild@0.19.5 frontend/src/components/KeyboardShortcutsEducation/KeyboardShortcutsEducation.tsx --bundle '--external:*' --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=/tmp/highlight-keyboard-shortcuts-education.js --log-level=error`
- `rg '@components/Input/Input|from .antd.|AntDesignInput|SvgSearchIcon' frontend/src/components/KeyboardShortcutsEducation/KeyboardShortcutsEducation.tsx frontend/src/components/KeyboardShortcutsEducation/KeyboardShortcutsEducation.module.css` -> no matches
- `git diff --check`

/claim #8635