### PR TITLE
Replace project error settings selects

### DIFF
--- a/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
@@ -1,8 +1,6 @@
 import { LoadingBar } from '@components/Loading/Loading'
-import Select from '@components/Select/Select'
 import { toast } from '@components/Toaster'
-import { Stack } from '@highlight-run/ui/components'
-import { Text } from 'recharts'
+import { Select, Stack, type SelectOption } from '@highlight-run/ui/components'
 
 import BoxLabel from '@/components/BoxLabel/BoxLabel'
 import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
@@ -19,6 +17,11 @@ const isValidRegex = function (p: string) {
 	return true
 }
 
+const selectValuesToStrings = (values: Array<string | SelectOption>) =>
+	values.map((value) =>
+		typeof value === 'string' ? value : String(value.value),
+	)
+
 export const ErrorFiltersForm = () => {
 	const {
 		allProjectSettings: data,
@@ -30,6 +33,8 @@ export const ErrorFiltersForm = () => {
 		return <LoadingBar />
 	}
 
+	const errorFilters = data?.projectSettings?.error_filters || []
+
 	return (
 		<form>
 			<Stack gap="8">
@@ -40,16 +45,18 @@ export const ErrorFiltersForm = () => {
 				<div className={styles.inputAndButtonRow}>
 					<Select
 						className={styles.input}
-						mode="tags"
+						creatable
+						filterable
+						displayMode="tags"
 						placeholder="TypeError: Failed to fetch"
-						value={data?.projectSettings?.error_filters || []}
-						notFoundContent={
-							<Text>
-								Provide a regex pattern to filter out errors.
-							</Text>
-						}
-						onChange={(patterns: string[]) => {
-							patterns.filter(isValidRegex)
+						value={errorFilters}
+						options={errorFilters}
+						onValueChange={(
+							patternValues: Array<string | SelectOption>,
+						) => {
+							const patterns =
+								selectValuesToStrings(patternValues)
+							patterns.forEach(isValidRegex)
 							setAllProjectSettings((currentProjectSettings) =>
 								currentProjectSettings?.projectSettings
 									? {

--- a/frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx
@@ -1,10 +1,14 @@
 import { LoadingBar } from '@components/Loading/Loading'
-import Select from '@components/Select/Select'
-import { Stack } from '@highlight-run/ui/components'
+import { Select, Stack, type SelectOption } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
 
 import BoxLabel from '@/components/BoxLabel/BoxLabel'
 import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
+
+const selectValuesToStrings = (values: Array<string | SelectOption>) =>
+	values.map((value) =>
+		typeof value === 'string' ? value : String(value.value),
+	)
 
 export const ErrorSettingsForm = () => {
 	const { project_id } = useParams<{
@@ -20,6 +24,8 @@ export const ErrorSettingsForm = () => {
 		return <LoadingBar />
 	}
 
+	const errorJsonPaths = data?.projectSettings?.error_json_paths || []
+
 	return (
 		<form key={project_id}>
 			<Stack gap="8">
@@ -28,10 +34,16 @@ export const ErrorSettingsForm = () => {
 					info="Enter JSON expressions to use for grouping your errors."
 				/>
 				<Select
-					mode="tags"
+					creatable
+					filterable
+					displayMode="tags"
 					placeholder="$.context.messages[0]"
-					value={data?.projectSettings?.error_json_paths || []}
-					onChange={(paths: string[]) => {
+					value={errorJsonPaths}
+					options={errorJsonPaths}
+					onValueChange={(
+						pathValues: Array<string | SelectOption>,
+					) => {
+						const paths = selectValuesToStrings(pathValues)
 						setAllProjectSettings((currentProjectSettings) =>
 							currentProjectSettings?.projectSettings
 								? {


### PR DESCRIPTION
/claim #8635

## Summary
- Replaced the Project Settings error filter tag selector with `@highlight-run/ui` `Select`.
- Replaced the Project Settings error grouping JSON-path selector with `@highlight-run/ui` `Select`.
- Preserved `error_filters` and `error_json_paths` as `string[]` values in project settings state, including the existing regex validation/toast behavior for error filters.

## Demo
- Shared evidence video: https://github.com/ManmohanBuildsProducts/highlight/releases/download/highlight-8635-demo-20260531/highlight-8635-demo.mp4

## Validation
- `npx -y prettier@3.3.3 --check frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx`
- `npx -y esbuild@0.19.5 frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=/tmp/highlight-error-filters.mjs --log-level=error`
- `npx -y esbuild@0.19.5 frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=/tmp/highlight-error-settings.mjs --log-level=error`
- `rg -n '@components/Select/Select|mode="tags"|onChange=' frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx` -> no matches\n- `git diff --check`\n\n## Notes\n- UI-only project settings change; no GraphQL, auth, project mutation, or backend behavior changed.\n- I could not run a full authenticated visual demo in this local checkout; the targeted TSX bundle checks verify the changed forms parse and bundle with repo aliases externalized.
