### PR TITLE
Replace auto join checkbox dependency

### DIFF
--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.module.css
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.module.css
@@ -8,10 +8,46 @@
 	min-height: var(--size-xxLarge);
 }
 
-.select {
-	width: 100%;
+.checkboxRow {
+	align-items: center;
+	column-gap: var(--size-xxSmall);
+	cursor: pointer;
+	display: flex;
+	line-height: normal;
+	margin: 0;
+}
 
-	&:global(.ant-select-disabled .ant-select-selector) {
-		background-color: var(--color-primary-background) !important;
-	}
+.checkbox {
+	appearance: none;
+	background: var(--color-primary-background);
+	border: 1px solid var(--color-gray-300);
+	border-radius: 4px;
+	cursor: pointer;
+	flex-shrink: 0;
+	height: 16px;
+	margin: 0;
+	position: relative;
+	width: 16px;
+}
+
+.checkbox:checked {
+	background: var(--color-purple);
+	border-color: var(--color-purple);
+}
+
+.checkbox:checked::after {
+	border: solid var(--color-white);
+	border-width: 0 2px 2px 0;
+	content: '';
+	height: 8px;
+	left: 5px;
+	position: absolute;
+	top: 2px;
+	transform: rotate(45deg);
+	width: 4px;
+}
+
+.checkbox:focus-visible {
+	outline: 2px solid var(--color-purple-400);
+	outline-offset: 2px;
 }

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -6,9 +6,8 @@ import {
 	useUpdateAllowedEmailOriginsMutation,
 } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
-import { Box, Select, Text } from '@highlight-run/ui/components'
+import { Select, Text } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React, { useState } from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -61,7 +60,9 @@ export const AutoJoinForm: React.FC = () => {
 		}
 	}
 
-	const handleCheckboxChange = (event: CheckboxChangeEvent) => {
+	const handleCheckboxChange = (
+		event: React.ChangeEvent<HTMLInputElement>,
+	) => {
 		const checked = event.target.checked
 		if (checked) {
 			onChangeMsg([adminsEmailDomain], 'Successfully enabled auto-join!')
@@ -84,13 +85,16 @@ export const AutoJoinForm: React.FC = () => {
 			mouseEnterDelay={0}
 		>
 			<div className={styles.container}>
-				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
+				<label className={styles.checkboxRow}>
+					<input
+						aria-label="Enable auto-approved email domains"
 						checked={autoJoinDomains.length > 0}
+						className={styles.checkbox}
 						onChange={handleCheckboxChange}
+						type="checkbox"
 					/>
 					<Text>Auto-approved email domains</Text>
-				</Box>
+				</label>
 				<Select
 					creatable
 					filterable


### PR DESCRIPTION
## Summary
/claim #8635

- replace the Workspace Team auto-join Ant Design checkbox with a native checkbox styled in the existing CSS module
- preserve the existing checked state, enable/disable mutation behavior, toast messages, tooltip, and auto-join domain selector flow
- remove a stale Ant Select CSS override from the same module because this form already uses Highlight UI `Select`

## Demo
- Shared evidence video: https://github.com/ManmohanBuildsProducts/highlight/releases/download/highlight-8635-demo-20260531/highlight-8635-demo.mp4

## Verification
- `npx -y prettier@3.3.3 --check frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.module.css`
- `npx -y esbuild@0.19.5 frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=/tmp/highlight-auto-join-form.mjs --log-level=error`
- `rg -n 'antd/es/checkbox|CheckboxChangeEvent|<Checkbox|ant-select|styles\.select' frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.module.css` -> no matches
- `git diff --check`

Security: UI-only settings form refactor; no auth, GraphQL schema, workspace mutation, allowed-domain payload, or backend behavior changes.

Prepared with AI assistance and manually reviewed before submission.
