### PR TITLE
refactor: replace sourcemap settings legacy inputs

### DIFF
--- a/frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.module.css
+++ b/frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.module.css
@@ -13,20 +13,39 @@
 }
 
 .listHeader {
+	display: flex;
+	flex-direction: column;
+	gap: var(--size-small);
 	margin-bottom: var(--size-medium);
 
 	& h3 {
 		margin-bottom: 0 !important;
 	}
 
-	:global(.ant-input-affix-wrapper) {
-		width: 150px;
-	}
-
 	& .versionSelect {
-		margin-bottom: var(--size-medium);
 		width: 100%;
 	}
+}
+
+.searchInput {
+	background: var(--color-primary-background);
+	border: 1px solid var(--color-gray-300);
+	border-radius: var(--border-radius);
+	color: var(--color-gray-700);
+	font-size: 13px;
+	height: 32px;
+	padding: 0 var(--size-small);
+	width: 100%;
+}
+
+.searchInput:focus {
+	border-color: var(--color-purple-400);
+	outline: none;
+}
+
+.searchInput:disabled {
+	cursor: not-allowed;
+	opacity: 0.7;
 }
 
 .listRow {

--- a/frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.tsx
@@ -1,14 +1,12 @@
 import Card from '@components/Card/Card'
 import CopyText from '@components/CopyText/CopyText'
-import Input from '@components/Input/Input'
 import ProgressBarTable from '@components/ProgressBarTable/ProgressBarTable'
-import Select from '@components/Select/Select'
 import {
 	useGetProjectQuery,
 	useGetSourcemapFilesLazyQuery,
 	useGetSourcemapVersionsQuery,
 } from '@graph/hooks'
-import { Box, Stack } from '@highlight-run/ui/components'
+import { Box, Select, Stack } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
 import { debounce } from 'lodash'
 import React, { useEffect } from 'react'
@@ -83,6 +81,10 @@ const SourcemapSettings = () => {
 		setQuery(query)
 	}, 300)
 
+	const handleVersionChange = (version: { value: string | number }) => {
+		setSelectedVersion(String(version.value))
+	}
+
 	return (
 		<BorderBox>
 			<Stack gap="8">
@@ -128,25 +130,16 @@ const SourcemapSettings = () => {
 										aria-label="Sourcemap app version"
 										className={styles.versionSelect}
 										placeholder="Select a version of your app"
-										options={versions.map((v) => ({
-											id: v,
-											value: v,
-											displayValue: v,
-										}))}
-										onChange={setSelectedVersion}
+										options={versions}
+										onValueChange={handleVersionChange}
 										value={selectedVersion}
-										notFoundContent={
-											<p>No sourcemaps found</p>
-										}
 									/>
 								</div>
 							)}
-							<Input
-								allowClear
-								style={{ width: '100%' }}
+							<input
+								className={styles.searchInput}
 								placeholder="Search for a file"
 								onChange={(e) => filterResults(e.target.value)}
-								size="small"
 								disabled={versionsLoading || loading}
 							/>
 						</div>


### PR DESCRIPTION
Closes #8635

## Summary

Closes #8635

Replaces the remaining legacy Input/Select usage in the Workspace Settings sourcemap settings slice.

## Changes

- Replaced `@components/Input/Input` with a native styled input
- Replaced `@components/Select/Select` with `Select` from `@highlight-run/ui/components`
- Removed the old Ant Design input wrapper CSS override
- Preserved sourcemap version selection, search debounce, loading/disabled states, empty states, and table behavior

## Verification

- `npx -y prettier@3.3.3 --check frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.tsx frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.module.css`
- `npx -y esbuild@0.19.5 frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=<temp> --log-level=error`
- `rg '@components/Input/Input|@components/Select/Select|from 'antd|antd/es|ant-input-affix-wrapper' frontend/src/pages/WorkspaceSettings/SourcemapSettings`
- `git diff --check`