### PR TITLE
refactor: replace settings fields legacy inputs

### DIFF
--- a/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.module.css
+++ b/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.module.css
@@ -13,3 +13,24 @@
 	display: flex;
 	height: 100%;
 }
+
+.fieldInput {
+	background: var(--color-primary-background);
+	border: 1px solid var(--color-gray-300);
+	border-radius: var(--border-radius);
+	color: var(--color-gray-700);
+	font-size: 13px;
+	height: 32px;
+	padding: 0 var(--size-small);
+	width: 100%;
+}
+
+.fieldInput:focus {
+	border-color: var(--color-purple-400);
+	outline: none;
+}
+
+.fieldInput:disabled {
+	cursor: not-allowed;
+	opacity: 0.7;
+}

--- a/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx
+++ b/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx
@@ -1,8 +1,7 @@
-import Input from '@components/Input/Input'
-import { Tooltip } from '@highlight-run/ui/components'
 import { toast } from '@components/Toaster'
 import { useEditProjectMutation, useEditWorkspaceMutation } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
+import { Tooltip } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
 import React, { useState } from 'react'
 
@@ -69,7 +68,8 @@ export const FieldsForm: React.FC<Props> = ({
 		<form onSubmit={onSubmit} key={project_id}>
 			<div className={styles.fieldRow}>
 				<label className={styles.fieldKey}>Name</label>
-				<Input
+				<input
+					className={styles.fieldInput}
 					name="name"
 					value={name}
 					onChange={(e) => {
@@ -83,7 +83,8 @@ export const FieldsForm: React.FC<Props> = ({
 					{' '}
 					<div className={styles.fieldRow}>
 						<label className={styles.fieldKey}>Billing Email</label>
-						<Input
+						<input
+							className={styles.fieldInput}
 							placeholder="Billing Email"
 							type="email"
 							name="email"


### PR DESCRIPTION
Closes #8635

## Summary

Replaces the remaining legacy `@components/Input/Input` usage in the workspace/project fields form.

## Changes

- Replaced the legacy Input wrapper with native styled inputs
- Preserved name and billing email state updates
- Preserved disabled state, submit behavior, mutations, and toast messages
- Kept scope limited to `FieldsForm` UI only

## Verification

- `npx -y prettier@3.3.3 --check frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.module.css`
- `npx -y esbuild@0.19.5 frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=<temp> --log-level=error`
- `rg '@components/Input/Input|from 'antd|antd/es' frontend/src/pages/WorkspaceSettings/FieldsForm`
- `git diff --check`