### PR TITLE
refactor: replace excluded users legacy select

### DIFF
--- a/frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx
@@ -1,9 +1,8 @@
 import { LoadingBar } from '@components/Loading/Loading'
-import Select from '@components/Select/Select'
 import TextHighlighter from '@components/TextHighlighter/TextHighlighter'
 import { toast } from '@components/Toaster'
 import { useGetIdentifierSuggestionsQuery } from '@graph/hooks'
-import { Form, Stack } from '@highlight-run/ui/components'
+import { Form, Select, Stack } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
 import { useState } from 'react'
 
@@ -46,13 +45,12 @@ export const ExcludedUsersForm = () => {
 		: (identifierSuggestionsApiResponse?.identifier_suggestion || []).map(
 				(suggestion) => ({
 					value: suggestion,
-					displayValue: (
+					name: (
 						<TextHighlighter
 							searchWords={[identifierQuery]}
 							textToHighlight={suggestion}
 						/>
-					),
-					id: suggestion,
+					) as unknown as string,
 				}),
 			)
 
@@ -77,18 +75,25 @@ export const ExcludedUsersForm = () => {
 						name="Filtered users"
 					>
 						<Select
-							mode="tags"
+							creatable
+							customFilterable
+							displayMode="tags"
 							placeholder=".*@yourdomain.com"
 							value={
 								data?.projectSettings?.excluded_users ||
 								undefined
 							}
-							onSearch={handleIdentifierSearch}
+							onSearchValueChange={handleIdentifierSearch}
 							options={identifierSuggestions}
-							onChange={(excluded: string[]) => {
+							onValueChange={(
+								excluded: { value: string | number }[],
+							) => {
+								const excludedValues = excluded.map((option) =>
+									String(option.value),
+								)
 								const validRegexes: string[] = []
 								const invalidRegexes: string[] = []
-								excluded.forEach((expression) => {
+								excludedValues.forEach((expression) => {
 									try {
 										new RegExp(expression)
 										validRegexes.push(expression)
@@ -97,16 +102,20 @@ export const ExcludedUsersForm = () => {
 									}
 								})
 								if (
-									excluded.length > 0 &&
+									excludedValues.length > 0 &&
 									invalidRegexes.length > 0 &&
-									excluded[excluded.length - 1] ===
+									excludedValues[
+										excludedValues.length - 1
+									] ===
 										invalidRegexes[
 											invalidRegexes.length - 1
 										]
 								) {
 									toast.error(
 										"'" +
-											excluded[excluded.length - 1] +
+											excludedValues[
+												excludedValues.length - 1
+											] +
 											"' is not a valid regular expression",
 										{ duration: 5000 },
 									)

--- a/frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx
@@ -1,5 +1,4 @@
 import { LoadingBar } from '@components/Loading/Loading'
-import TextHighlighter from '@components/TextHighlighter/TextHighlighter'
 import { toast } from '@components/Toaster'
 import { useGetIdentifierSuggestionsQuery } from '@graph/hooks'
 import { Form, Select, Stack } from '@highlight-run/ui/components'
@@ -45,12 +44,7 @@ export const ExcludedUsersForm = () => {
 		: (identifierSuggestionsApiResponse?.identifier_suggestion || []).map(
 				(suggestion) => ({
 					value: suggestion,
-					name: (
-						<TextHighlighter
-							searchWords={[identifierQuery]}
-							textToHighlight={suggestion}
-						/>
-					) as unknown as string,
+					name: suggestion,
 				}),
 			)
 


### PR DESCRIPTION
Closes #8635

## Summary

Replaces the remaining legacy `@components/Select/Select` usage in the project excluded users settings form.

## Changes

- Replaced the legacy Select wrapper with `Select` from `@highlight-run/ui/components`
- Preserved tag-style excluded user identifiers
- Preserved remote identifier suggestion search
- Preserved regex validation, invalid regex tracking, toast messages, and project settings updates
- Kept scope limited to `ExcludedUsersForm` UI only

## Verification

- `npx -y prettier@3.3.3 --check frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx`
- `npx -y esbuild@0.19.5 frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=<temp> --log-level=error`
- `rg '@components/Select/Select|from 'antd|antd/es' frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx`
- `git diff --check`