### PR TITLE
refactor: replace project danger form legacy input

### DIFF
--- a/frontend/src/pages/ProjectSettings/DangerForm/DangerForm.module.css
+++ b/frontend/src/pages/ProjectSettings/DangerForm/DangerForm.module.css
@@ -5,6 +5,29 @@
 	margin-top: 5px;
 }
 
+.confirmInput {
+	background: var(--color-primary-background);
+	border: 1px solid var(--color-gray-300);
+	border-radius: 8px;
+	box-sizing: border-box;
+	color: var(--color-gray-500);
+	font-size: 14px;
+	height: 40px;
+	line-height: 20px;
+	padding: 9px 11px;
+	width: 100%;
+}
+
+.confirmInput::placeholder {
+	color: var(--color-gray-400);
+}
+
+.confirmInput:focus {
+	border-color: var(--color-purple);
+	box-shadow: 0 0 0 1px var(--color-purple);
+	outline: none;
+}
+
 .deleteButton {
 	background-color: var(--color-red-400);
 	margin-left: 15px;

--- a/frontend/src/pages/ProjectSettings/DangerForm/DangerForm.tsx
+++ b/frontend/src/pages/ProjectSettings/DangerForm/DangerForm.tsx
@@ -1,5 +1,4 @@
 import { FieldsBox } from '@components/FieldsBox/FieldsBox'
-import Input from '@components/Input/Input'
 import LoadingBox from '@components/LoadingBox'
 import { useDeleteProjectMutation, useGetProjectQuery } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
@@ -63,7 +62,8 @@ export const DangerForm = () => {
 									{`${data?.project?.name}`}' to confirm.
 								</p>
 								<div className={styles.dangerRow}>
-									<Input
+									<input
+										className={styles.confirmInput}
 										placeholder={`${data?.project?.name}`}
 										name="text"
 										value={confirmationText}


### PR DESCRIPTION
## Summary

- Replaces the project danger-zone confirmation field legacy `@components/Input/Input` usage with a native styled input.
- Preserves the existing confirmation text state, placeholder, disabled delete-button gate, submit flow, and delete mutation behavior.
- Scope is UI-only for the project danger form; no GraphQL, auth, routing, project mutation payload, or backend behavior changes.

/claim #8635

## How did you test this change?

- `npx -y prettier@3.3.3 --check frontend/src/pages/ProjectSettings/DangerForm/DangerForm.tsx frontend/src/pages/ProjectSettings/DangerForm/DangerForm.module.css`
- `npx -y esbuild@0.19.5 frontend/src/pages/ProjectSettings/DangerForm/DangerForm.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=$env:TEMP\highlight-danger-form.mjs --log-level=error`
- `rg -n '@components/Input/Input|<Input' frontend/src/pages/ProjectSettings/DangerForm/DangerForm.tsx frontend/src/pages/ProjectSettings/DangerForm/DangerForm.module.css` -> no matches
- `git diff --check`

## Are there any deployment considerations?

No deployment considerations. This is a small UI refactor only.