### PR TITLE
refactor: replace github settings antd select

### DIFF
--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -10,12 +10,13 @@ import {
 	IconSolidQuestionMarkCircle,
 	IconSolidTrash,
 	IconSolidX,
+	Select,
+	type SelectOption,
 	Text,
 	TextLink,
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -120,8 +121,7 @@ const GithubSettingsForm = ({
 	const githubOptions = useMemo(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
-				id: repo.key,
-				label: repo.name.split('/').pop(),
+				name: repo.name.split('/').pop() ?? repo.name,
 				value: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
@@ -155,20 +155,15 @@ const GithubSettingsForm = ({
 							aria-label="GitHub repository"
 							className={styles.repoSelect}
 							placeholder="Search repos..."
-							onSelect={(repo: string) =>
+							onValueChange={(repo: SelectOption) =>
 								formStore.setValue(
 									formStore.names.githubRepo,
-									repo,
+									String(repo.value),
 								)
 							}
-							value={formState.values.githubRepo
-								?.split('/')
-								.pop()}
+							value={formState.values.githubRepo}
 							options={githubOptions}
-							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
-							filterOption
-							showSearch
+							filterable
 						/>
 						<ButtonIcon
 							kind="secondary"


### PR DESCRIPTION
## Summary

- Replaces the project GitHub settings modal Ant Design `Select` with the Highlight UI `Select`.
- Preserves repo search/filtering, selected repo storage as `owner/name`, clear behavior, save/cancel flow, and existing form state.
- Scope is UI-only for the GitHub settings modal; no GraphQL, auth, routing, service mutation payload, or backend behavior changes.

/claim #8635

## How did you test this change?

- `npx -y prettier@3.3.3 --check frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx`
- `npx -y esbuild@0.19.5 frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=$env:TEMP\highlight-github-settings-modal.mjs --log-level=error`
- `rg -n 'antd|showSearch|optionFilterProp|notFoundContent' frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx` -> no matches
- `git diff --check`

## Are there any deployment considerations?

No deployment considerations. This is a small UI refactor only.