### PR TITLE
refactor: replace clickup settings legacy select

### DIFF
--- a/frontend/src/pages/IntegrationsPage/components/ClickUpIntegration/ClickUpIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/ClickUpIntegration/ClickUpIntegrationConfig.tsx
@@ -3,10 +3,10 @@ import React, { useEffect } from 'react'
 
 import Button from '@components/Button/Button/Button'
 import Card from '@components/Card/Card'
-import Select from '@components/Select/Select'
 import Table from '@components/Table/Table'
 import { toast } from '@components/Toaster'
 import { ClickUpProjectMappingInput } from '@graph/schemas'
+import { Select, type SelectOption } from '@highlight-run/ui/components'
 import SvgHighlightLogoOnLight from '@icons/HighlightLogoOnLight'
 import PlugIcon from '@icons/PlugIcon'
 import Sparkles2Icon from '@icons/Sparkles2Icon'
@@ -195,13 +195,11 @@ export const ClickUpIntegrationSettings: React.FC<
 			if (!!p) {
 				highlightProjects.push({
 					...p,
-					onUpdateProjectLink: (label: string) => {
-						const match = allSpaces.find((s) => s.label === label)
-
-						if (match === undefined) {
+					onUpdateProjectLink: (clickUpSpaceId?: string) => {
+						if (!clickUpSpaceId) {
 							projectMapDelete(p.id)
 						} else {
-							projectMapSet(p.id, match.id)
+							projectMapSet(p.id, clickUpSpaceId)
 						}
 					},
 				})
@@ -211,9 +209,8 @@ export const ClickUpIntegrationSettings: React.FC<
 
 	const selectOptions =
 		allSpaces.map((p) => ({
-			id: p.id,
-			value: p.label,
-			displayValue: p.label,
+			name: p.label,
+			value: p.id,
 		})) || []
 
 	const tableColumns = [
@@ -249,16 +246,22 @@ export const ClickUpIntegrationSettings: React.FC<
 			width: '55%',
 			render: (_: string, row: any) => {
 				const clickUpSpaceId = projectMap.get(row.id)
-				const opts = allSpaces.find((s) => s.id === clickUpSpaceId)
 				return (
 					<div className={styles.select}>
 						<Select
 							className="w-full"
-							value={opts}
-							onChange={row.onUpdateProjectLink}
+							value={clickUpSpaceId}
+							onValueChange={(option?: SelectOption) =>
+								row.onUpdateProjectLink(
+									option?.value
+										? String(option.value)
+										: undefined,
+								)
+							}
 							options={selectOptions}
 							placeholder="ClickUp space"
-							allowClear
+							clearable
+							filterable
 						/>
 					</div>
 				)


### PR DESCRIPTION
## Summary

- Replaces the ClickUp integration settings legacy `@components/Select/Select` usage with the Highlight UI `Select`.
- Keeps project-to-ClickUp-space mapping stored by `clickup_space_id`, preserves clear behavior, filtering, save/cancel flow, and existing mutation payloads.
- Scope is UI-only for the ClickUp settings table; no GraphQL, auth, routing, or backend behavior changes.

/claim #8635

## How did you test this change?

- `npx -y prettier@3.3.3 --check frontend/src/pages/IntegrationsPage/components/ClickUpIntegration/ClickUpIntegrationConfig.tsx`
- `npx -y esbuild@0.19.5 frontend/src/pages/IntegrationsPage/components/ClickUpIntegration/ClickUpIntegrationConfig.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=$env:TEMP\highlight-clickup-settings.mjs --log-level=error`
- `rg -n '@components/Select/Select|allowClear|onChange=|displayValue' frontend/src/pages/IntegrationsPage/components/ClickUpIntegration/ClickUpIntegrationConfig.tsx` -> no matches
- `git diff --check`

## Are there any deployment considerations?

No deployment considerations. This is a small UI refactor only.