### PR TITLE
refactor: replace pending invites legacy button

### DIFF
--- a/.changeset/codex-pending-invites-button.md
+++ b/.changeset/codex-pending-invites-button.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+Replace pending invite removal legacy button usage with the current Highlight UI icon button.

--- a/.changeset/nine-mails-bake.md
+++ b/.changeset/nine-mails-bake.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+Refactor the Workspace Team pending invite removal action to use the shared Highlight UI icon button.

--- a/frontend/src/pages/WorkspaceTeam/components/PendingInvites.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/PendingInvites.tsx
@@ -1,5 +1,4 @@
 import { AdminAvatar } from '@components/Avatar/Avatar'
-import Button from '@components/Button/Button/Button'
 import Card from '@components/Card/Card'
 import PopConfirm from '@components/PopConfirm/PopConfirm'
 import Table from '@components/Table/Table'
@@ -9,8 +8,9 @@ import {
 	useGetWorkspacePendingInvitesQuery,
 } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
-import { Box } from '@highlight-run/ui/components'
+import { Box, ButtonIcon } from '@highlight-run/ui/components'
 import SvgTrashIconSolid from '@icons/TrashIconSolid'
+import analytics from '@util/analytics'
 import { useAuthorization } from '@util/authorization/authorization'
 import { POLICY_NAMES } from '@util/authorization/authorizationPolicies'
 import { titleCaseString } from '@util/string'
@@ -161,13 +161,13 @@ const TABLE_COLUMNS = [
 					}}
 					okButtonProps={{ danger: true }}
 				>
-					<Button
+					<ButtonIcon
 						className={styles.removeTeamMemberButton}
-						trackingId="DeleteInvite"
-						iconButton
-					>
-						<SvgTrashIconSolid />
-					</Button>
+						kind="secondary"
+						emphasis="low"
+						icon={<SvgTrashIconSolid />}
+						onClick={() => analytics.track('Button-DeleteInvite')}
+					/>
 				</PopConfirm>
 			)
 		},


### PR DESCRIPTION
## Summary
- replace the Workspace Team pending invites remove action's direct `@components/Button/Button/Button` usage with Highlight UI `ButtonIcon`
- keep the delete confirmation flow unchanged
- preserve the existing `Button-DeleteInvite` analytics event on click

## Verification
- `npx -y prettier@3.3.3 --check frontend/src/pages/WorkspaceTeam/components/PendingInvites.tsx`
- `npx -y esbuild@0.19.5 frontend/src/pages/WorkspaceTeam/components/PendingInvites.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=<temp> --log-level=error`
- `git diff --check`

/claim #8635