### PR TITLE
Replace Height integration legacy select

### DIFF
--- a/frontend/src/pages/IntegrationsPage/components/HeightIntegration/HeightIntegrationConfig.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/HeightIntegration/HeightIntegrationConfig.module.css
@@ -21,9 +21,7 @@
 }
 
 .select {
-	:global(.ant-select-selection-item-content) {
-		max-width: 150px;
-	}
+	display: block;
 }
 
 .projectInput {

--- a/frontend/src/pages/IntegrationsPage/components/HeightIntegration/HeightIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/HeightIntegration/HeightIntegrationConfig.tsx
@@ -3,10 +3,10 @@ import React, { useEffect } from 'react'
 
 import Button from '@components/Button/Button/Button'
 import Card from '@components/Card/Card'
-import Select from '@components/Select/Select'
 import Table from '@components/Table/Table'
 import { toast } from '@components/Toaster'
 import { IntegrationProjectMappingInput, IntegrationType } from '@graph/schemas'
+import { Select, type SelectOption } from '@highlight-run/ui/components'
 import SvgHighlightLogoOnLight from '@icons/HighlightLogoOnLight'
 import PlugIcon from '@icons/PlugIcon'
 import Sparkles2Icon from '@icons/Sparkles2Icon'
@@ -191,15 +191,13 @@ export const HeightIntegrationSettings: React.FC<
 			if (!!p) {
 				highlightProjects.push({
 					...p,
-					onUpdateProjectLink: (label: string) => {
-						const match = settings.height_workspaces.find(
-							(w) => w.name === label,
-						)
+					onUpdateProjectLink: (workspace?: SelectOption) => {
+						const workspaceId = workspace?.value
 
-						if (match === undefined) {
+						if (workspaceId === undefined) {
 							projectMapDelete(p.id)
 						} else {
-							projectMapSet(p.id, match.id)
+							projectMapSet(p.id, String(workspaceId))
 						}
 					},
 				})
@@ -209,9 +207,8 @@ export const HeightIntegrationSettings: React.FC<
 
 	const selectOptions =
 		settings.height_workspaces.map((w) => ({
-			id: w.id,
-			value: w.name,
-			displayValue: w.name,
+			name: w.name,
+			value: w.id,
 		})) || []
 
 	const tableColumns = [
@@ -250,20 +247,21 @@ export const HeightIntegrationSettings: React.FC<
 				const selectedWorkspace = settings.height_workspaces.find(
 					(w) => w.id === heightWorkspaceId,
 				)
-				const value = {
-					id: selectedWorkspace?.id,
-					value: selectedWorkspace?.id,
-					label: selectedWorkspace?.name,
-				}
+				const value = selectedWorkspace
+					? {
+							name: selectedWorkspace.name,
+							value: selectedWorkspace.id,
+						}
+					: undefined
 				return (
 					<div className={styles.select}>
 						<Select
 							className="w-full"
 							value={value}
-							onChange={row.onUpdateProjectLink}
+							onValueChange={row.onUpdateProjectLink}
 							options={selectOptions}
 							placeholder="Height workspace"
-							allowClear
+							clearable
 						/>
 					</div>
 				)


### PR DESCRIPTION
## Summary

- Replaces the Height integration settings legacy `@components/Select/Select` usage with the Highlight UI `Select`.
- Stores the selected Height workspace by workspace id instead of matching by display label, preserving the existing `external_id` mapping payload.
- Keeps the change UI-only for the Height settings mapping table; no GraphQL, auth, integration mutation, routing, or backend behavior changes.

/claim #8635

## How did you test this change?

- `npx -y prettier@3.3.3 --check frontend/src/pages/IntegrationsPage/components/HeightIntegration/HeightIntegrationConfig.tsx frontend/src/pages/IntegrationsPage/components/HeightIntegration/HeightIntegrationConfig.module.css`
- `npx -y esbuild@0.19.5 frontend/src/pages/IntegrationsPage/components/HeightIntegration/HeightIntegrationConfig.tsx --bundle '--external:*' --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=$env:TEMP\highlight-height-settings.mjs --log-level=error`
- `rg -n "@components/Select/Select|allowClear|onChange=|displayValue|ant-select" frontend/src/pages/IntegrationsPage/components/HeightIntegration/HeightIntegrationConfig.tsx frontend/src/pages/IntegrationsPage/components/HeightIntegration/HeightIntegrationConfig.module.css` -> no matches
- `git diff --check`

Note: `node .yarn/releases/yarn-4.6.0.cjs workspace @highlight-run/frontend eslint src/pages/IntegrationsPage/components/HeightIntegration/HeightIntegrationConfig.tsx` could not run in this checkout because Yarn reported the missing node_modules state file.

## Are there any deployment considerations?

No deployment considerations. This is a small UI refactor only.