### PR TITLE
Replace GitLab integration config Button usage

### DIFF
--- a/.changeset/codex-gitlab-config-button.md
+++ b/.changeset/codex-gitlab-config-button.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+Replace GitLab integration legacy button usage with current Highlight UI components.

--- a/frontend/src/pages/IntegrationsPage/components/GitlabIntegration/GitlabIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/GitlabIntegration/GitlabIntegrationConfig.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button/Button/Button'
+import { Button } from '@components/Button'
 import AppsIcon from '@icons/AppsIcon'
 import PlugIcon from '@icons/PlugIcon'
 import {
@@ -36,6 +36,8 @@ const GitlabIntegrationSetup: React.FC<IntegrationConfigProps> = ({
 				<Button
 					trackingId="IntegrationConfigurationCancel-GitLab"
 					className={styles.modalBtn}
+					kind="secondary"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(false)
@@ -46,8 +48,11 @@ const GitlabIntegrationSetup: React.FC<IntegrationConfigProps> = ({
 				<Button
 					trackingId="IntegrationConfigurationSave-GitLab"
 					className={styles.modalBtn}
-					type="primary"
-					href={authUrl}
+					kind="primary"
+					emphasis="high"
+					onClick={() => {
+						window.location.assign(authUrl)
+					}}
 				>
 					<AppsIcon className={styles.modalBtnIcon} /> Connect
 					Highlight with GitLab
@@ -72,6 +77,8 @@ const GitlabIntegrationDisconnect: React.FC<
 				<Button
 					trackingId="IntegrationDisconnectCancel-GitLab"
 					className={styles.modalBtn}
+					kind="secondary"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(true)
@@ -82,8 +89,7 @@ const GitlabIntegrationDisconnect: React.FC<
 				<Button
 					trackingId="IntegrationDisconnectSave-GitLab"
 					className={styles.modalBtn}
-					type="primary"
-					danger
+					kind="danger"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(false)


### PR DESCRIPTION
## Summary
- replace the GitLab integration config legacy deep Button import with the current tracked Button wrapper
- map the old primary/danger button props to current Highlight UI `kind`/`emphasis` variants
- keep the existing GitLab OAuth and disconnect flows intact

## Validation
- `npx -y prettier@3.3.3 --check frontend/src/pages/IntegrationsPage/components/GitlabIntegration/GitlabIntegrationConfig.tsx`
- `git diff --check`
- `npx -y esbuild@0.19.5 frontend/src/pages/IntegrationsPage/components/GitlabIntegration/GitlabIntegrationConfig.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=$env:TEMP\highlight-gitlab-integration.mjs --log-level=error`
- `rg -n '@components/Button/Button/Button|type="primary"|type="danger"|href=' frontend/src/pages/IntegrationsPage/components/GitlabIntegration/GitlabIntegrationConfig.tsx` returned no matches

Part of #8635.