### PR TITLE
Replace Clearbit integration config Button usage

### DIFF
--- a/.changeset/codex-clearbit-config-button.md
+++ b/.changeset/codex-clearbit-config-button.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+Replace Clearbit integration legacy button usage with current Highlight UI components.

--- a/frontend/src/pages/IntegrationsPage/components/ClearbitIntegration/ClearbitIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/ClearbitIntegration/ClearbitIntegrationConfig.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button/Button/Button'
+import { Button } from '@components/Button'
 import { toast } from '@components/Toaster'
 import { PlanType } from '@graph/schemas'
 import PlugIcon from '@icons/PlugIcon'
@@ -53,6 +53,8 @@ const ClearbitIntegrationConfig: React.FC<
 					<Button
 						trackingId="IntegrationDisconnectCancel-Slack"
 						className={styles.modalBtn}
+						kind="secondary"
+						emphasis="medium"
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(true)
@@ -63,8 +65,7 @@ const ClearbitIntegrationConfig: React.FC<
 					<Button
 						trackingId="IntegrationDisconnectSave-Slack"
 						className={styles.modalBtn}
-						type="primary"
-						danger
+						kind="danger"
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(false)
@@ -102,6 +103,8 @@ const ClearbitIntegrationConfig: React.FC<
 						<Button
 							trackingId="IntegrationConfigurationCancelUpgrade-Clearbit"
 							className={styles.modalBtn}
+							kind="secondary"
+							emphasis="medium"
 							onClick={() => {
 								setModalOpen(false)
 								setIntegrationEnabled(false)
@@ -112,7 +115,8 @@ const ClearbitIntegrationConfig: React.FC<
 						<Button
 							trackingId="IntegrationConfigurationViewUpgrade-Clearbit"
 							className={styles.modalBtn}
-							type="primary"
+							kind="primary"
+							emphasis="high"
 							onClick={() => {
 								navigate(`/${projectID}/integrations`)
 								setRedirectToBilling(true)
@@ -127,6 +131,8 @@ const ClearbitIntegrationConfig: React.FC<
 					<Button
 						trackingId="IntegrationConfigurationCancel-Clearbit"
 						className={styles.modalBtn}
+						kind="secondary"
+						emphasis="medium"
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(false)
@@ -137,7 +143,8 @@ const ClearbitIntegrationConfig: React.FC<
 					<Button
 						trackingId="IntegrationConfigurationSave-Clearbit"
 						className={styles.modalBtn}
-						type="primary"
+						kind="primary"
+						emphasis="high"
 						onClick={() => {
 							modifyClearbit({ enabled: true })
 						}}


### PR DESCRIPTION
## Summary
- replace the Clearbit integration config legacy deep Button import with the current tracked Button wrapper
- map the old primary/danger button props to current Highlight UI `kind`/`emphasis` variants
- keep the existing Clearbit enable, upgrade, cancel, and disconnect flows intact

## Validation
- `npx -y prettier@3.3.3 --check frontend/src/pages/IntegrationsPage/components/ClearbitIntegration/ClearbitIntegrationConfig.tsx`
- `git diff --check`
- `npx -y esbuild@0.19.5 frontend/src/pages/IntegrationsPage/components/ClearbitIntegration/ClearbitIntegrationConfig.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=$env:TEMP\highlight-clearbit-integration.mjs --log-level=error`
- `rg -n '@components/Button/Button/Button|type="primary"|type="danger"|href=' frontend/src/pages/IntegrationsPage/components/ClearbitIntegration/ClearbitIntegrationConfig.tsx` returned no matches

Part of #8635.