### PR TITLE
Replace Cloudflare integration config Button usage

### DIFF
--- a/.changeset/codex-cloudflare-config-button.md
+++ b/.changeset/codex-cloudflare-config-button.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+Replace Cloudflare integration legacy button usage with current Highlight UI components.

--- a/frontend/src/pages/IntegrationsPage/components/CloudflareIntegration/CloudflareIntegration.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/CloudflareIntegration/CloudflareIntegration.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button/Button/Button'
+import { Button } from '@components/Button'
 import { Form, Stack } from '@highlight-run/ui/components'
 import AppsIcon from '@icons/AppsIcon'
 import PlugIcon from '@icons/PlugIcon'
@@ -14,7 +14,7 @@ import { useCloudflareIntegration } from './utils'
 
 const CloudflareIntegration: React.FC<
 	React.PropsWithChildren<IntegrationConfigProps>
-> = ({ setModalOpen: setModalOpen, action }) => {
+> = ({ setModalOpen: setModalOpen, setIntegrationEnabled, action }) => {
 	const { addCloudflareToProject, removeCloudflareIntegrationFromProject } =
 		useCloudflareIntegration()
 	const { currentWorkspace } = useApplicationContext()
@@ -44,8 +44,11 @@ const CloudflareIntegration: React.FC<
 					<Button
 						trackingId="IntegrationDisconnectCancel-Cloudflare"
 						className={styles.modalBtn}
+						kind="secondary"
+						emphasis="medium"
 						onClick={() => {
 							setModalOpen(false)
+							setIntegrationEnabled(true)
 						}}
 					>
 						Cancel
@@ -53,11 +56,11 @@ const CloudflareIntegration: React.FC<
 					<Button
 						trackingId="IntegrationDisconnectSave-Cloudflare"
 						className={styles.modalBtn}
-						type="primary"
-						danger
+						kind="danger"
 						onClick={async () => {
-							setModalOpen(false)
 							await removeCloudflareIntegrationFromProject()
+							setModalOpen(false)
+							setIntegrationEnabled(false)
 						}}
 					>
 						<PlugIcon className={styles.modalBtnIcon} />
@@ -106,8 +109,11 @@ const CloudflareIntegration: React.FC<
 				<Button
 					trackingId="IntegrationConfigurationCancel-Cloudflare"
 					className={styles.modalBtn}
+					kind="secondary"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
+						setIntegrationEnabled(false)
 					}}
 				>
 					Cancel
@@ -115,11 +121,13 @@ const CloudflareIntegration: React.FC<
 				<Button
 					trackingId="IntegrationConfigurationSave-Cloudflare"
 					className={styles.modalBtn}
-					type="primary"
+					kind="primary"
+					emphasis="high"
 					disabled={token.length < 40 || proxySubdomain.length < 3}
 					onClick={async () => {
-						setModalOpen(false)
 						await addCloudflareToProject(token, proxySubdomain)
+						setModalOpen(false)
+						setIntegrationEnabled(true)
 					}}
 				>
 					<AppsIcon className={styles.modalBtnIcon} /> Connect


### PR DESCRIPTION
## Summary
- replace the Cloudflare integration config legacy Button import with the shared @components/Button wrapper
- map primary/danger/default button props to kind/emphasis
- keep the integration enabled state aligned when cancelling, connecting, or disconnecting Cloudflare

## Verification
- 
pm exec --yes prettier@3.3.3 -- --check frontend/src/pages/IntegrationsPage/components/CloudflareIntegration/CloudflareIntegration.tsx
- git diff --check
- 
pm exec --yes esbuild@0.24.0 -- frontend/src/pages/IntegrationsPage/components/CloudflareIntegration/CloudflareIntegration.tsx --bundle=false --format=esm --loader:.tsx=tsx --outfile=NUL
- g 'Button/Button/Button|type="primary"' frontend/src/pages/IntegrationsPage/components/CloudflareIntegration/CloudflareIntegration.tsx

Part of #8635.