### PR TITLE
Replace Linear integration config Button usage

### DIFF
--- a/.changeset/codex-linear-config-button.md
+++ b/.changeset/codex-linear-config-button.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+Replace Linear integration legacy button usage with current Highlight UI components.

--- a/frontend/src/pages/IntegrationsPage/components/LinearIntegration/LinearIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/LinearIntegration/LinearIntegrationConfig.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button/Button/Button'
+import { Button } from '@components/Button'
 import AppsIcon from '@icons/AppsIcon'
 import PlugIcon from '@icons/PlugIcon'
 import {
@@ -31,6 +31,8 @@ const LinearIntegrationConfig: React.FC<
 					<Button
 						trackingId="IntegrationDisconnectCancel-Slack"
 						className={styles.modalBtn}
+						kind="secondary"
+						emphasis="medium"
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(true)
@@ -41,8 +43,7 @@ const LinearIntegrationConfig: React.FC<
 					<Button
 						trackingId="IntegrationDisconnectSave-Slack"
 						className={styles.modalBtn}
-						type="primary"
-						danger
+						kind="danger"
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(false)
@@ -67,6 +68,8 @@ const LinearIntegrationConfig: React.FC<
 				<Button
 					trackingId="IntegrationConfigurationCancel-Slack"
 					className={styles.modalBtn}
+					kind="secondary"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(false)
@@ -77,8 +80,11 @@ const LinearIntegrationConfig: React.FC<
 				<Button
 					trackingId="IntegrationConfigurationSave-Slack"
 					className={styles.modalBtn}
-					type="primary"
-					href={authUrl}
+					kind="primary"
+					emphasis="high"
+					onClick={() => {
+						window.location.assign(authUrl)
+					}}
 				>
 					<AppsIcon className={styles.modalBtnIcon} /> Connect
 					Highlight with Linear


### PR DESCRIPTION
## Summary
- replace the Linear integration config legacy Button import with the shared @components/Button wrapper
- map primary/danger/default button props to kind/emphasis
- keep the Linear OAuth redirect behavior using an explicit click handler

## Verification
- 
pm exec --yes prettier@3.3.3 -- --check frontend/src/pages/IntegrationsPage/components/LinearIntegration/LinearIntegrationConfig.tsx
- git diff --check
- 
pm exec --yes esbuild@0.24.0 -- frontend/src/pages/IntegrationsPage/components/LinearIntegration/LinearIntegrationConfig.tsx --bundle=false --format=esm --loader:.tsx=tsx --outfile=NUL
- g 'Button/Button/Button|type="primary"' frontend/src/pages/IntegrationsPage/components/LinearIntegration/LinearIntegrationConfig.tsx

Part of #8635.