### PR TITLE
Replace Jira integration config Button usage

### DIFF
--- a/.changeset/codex-jira-config-button.md
+++ b/.changeset/codex-jira-config-button.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+Replace Jira integration legacy button usage with current Highlight UI components.

--- a/frontend/src/pages/IntegrationsPage/components/JiraIntegration/JiraIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/JiraIntegration/JiraIntegrationConfig.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button/Button/Button'
+import { Button } from '@components/Button'
 import AppsIcon from '@icons/AppsIcon'
 import PlugIcon from '@icons/PlugIcon'
 import {
@@ -36,6 +36,8 @@ const JiraIntegrationSetup: React.FC<IntegrationConfigProps> = ({
 				<Button
 					trackingId="IntegrationConfigurationCancel-Jira"
 					className={styles.modalBtn}
+					kind="secondary"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(false)
@@ -46,8 +48,11 @@ const JiraIntegrationSetup: React.FC<IntegrationConfigProps> = ({
 				<Button
 					trackingId="IntegrationConfigurationSave-Jira"
 					className={styles.modalBtn}
-					type="primary"
-					href={authUrl}
+					kind="primary"
+					emphasis="high"
+					onClick={() => {
+						window.location.assign(authUrl)
+					}}
 				>
 					<AppsIcon className={styles.modalBtnIcon} /> Connect
 					Highlight with Jira
@@ -72,6 +77,8 @@ const JiraIntegrationDisconnect: React.FC<
 				<Button
 					trackingId="IntegrationDisconnectCancel-Jira"
 					className={styles.modalBtn}
+					kind="secondary"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(true)
@@ -82,8 +89,7 @@ const JiraIntegrationDisconnect: React.FC<
 				<Button
 					trackingId="IntegrationDisconnectSave-Jira"
 					className={styles.modalBtn}
-					type="primary"
-					danger
+					kind="danger"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(false)


### PR DESCRIPTION
## Summary
- replace the Jira integration config legacy Button import with the shared @components/Button wrapper
- map primary/danger/default button props to kind/emphasis
- keep the Jira OAuth redirect behavior using an explicit click handler

## Verification
- 
pm exec --yes prettier@3.3.3 -- --check frontend/src/pages/IntegrationsPage/components/JiraIntegration/JiraIntegrationConfig.tsx
- git diff --check
- 
pm exec --yes esbuild@0.24.0 -- frontend/src/pages/IntegrationsPage/components/JiraIntegration/JiraIntegrationConfig.tsx --bundle=false --format=esm --loader:.tsx=tsx --outfile=NUL
- g 'Button/Button/Button|type="primary"' frontend/src/pages/IntegrationsPage/components/JiraIntegration/JiraIntegrationConfig.tsx

Part of #8635.