### PR TITLE
Replace GitHub integration legacy Button usage

### DIFF
--- a/.changeset/codex-github-config-button.md
+++ b/.changeset/codex-github-config-button.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+Replace GitHub integration legacy button usage with current Highlight UI components.

--- a/frontend/src/pages/IntegrationsPage/components/GitHubIntegration/GitHubIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/GitHubIntegration/GitHubIntegrationConfig.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button/Button/Button'
+import { Button } from '@components/Button'
 import { useProjectId } from '@hooks/useProjectId'
 import AppsIcon from '@icons/AppsIcon'
 import PlugIcon from '@icons/PlugIcon'
@@ -41,6 +41,8 @@ const GitHubIntegrationConfig: React.FC<
 					<Button
 						trackingId="IntegrationDisconnectCancel-GitHub"
 						className={styles.modalBtn}
+						kind="secondary"
+						emphasis="medium"
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(true)
@@ -51,8 +53,7 @@ const GitHubIntegrationConfig: React.FC<
 					<Button
 						trackingId="IntegrationDisconnectSave-GitHub"
 						className={styles.modalBtn}
-						type="primary"
-						danger
+						kind="danger"
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(false)
@@ -77,6 +78,8 @@ const GitHubIntegrationConfig: React.FC<
 				<Button
 					trackingId="IntegrationConfigurationCancel-GitHub"
 					className={styles.modalBtn}
+					kind="secondary"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(false)
@@ -87,8 +90,11 @@ const GitHubIntegrationConfig: React.FC<
 				<Button
 					trackingId="IntegrationConfigurationSave-GitHub"
 					className={styles.modalBtn}
-					type="primary"
-					href={authUrl}
+					kind="primary"
+					emphasis="high"
+					onClick={() => {
+						window.location.assign(authUrl)
+					}}
 				>
 					<AppsIcon className={styles.modalBtnIcon} /> Connect
 					Highlight with GitHub


### PR DESCRIPTION
Contributor: Tristan Tang

## Summary
- Replace the GitHub integration config legacy Button import with the shared Button entrypoint.
- Migrate modal actions from `type="primary"`/`danger` to `kind`/`emphasis` props.
- Preserve the GitHub OAuth connect behavior by using the primary Button `onClick` handler to navigate to the auth URL.

## Verification
- `npm exec --yes prettier@3.3.3 -- --check frontend/src/pages/IntegrationsPage/components/GitHubIntegration/GitHubIntegrationConfig.tsx`
- `git diff --check`
- `npm exec --yes esbuild@0.24.0 -- frontend/src/pages/IntegrationsPage/components/GitHubIntegration/GitHubIntegrationConfig.tsx --bundle=false --format=esm --loader:.tsx=tsx --outfile=NUL`
- Confirmed no legacy `@components/Button/Button/Button`, `type="primary"`, standalone `danger`, or `href={authUrl}` usage remains in the touched file.

Relates to #8635.