### PR TITLE
Replace integration settings legacy icon button

### DIFF
--- a/.changeset/codex-integration-settings-button.md
+++ b/.changeset/codex-integration-settings-button.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+Replace integration settings legacy icon button usage with the current Highlight UI icon button.

--- a/frontend/src/pages/IntegrationsPage/components/Integration.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.tsx
@@ -1,9 +1,10 @@
-import Button from '@components/Button/Button/Button'
 import Card from '@components/Card/Card'
 import LoadingBox from '@components/LoadingBox'
 import Switch from '@components/Switch/Switch'
+import { ButtonIcon } from '@highlight-run/ui/components'
 import SettingsIcon from '@icons/SettingsIcon'
 import { Integration as IntegrationType } from '@pages/IntegrationsPage/Integrations'
+import analytics from '@util/analytics'
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 
@@ -145,16 +146,19 @@ const Integration = ({
 						)}
 						{hasSettings && (
 							<div className="flex h-[18px] w-full justify-end">
-								<Button
-									trackingId="IntegrationSettings"
-									iconButton
+								<ButtonIcon
 									onClick={() => {
+										analytics.track(
+											'Button-IntegrationSettings',
+										)
 										setShowUpdateSettings(true)
 									}}
 									disabled={!integrationEnabled}
-								>
-									<SettingsIcon />
-								</Button>
+									icon={<SettingsIcon />}
+									kind="secondary"
+									emphasis="low"
+									size="xSmall"
+								/>
 							</div>
 						)}
 					</div>


### PR DESCRIPTION
Contributor: Tristan Tang

## Summary
- Replace the integrations card settings action from the legacy Button/iconButton API to the shared ButtonIcon component.
- Preserve the existing `Button-IntegrationSettings` analytics event before opening the settings modal.
- Keep the disabled state for disconnected integrations.

## Verification
- `npm exec --yes prettier@3.3.3 -- --check frontend/src/pages/IntegrationsPage/components/Integration.tsx`
- `git diff --check`
- `npm exec --yes esbuild@0.24.0 -- frontend/src/pages/IntegrationsPage/components/Integration.tsx --bundle=false --format=esm --loader:.tsx=tsx --outfile=NUL`
- Confirmed no legacy `@components/Button/Button/Button`, `iconButton`, or `trackingId="IntegrationSettings"` usage remains in the touched file.

Relates to #8635.