### PR TITLE
Replace shared legacy button usages

### DIFF
--- a/.changeset/humble-lions-fail.md
+++ b/.changeset/humble-lions-fail.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+Replace shared legacy button usages

--- a/frontend/src/components/ErrorState/RequestAccess/RequestAccess.tsx
+++ b/frontend/src/components/ErrorState/RequestAccess/RequestAccess.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button/Button/Button'
+import { Button } from '@components/Button'
 import { toast } from '@components/Toaster'
 import { useRequestAccessMutation } from '@graph/hooks'
 import { useParams } from '@util/react-router/useParams'
@@ -12,10 +12,11 @@ const RequestAccess = () => {
 	const [sentAccessRequest, setSentAccessRequest] = useState(false)
 	return (
 		<Button
-			small
 			trackingId="ErrorStateRequestAccess"
+			size="small"
+			kind="primary"
+			emphasis="high"
 			disabled={sentAccessRequest}
-			type="primary"
 			onClick={async () => {
 				try {
 					await requestAccess({

--- a/frontend/src/components/JsonViewer/JsonViewer.tsx
+++ b/frontend/src/components/JsonViewer/JsonViewer.tsx
@@ -1,6 +1,7 @@
-import Button from '@components/Button/Button/Button'
 import Tooltip from '@components/Tooltip/Tooltip'
+import { ButtonIcon } from '@highlight-run/ui/components'
 import SvgDownloadIcon from '@icons/DownloadIcon'
+import analytics from '@util/analytics'
 // @ts-expect-error
 import { specific } from 'react-files-hooks'
 import ReactJson, { ReactJsonViewProps } from 'react-json-view'
@@ -30,21 +31,21 @@ const JsonViewer = ({
 		<div className={styles.container}>
 			{allowDownload && (
 				<Tooltip title="Download this as JSON" placement="left">
-					<Button
-						className={styles.downloadButton}
-						trackingId="JsonViewerDownload"
-						iconButton
-						type="text"
+					<ButtonIcon
+						cssClass={styles.downloadButton}
+						kind="secondary"
+						emphasis="low"
 						size="small"
+						shape="square"
+						icon={<SvgDownloadIcon />}
 						onClick={() => {
 							download({
 								data: JSON.stringify(props.src, undefined, 2),
 								name: downloadFileName,
 							})
+							analytics.track('Button-JsonViewerDownload')
 						}}
-					>
-						<SvgDownloadIcon />
-					</Button>
+					/>
 				</Tooltip>
 			)}
 			<ReactJson


### PR DESCRIPTION
## Summary

- Replaces `RequestAccess`'s legacy Ant Design-backed button import with the current tracked `@components/Button` API while preserving disabled state, click mutation flow, toast text, and label behavior.
- Replaces `JsonViewer`'s icon-only download button with `@highlight-run/ui` `ButtonIcon` while preserving tooltip placement, absolute positioning, JSON download behavior, and the existing `Button-JsonViewerDownload` analytics event.
- Scope is UI-only: no GraphQL, auth, download payload, routing, or backend behavior changes.

Fixes #8635
/claim #8635

## How did you test this change?

- `npx -y prettier@3.3.3 --check frontend/src/components/ErrorState/RequestAccess/RequestAccess.tsx frontend/src/components/JsonViewer/JsonViewer.tsx`
- `npx -y esbuild@0.19.5 frontend/src/components/ErrorState/RequestAccess/RequestAccess.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=/tmp/highlight-request-access.mjs --log-level=error`
- `npx -y esbuild@0.19.5 frontend/src/components/JsonViewer/JsonViewer.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=/tmp/highlight-json-viewer.mjs --log-level=error`
- `rg -n '@components/Button/Button/Button|iconButton|type="text"|type="primary"' frontend/src/components/ErrorState/RequestAccess/RequestAccess.tsx frontend/src/components/JsonViewer/JsonViewer.tsx` -> no matches
- `git diff --check`

## Notes

Prepared with AI assistance and manually reviewed before submission.