### PR TITLE
Remove Ant Divider from event steps

### DIFF
--- a/frontend/src/pages/Graphing/EventSelection/EventSteps.tsx
+++ b/frontend/src/pages/Graphing/EventSelection/EventSteps.tsx
@@ -18,7 +18,6 @@ import {
 	Text,
 } from '@highlight-run/ui/components'
 import { LabeledRow } from '@pages/Graphing/LabeledRow'
-import { Divider } from 'antd'
 import { EventSelection } from '@pages/Graphing/EventSelection/index'
 import {
 	EventSelectionDetails,
@@ -180,7 +179,7 @@ const AddEventStep: React.FC<AddEventStepProps> = ({
 					}}
 				/>
 			</LabeledRow>
-			<Divider className="m-0" />
+			<Box borderBottom="divider" width="full" />
 			<EventSelection
 				initialQuery={query}
 				setQuery={setQuery}


### PR DESCRIPTION
## Summary

- Replaces the remaining Ant Design `Divider` usage in `EventSteps.tsx` with an existing Highlight UI `Box` divider.
- Removes the `antd` import from the graphing event step form.
- Keeps the event step form layout and behavior unchanged.

/claim #8635

## How did you test this change?

- Inspected the branch diff: 1 file changed, 1 addition, 2 deletions.
- Verified the touched file no longer imports from `antd`.
- Not run locally: this Codex environment does not have a usable local Node/Yarn checkout for the Highlight frontend.

## Are there any deployment considerations?

No deployment considerations. This is a small UI-only refactor.
