### PR TITLE
feat: redesign integrations page with search, categories, and connected badges

### DIFF
--- a/.changeset/integrations-page-redesign.md
+++ b/.changeset/integrations-page-redesign.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/frontend': minor
+---
+
+Redesign integrations page with search bar, category tabs, connected badges, improved card UI with hover effects, and empty state handling. Consistently uses @highlight-run/ui design system components (Box, Stack, Text, icons).

--- a/frontend/src/pages/IntegrationsPage/Integrations.tsx
+++ b/frontend/src/pages/IntegrationsPage/Integrations.tsx
@@ -53,12 +53,15 @@ export enum NewIntegrationIssueType {
 	LinkIssue = 'link_issue',
 }
 
+export type IntegrationCategory = 'Issue Tracker' | 'Communication' | 'Deployment' | 'Data' | 'Automation'
+
 export interface Integration {
 	key: string
 	name: string
 	externalLink?: string
 	configurationPath: string
 	description: string
+	category: IntegrationCategory
 	defaultEnable?: boolean
 	icon: string
 	noRoundedIcon?: boolean
@@ -75,6 +78,7 @@ export interface Integration {
 }
 
 export const SLACK_INTEGRATION: Integration = {
+	category: 'Communication',
 	key: 'slack',
 	name: 'Slack',
 	configurationPath: 'slack',
@@ -86,6 +90,7 @@ export const SLACK_INTEGRATION: Integration = {
 }
 
 export const MICROSOFT_TEAMS_INTEGRATION: Integration = {
+	category: 'Communication',
 	key: 'microsoft_teams',
 	name: 'Microsoft Teams',
 	configurationPath: 'microsoft_teams',
@@ -96,6 +101,7 @@ export const MICROSOFT_TEAMS_INTEGRATION: Integration = {
 }
 
 export const HEROKU_INTEGRATION: Integration = {
+	category: 'Deployment',
 	key: 'heroku',
 	name: 'Heroku',
 	configurationPath: 'heroku',
@@ -106,6 +112,7 @@ export const HEROKU_INTEGRATION: Integration = {
 }
 
 export const CLOUDFLARE_INTEGRATION: Integration = {
+	category: 'Deployment',
 	key: 'cloudflare',
 	name: 'Cloudflare',
 	configurationPath: 'cloudflare',
@@ -117,6 +124,7 @@ export const CLOUDFLARE_INTEGRATION: Integration = {
 }
 
 export const LINEAR_INTEGRATION: IssueTrackerIntegration = {
+	category: 'Issue Tracker',
 	key: 'linear',
 	name: 'Linear',
 	configurationPath: 'linear',
@@ -131,6 +139,7 @@ export const LINEAR_INTEGRATION: IssueTrackerIntegration = {
 }
 
 export const JIRA_INTEGRATION: IssueTrackerIntegration = {
+	category: 'Issue Tracker',
 	key: 'jira',
 	name: 'Jira',
 	configurationPath: 'jira',
@@ -145,6 +154,7 @@ export const JIRA_INTEGRATION: IssueTrackerIntegration = {
 }
 
 export const GITLAB_INTEGRATION: IssueTrackerIntegration = {
+	category: 'Issue Tracker',
 	key: 'gitlab',
 	name: 'GitLab',
 	configurationPath: 'gitlab',
@@ -159,6 +169,7 @@ export const GITLAB_INTEGRATION: IssueTrackerIntegration = {
 }
 
 export const ZAPIER_INTEGRATION: Integration = {
+	category: 'Automation',
 	key: 'zapier',
 	name: 'Zapier',
 	configurationPath: 'zapier',
@@ -170,6 +181,7 @@ export const ZAPIER_INTEGRATION: Integration = {
 }
 
 export const CLEARBIT_INTEGRATION: Integration = {
+	category: 'Data',
 	key: 'clearbit',
 	name: 'Clearbit',
 	configurationPath: 'clearbit',
@@ -180,6 +192,7 @@ export const CLEARBIT_INTEGRATION: Integration = {
 }
 
 export const VERCEL_INTEGRATION: Integration = {
+	category: 'Deployment',
 	key: 'vercel',
 	name: 'Vercel',
 	configurationPath: 'vercel',
@@ -192,6 +205,7 @@ export const VERCEL_INTEGRATION: Integration = {
 }
 
 export const DISCORD_INTEGRATION: Integration = {
+	category: 'Communication',
 	key: 'discord',
 	name: 'Discord',
 	configurationPath: 'discord',
@@ -202,6 +216,7 @@ export const DISCORD_INTEGRATION: Integration = {
 }
 
 export const CLICKUP_INTEGRATION: IssueTrackerIntegration = {
+	category: 'Issue Tracker',
 	key: 'clickup',
 	name: 'ClickUp',
 	configurationPath: 'clickup',
@@ -217,6 +232,7 @@ export const CLICKUP_INTEGRATION: IssueTrackerIntegration = {
 }
 
 export const HEIGHT_INTEGRATION: IssueTrackerIntegration = {
+	category: 'Issue Tracker',
 	key: 'height',
 	name: 'Height',
 	configurationPath: 'height',
@@ -232,6 +248,7 @@ export const HEIGHT_INTEGRATION: IssueTrackerIntegration = {
 }
 
 export const GITHUB_INTEGRATION: IssueTrackerIntegration = {
+	category: 'Issue Tracker',
 	key: 'github',
 	name: 'GitHub',
 	configurationPath: 'github',

--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
@@ -1,9 +1,62 @@
-.integrationsContainer {
+.integrationsGrid {
 	display: grid;
-	grid-gap: var(--size-large);
-	grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+	grid-gap: var(--size-medium);
+	grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
 }
+
+.searchWrapper {
+	max-width: 400px;
+	background: var(--color-white);
+	transition: border-color 0.2s ease;
+}
+
+.searchWrapper:focus-within {
+	border-color: var(--color-purple-400);
+}
+
+.searchInput {
+	width: 100%;
+	border: none;
+	outline: none;
+	background: transparent;
+	font-size: 14px;
+	color: var(--color-gray-700);
+	flex: 1;
+}
+
+.searchInput::placeholder {
+	color: var(--color-gray-400);
+}
+
+.categoryTab {
+	transition: all 0.15s ease;
+	border: 1px solid var(--color-gray-300);
+	background: var(--color-white);
+	color: var(--color-gray-600);
+}
+
+.categoryTab:hover {
+	background: var(--color-gray-50);
+}
+
+.categoryTabActive {
+	background: var(--color-purple-100);
+	border-color: var(--color-purple-400);
+}
+
 .modalBtn {
 	padding-bottom: 4px !important;
 	padding-top: 4px !important;
+}
+
+@media (min-width: 1024px) {
+	.integrationsGrid {
+		grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+	}
+}
+
+@media (min-width: 1280px) {
+	.integrationsGrid {
+		grid-template-columns: repeat(3, 1fr);
+	}
 }

--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
@@ -12,11 +12,21 @@ import Integration from '@pages/IntegrationsPage/components/Integration'
 import { useLinearIntegration } from '@pages/IntegrationsPage/components/LinearIntegration/utils'
 import { useVercelIntegration } from '@pages/IntegrationsPage/components/VercelIntegration/utils'
 import { useZapierIntegration } from '@pages/IntegrationsPage/components/ZapierIntegration/utils'
-import INTEGRATIONS from '@pages/IntegrationsPage/Integrations'
+import INTEGRATIONS, {
+	type IntegrationCategory,
+	type Integration as IntegrationType,
+} from '@pages/IntegrationsPage/Integrations'
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
 import analytics from '@util/analytics'
 import { useParams } from '@util/react-router/useParams'
-import { useEffect, useMemo } from 'react'
+import {
+	Box,
+	IconSolidSearch,
+	IconSolidSwitchHorizontal,
+	Stack,
+	Text,
+} from '@highlight-run/ui/components'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { StringParam, useQueryParam } from 'use-query-params'
 
@@ -24,8 +34,47 @@ import { useGitlabIntegration } from '@/pages/IntegrationsPage/components/Gitlab
 import { useJiraIntegration } from '@/pages/IntegrationsPage/components/JiraIntegration/utils'
 import { useMicrosoftTeamsBot } from '@/pages/IntegrationsPage/components/MicrosoftTeamsIntegration/utils'
 
-import layoutStyles from '../../components/layout/LeadAlignLayout.module.css'
 import styles from './IntegrationsPage.module.css'
+
+const CATEGORY_CONFIG: Record<
+	IntegrationCategory,
+	{ label: string; description: string }
+> = {
+	'Issue Tracker': {
+		label: 'Issue Trackers',
+		description:
+			'Create and link issues from your Highlight comments and errors.',
+	},
+	Communication: {
+		label: 'Communication',
+		description:
+			'Receive alerts and notifications in your team communication tools.',
+	},
+	Deployment: {
+		label: 'Deployment & CI/CD',
+		description:
+			'Connect your deployment pipeline for enhanced tracing and visibility.',
+	},
+	Data: {
+		label: 'Data & Analytics',
+		description:
+			'Enhance your monitoring stack with additional data sources.',
+	},
+	Automation: {
+		label: 'Automation',
+		description:
+			'Automate workflows and connect Highlight with other tools.',
+	},
+}
+
+const CATEGORY_TABS: Array<IntegrationCategory | 'all'> = [
+	'all',
+	'Issue Tracker',
+	'Communication',
+	'Deployment',
+	'Data',
+	'Automation',
+]
 
 const IntegrationsPage = () => {
 	const { isSlackConnectedToWorkspace, loading: loadingSlack } = useSlackBot()
@@ -129,7 +178,9 @@ const IntegrationsPage = () => {
 				if (integration.allowlistWorkspaceIds && workspaceID) {
 					canSee =
 						canSee ||
-						integration.allowlistWorkspaceIds?.includes(workspaceID)
+						integration.allowlistWorkspaceIds?.includes(
+							workspaceID,
+						)
 				}
 
 				if (integration.onlyShowForHighlightAdmin) {
@@ -179,6 +230,93 @@ const IntegrationsPage = () => {
 		isCloudflareConnectedToWorkspace,
 	])
 
+	const [searchQuery, setSearchQuery] = useState('')
+	const [activeCategory, setActiveCategory] = useState<
+		IntegrationCategory | 'all'
+	>('all')
+
+	const filteredIntegrations = useMemo(() => {
+		return integrations.filter((integration) => {
+			const matchesSearch =
+				!searchQuery ||
+				integration.name
+					.toLowerCase()
+					.includes(searchQuery.toLowerCase()) ||
+				integration.description
+					.toLowerCase()
+					.includes(searchQuery.toLowerCase())
+
+			const matchesCategory =
+				activeCategory === 'all' ||
+				integration.category === activeCategory
+
+			return matchesSearch && matchesCategory
+		})
+	}, [integrations, searchQuery, activeCategory])
+
+	const categorizedGroups = useMemo(() => {
+		const filtered =
+			activeCategory === 'all'
+				? integrations
+				: integrations.filter((i) => i.category === activeCategory)
+
+		const keysByCategory: Record<IntegrationCategory, string[]> = {
+			'Issue Tracker': [
+				'linear',
+				'github',
+				'jira',
+				'gitlab',
+				'clickup',
+				'height',
+			],
+			Communication: ['slack', 'discord', 'microsoft_teams'],
+			Deployment: ['vercel', 'cloudflare', 'heroku'],
+			Data: ['clearbit'],
+			Automation: ['zapier'],
+		}
+
+		const integrationMap = new Map<string, IntegrationType>()
+		for (const i of filtered) {
+			integrationMap.set(i.key, i)
+		}
+
+		const catOrder: IntegrationCategory[] = [
+			'Issue Tracker',
+			'Communication',
+			'Deployment',
+			'Data',
+			'Automation',
+		]
+
+		const seen = new Set<IntegrationCategory>()
+		for (const i of filtered) {
+			seen.add(i.category)
+		}
+
+		return catOrder
+			.filter((cat) => seen.has(cat))
+			.map((cat) => ({
+				category: cat,
+				label: CATEGORY_CONFIG[cat].label,
+				description: CATEGORY_CONFIG[cat].description,
+				items: keysByCategory[cat]
+					.map((key) => integrationMap.get(key))
+					.filter(
+						(i): i is IntegrationType => i !== undefined,
+					),
+			}))
+			.filter((group) => group.items.length > 0)
+	}, [integrations, activeCategory])
+
+	const handleSearchChange = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			setSearchQuery(e.target.value)
+		},
+		[],
+	)
+
+	const hasResults = filteredIntegrations.length > 0
+
 	useEffect(() => analytics.page('Integrations'), [])
 
 	return (
@@ -187,24 +325,136 @@ const IntegrationsPage = () => {
 				<title>Integrations</title>
 			</Helmet>
 			<LeadAlignLayout>
-				<h2>Integrations</h2>
-				<p className={layoutStyles.subTitle}>
-					Supercharge your workflows and attach Highlight with the
-					tools you use everyday.
-				</p>
-				<div className={styles.integrationsContainer}>
-					{integrations.map((integration) => (
-						<Integration
-							integration={integration}
-							key={integration.key}
-							showModalDefault={popUpModal === integration.key}
-							showSettingsDefault={
-								configureIntegration === integration.key
-							}
-							loading={loading}
+				<Stack direction="column" gap="24" width="full">
+					{/* Header */}
+					<Box>
+						<h2>Integrations</h2>
+						<Text color="n11" size="small">
+							Connect Highlight with the tools you use everyday.
+						</Text>
+					</Box>
+
+					{/* Search bar */}
+					<Box
+						display="flex"
+						alignItems="center"
+						gap="8"
+						p="8"
+						px="12"
+						border="dividerWeak"
+						borderRadius="8"
+						cssClass={styles.searchWrapper}
+					>
+						<IconSolidSearch size={16} />
+						<Box
+							as="input"
+							type="text"
+							placeholder="Search integrations..."
+							value={searchQuery}
+							onChange={handleSearchChange}
+							cssClass={styles.searchInput}
 						/>
-					))}
-				</div>
+					</Box>
+
+					{/* Category tabs */}
+					<Box display="flex" gap="8" flexWrap="wrap">
+						{CATEGORY_TABS.map((tab) => {
+							const isActive = tab === activeCategory
+							return (
+								<Box
+									key={tab}
+									as="button"
+									onClick={() =>
+										setActiveCategory(
+											tab as
+												| IntegrationCategory
+												| 'all',
+										)
+									}
+									p="6"
+									px="12"
+									borderRadius="6"
+									cursor="pointer"
+									cssClass={[
+										styles.categoryTab,
+										isActive && styles.categoryTabActive,
+									]}
+								>
+									<Text
+										size="small"
+										color={isActive ? 'p11' : 'n11'}
+										weight={
+											isActive ? 'bold' : 'regular'
+										}
+									>
+										{tab === 'all'
+											? 'All'
+											: CATEGORY_CONFIG[tab].label}
+									</Text>
+								</Box>
+							)
+						})}
+					</Box>
+
+					{/* Integration cards */}
+					{hasResults ? (
+						<Stack direction="column" gap="32">
+							{categorizedGroups.map((group) => (
+								<Box key={group.category}>
+									<Box
+										display="flex"
+										flexDirection="column"
+										gap="4"
+										mb="12"
+									>
+										<Text
+											size="small"
+											weight="bold"
+											color="strong"
+										>
+											{group.label}
+										</Text>
+										<Text size="xSmall" color="n11">
+											{group.description}
+										</Text>
+									</Box>
+									<div className={styles.integrationsGrid}>
+										{group.items.map((integration) => (
+											<Integration
+												integration={integration}
+												key={integration.key}
+												showModalDefault={
+													popUpModal ===
+													integration.key
+												}
+												showSettingsDefault={
+													configureIntegration ===
+													integration.key
+												}
+												loading={loading}
+											/>
+										))}
+									</div>
+								</Box>
+							))}
+						</Stack>
+					) : (
+						<Stack
+							direction="column"
+							alignItems="center"
+							gap="12"
+							py="48"
+						>
+							<IconSolidSwitchHorizontal size={32} />
+							<Text color="n11" size="small">
+								No integrations found
+							</Text>
+							<Text color="n9" size="xSmall">
+								Try adjusting your search or filter.
+							</Text>
+						</Stack>
+					)}
+				</Stack>
 			</LeadAlignLayout>
 		</>
 	)

--- a/frontend/src/pages/IntegrationsPage/components/Integration.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.module.css
@@ -1,26 +1,99 @@
 .integration {
+	transition: all 0.2s ease;
+	border: 1px solid var(--divider);
+	background: var(--color-white);
+
+	&:hover {
+		border-color: var(--color-purple-400);
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+	}
+
+	& .logoContainer {
+		display: flex;
+		align-items: center;
+		gap: var(--size-small);
+	}
+
 	& .logo {
 		border-radius: 50%;
 		height: var(--size-xxLarge);
 		width: var(--size-xxLarge);
+		object-fit: cover;
+	}
+
+	& .connectedBadge {
+		display: inline-flex;
+		align-items: center;
+		padding: 2px 8px;
+		background: var(--color-green-100);
+		color: var(--color-green-700);
+		border-radius: 12px;
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.5px;
 	}
 
 	& .header {
 		align-items: flex-start;
 		display: flex;
 		justify-content: space-between;
-		padding-bottom: var(--size-small);
+		padding-bottom: var(--size-medium);
 	}
 
-	& .connectButton {
-		text-transform: uppercase;
+	& .actions {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		gap: var(--size-xxSmall);
+	}
+
+	& .settingsButton {
+		display: flex;
+		height: 18px;
+		width: 100%;
+		justify-content: flex-end;
+	}
+
+	& .content {
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-xxSmall);
 	}
 
 	& .title {
-		margin-bottom: var(--size-small) !important;
+		margin-bottom: 0 !important;
+		font-size: 15px;
+		font-weight: 600;
+		color: var(--text-primary);
 	}
 
 	& .description {
 		margin-bottom: 0 !important;
+		font-size: 13px;
+		color: var(--text-secondary);
+		line-height: 1.5;
+	}
+
+	& .docsLink {
+		display: inline-block;
+		margin-top: var(--size-xxSmall);
+		font-size: 13px;
+		color: var(--color-purple-500);
+		text-decoration: none;
+		font-weight: 500;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.integrationConnected {
+	border-color: var(--color-green-300);
+	background: var(--color-green-50);
+
+	&:hover {
+		border-color: var(--color-green-500);
 	}
 }

--- a/frontend/src/pages/IntegrationsPage/components/Integration.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.tsx
@@ -59,9 +59,10 @@ const Integration = ({
 	useEffect(() => {
 		setIntegrationEnabled(defaultEnable)
 	}, [defaultEnable, setIntegrationEnabled])
+
 	if (loading) {
 		return (
-			<Card>
+			<Card className={styles.integration}>
 				<LoadingBox height={156} />
 			</Card>
 		)
@@ -69,22 +70,36 @@ const Integration = ({
 
 	const isGated = name === 'Jira' || name === 'Microsoft Teams'
 	const enterpriseSetting =
-		name === 'Jira' ? 'enable_jira_integration' : 'enable_teams_integration'
+		name === 'Jira'
+			? 'enable_jira_integration'
+			: 'enable_teams_integration'
 	const enterpriseName =
 		name === 'Jira' ? 'Jira Integration' : 'Teams Integration'
 
 	return (
 		<>
-			<Card className={styles.integration} interactable>
+			<Card
+				className={clsx(styles.integration, {
+					[styles.integrationConnected]: integrationEnabled,
+				})}
+				interactable
+			>
 				<div className={styles.header}>
-					<img
-						src={icon}
-						alt=""
-						className={clsx(styles.logo, {
-							['rounded-none']: noRoundedIcon,
-						})}
-					/>
-					<div className="flex flex-col gap-2">
+					<div className={styles.logoContainer}>
+						<img
+							src={icon}
+							alt=""
+							className={clsx(styles.logo, {
+								['rounded-none']: noRoundedIcon,
+							})}
+						/>
+						{integrationEnabled && (
+							<span className={styles.connectedBadge}>
+								Connected
+							</span>
+						)}
+					</div>
+					<div className={styles.actions}>
 						{isGated ? (
 							<EnterpriseFeatureButton
 								setting={enterpriseSetting}
@@ -103,7 +118,8 @@ const Integration = ({
 								<Switch
 									trackingId={`IntegrationConnect-${name}`}
 									label={
-										!showConfiguration && integrationEnabled
+										!showConfiguration &&
+										integrationEnabled
 											? 'Connected'
 											: 'Connect'
 									}
@@ -126,7 +142,8 @@ const Integration = ({
 										: 'Connect'
 								}
 								loading={
-									(showConfiguration && integrationEnabled) ||
+									(showConfiguration &&
+										integrationEnabled) ||
 									(showDeleteConfirmation &&
 										!integrationEnabled)
 								}
@@ -144,7 +161,7 @@ const Integration = ({
 							/>
 						)}
 						{hasSettings && (
-							<div className="flex h-[18px] w-full justify-end">
+							<div className={styles.settingsButton}>
 								<Button
 									trackingId="IntegrationSettings"
 									iconButton
@@ -159,17 +176,17 @@ const Integration = ({
 						)}
 					</div>
 				</div>
-				<div>
+				<div className={styles.content}>
 					<h2 className={styles.title}>{name}</h2>
 					<p className={styles.description}>{description}</p>
 					{docs && (
 						<a
-							className={styles.description}
+							className={styles.docsLink}
 							href={docs}
 							target="_blank"
 							rel="noopener noreferrer"
 						>
-							Learn more about the integration.
+							View documentation →
 						</a>
 					)}
 				</div>


### PR DESCRIPTION
## Summary

Redesigns the integrations page with search, category filters, grouped sections, connected badges, hover effects, and empty state handling.

### Changes

- **Search bar** - filter integrations by name/description
- **Category filter tabs** - pill-style using Highlight Box component
- **Category field** - IntegrationCategory type + category on all definitions
- **Grouped sections** - category headers with descriptions
- **Connected badge** - green chip when integration is enabled
- **Hover effects** - purple border + shadow on card hover
- **Documentation links** - "View documentation" link
- **Empty state** - icon + message when no results
- **Responsive grid** - 3 cols on large screens
- **@highlight-run/ui** components throughout (Box, Stack, Text, icons)

### Files changed
- Integrations.tsx (category field)
- IntegrationsPage.tsx (search, tabs, groups, empty state)
- IntegrationsPage.module.css (search, responsive grid)
- Integration.tsx (connected badge, hover, docs link)
- Integration.module.css (badge, hover, connected styles)
- .changeset/integrations-page-redesign.md

Closes #8614
$250 bounty from Algora