### PR TITLE
fix(rrweb): avoid Safari canvas snapshot resize stalls

### DIFF
--- a/.changeset/quiet-pumas-resize.md
+++ b/.changeset/quiet-pumas-resize.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+Avoid Safari canvas snapshot stalls by pre-scaling canvas and video frames before creating ImageBitmaps.

--- a/__generated/rr/rrweb/rr.js
+++ b/__generated/rr/rrweb/rr.js
@@ -13799,6 +13799,37 @@ var CanvasManager = class {
     }
     this.logger.debug(prefix, element, ...args);
   }
+  shouldAvoidImageBitmapResizeOptions() {
+    var _a2, _b;
+    const navigator2 = (_b = (_a2 = this.options) == null ? void 0 : _a2.win) == null ? void 0 : _b.navigator;
+    if (!navigator2) return false;
+    const userAgent = navigator2.userAgent || "";
+    return navigator2.vendor === "Apple Computer, Inc." || /Safari/i.test(userAgent) && !/(Chrome|Chromium|CriOS|FxiOS|Edg|OPR|Android)/i.test(userAgent);
+  }
+  async createSnapshotBitmap(source, width, height) {
+    const resizeWidth = Math.max(1, Math.round(width));
+    const resizeHeight = Math.max(1, Math.round(height));
+    if (!this.shouldAvoidImageBitmapResizeOptions()) {
+      return createImageBitmap(source, {
+        resizeWidth,
+        resizeHeight
+      });
+    }
+    const win = this.options.win;
+    const scaledCanvas = typeof OffscreenCanvas !== "undefined" ? new OffscreenCanvas(resizeWidth, resizeHeight) : win.document.createElement("canvas");
+    scaledCanvas.width = resizeWidth;
+    scaledCanvas.height = resizeHeight;
+    const context = scaledCanvas.getContext("2d");
+    if (!context) {
+      return createImageBitmap(source, {
+        resizeWidth,
+        resizeHeight
+      });
+    }
+    context.imageSmoothingEnabled = true;
+    context.drawImage(source, 0, 0, resizeWidth, resizeHeight);
+    return createImageBitmap(scaledCanvas);
+  }
   async snapshot(canvas) {
     var _a2;
     const id = this.mirror.getId(canvas);
@@ -13843,12 +13874,9 @@ var CanvasManager = class {
         const maxDim = Math.max(canvas.width, canvas.height);
         scale = Math.min(scale, this.options.maxSnapshotDimension / maxDim);
       }
-      const width = canvas.width * scale;
-      const height = canvas.height * scale;
-      const bitmap = await createImageBitmap(canvas, {
-        resizeWidth: width,
-        resizeHeight: height
-      });
+      const width = Math.max(1, Math.round(canvas.width * scale));
+      const height = Math.max(1, Math.round(canvas.height * scale));
+      const bitmap = await this.createSnapshotBitmap(canvas, width, height);
       this.debug(canvas, "created image bitmap", {
         width: bitmap.width,
         height: bitmap.height
@@ -13993,12 +14021,9 @@ var CanvasManager = class {
             if (maxSnapshotDimension) {
               scale = Math.min(scale, maxSnapshotDimension / maxDim);
             }
-            const width = actualWidth * scale;
-            const height = actualHeight * scale;
-            const bitmap = await createImageBitmap(video, {
-              resizeWidth: width,
-              resizeHeight: height
-            });
+            const width = Math.max(1, Math.round(actualWidth * scale));
+            const height = Math.max(1, Math.round(actualHeight * scale));
+            const bitmap = await this.createSnapshotBitmap(video, width, height);
             const outputScale = Math.max(boxWidth, boxHeight) / maxDim;
             const outputWidth = actualWidth * outputScale;
             const outputHeight = actualHeight * outputScale;


### PR DESCRIPTION
/claim #6775

## Summary

Fixes the Safari/WebKit canvas snapshot hot path by avoiding `createImageBitmap(source, { resizeWidth, resizeHeight })` for Apple WebKit browsers.

Safari/iOS WebKit can perform the resize-options path synchronously on the main thread, which causes the frame stalls described in #6775. This PR pre-scales canvas/video frames into a temporary canvas on Apple WebKit, then calls `createImageBitmap` on the already-sized canvas without resize options.

## What changed

- Adds a shared `createSnapshotBitmap()` helper in the generated rrweb bundle.
- Keeps Chromium/Firefox/Edge on the existing `createImageBitmap(..., resize options)` path.
- Uses the manual pre-scale path for Apple WebKit browsers, including iOS WebKit browsers where the issue was also reported.
- Applies the helper to both:
  - canvas snapshots
  - video snapshots
- Rounds/clamps target bitmap dimensions to valid integer pixels.
- Adds a patch changeset for `highlight.run`.

## Why this differs from prior attempts

Several open PRs already target this issue. This version is intentionally small, generated-bundle-only, and avoids changing the rrweb submodule pointer or `.gitmodules`.

It also does not exclude iOS Chrome (`CriOS`) from the Apple WebKit workaround. On iOS, Chrome still uses WebKit, and the issue thread specifically notes that iOS 17 is affected. Desktop Chrome/Chromium/Edge/Firefox remain on the existing path.

## Validation

Local static gates:

```text
node --check __generated/rr/rrweb/rr.js
# exit 0

git diff --check
# exit 0

static canvas patch assertions
# confirmed both canvas and video hot paths now call createSnapshotBitmap()
```

Artifacts saved during validation:

- `node_check_rr_js.log`
- `git_diff_check.log`
- `static_canvas_patch_check.log`
- `our_patch.diff`

## Demo note

I attempted to run a local Playwright WebKit benchmark, but this Linux worker does not have Playwright browser binaries installed and the filesystem was near-full, so I did not download browsers during this PR prep. The attempted benchmark script and launch failure are captured in `canvas_snapshot_benchmark.log`.

Closes #6775
