### PR TITLE
feat(integrations): refresh integrations page design

### DIFF
--- a/.changeset/lucky-lobsters-integrate.md
+++ b/.changeset/lucky-lobsters-integrate.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+Refresh the integrations page layout with search, connected summaries, and updated integration cards.

--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
@@ -1,9 +1,129 @@
+.pageHeader {
+	align-items: flex-start;
+	background:
+		linear-gradient(135deg, rgba(86, 67, 255, 0.1), rgba(56, 189, 248, 0.06)),
+		var(--color-primary-background);
+	border: 1px solid var(--color-gray-300);
+	border-radius: var(--border-radius);
+	display: flex;
+	gap: var(--size-large);
+	justify-content: space-between;
+	margin-bottom: var(--size-large);
+	padding: var(--size-large);
+}
+
+.eyebrow {
+	color: var(--color-purple-600);
+	font-size: 12px;
+	font-weight: 600;
+	letter-spacing: 0.08em;
+	margin-bottom: var(--size-xSmall) !important;
+	text-transform: uppercase;
+}
+
+.pageTitle {
+	margin-bottom: var(--size-small) !important;
+}
+
+.summaryCards {
+	display: flex;
+	flex-shrink: 0;
+	gap: var(--size-small);
+}
+
+.summaryCard {
+	background: var(--color-primary-background);
+	border: 1px solid var(--color-gray-300);
+	border-radius: var(--border-radius);
+	box-shadow: 0 8px 24px rgba(18, 20, 31, 0.06);
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 112px;
+	padding: var(--size-medium);
+}
+
+.summaryCard strong {
+	font-size: 28px;
+	line-height: 1;
+}
+
+.summaryCard span {
+	color: var(--color-gray-500);
+	font-size: 13px;
+}
+
+.toolbar {
+	align-items: center;
+	display: flex;
+	justify-content: space-between;
+	margin-bottom: var(--size-large);
+}
+
+.searchLabel {
+	color: var(--color-gray-500);
+	font-size: 13px;
+	font-weight: 600;
+}
+
+.searchInput {
+	background: var(--color-primary-background);
+	border: 1px solid var(--color-gray-300);
+	border-radius: 999px;
+	min-width: min(100%, 320px);
+	padding: 10px 16px;
+	transition:
+		border-color 120ms ease,
+		box-shadow 120ms ease;
+}
+
+.searchInput:focus {
+	border-color: var(--color-purple-500);
+	box-shadow: 0 0 0 3px rgba(86, 67, 255, 0.14);
+	outline: none;
+}
+
 .integrationsContainer {
 	display: grid;
 	grid-gap: var(--size-large);
-	grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+	grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
+
+.emptyState {
+	align-items: center;
+	border: 1px dashed var(--color-gray-300);
+	border-radius: var(--border-radius);
+	color: var(--color-gray-500);
+	display: flex;
+	flex-direction: column;
+	gap: var(--size-xSmall);
+	margin-top: var(--size-large);
+	padding: var(--size-xxLarge);
+	text-align: center;
+}
+
+.emptyState h3,
+.emptyState p {
+	margin: 0 !important;
+}
+
 .modalBtn {
 	padding-bottom: 4px !important;
 	padding-top: 4px !important;
+}
+
+@media screen and (max-width: 768px) {
+	.pageHeader,
+	.toolbar {
+		flex-direction: column;
+	}
+
+	.summaryCards,
+	.searchInput {
+		width: 100%;
+	}
+
+	.summaryCard {
+		flex: 1;
+	}
 }

--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
@@ -16,7 +16,7 @@ import INTEGRATIONS from '@pages/IntegrationsPage/Integrations'
 import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
 import analytics from '@util/analytics'
 import { useParams } from '@util/react-router/useParams'
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { StringParam, useQueryParam } from 'use-query-params'
 
@@ -35,6 +35,7 @@ const IntegrationsPage = () => {
 	}>()
 
 	const [popUpModal] = useQueryParam('enable', StringParam)
+	const [searchQuery, setSearchQuery] = useState('')
 
 	const { isHighlightAdmin } = useAuthContext()
 	const { currentWorkspace } = useApplicationContext()
@@ -179,6 +180,33 @@ const IntegrationsPage = () => {
 		isCloudflareConnectedToWorkspace,
 	])
 
+	const connectedIntegrations = useMemo(
+		() => integrations.filter((integration) => integration.defaultEnable),
+		[integrations],
+	)
+	const availableIntegrations = useMemo(
+		() => integrations.filter((integration) => !integration.defaultEnable),
+		[integrations],
+	)
+	const filteredIntegrations = useMemo(() => {
+		const normalizedSearch = searchQuery.trim().toLowerCase()
+		const sortedIntegrations = [
+			...connectedIntegrations,
+			...availableIntegrations,
+		]
+
+		if (!normalizedSearch) {
+			return sortedIntegrations
+		}
+
+		return sortedIntegrations.filter((integration) =>
+			[integration.name, integration.description]
+				.join(' ')
+				.toLowerCase()
+				.includes(normalizedSearch),
+		)
+	}, [availableIntegrations, connectedIntegrations, searchQuery])
+
 	useEffect(() => analytics.page('Integrations'), [])
 
 	return (
@@ -187,13 +215,43 @@ const IntegrationsPage = () => {
 				<title>Integrations</title>
 			</Helmet>
 			<LeadAlignLayout>
-				<h2>Integrations</h2>
-				<p className={layoutStyles.subTitle}>
-					Supercharge your workflows and attach Highlight with the
-					tools you use everyday.
-				</p>
+				<section className={styles.pageHeader}>
+					<div>
+						<p className={styles.eyebrow}>Workspace integrations</p>
+						<h2 className={styles.pageTitle}>Connect your workflow</h2>
+						<p className={layoutStyles.subTitle}>
+							Supercharge your workflows and attach Highlight with the
+							tools you use everyday.
+						</p>
+					</div>
+					<div className={styles.summaryCards}>
+						<div className={styles.summaryCard}>
+							<strong>{connectedIntegrations.length}</strong>
+							<span>Connected</span>
+						</div>
+						<div className={styles.summaryCard}>
+							<strong>{availableIntegrations.length}</strong>
+							<span>Available</span>
+						</div>
+					</div>
+				</section>
+
+				<div className={styles.toolbar}>
+					<label className={styles.searchLabel} htmlFor="integration-search">
+						Search integrations
+					</label>
+					<input
+						id="integration-search"
+						className={styles.searchInput}
+						type="search"
+						placeholder="Search by app or workflow"
+						value={searchQuery}
+						onChange={(event) => setSearchQuery(event.target.value)}
+					/>
+				</div>
+
 				<div className={styles.integrationsContainer}>
-					{integrations.map((integration) => (
+					{filteredIntegrations.map((integration) => (
 						<Integration
 							integration={integration}
 							key={integration.key}
@@ -205,6 +263,12 @@ const IntegrationsPage = () => {
 						/>
 					))}
 				</div>
+				{filteredIntegrations.length === 0 && (
+					<div className={styles.emptyState}>
+						<h3>No integrations found</h3>
+						<p>Try a different search term or clear the search field.</p>
+					</div>
+				)}
 			</LeadAlignLayout>
 		</>
 	)

--- a/frontend/src/pages/IntegrationsPage/components/Integration.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.module.css
@@ -1,15 +1,33 @@
 .integration {
+	border: 1px solid var(--color-gray-300);
+	box-shadow: 0 8px 24px rgba(18, 20, 31, 0.06);
+	min-height: 204px;
+	transition:
+		border-color 120ms ease,
+		box-shadow 120ms ease,
+		transform 120ms ease;
+
+	&:hover {
+		border-color: var(--color-purple-400);
+		box-shadow: 0 14px 36px rgba(18, 20, 31, 0.1);
+		transform: translateY(-2px);
+	}
+
 	& .logo {
-		border-radius: 50%;
-		height: var(--size-xxLarge);
-		width: var(--size-xxLarge);
+		background: var(--color-primary-background);
+		border: 1px solid var(--color-gray-300);
+		border-radius: 18px;
+		height: 48px;
+		object-fit: contain;
+		padding: 8px;
+		width: 48px;
 	}
 
 	& .header {
 		align-items: flex-start;
 		display: flex;
 		justify-content: space-between;
-		padding-bottom: var(--size-small);
+		padding-bottom: var(--size-medium);
 	}
 
 	& .connectButton {
@@ -17,10 +35,41 @@
 	}
 
 	& .title {
-		margin-bottom: var(--size-small) !important;
+		font-size: 18px;
+		line-height: 1.25;
+		margin: 0 !important;
 	}
 
 	& .description {
+		color: var(--color-gray-500);
+		line-height: 1.45;
 		margin-bottom: 0 !important;
 	}
+}
+
+.connected {
+	border-color: rgba(22, 163, 74, 0.35);
+}
+
+.titleRow {
+	align-items: center;
+	display: flex;
+	gap: var(--size-small);
+	justify-content: space-between;
+	margin-bottom: var(--size-small);
+}
+
+.statusBadge {
+	background: var(--color-gray-200);
+	border-radius: 999px;
+	color: var(--color-gray-600);
+	font-size: 12px;
+	font-weight: 600;
+	line-height: 1;
+	padding: 6px 10px;
+}
+
+.connected .statusBadge {
+	background: rgba(22, 163, 74, 0.12);
+	color: rgb(22, 101, 52);
 }

--- a/frontend/src/pages/IntegrationsPage/components/Integration.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.tsx
@@ -75,7 +75,12 @@ const Integration = ({
 
 	return (
 		<>
-			<Card className={styles.integration} interactable>
+			<Card
+				className={clsx(styles.integration, {
+					[styles.connected]: integrationEnabled,
+				})}
+				interactable
+			>
 				<div className={styles.header}>
 					<img
 						src={icon}
@@ -160,7 +165,12 @@ const Integration = ({
 					</div>
 				</div>
 				<div>
-					<h2 className={styles.title}>{name}</h2>
+					<div className={styles.titleRow}>
+						<h2 className={styles.title}>{name}</h2>
+						<span className={styles.statusBadge}>
+							{integrationEnabled ? 'Connected' : 'Available'}
+						</span>
+					</div>
 					<p className={styles.description}>{description}</p>
 					{docs && (
 						<a


### PR DESCRIPTION
/claim #8614

## Summary

Refreshes the integrations page with a more structured landing experience while keeping the existing integration setup/settings behavior intact.

## Changes

- Adds a redesigned page header/hero with clearer page framing.
- Adds connected and available integration summary counts.
- Sorts connected integrations first so active workflows are easier to find.
- Adds search over integration name/description with an empty state.
- Updates integration cards with:
  - stronger hover/focus visual treatment
  - larger app icons
  - connected/available status badges
  - connected-card border treatment
- Adds a patch changeset for `highlight.run`.

## Notes on existing PRs

There are many previous attempts on this issue. This PR is intentionally scoped to a small, reviewable design refresh of the current page instead of a broad router/modal rewrite, and it avoids touching generated CSS or unrelated settings pages.

## Validation

Local checks run:

```text
git diff --check
# passed

static integrations patch assertions
# passed: verified search, connected/available summaries, empty state, card status badges, and responsive CSS hooks exist
```

I attempted to run the repo formatter through Yarn, but this checkout has no Yarn install state and the worker filesystem is almost full, so a dependency install/build was not safe in this environment. I did not fabricate a demo video from an unbuilt app.

Closes #8614
