### PR TITLE
Remove legacy ButtonLink AntD dependency

### DIFF
--- a/frontend/src/components/Button/ButtonLink/ButtonLink.tsx
+++ b/frontend/src/components/Button/ButtonLink/ButtonLink.tsx
@@ -1,11 +1,11 @@
-import Button from '@components/Button/Button/Button'
 import analytics from '@util/analytics'
-import { ButtonType } from 'antd/es/button'
 import clsx from 'clsx'
 import React from 'react'
 import { Link, LinkProps } from 'react-router-dom'
 
 import styles from './ButtonLink.module.css'
+
+type ButtonLinkType = 'default' | 'primary' | 'dashed' | 'link' | 'text'
 
 type Props = {
 	/** The ID used for identifying that this button was clicked for analytics. */
@@ -17,7 +17,7 @@ type Props = {
 	icon?: React.ReactNode
 	fullWidth?: boolean
 	disabled?: boolean
-	type?: ButtonType
+	type?: ButtonLinkType
 } & Partial<Pick<LinkProps, 'to' | 'onClick' | 'state'>>
 
 const ButtonLink: React.FC<React.PropsWithChildren<Props>> = ({
@@ -36,18 +36,18 @@ const ButtonLink: React.FC<React.PropsWithChildren<Props>> = ({
 }) => {
 	if (disabled) {
 		return (
-			<Button
-				type={type}
+			<button
+				type="button"
 				disabled
-				trackingId={trackingId}
 				className={clsx(styles.link, className, {
 					[styles.withIcon]: icon,
 					[styles.fullWidth]: fullWidth,
+					[styles.defaultButtonStyles]: type === 'default',
 				})}
 			>
 				{icon}
 				{children}
-			</Button>
+			</button>
 		)
 	}
 


### PR DESCRIPTION
## Summary
- remove the legacy Ant Design-backed Button wrapper import from `ButtonLink`
- replace the `antd/es/button` type import with a local style type union
- preserve existing anchor, router link, disabled, icon, full-width, and analytics behavior

Fixes #8635
/claim #8635

## Validation
- `npx -y prettier@3.3.3 --check frontend/src/components/Button/ButtonLink/ButtonLink.tsx`
- `npx -y esbuild@0.19.5 frontend/src/components/Button/ButtonLink/ButtonLink.tsx --bundle '--external:*' --loader:.tsx=tsx --loader:.ts=ts --format=esm --outfile=/tmp/highlight-button-link.mjs --log-level=error`
- `git diff --check`
- `rg -n "@components/Button/Button/Button|antd/es/button|from 'antd" frontend/src/components/Button/ButtonLink/ButtonLink.tsx || true`

## Demo
This is a shared wrapper cleanup with no intended visual behavior change or standalone route. The touched call sites do not currently pass `disabled`, and existing anchor/router-link behavior is unchanged.

## Notes
Prepared with AI assistance and manually reviewed before submission.
