### PR TITLE
refactor(settings): replace remaining antd components with custom @highlight-run/ui components

### DIFF
--- a/frontend/src/pages/NewProject/AutoJoinInput.tsx
+++ b/frontend/src/pages/NewProject/AutoJoinInput.tsx
@@ -1,8 +1,6 @@
 import { useAuthContext } from '@authentication/AuthContext'
 import Tooltip from '@components/Tooltip/Tooltip'
-import { Box, Text } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
+import { Box, SwitchButton, Text } from '@highlight-run/ui/components'
 import React from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -23,8 +21,9 @@ export const AutoJoinInput: React.FC<Props> = ({
 	const { admin } = useAuthContext()
 	const adminsEmailDomain = getEmailDomain(admin?.email)
 
-	const handleMessageChecked = (event: CheckboxChangeEvent) => {
-		const domains = event.target.checked ? [adminsEmailDomain] : []
+	const handleMessageChecked = () => {
+		const isCurrentlyChecked = autoJoinDomains.length > 0
+		const domains = !isCurrentlyChecked ? [adminsEmailDomain] : []
 		setAutoJoinDomains(domains)
 	}
 
@@ -43,18 +42,18 @@ export const AutoJoinInput: React.FC<Props> = ({
 		>
 			<div className={styles.container}>
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
+					<SwitchButton
 						checked={autoJoinDomains.length > 0}
 						onChange={handleMessageChecked}
 					/>
 					<Text>Allowed email domains</Text>
 				</Box>
-				<Divider className="m-0 border-none pt-1" />
+				<Box pt="4" />
 				<Text color="n11">
 					Allow everyone with a <b>{getEmailDomain(admin?.email)}</b>{' '}
 					email to join your workspace.
 				</Text>
-				<Divider className="m-0 border-none pt-1" />
+				<Box pt="4" />
 			</div>
 		</Tooltip>
 	)

--- a/frontend/src/pages/NewProject/NewProjectPage.tsx
+++ b/frontend/src/pages/NewProject/NewProjectPage.tsx
@@ -12,7 +12,6 @@ import { namedOperations } from '@graph/operations'
 import { Box, Callout, Stack, Text } from '@highlight-run/ui/components'
 import analytics from '@util/analytics'
 import { client } from '@util/graph'
-import { Divider } from 'antd'
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
@@ -147,7 +146,7 @@ const NewProjectPage = ({ workspace_id }: { workspace_id: string }) => {
 								}}
 							/>
 						</Box>
-						<Divider className="m-0" />
+						<Box borderTop="dividerWeak" width="full" />
 						<Box
 							py="8"
 							px="12"

--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -15,7 +15,6 @@ import {
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -40,7 +39,7 @@ export const GitHubSettingsModal = ({
 	githubRepos,
 	handleSave,
 	closeModal,
-}: Props) => {
+	}: Props) => {
 	const handleSubmit = (formValues: GithubSettingsFormValues) => {
 		const submittedValues = formValues.githubRepo
 			? formValues
@@ -121,7 +120,7 @@ const GithubSettingsForm = ({
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
 				id: repo.key,
-				label: repo.name.split('/').pop(),
+				name: repo.name.split('/').pop() || '',
 				value: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
@@ -151,24 +150,13 @@ const GithubSettingsForm = ({
 					name="githubRepo"
 				>
 					<Box display="flex" alignItems="center" gap="8">
-						<Select
+						<Form.Select
+							name={formStore.names.githubRepo}
 							aria-label="GitHub repository"
 							className={styles.repoSelect}
 							placeholder="Search repos..."
-							onSelect={(repo: string) =>
-								formStore.setValue(
-									formStore.names.githubRepo,
-									repo,
-								)
-							}
-							value={formState.values.githubRepo
-								?.split('/')
-								.pop()}
 							options={githubOptions}
-							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
-							filterOption
-							showSearch
+							filterable
 						/>
 						<ButtonIcon
 							kind="secondary"

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -6,9 +6,8 @@ import {
 	useUpdateAllowedEmailOriginsMutation,
 } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
-import { Box, Select, Text } from '@highlight-run/ui/components'
+import { Box, Select, SwitchButton, Text } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React, { useState } from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -61,9 +60,9 @@ export const AutoJoinForm: React.FC = () => {
 		}
 	}
 
-	const handleCheckboxChange = (event: CheckboxChangeEvent) => {
-		const checked = event.target.checked
-		if (checked) {
+	const handleCheckboxChange = () => {
+		const isCurrentlyChecked = autoJoinDomains.length > 0
+		if (!isCurrentlyChecked) {
 			onChangeMsg([adminsEmailDomain], 'Successfully enabled auto-join!')
 		} else {
 			onChangeMsg([], 'Successfully disabled auto-join!')
@@ -85,7 +84,7 @@ export const AutoJoinForm: React.FC = () => {
 		>
 			<div className={styles.container}>
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
+					<SwitchButton
 						checked={autoJoinDomains.length > 0}
 						onChange={handleCheckboxChange}
 					/>


### PR DESCRIPTION
This PR completes the migration away from Ant Design (`antd`) in the settings components:

- Replaced `<Checkbox>` with the custom `<SwitchButton>` component in both `AutoJoinInput.tsx` and `AutoJoinForm.tsx`, updating the handler callbacks to use value-based boolean states.
- Replaced `<Divider>` elements with spacing `<Box>` layouts in `AutoJoinInput.tsx` and `NewProjectPage.tsx`.
- Replaced the Ant Design `<Select>` dropdown with the custom `<Form.Select>` component in `GitHubSettingsModal.tsx`, mapping the repository options structure (utilizing `id`, `name`, and `value`) and wiring it up cleanly to the `formStore` bindings.

Verified that the implementation and component options structure matches correct usage patterns (such as `AdminForm.tsx`) and compiles successfully.