### PR TITLE
refactor: replace antd Divider with Highlight UI Box in Alerts and NewProjectPage

### DIFF
--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -640,7 +640,7 @@ export const AlertForm: React.FC = () => {
 										/>
 									</LabeledRow>
 								</SidebarSection>
-								<Divider className="m-0" />
+								<Box borderTop="dividerWeak" />
 								<SidebarSection>
 									<Box cssClass={style.editorSection}>
 										<Box cssClass={style.editorHeader}>
@@ -718,7 +718,7 @@ export const AlertForm: React.FC = () => {
 															</Callout>
 														)}
 												</SidebarSection>
-												<Divider className="m-0" />
+												<Box borderTop="dividerWeak" />
 												<SidebarSection>
 													{productType ===
 													ProductType.Events ? (
@@ -775,7 +775,7 @@ export const AlertForm: React.FC = () => {
 														!isErrorAlert)) && (
 													<>
 														<Box px="12">
-															<Divider className="m-0" />
+															<Box borderTop="dividerWeak" />
 														</Box>
 														<SidebarSection>
 															<LabeledRow
@@ -850,7 +850,7 @@ export const AlertForm: React.FC = () => {
 										)}
 									</Box>
 								</SidebarSection>
-								<Divider className="m-0" />
+								<Box borderTop="dividerWeak" />
 								<SidebarSection>
 									<LabeledRow
 										label="Alert threshold type"
@@ -970,7 +970,7 @@ export const AlertForm: React.FC = () => {
 										</>
 									)}
 								</SidebarSection>
-								<Divider className="m-0" />
+								<Box borderTop="dividerWeak" />
 								<SidebarSection>
 									<DestinationInput
 										initialDestinations={

--- a/frontend/src/pages/NewProject/NewProjectPage.tsx
+++ b/frontend/src/pages/NewProject/NewProjectPage.tsx
@@ -12,7 +12,6 @@ import { namedOperations } from '@graph/operations'
 import { Box, Callout, Stack, Text } from '@highlight-run/ui/components'
 import analytics from '@util/analytics'
 import { client } from '@util/graph'
-import { Divider } from 'antd'
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
@@ -252,6 +251,9 @@ const NewProjectPage = ({ workspace_id }: { workspace_id: string }) => {
 			</Box>
 		</>
 	) : null
+}
+
+export default NewProjectPage
 }
 
 export default NewProjectPage


### PR DESCRIPTION
## Summary
Replaced legacy antd Divider components with internal @highlight-run/ui Box components for better consistency and alignment with the new design system.

## Changes
- Updated frontend/src/pages/Alerts/AlertForm/index.tsx
- Updated frontend/src/pages/NewProject/NewProjectPage.tsx
- Replaced Divider with Box borderTop="dividerWeak".

Closes #8635