### PR TITLE
Replace join workspace legacy button

### DIFF
--- a/.changeset/join-workspace-button.md
+++ b/.changeset/join-workspace-button.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+Replace the error state join workspace legacy button usage

--- a/.changeset/join-workspace-button.md
+++ b/.changeset/join-workspace-button.md
@@ -2,4 +2,4 @@
 "@highlight-run/frontend": patch
 ---
 
-Replace the error state join workspace legacy button usage
+Replace remaining targeted settings legacy button usages

--- a/frontend/src/components/ErrorState/JoinWorkspace/JoinWorkspace.tsx
+++ b/frontend/src/components/ErrorState/JoinWorkspace/JoinWorkspace.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button/Button/Button'
+import { Button } from '@components/Button'
 import { toast } from '@components/Toaster'
 import { useJoinWorkspaceMutation } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
@@ -22,7 +22,8 @@ const JoinWorkspace = ({
 	return (
 		<Button
 			trackingId="ErrorStateJoinWorkspace"
-			type="primary"
+			kind="primary"
+			emphasis="high"
 			onClick={async () => {
 				try {
 					await JoinWorkspace({

--- a/frontend/src/pages/ProjectSettings/DangerForm/DangerForm.tsx
+++ b/frontend/src/pages/ProjectSettings/DangerForm/DangerForm.tsx
@@ -12,7 +12,7 @@ import { useAuthContext } from '@/authentication/AuthContext'
 import { AdminRole } from '@/graph/generated/schemas'
 
 import commonStyles from '../../../Common.module.css'
-import Button from '../../../components/Button/Button/Button'
+import { Button } from '../../../components/Button'
 import styles from './DangerForm.module.css'
 
 export const DangerForm = () => {
@@ -73,8 +73,8 @@ export const DangerForm = () => {
 									/>
 									<Button
 										trackingId="DeleteProject"
-										danger
-										type="primary"
+										kind="primary"
+										emphasis="high"
 										className={clsx(
 											commonStyles.submitButton,
 											styles.deleteButton,
@@ -83,7 +83,7 @@ export const DangerForm = () => {
 											confirmationText !==
 											data?.project?.name
 										}
-										htmlType="submit"
+										type="submit"
 										loading={deleteLoading}
 									>
 										Delete

--- a/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx
+++ b/frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx
@@ -7,7 +7,7 @@ import { useParams } from '@util/react-router/useParams'
 import React, { useState } from 'react'
 
 import commonStyles from '../../../Common.module.css'
-import Button from '../../../components/Button/Button/Button'
+import { Button } from '../../../components/Button'
 import { CircularSpinner } from '../../../components/Loading/Loading'
 import styles from './FieldsForm.module.css'
 
@@ -104,8 +104,9 @@ export const FieldsForm: React.FC<Props> = ({
 							trackingId={`${
 								isWorkspace ? 'Workspace' : 'Project'
 							}Update`}
-							htmlType="submit"
-							type="primary"
+							type="submit"
+							kind="primary"
+							emphasis="high"
 							className={commonStyles.submitButton}
 							disabled={formDisabled}
 						>


### PR DESCRIPTION
## Summary

- Replaces legacy Ant Design-backed button imports in the targeted settings flow with the current tracked `@components/Button` API.
- Covers `ErrorState/JoinWorkspace`, `WorkspaceSettings/FieldsForm`, and `ProjectSettings/DangerForm`.
- Preserves submit/delete behavior, loading states, disabled states, tracking IDs, toast behavior, support fallback, and mutation wiring.
- Scope is UI-only: no GraphQL, auth, routing, or backend behavior changes.

Fixes #8635
/claim #8635

## How did you test this change?

- `npx -y prettier@3.3.3 --check frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx frontend/src/pages/ProjectSettings/DangerForm/DangerForm.tsx frontend/src/components/ErrorState/JoinWorkspace/JoinWorkspace.tsx .changeset/join-workspace-button.md`
- `npx -y esbuild@0.19.5 frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx frontend/src/pages/ProjectSettings/DangerForm/DangerForm.tsx frontend/src/components/ErrorState/JoinWorkspace/JoinWorkspace.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outdir=/tmp/highlight-settings-bounty --log-level=error`
- `rg -n "components/Button/Button/Button|htmlType=\"submit\"|type=\"primary\"" frontend/src/pages/WorkspaceSettings/FieldsForm/FieldsForm.tsx frontend/src/pages/ProjectSettings/DangerForm/DangerForm.tsx frontend/src/components/ErrorState/JoinWorkspace/JoinWorkspace.tsx` -> no matches
- `git diff --check`

## Notes

Prepared with AI assistance and manually reviewed before submission.