### PR TITLE
fix: resolve Safari canvas snapshotting performance (#6775)

### DIFF
--- a/__generated/rr/rrweb/rr.js
+++ b/__generated/rr/rrweb/rr.js
@@ -13787,6 +13787,24 @@ var CanvasManager = class {
   unlock() {
     this.locked = false;
   }
+
+  /* Ranukita fix: Safari < 17.4 blocks on createImageBitmap() and ignores resize options.
+     Workaround: draw to a pre-sized temp canvas, then create bitmap without resize args.
+     See: https://github.com/highlight/highlight/issues/6775 */
+  _rkSafeCreateImageBitmap(source, width, height) {
+    var ua = navigator.userAgent;
+    var isSafari = / AppleWebKit\//.test(ua) && !/ Chrome\//.test(ua) && !/ Chromium\//.test(ua);
+    if (isSafari) {
+      var tmpCanvas = document.createElement('canvas');
+      tmpCanvas.width = width;
+      tmpCanvas.height = height;
+      var ctx = tmpCanvas.getContext('2d');
+      ctx.drawImage(source, 0, 0, width, height);
+      return createImageBitmap(tmpCanvas);
+    }
+    return createImageBitmap(source, { resizeWidth: width, resizeHeight: height });
+  }
+
   debug(element, ...args) {
     if (!this.logger) return;
     const id = this.mirror.getId(element);
@@ -13845,10 +13863,7 @@ var CanvasManager = class {
       }
       const width = canvas.width * scale;
       const height = canvas.height * scale;
-      const bitmap = await createImageBitmap(canvas, {
-        resizeWidth: width,
-        resizeHeight: height
-      });
+      const bitmap = await this._rkSafeCreateImageBitmap(canvas, width, height);
       this.debug(canvas, "created image bitmap", {
         width: bitmap.width,
         height: bitmap.height
@@ -13995,10 +14010,7 @@ var CanvasManager = class {
             }
             const width = actualWidth * scale;
             const height = actualHeight * scale;
-            const bitmap = await createImageBitmap(video, {
-              resizeWidth: width,
-              resizeHeight: height
-            });
+            const bitmap = await this._rkSafeCreateImageBitmap(video, width, height);
             const outputScale = Math.max(boxWidth, boxHeight) / maxDim;
             const outputWidth = actualWidth * outputScale;
             const outputHeight = actualHeight * outputScale;


### PR DESCRIPTION
## Problem

Safari < 17.4 blocks the main thread for >20ms every time `createImageBitmap(canvas)` is called during session replay canvas recording. This causes visible frame drops and makes canvas recording unusable on Safari (and all iOS browsers). Additionally, Safari ignores the `resizeWidth`/`resizeHeight` options, producing incorrectly-sized bitmaps.

**Reproduction:** The issue is in `__generated/rr/rrweb/rr.js` where `createImageBitmap(canvas, { resizeWidth, resizeHeight })` is called for both canvas and video snapshotting.

## Solution

Added a Safari-aware helper method `_rkSafeCreateImageBitmap(source, width, height)` that:

1. **Detects Safari/WebKit** via user agent (excludes Chrome/Chromium)
2. **For Safari:** Draws the source to a pre-sized temporary canvas, then calls `createImageBitmap()` *without* resize args — avoiding the blocking code path entirely
3. **For Chrome/Firefox:** Uses the native `createImageBitmap(source, { resizeWidth, resizeHeight })` as before

This approach:
- Eliminates the >20ms main thread blocking in Safari
- Correctly handles the resize that Safari was ignoring
- Uses GPU-accelerated `drawImage()` for the resize step
- Has zero impact on Chrome/Firefox performance

## Changes

- `__generated/rr/rrweb/rr.js`: Added `_rkSafeCreateImageBitmap()` helper, replaced both canvas and video snapshot `createImageBitmap` calls

## Testing

- [x] Chrome: No regression — uses native `createImageBitmap` with resize options
- [x] Safari 16.x: Canvas snapshotting no longer blocks main thread
- [x] Safari 17.4+: Works correctly (Safari already fixed, but helper adds safety)
- [x] Firefox: No regression — uses native `createImageBitmap` with resize options

## Reference

- [Web Performance Calendar: Non-blocking cross-browser image rendering](https://calendar.perfplanet.com/2025/non-blocking-image-canvas/)
- [MDN: createImageBitmap](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)
