### PR TITLE
Remove antd tooltip type from TimelineBar

### DIFF
--- a/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineBar/TimelineBar.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineBar/TimelineBar.tsx
@@ -7,7 +7,6 @@ import { getAnnotationColor } from '@pages/Player/Toolbar/Toolbar'
 import { getTimelineEventDisplayName } from '@pages/Player/utils/utils'
 import { serializeErrorIdentifier } from '@util/error'
 import { clamp } from '@util/numbers'
-import { TooltipPlacement } from 'antd/es/tooltip'
 import clsx from 'clsx'
 import { useEffect, useLayoutEffect, useMemo, useState } from 'react'
 
@@ -18,6 +17,8 @@ import {
 import { useReplayerContext } from '@/pages/Player/ReplayerContext'
 
 import styles from './TimelineBar.module.css'
+
+type TooltipPlacement = 'top' | 'topLeft' | 'topRight'
 
 interface IBar {
 	bucket: EventBucket


### PR DESCRIPTION
## Summary
- remove the `antd/es/tooltip` type-only import from `TimelineBar.tsx`
- replace it with a local `TooltipPlacement` union covering the placements used by this component: `top`, `topLeft`, and `topRight`
- keep the Popover runtime behavior unchanged

/claim #8635

## Verification
- GitHub compare confirms this PR only changes `frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineBar/TimelineBar.tsx`
- touched-file check confirms the `antd/es/tooltip` import is removed