### PR TITLE
docs: add SvelteKit server instrumentation guide

### DIFF
--- a/docs-content/getting-started/4_server/2_js/1_overview.md
+++ b/docs-content/getting-started/4_server/2_js/1_overview.md
@@ -36,6 +36,9 @@ updatedAt: 2022-04-01T19:52:59.000Z
     <DocsCard title="Node.js" href="../js/nodejs">
         {"Get started with Node.js"}
     </DocsCard>
+    <DocsCard title="SvelteKit" href="../js/sveltekit">
+        {"Get started with SvelteKit"}
+    </DocsCard>
     <DocsCard title="Pino" href="../js/pino">
         {"Get started with Pino"}
     </DocsCard>

--- a/docs-content/getting-started/4_server/2_js/sveltekit.md
+++ b/docs-content/getting-started/4_server/2_js/sveltekit.md
@@ -1,0 +1,92 @@
+---
+title: SvelteKit
+heading: SvelteKit Server Quick Start
+metaTitle: SvelteKit Server Quick Start
+slug: sveltekit
+createdAt: 2026-06-05T00:00:00.000Z
+updatedAt: 2026-06-05T00:00:00.000Z
+---
+
+This guide shows how to set up highlight.io server-side instrumentation for a SvelteKit app running on a Node-compatible adapter.
+
+## Install the Node SDK
+
+Install [@highlight-run/node](https://www.npmjs.com/package/@highlight-run/node) with your package manager.
+
+```bash
+npm install --save @highlight-run/node
+```
+
+## Initialize Highlight in your server hook
+
+Initialize the Highlight Node SDK in `hooks.server.ts` with your project ID. Set `serviceName`, `serviceVersion`, and `environment` so traces, logs, and errors are grouped clearly in Highlight.
+
+```ts
+// hooks.server.ts
+import { H } from '@highlight-run/node'
+import type { Handle } from '@sveltejs/kit'
+
+H.init({
+	projectID: '<YOUR_PROJECT_ID>',
+	serviceName: 'my-sveltekit-app',
+	serviceVersion: 'git-sha',
+	environment: 'production',
+})
+
+export const handle: Handle = async ({ event, resolve }) => {
+	return H.runWithHeaders(
+		`${event.request.method} ${event.url.pathname}`,
+		event.request.headers,
+		async () => resolve(event),
+	)
+}
+```
+
+`H.runWithHeaders()` reads the incoming SvelteKit request headers and propagates Highlight context to spans created while `resolve(event)` runs. When your frontend Highlight setup sends tracing headers, server traces can be connected back to the originating session and request.
+
+## Report uncaught server errors
+
+Use SvelteKit's `handleError` hook to report uncaught server-side errors. `H.parseHeaders()` extracts the Highlight session and request IDs from the active request.
+
+```ts
+// hooks.server.ts
+import { H } from '@highlight-run/node'
+import type { HandleServerError } from '@sveltejs/kit'
+
+export const handleError: HandleServerError = ({ error, event }) => {
+	const { secureSessionId, requestId } = H.parseHeaders(
+		event.request.headers,
+	)
+
+	H.consumeError(
+		error instanceof Error ? error : new Error(String(error)),
+		secureSessionId,
+		requestId,
+	)
+}
+```
+
+## Report manual errors
+
+If you need to report exceptions outside of `handleError`, use the Highlight SDK with headers from the active SvelteKit request event.
+
+```ts
+const { secureSessionId, requestId } = H.parseHeaders(
+	event.request.headers,
+)
+
+H.consumeError(error, secureSessionId, requestId)
+```
+
+## Verify the setup
+
+Create a temporary server endpoint that throws an error, then request it locally or in a deployed environment.
+
+```ts
+// src/routes/error/+server.ts
+export const GET = () => {
+	throw new Error('sample SvelteKit server error!')
+}
+```
+
+After calling the route, verify that the error appears in [Highlight errors](https://app.highlight.io/errors). Then make a normal server request and check [Highlight traces](https://app.highlight.io/traces) for the SvelteKit request span.


### PR DESCRIPTION
## Summary
Adds a SvelteKit server-side instrumentation guide for Highlight's JavaScript server docs.

Covers:
- installing `@highlight-run/node`
- initializing Highlight from `hooks.server.ts`
- tracing SvelteKit requests with `H.runWithHeaders`
- reporting server errors with `handleError`
- verifying errors and traces in Highlight

Closes #8032

## How did you test this change?
Documentation-only change. Reviewed the rendered GitHub diff.

## Are there any deployment considerations?
No.

## Does this work require review from our design team?
No.