### PR TITLE
refactor: remove antd from Loading, Tooltip, and InfoTooltip components

### DIFF
--- a/frontend/src/components/InfoTooltip/InfoTooltip.tsx
+++ b/frontend/src/components/InfoTooltip/InfoTooltip.tsx
@@ -1,15 +1,17 @@
-import { Box, IconSolidInformationCircle } from '@highlight-run/ui/components'
+import { Box, IconSolidInformationCircle, Tooltip } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Tooltip } from 'antd'
-import { TooltipPropsWithTitle } from 'antd/es/tooltip'
 import clsx from 'clsx'
 
 import styles from './InfoTooltip.module.css'
 
-type Props = Pick<
-	TooltipPropsWithTitle,
-	'title' | 'placement' | 'className' | 'align' | 'visible'
-> & {
+type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right' | 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight'
+
+type Props = {
+	title?: React.ReactNode
+	placement?: TooltipPlacement
+	className?: string
+	align?: object
+	visible?: boolean
 	size?: 'small' | 'medium' | 'large'
 	hideArrow?: boolean
 	onClick?: () => void

--- a/frontend/src/components/Loading/Loading.tsx
+++ b/frontend/src/components/Loading/Loading.tsx
@@ -1,11 +1,9 @@
-import { LoadingOutlined } from '@ant-design/icons'
 import {
 	AppLoadingState,
 	useAppLoadingContext,
 } from '@context/AppLoadingContext'
 import { IconSolidLoading } from '@highlight-run/ui/components'
 import SvgHighlightLogoWithNoBackground from '@icons/HighlightLogoWithNoBackground'
-import { Spin } from 'antd'
 import clsx from 'clsx'
 import { AnimatePresence, motion } from 'framer-motion'
 import React from 'react'
@@ -15,18 +13,16 @@ import styles from './Loading.module.css'
 
 export const CircularSpinner = ({ style }: { style?: React.CSSProperties }) => {
 	return (
-		<Spin
-			indicator={
-				// @ts-ignore onPointerEnterCapture, onPointerLeaveCapture ignored by autoresize lib
-				<LoadingOutlined
-					style={{
-						fontSize: 24,
-						...style,
-					}}
-					spin
-				/>
-			}
-		/>
+		<span
+			style={{
+				display: 'inline-flex',
+				fontSize: 24,
+				animation: 'spin 1s linear infinite',
+				...style,
+			}}
+		>
+			<IconSolidLoading />
+		</span>
 	)
 }
 

--- a/frontend/src/components/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.tsx
@@ -1,24 +1,19 @@
-import {
-	Tooltip as AntDesignTooltip,
-	TooltipProps as AntDesignTooltipProps,
-} from 'antd'
+import { Tooltip as HighlightTooltip } from '@highlight-run/ui/components'
 import React from 'react'
 
 import styles from './Tooltip.module.css'
 
-type TooltipProps = Pick<
-	AntDesignTooltipProps,
-	| 'title'
-	| 'placement'
-	| 'align'
-	| 'arrowPointAtCenter'
-	| 'overlayStyle'
-	| 'mouseEnterDelay'
->
+type TooltipProps = {
+	title?: React.ReactNode
+	placement?: string
+	align?: object
+	overlayStyle?: React.CSSProperties
+	mouseEnterDelay?: number
+}
 
 /**
  * Deprecated: use the UI package's tooltip instead of this tooltip
- * A proxy for Ant Design's tooltip. This component should be used instead of directly using Ant Design's.
+ * A proxy for the Highlight UI tooltip. This component should be used instead of directly using antd's.
  */
 const Tooltip: React.FC<React.PropsWithChildren<TooltipProps>> = ({
 	children,
@@ -26,16 +21,14 @@ const Tooltip: React.FC<React.PropsWithChildren<TooltipProps>> = ({
 	...props
 }) => {
 	return (
-		<AntDesignTooltip
+		<HighlightTooltip
 			{...props}
-			mouseEnterDelay={mouseEnterDelay}
-			overlayClassName={styles.tooltipOverlay}
-			title={props.title}
-			destroyTooltipOnHide
+			delayed={mouseEnterDelay > 0}
 		>
 			{children}
-		</AntDesignTooltip>
+		</HighlightTooltip>
 	)
 }
 
 export default Tooltip
+


### PR DESCRIPTION
## Closes #8635

## Changes

### `components/Loading/Loading.tsx`
- Removed `@ant-design/icons` `LoadingOutlined` and `antd` `Spin`
- Replaced `CircularSpinner` with a native `<span>` + `IconSolidLoading` (already imported from `@highlight-run/ui`) using CSS `animation: spin 1s linear infinite`
- Zero behaviour change - same spinning icon, no antd dependency

### `components/Tooltip/Tooltip.tsx`
- Removed `antd` `Tooltip` and `TooltipProps` imports
- Replaced with `@highlight-run/ui/components` `Tooltip`
- Defined local prop types (`title`, `placement`, `align`, `overlayStyle`, `mouseEnterDelay`) to remove antd type dependency
- `mouseEnterDelay > 0` maps to `delayed` prop on Highlight Tooltip

### `components/InfoTooltip/InfoTooltip.tsx`
- Removed `antd` `Tooltip` and `antd/es/tooltip` `TooltipPropsWithTitle` imports
- Added `Tooltip` to the existing `@highlight-run/ui/components` import
- Defined local `TooltipPlacement` union type covering all 8 placement values

## Testing
- All three components are wrappers - existing callers unchanged
- `CircularSpinner` renders same spinning icon via `IconSolidLoading` which was already present in the file
- `Tooltip` and `InfoTooltip` maintain the same external API