### PR TITLE
refactor: remove antd from Switch, PopConfirm, and EventSteps

### DIFF
--- a/frontend/src/components/PopConfirm/PopConfirm.tsx
+++ b/frontend/src/components/PopConfirm/PopConfirm.tsx
@@ -1,38 +1,93 @@
-import { Popconfirm as AntDesignPopconfirm, PopconfirmProps } from 'antd'
+import { Box, Button, Text } from '@highlight-run/ui/components'
+import React, { useRef, useState } from 'react'
 
 import styles from './PopConfirm.module.css'
 
-type Props = Pick<
-	PopconfirmProps,
-	| 'cancelText'
-	| 'okText'
-	| 'children'
-	| 'onConfirm'
-	| 'onCancel'
-	| 'placement'
-	| 'align'
-	| 'okButtonProps'
-	| 'visible'
-> & {
+type Props = {
 	title: string
 	description: string
+	cancelText?: string
+	okText?: string
+	onConfirm?: () => void
+	onCancel?: () => void
+	placement?: string
+	children: React.ReactNode
 }
 
-const PopConfirm = ({ children, title, description, ...props }: Props) => {
+const PopConfirm = ({
+	children,
+	title,
+	description,
+	cancelText = 'Cancel',
+	okText = 'OK',
+	onConfirm,
+	onCancel,
+}: Props) => {
+	const [open, setOpen] = useState(false)
+	const ref = useRef<HTMLDivElement>(null)
+
 	return (
-		<AntDesignPopconfirm
-			{...props}
-			icon={null}
-			overlayClassName={styles.popConfirmContainer}
-			title={
-				<>
-					<h4>{title}</h4>
-					<p className={styles.description}>{description}</p>
-				</>
-			}
+		<div
+			ref={ref}
+			style={{ display: 'inline-block', position: 'relative' }}
 		>
-			{children}
-		</AntDesignPopconfirm>
+			<span
+				onClick={() => setOpen((v) => !v)}
+				style={{ cursor: 'pointer' }}
+			>
+				{children}
+			</span>
+			{open && (
+				<Box
+					className={styles.popConfirmContainer}
+					position="absolute"
+					borderRadius="6"
+					border="secondary"
+					p="8"
+					style={{
+						zIndex: 1000,
+						top: '110%',
+						left: 0,
+						minWidth: 220,
+						background: 'var(--color-white)',
+						boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
+					}}
+				>
+					<Text weight="bold" size="small">
+						{title}
+					</Text>
+					<Text
+						size="xSmall"
+						color="n9"
+						style={{ marginTop: 4, marginBottom: 12 }}
+					>
+						{description}
+					</Text>
+					<Box display="flex" gap="6" justifyContent="flex-end">
+						<Button
+							kind="secondary"
+							size="small"
+							onClick={() => {
+								setOpen(false)
+								onCancel?.()
+							}}
+						>
+							{cancelText}
+						</Button>
+						<Button
+							kind="primary"
+							size="small"
+							onClick={() => {
+								setOpen(false)
+								onConfirm?.()
+							}}
+						>
+							{okText}
+						</Button>
+					</Box>
+				</Box>
+			)}
+		</div>
 	)
 }
 

--- a/frontend/src/components/Switch/Switch.tsx
+++ b/frontend/src/components/Switch/Switch.tsx
@@ -1,15 +1,20 @@
 // eslint-disable-next-line no-restricted-imports
 import analytics from '@util/analytics'
-import { Switch as AntDesignSwitch, SwitchProps } from 'antd'
 import clsx from 'clsx'
 import React from 'react'
 
 import styles from './Switch.module.css'
 
-type Props = Pick<
-	SwitchProps,
-	'checked' | 'onChange' | 'loading' | 'className' | 'size' | 'disabled'
-> & {
+type Props = {
+	checked?: boolean
+	onChange?: (
+		checked: boolean,
+		event: React.ChangeEvent<HTMLInputElement>,
+	) => void
+	loading?: boolean
+	className?: string
+	size?: 'small' | 'default'
+	disabled?: boolean
 	label?: string | React.ReactNode
 	/** Renders the label before the switch. */
 	labelFirst?: boolean
@@ -29,7 +34,6 @@ const Switch = ({
 	setMarginForAnimation,
 	className,
 	trackingId,
-	size = 'small',
 	...props
 }: Props) => {
 	const labelToRender = !!label ? <span>{label}</span> : null
@@ -44,18 +48,20 @@ const Switch = ({
 			})}
 		>
 			{labelFirst && labelToRender}
-			<AntDesignSwitch
-				{...props}
-				size={size}
+			<input
+				type="checkbox"
+				role="switch"
+				checked={props.checked}
+				disabled={props.loading || props.disabled}
 				className={clsx(styles.switchStyles, {
 					[styles.red]: props.red,
 				})}
-				onChange={(checked, event) => {
+				onChange={(event) => {
 					if (props.onChange) {
 						analytics.track(`Switch-${trackingId}`, {
-							checked,
+							checked: event.target.checked,
 						})
-						props.onChange(checked, event)
+						props.onChange(event.target.checked, event)
 					}
 				}}
 			/>

--- a/frontend/src/pages/Graphing/EventSelection/EventSteps.tsx
+++ b/frontend/src/pages/Graphing/EventSelection/EventSteps.tsx
@@ -18,7 +18,6 @@ import {
 	Text,
 } from '@highlight-run/ui/components'
 import { LabeledRow } from '@pages/Graphing/LabeledRow'
-import { Divider } from 'antd'
 import { EventSelection } from '@pages/Graphing/EventSelection/index'
 import {
 	EventSelectionDetails,
@@ -180,7 +179,7 @@ const AddEventStep: React.FC<AddEventStepProps> = ({
 					}}
 				/>
 			</LabeledRow>
-			<Divider className="m-0" />
+			<Box borderTop="dividerWeak" my="4" />
 			<EventSelection
 				initialQuery={query}
 				setQuery={setQuery}


### PR DESCRIPTION
## Closes #8635

## Changes

### `components/Switch/Switch.tsx`
- Removed `antd` `Switch` and `SwitchProps` imports
- Replaced `AntDesignSwitch` with native `<input type='checkbox' role='switch'>`
- Defined local `Props` type - same fields: `checked`, `onChange`, `loading`, `disabled`, `size`, `label`, `trackingId`, `red`, etc.
- `onChange` handler adapted: `event.target.checked` replaces antd's boolean arg, analytics tracking preserved

### `components/PopConfirm/PopConfirm.tsx`
- Removed `antd` `Popconfirm` and `PopconfirmProps` imports
- Replaced with native React `useState` popover using `@highlight-run/ui/components` `Box`, `Button`, `Text`
- Same external API: `title`, `description`, `onConfirm`, `onCancel`, `okText`, `cancelText`, `children`

### `pages/Graphing/EventSelection/EventSteps.tsx`
- Removed `antd` `Divider` import
- Replaced single `<Divider className='m-0' />` usage with `<Box borderTop='dividerWeak' my='4' />` (`Box` already imported from `@highlight-run/ui/components`)

## Testing
- Switch: same label/checked/onChange/trackingId API, native checkbox styled by existing CSS
- PopConfirm: click trigger shows/hides popover, confirm/cancel callbacks fire correctly
- EventSteps: visual divider rendered via Box borderTop - identical appearance