### PR TITLE
Remove TimelineBar Ant tooltip placement type import

### DIFF
--- a/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineBar/TimelineBar.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineBar/TimelineBar.tsx
@@ -7,7 +7,6 @@ import { getAnnotationColor } from '@pages/Player/Toolbar/Toolbar'
 import { getTimelineEventDisplayName } from '@pages/Player/utils/utils'
 import { serializeErrorIdentifier } from '@util/error'
 import { clamp } from '@util/numbers'
-import { TooltipPlacement } from 'antd/es/tooltip'
 import clsx from 'clsx'
 import { useEffect, useLayoutEffect, useMemo, useState } from 'react'
 
@@ -18,6 +17,13 @@ import {
 import { useReplayerContext } from '@/pages/Player/ReplayerContext'
 
 import styles from './TimelineBar.module.css'
+
+type TimelineBarPopoverPlacement = 'top' | 'topLeft' | 'topRight'
+
+interface TimelineBarPopoverPosition {
+	rightOffset: number
+	placement: TimelineBarPopoverPlacement
+}
 
 interface IBar {
 	bucket: EventBucket
@@ -119,12 +125,12 @@ const TimelineIndicatorsBar = ({
 
 	const viewportBbox = viewportRef.current?.getBoundingClientRect()
 
-	const tooltipPosition = useMemo(() => {
+	const tooltipPosition = useMemo<TimelineBarPopoverPosition>(() => {
 		const viewportDiv = viewportRef.current
 		if (!viewportDiv || !viewportBbox) {
 			return {
 				rightOffset: 0,
-				placement: 'top' as TooltipPlacement,
+				placement: 'top',
 			}
 		}
 		const { scrollWidth, scrollLeft } = viewportDiv
@@ -144,7 +150,7 @@ const TimelineIndicatorsBar = ({
 		// move by the 8th of the bar width
 		let offset = (scrollWidth * (width / 100)) / 8
 
-		let placement: TooltipPlacement = 'top'
+		let placement: TimelineBarPopoverPlacement = 'top'
 		if (relPos === 2) {
 			placement = 'topRight'
 		} else if (relPos === 1) {


### PR DESCRIPTION
Description

This removes the remaining antd/es/tooltip type-only import from TimelineBar.tsx by replacing TooltipPlacement with a local placement union.

The component only uses three placements: top, topLeft, and topRight, so the local type keeps the same runtime behavior while removing the Ant Design type dependency from this player timeline slice.

Validation:

Focused ESLint passed for TimelineBar.tsx
Frontend source TypeScript check passed with test files excluded
Full frontend typecheck is blocked by existing test-global typing issues unrelated to this change