### PR TITLE
fix: remove antd Divider from Alerts page (#9091)

### DIFF
--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -13,7 +13,6 @@ import {
 	Tag,
 	Text,
 } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
 import React, { PropsWithChildren, useEffect, useMemo, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { useNavigate, useSearchParams } from 'react-router-dom'
@@ -640,7 +639,7 @@ export const AlertForm: React.FC = () => {
 										/>
 									</LabeledRow>
 								</SidebarSection>
-								<Divider className="m-0" />
+								<hr className="m-0 border-0 border-t border-solid border-[--color-gray-300]" />
 								<SidebarSection>
 									<Box cssClass={style.editorSection}>
 										<Box cssClass={style.editorHeader}>
@@ -718,7 +717,7 @@ export const AlertForm: React.FC = () => {
 															</Callout>
 														)}
 												</SidebarSection>
-												<Divider className="m-0" />
+												<hr className="m-0 border-0 border-t border-solid border-[--color-gray-300]" />
 												<SidebarSection>
 													{productType ===
 													ProductType.Events ? (
@@ -775,7 +774,7 @@ export const AlertForm: React.FC = () => {
 														!isErrorAlert)) && (
 													<>
 														<Box px="12">
-															<Divider className="m-0" />
+															<hr className="m-0 border-0 border-t border-solid border-[--color-gray-300]" />
 														</Box>
 														<SidebarSection>
 															<LabeledRow
@@ -850,7 +849,7 @@ export const AlertForm: React.FC = () => {
 										)}
 									</Box>
 								</SidebarSection>
-								<Divider className="m-0" />
+								<hr className="m-0 border-0 border-t border-solid border-[--color-gray-300]" />
 								<SidebarSection>
 									<LabeledRow
 										label="Alert threshold type"
@@ -970,7 +969,7 @@ export const AlertForm: React.FC = () => {
 										</>
 									)}
 								</SidebarSection>
-								<Divider className="m-0" />
+								<hr className="m-0 border-0 border-t border-solid border-[--color-gray-300]" />
 								<SidebarSection>
 									<DestinationInput
 										initialDestinations={


### PR DESCRIPTION
## Summary

Fixes #9091 — Removes antd  import from the Alerts page and replaces it with native  elements using Tailwind CSS classes.

## Changes

- Remove  from 
- Replace all 5 instances of  with styled  elements
- Uses Tailwind border classes: 

## Why

This is part of the ongoing antd removal effort. The Alerts page was one of the remaining pages still using antd components.

## Testing

- Verified the divider styling matches the original antd Divider appearance
- No functional changes — purely visual replacement

Closes #9091