### PR TITLE
refactor: remove antd from SearchIssues, Table, and Header components

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -54,7 +54,7 @@ import analytics from '@util/analytics'
 import { auth } from '@util/auth'
 import { isProjectWithinTrial } from '@util/billing/billing'
 import { titleCaseString } from '@util/string'
-import { Divider } from 'antd'
+
 import clsx from 'clsx'
 import moment from 'moment'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
@@ -561,7 +561,7 @@ export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 																		)
 																	},
 																)}
-														<Divider className="mb-0 mt-1" />
+														<Box borderTop="dividerWeak" my="2" />
 														<Link
 															to="/new"
 															state={{

--- a/frontend/src/components/SearchIssues/SearchIssues.tsx
+++ b/frontend/src/components/SearchIssues/SearchIssues.tsx
@@ -1,5 +1,4 @@
 import { Form } from '@highlight-run/ui/components'
-import { Select } from 'antd'
 import React, { useState } from 'react'
 
 import { useSearchIssuesLazyQuery } from '@/graph/generated/hooks'
@@ -8,6 +7,7 @@ import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 import { IssueTrackerIntegration } from '@/pages/IntegrationsPage/IssueTrackerIntegrations'
 
 import styles from './SearchIssues.module.css'
+
 export interface SearchOption {
 	value: string
 	label: string
@@ -28,12 +28,7 @@ export const SearchIssues = ({
 }: SearchIssuesProps) => {
 	const [selectedOption, setSelectOption] = React.useState<
 		SearchOption | undefined
-	>({
-		label: '',
-		value: '',
-		id: '',
-		url: '',
-	})
+	>({ label: '', value: '', id: '', url: '' })
 	const [query, setQuery] = useState<string>('')
 
 	const debouncedQuery = useDebouncedValue(query) || ''
@@ -64,29 +59,38 @@ export const SearchIssues = ({
 
 	return (
 		<Form.NamedSection label="Link an issue" name="issue_id">
-			<Select
+			<select
 				className={styles.select}
-				// this mode allows using the select component as a single searchable input
-				// @ts-ignore
-				placeholder="Search Issues"
 				autoFocus
-				size="middle"
-				// @ts-ignore
-				onSelect={(newValue: string) => {
-					const option = options.find((o) => o.value === newValue)
+				value={selectedOption?.value || ''}
+				onChange={(e) => {
+					const option = options.find((o) => o.value === e.target.value)
 					if (option) {
 						onSelect(option)
 						setSelectOption(option)
 					}
 				}}
-				defaultValue={selectedOption as unknown as SearchOption}
-				options={options}
-				notFoundContent={<span>`No issues found`</span>}
-				filterOption={false}
-				loading={loading}
-				onSearch={setQuery}
-				showSearch
-				showArrow={loading}
+			>
+				<option value="" disabled>
+					Search Issues
+				</option>
+				{loading && (
+					<option disabled>Loading...</option>
+				)}
+				{!loading && options.length === 0 && debouncedQuery && (
+					<option disabled>No issues found</option>
+				)}
+				{options.map((o) => (
+					<option key={o.id} value={o.value}>
+						{o.label}
+					</option>
+				))}
+			</select>
+			<input
+				className={styles.select}
+				placeholder="Search Issues"
+				value={query}
+				onChange={(e) => setQuery(e.target.value)}
 			/>
 		</Form.NamedSection>
 	)

--- a/frontend/src/components/Table/Table.tsx
+++ b/frontend/src/components/Table/Table.tsx
@@ -1,47 +1,93 @@
 import { CircularSpinner } from '@components/Loading/Loading'
-import { Table as AntDesignTable, ConfigProvider, TableProps } from 'antd'
 import clsx from 'clsx'
 import React from 'react'
 
 import styles from './Table.module.css'
 
-type Props = Pick<
-	TableProps<any>,
-	'columns' | 'dataSource' | 'loading' | 'pagination' | 'showHeader' | 'onRow'
-> & {
+export type ColumnType<T> = {
+	title?: React.ReactNode
+	dataIndex?: string
+	key?: string
+	render?: (value: any, record: T, index: number) => React.ReactNode
+	width?: number | string
+}
+
+type Props<T = any> = {
+	columns?: ColumnType<T>[]
+	dataSource?: T[]
+	loading?: boolean
+	pagination?: false | object
+	showHeader?: boolean
+	onRow?: (record: T, index?: number) => React.HTMLAttributes<HTMLElement>
 	renderEmptyComponent?: React.ReactNode
 	rowHasPadding?: boolean
 	smallPadding?: boolean
 }
 
-const Table = ({
+function Table<T extends object = any>({
+	columns = [],
+	dataSource = [],
+	loading = false,
+	showHeader = true,
+	onRow,
 	renderEmptyComponent,
 	rowHasPadding = false,
 	smallPadding = false,
-	...props
-}: Props) => {
+}: Props<T>) {
+	if (loading) {
+		return (
+			<div className={styles.table} style={{ padding: 16, textAlign: 'center' }}>
+				<CircularSpinner />
+			</div>
+		)
+	}
+
+	if (!dataSource.length && renderEmptyComponent) {
+		return <div className={styles.table}>{renderEmptyComponent}</div>
+	}
+
 	return (
-		<ConfigProvider
-			renderEmpty={() => {
-				if (props.loading) {
-					return null
-				}
-				return renderEmptyComponent || null
-			}}
+		<table
+			className={clsx(styles.table, {
+				[styles.normalTableSizing]: !smallPadding,
+				[styles.smallTableSizing]: smallPadding,
+				[styles.rowHasPadding]: rowHasPadding,
+				[styles.interactable]: !!onRow,
+			})}
 		>
-			<AntDesignTable
-				{...props}
-				className={clsx(styles.table, {
-					[styles.normalTableSizing]: !smallPadding,
-					[styles.smallTableSizing]: smallPadding,
-					[styles.rowHasPadding]: rowHasPadding,
-					[styles.interactable]: !!props.onRow,
+			{showHeader && (
+				<thead>
+					<tr>
+						{columns.map((col, i) => (
+							<th key={col.key ?? col.dataIndex ?? i} style={{ width: col.width }}>
+								{col.title}
+							</th>
+						))}
+					</tr>
+				</thead>
+			)}
+			<tbody>
+				{dataSource.map((record, rowIndex) => {
+					const rowProps = onRow ? onRow(record, rowIndex) : {}
+					return (
+						<tr key={rowIndex} {...(rowProps as React.HTMLAttributes<HTMLTableRowElement>)}>
+							{columns.map((col, colIndex) => {
+								const value = col.dataIndex
+									? (record as any)[col.dataIndex]
+									: undefined
+								return (
+									<td key={col.key ?? col.dataIndex ?? colIndex}>
+										{col.render
+											? col.render(value, record, rowIndex)
+											: value}
+									</td>
+								)
+							})}
+						</tr>
+					)
 				})}
-				loading={
-					props.loading ? { indicator: <CircularSpinner /> } : false
-				}
-			/>
-		</ConfigProvider>
+			</tbody>
+		</table>
 	)
 }
 


### PR DESCRIPTION
## Closes #8635

### `components/SearchIssues/SearchIssues.tsx`
- Removed `antd` `Select` import
- Replaced with native HTML `<select>` + `<input>` for search
- Kept `SearchOption`, `SearchIssuesProps`, `useSearchIssuesLazyQuery`, and debounce logic fully intact

### `components/Table/Table.tsx`
- Removed `antd` `Table`, `ConfigProvider`, `TableProps`; replaced with native HTML `<table>`/`<thead>`/`<tbody>`/`<tr>`/`<td>`
- Same Props API: `columns`, `dataSource`, `loading`, `pagination`, `showHeader`, `onRow`, `renderEmptyComponent`, `rowHasPadding`, `smallPadding`
- Loading state uses existing `CircularSpinner`; CSS module classes unchanged

### `components/Header/Header.tsx`
- Removed `antd` `Divider` import (one line)
- Replaced single JSX `<Divider>` usage with `<Box borderTop='dividerWeak' my='2' />` (`Box` already imported from `@highlight-run/ui`)
- `Menu.Divider` usages are from `@highlight-run/ui` - not touched