### PR TITLE
[codex] Remove ProgressBarTable AntD usage

### DIFF
--- a/.changeset/progress-table-antd.md
+++ b/.changeset/progress-table-antd.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+Remove ProgressBarTable AntD usage.

--- a/frontend/src/components/ProgressBarTable/ProgressBarTable.module.css
+++ b/frontend/src/components/ProgressBarTable/ProgressBarTable.module.css
@@ -1,46 +1,50 @@
-.table {
+.tableFrame {
 	margin-bottom: -24px;
 	margin-left: -24px;
 	margin-right: -24px;
-	max-width: initial !important;
+	max-height: 287px;
+	overflow-y: auto;
+}
 
-	:global(.ant-table) {
-		background: var(--color-primary-background) !important;
-		color: var(--text-primary) !important;
-	}
+.table {
+	background: var(--color-primary-background);
+	border-collapse: collapse;
+	color: var(--text-primary);
+	max-width: initial;
+	width: 100%;
+}
 
-	:global(.ant-table-cell) {
-		border-bottom: 1px solid var(--color-gray-300) !important;
-		padding: 12px 0 !important;
-	}
+.table tr:hover td,
+.table tr:focus td {
+	background: var(--color-gray-300);
+	cursor: pointer;
+	outline: none;
+}
 
-	:global(.ant-table-cell:first-of-type) {
-		padding-left: var(--size-large) !important;
-	}
+.table td {
+	border-bottom: 1px solid var(--color-gray-300);
+	padding: 12px 0;
+}
 
-	:global(.ant-table-cell:last-of-type) {
-		padding-right: var(--size-large) !important;
-	}
+.table td:first-of-type {
+	padding-left: var(--size-large);
+}
 
-	:global(.ant-table-row:last-of-type) {
-		:global(.ant-table-cell) {
-			border-bottom: 0 !important;
-		}
-	}
+.table td:last-of-type {
+	padding-right: var(--size-large);
+}
 
-	:global(.ant-table-tbody > tr.ant-table-row:hover > td) {
-		background: var(--color-gray-300) !important;
-	}
+.table tr:last-of-type td {
+	border-bottom: 0;
+}
 
-	:global(.ant-table-tbody > tr.ant-table-placeholder:hover > td) {
-		background: transparent !important;
-	}
+.emptyState {
+	margin-top: var(--size-xxLarge);
+	padding: 0 var(--size-large) var(--size-large);
+}
 
-	:global(.ant-table-empty) {
-		margin-top: var(--size-xxLarge);
-
-		:global(.ant-table-cell) {
-			border-bottom: 0 !important;
-		}
-	}
+.loadingState {
+	color: var(--color-gray-500);
+	padding: var(--size-xxLarge) var(--size-large);
+	text-align: center;
 }

--- a/frontend/src/components/ProgressBarTable/ProgressBarTable.tsx
+++ b/frontend/src/components/ProgressBarTable/ProgressBarTable.tsx
@@ -1,52 +1,106 @@
-import { ConfigProvider, Table } from 'antd'
-import { ColumnsType } from 'antd/es/table'
 import React from 'react'
 
 import EmptyCardPlaceholder from '../../pages/Home/components/EmptyCardPlaceholder/EmptyCardPlaceholder'
 import styles from './ProgressBarTable.module.css'
 
-interface Props {
-	columns: ColumnsType<any>
-	data: any[]
-	onClickHandler: (record: any) => void
+type ProgressBarTableColumn<TRecord extends Record<string, any>> = {
+	dataIndex?: keyof TRecord | string
+	key?: React.Key
+	render?: (value: any, record: TRecord, index: number) => React.ReactNode
+	title?: React.ReactNode
+	width?: React.CSSProperties['width']
+}
+
+interface Props<TRecord extends Record<string, any>> {
+	columns: ProgressBarTableColumn<TRecord>[]
+	data: TRecord[]
+	onClickHandler: (record: TRecord) => void
 	/** The string shown to the user when the table has no data. */
 	noDataMessage?: string | React.ReactNode
 	noDataTitle?: string
 	loading: boolean
 }
 
-const ProgressBarTable = ({
+const ProgressBarTable = <TRecord extends Record<string, any>>({
 	columns,
 	data,
 	onClickHandler,
 	noDataMessage,
 	noDataTitle,
 	loading,
-}: Props) => {
-	return (
-		<ConfigProvider
-			renderEmpty={() => (
+}: Props<TRecord>) => {
+	const handleRowKeyDown = (
+		event: React.KeyboardEvent<HTMLTableRowElement>,
+		record: TRecord,
+	) => {
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault()
+			onClickHandler(record)
+		}
+	}
+
+	if (loading) {
+		return <div className={styles.loadingState}>Loading...</div>
+	}
+
+	if (!data.length) {
+		return (
+			<div className={styles.emptyState}>
 				<EmptyCardPlaceholder
 					message={noDataMessage}
 					title={noDataTitle}
 				/>
-			)}
-		>
-			<Table
-				className={styles.table}
-				loading={loading}
-				scroll={{ y: 287 }}
-				showHeader={false}
-				columns={columns}
-				dataSource={data}
-				pagination={false}
-				onRow={(record) => ({
-					onClick: () => {
-						onClickHandler(record)
-					},
-				})}
-			/>
-		</ConfigProvider>
+			</div>
+		)
+	}
+
+	return (
+		<div className={styles.tableFrame}>
+			<table className={styles.table}>
+				<tbody>
+					{data.map((record, index) => (
+						<tr
+							key={String(record.key ?? index)}
+							onClick={() => onClickHandler(record)}
+							onKeyDown={(event) =>
+								handleRowKeyDown(event, record)
+							}
+							role="button"
+							tabIndex={0}
+						>
+							{columns.map((column, columnIndex) => {
+								const dataIndex =
+									typeof column.dataIndex === 'string'
+										? column.dataIndex
+										: String(column.dataIndex ?? '')
+								const value = dataIndex
+									? record[dataIndex]
+									: undefined
+
+								return (
+									<td
+										key={String(
+											column.key ??
+												column.dataIndex ??
+												columnIndex,
+										)}
+										style={{ width: column.width }}
+									>
+										{column.render
+											? column.render(
+													value,
+													record,
+													index,
+												)
+											: String(value ?? '')}
+									</td>
+								)
+							})}
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
 	)
 }
 


### PR DESCRIPTION
/claim #8635

## Summary

- Removed the direct Ant Design Table, ConfigProvider, and ColumnsType imports from ProgressBarTable.
- Replaced the component with a small local table renderer that preserves the existing ProgressBarTable API used by SourcemapSettings.
- Moved the table styling away from .ant-* selectors while keeping the existing card alignment, 287px vertical scroll area, row hover, row click, loading, and empty-state behavior.

## Validation

- npx.cmd --yes prettier@3.3.3 --check frontend/src/components/ProgressBarTable/ProgressBarTable.tsx frontend/src/components/ProgressBarTable/ProgressBarTable.module.css
- git diff --check
- npx.cmd --yes esbuild@0.19.5 frontend/src/components/ProgressBarTable/ProgressBarTable.tsx --format=esm --platform=browser --outfile=NUL
- rg -n antd|ant- frontend/src/components/ProgressBarTable returned no matches