### PR TITLE
Add SvelteKit server tracing docs

### DIFF
--- a/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
@@ -3,11 +3,9 @@ import {
 	identifySnippet,
 	initializeSnippet,
 	packageInstallSnippet,
-	setupBackendSnippet,
 	verifySnippet,
 } from './shared-snippets'
-
-import { QuickStartContent } from '../QuickstartContent'
+import { QuickStartContent, QuickStartStep } from '../QuickstartContent'
 
 const svelteKitInitCodeSnippet = `// hooks.client.ts
 ...
@@ -31,6 +29,52 @@ H.init('<YOUR_PROJECT_ID>', {
 });
 ...
 `
+
+const svelteKitServerSnippet: QuickStartStep = {
+	title: 'Instrument your server.',
+	content:
+		'Add Highlight to `hooks.server.ts` so SvelteKit can trace server-side work and connect it back to the frontend session. Install `@highlight-run/node` if you have not already, then wrap your `handle` function with `H.runWithHeaders`.',
+	code: [
+		{
+			text: `// src/hooks.server.ts
+import { H } from '@highlight-run/node'
+import type { Handle } from '@sveltejs/kit'
+
+const nodeOptions = {
+	projectID: '<YOUR_PROJECT_ID>',
+	serviceName: 'my-sveltekit-app',
+	environment: 'production',
+	version: 'commit:abcdefg12345',
+}
+
+if (!H.isInitialized()) {
+	H.init(nodeOptions)
+}
+
+export const handle: Handle = async ({ event, resolve }) => {
+	return H.runWithHeaders(
+		\`\${event.request.method} \${event.url.pathname}\`,
+		event.request.headers,
+		async () => resolve(event),
+		{
+			attributes: {
+				'http.method': event.request.method,
+				'http.route': event.url.pathname,
+				'http.url': event.url.toString(),
+			},
+		},
+	)
+}
+`,
+			language: 'ts',
+		},
+		{
+			text: `# install the backend SDK if needed
+npm install @highlight-run/node`,
+			language: 'bash',
+		},
+	],
+}
 
 export const SvelteKitContent: QuickStartContent = {
 	title: 'SvelteKit',
@@ -79,6 +123,6 @@ export default config;`,
 		identifySnippet,
 		verifySnippet,
 		configureSourcemapsCI(),
-		setupBackendSnippet,
+		svelteKitServerSnippet,
 	],
 }


### PR DESCRIPTION
## Summary

Add a SvelteKit-specific backend instrumentation step to the quickstart so the docs show the full client/server tracing path.

- Keep the existing frontend `hooks.client.ts` setup.
- Add a `hooks.server.ts` example using `@highlight-run/node`.
- Show `H.init()` plus `H.runWithHeaders()` so server requests stay linked to the frontend session.
- Remove the generic backend handoff and replace it with SvelteKit-specific guidance.

## How did you test this change?

- `git diff --check`
- Reviewed the generated diff for the SvelteKit quickstart page.

## Are there any deployment considerations?

- Docs only.

## Does this work require review from our design team?

- No.

Closes #8032.