### PR TITLE
refactor: replace antd Table with @highlight-run/ui Table in ProgressBarTable

### DIFF
--- a/frontend/src/components/ProgressBarTable/ProgressBarTable.tsx
+++ b/frontend/src/components/ProgressBarTable/ProgressBarTable.tsx
@@ -1,12 +1,11 @@
-import { ConfigProvider, Table } from 'antd'
-import { ColumnsType } from 'antd/es/table'
+import { CircularSpinner } from '@components/Loading/Loading'
+import { Table } from '@highlight-run/ui/components'
 import React from 'react'
 
 import EmptyCardPlaceholder from '../../pages/Home/components/EmptyCardPlaceholder/EmptyCardPlaceholder'
 import styles from './ProgressBarTable.module.css'
 
 interface Props {
-	columns: ColumnsType<any>
 	data: any[]
 	onClickHandler: (record: any) => void
 	/** The string shown to the user when the table has no data. */
@@ -16,37 +15,43 @@ interface Props {
 }
 
 const ProgressBarTable = ({
-	columns,
 	data,
 	onClickHandler,
 	noDataMessage,
 	noDataTitle,
 	loading,
 }: Props) => {
-	return (
-		<ConfigProvider
-			renderEmpty={() => (
-				<EmptyCardPlaceholder
-					message={noDataMessage}
-					title={noDataTitle}
-				/>
-			)}
-		>
-			<Table
-				className={styles.table}
-				loading={loading}
-				scroll={{ y: 287 }}
-				showHeader={false}
-				columns={columns}
-				dataSource={data}
-				pagination={false}
-				onRow={(record) => ({
-					onClick: () => {
-						onClickHandler(record)
-					},
-				})}
+	if (loading) {
+		return (
+			<div style={{ display: 'flex', justifyContent: 'center', padding: 40 }}>
+				<CircularSpinner />
+			</div>
+		)
+	}
+
+	if (!data || data.length === 0) {
+		return (
+			<EmptyCardPlaceholder
+				message={noDataMessage}
+				title={noDataTitle}
 			/>
-		</ConfigProvider>
+		)
+	}
+
+	return (
+		<div style={{ height: 287, overflowY: 'auto' }}>
+			<Table className={styles.table} noBorder>
+				<Table.Body>
+					{data.map((record, i) => (
+						<Table.Row key={record.key || i} onClick={() => onClickHandler(record)}>
+							<Table.Cell>
+								<div className={styles.listRow}>{record.file || record.key}</div>
+							</Table.Cell>
+						</Table.Row>
+					))}
+				</Table.Body>
+			</Table>
+		</div>
 	)
 }
 

--- a/frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.tsx
@@ -154,17 +154,6 @@ const SourcemapSettings = () => {
 				>
 					<ProgressBarTable
 						loading={loading}
-						columns={[
-							{
-								title: 'Sourcemap',
-								dataIndex: 'key',
-								key: 'key',
-								width: '100%',
-								render: (key) => (
-									<div className={styles.listRow}>{key}</div>
-								),
-							},
-						]}
 						data={visibleFileKeys?.map((file) => ({
 							key: file,
 							file: file,


### PR DESCRIPTION
Addresses #8635

This PR removes the antd Table dependency from ProgressBarTable by rewriting it to use the @highlight-run/ui/components Table, and updates its only caller (SourcemapSettings) to match the new API.