### PR TITLE
refactor: replace remaining antd Dividers and Progress with @highlight-run/ui components

### DIFF
--- a/frontend/src/components/ProgressBarTable/ProgressBarTable.tsx
+++ b/frontend/src/components/ProgressBarTable/ProgressBarTable.tsx
@@ -1,12 +1,11 @@
-import { ConfigProvider, Table } from 'antd'
-import { ColumnsType } from 'antd/es/table'
+import { CircularSpinner } from '@components/Loading/Loading'
+import { Table } from '@highlight-run/ui/components'
 import React from 'react'
 
 import EmptyCardPlaceholder from '../../pages/Home/components/EmptyCardPlaceholder/EmptyCardPlaceholder'
 import styles from './ProgressBarTable.module.css'
 
 interface Props {
-	columns: ColumnsType<any>
 	data: any[]
 	onClickHandler: (record: any) => void
 	/** The string shown to the user when the table has no data. */
@@ -16,37 +15,43 @@ interface Props {
 }
 
 const ProgressBarTable = ({
-	columns,
 	data,
 	onClickHandler,
 	noDataMessage,
 	noDataTitle,
 	loading,
 }: Props) => {
-	return (
-		<ConfigProvider
-			renderEmpty={() => (
-				<EmptyCardPlaceholder
-					message={noDataMessage}
-					title={noDataTitle}
-				/>
-			)}
-		>
-			<Table
-				className={styles.table}
-				loading={loading}
-				scroll={{ y: 287 }}
-				showHeader={false}
-				columns={columns}
-				dataSource={data}
-				pagination={false}
-				onRow={(record) => ({
-					onClick: () => {
-						onClickHandler(record)
-					},
-				})}
+	if (loading) {
+		return (
+			<div style={{ display: 'flex', justifyContent: 'center', padding: 40 }}>
+				<CircularSpinner />
+			</div>
+		)
+	}
+
+	if (!data || data.length === 0) {
+		return (
+			<EmptyCardPlaceholder
+				message={noDataMessage}
+				title={noDataTitle}
 			/>
-		</ConfigProvider>
+		)
+	}
+
+	return (
+		<div style={{ height: 287, overflowY: 'auto' }}>
+			<Table className={styles.table} noBorder>
+				<Table.Body>
+					{data.map((record, i) => (
+						<Table.Row key={record.key || i} onClick={() => onClickHandler(record)}>
+							<Table.Cell>
+								<div className={styles.listRow}>{record.file || record.key}</div>
+							</Table.Cell>
+						</Table.Row>
+					))}
+				</Table.Body>
+			</Table>
+		</div>
 	)
 }
 

--- a/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorDistributions.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorDistributions.tsx
@@ -8,7 +8,6 @@ import {
 } from '@graph/schemas'
 import { colors } from '@highlight-run/ui/colors'
 import { Badge, Box, Stack, Text } from '@highlight-run/ui/components'
-import { Progress } from 'antd'
 import React, { useEffect, useState } from 'react'
 
 type Props = {
@@ -151,14 +150,23 @@ const Buckets: React.FC<
 								</Text>
 							</Box>
 						</Box>
-						<Progress
-							percent={Math.floor(bucket.percent * 100)}
-							showInfo={false}
-							strokeColor={colors.n8}
-							trailColor={colors.n4}
-							strokeWidth={4}
-							status="normal"
-						/>
+						<Box
+							mt="4"
+							style={{ height: 4, borderRadius: 2 }}
+							backgroundColor="n4"
+							width="full"
+						>
+							<Box
+								style={{
+									height: '100%',
+									width: `${Math.floor(
+										bucket.percent * 100,
+									)}%`,
+									borderRadius: 2,
+								}}
+								backgroundColor="n8"
+							/>
+						</Box>
 					</Box>
 				)
 			})}

--- a/frontend/src/pages/ErrorsV2/GitHubEnhancementSettings/GitHubEnhancementSettingsForm.tsx
+++ b/frontend/src/pages/ErrorsV2/GitHubEnhancementSettings/GitHubEnhancementSettingsForm.tsx
@@ -14,7 +14,7 @@ import {
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
+import Select from '@components/Select/Select'
 import React, { useEffect, useMemo, useState } from 'react'
 
 import LoadingBox from '@/components/LoadingBox'
@@ -65,7 +65,7 @@ export const GitHubEnhancementSettingsForm: React.FC<
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
 				id: repo.key,
-				label: repo.name.split('/').pop(),
+				displayValue: repo.name.split('/').pop(),
 				value: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
@@ -233,7 +233,7 @@ export const GitHubEnhancementSettingsForm: React.FC<
 								options={githubOptions}
 								disabled={disabled || testLoading}
 								notFoundContent={<span>No repos found</span>}
-								optionFilterProp="label"
+								optionFilterProp="displayValue"
 								filterOption
 								showSearch
 							/>

--- a/frontend/src/pages/Graphing/EventSelection/EventSteps.tsx
+++ b/frontend/src/pages/Graphing/EventSelection/EventSteps.tsx
@@ -18,7 +18,6 @@ import {
 	Text,
 } from '@highlight-run/ui/components'
 import { LabeledRow } from '@pages/Graphing/LabeledRow'
-import { Divider } from 'antd'
 import { EventSelection } from '@pages/Graphing/EventSelection/index'
 import {
 	EventSelectionDetails,
@@ -180,7 +179,7 @@ const AddEventStep: React.FC<AddEventStepProps> = ({
 					}}
 				/>
 			</LabeledRow>
-			<Divider className="m-0" />
+			<Box borderTop="dividerWeak" width="full" />
 			<EventSelection
 				initialQuery={query}
 				setQuery={setQuery}

--- a/frontend/src/pages/Graphing/GraphingEditor/FormPanel/VisualizationSection.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor/FormPanel/VisualizationSection.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
-import { Input, Select, Text } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
+import { Input, Select, Text, Box } from '@highlight-run/ui/components'
 
 import { useProjectId } from '@/hooks/useProjectId'
 import { useGraphingEditorContext } from '@/pages/Graphing/GraphingEditor/GraphingEditorContext'
@@ -102,7 +101,7 @@ export const VisualizationSection: React.FC<Props> = ({ isPreview }) => {
 					disabled={isPreview}
 				/>
 			</LabeledRow>
-			<Divider className="m-0" />
+			<Box borderTop="dividerWeak" width="full" />
 			<Text weight="bold">Visualization</Text>
 			<LabeledRow label="View type" name="viewType">
 				<OptionDropdown

--- a/frontend/src/pages/Graphing/GraphingEditor/FormPanel/index.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor/FormPanel/index.tsx
@@ -1,5 +1,4 @@
 import { Box, Form, Stack } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
 import React, { useMemo } from 'react'
 
 import { OptionDropdown } from '@/pages/Graphing/OptionDropdown'
@@ -74,7 +73,7 @@ export const FormPanel: React.FC<Props> = ({
 			<Form>
 				<Stack gap="16">
 					<VisualizationSection isPreview={isPreview} />
-					<Divider className="m-0" />
+					<Box borderTop="dividerWeak" width="full" />
 					<SidebarSection isError={errors.length > 0}>
 						<Box>
 							<Box cssClass={style.editorHeader}>

--- a/frontend/src/pages/NewProject/AutoJoinInput.tsx
+++ b/frontend/src/pages/NewProject/AutoJoinInput.tsx
@@ -1,7 +1,6 @@
 import { useAuthContext } from '@authentication/AuthContext'
 import Tooltip from '@components/Tooltip/Tooltip'
 import { Box, Text } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
 import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React from 'react'
 
@@ -49,12 +48,12 @@ export const AutoJoinInput: React.FC<Props> = ({
 					/>
 					<Text>Allowed email domains</Text>
 				</Box>
-				<Divider className="m-0 border-none pt-1" />
+				<Box pt="4" width="full" />
 				<Text color="n11">
 					Allow everyone with a <b>{getEmailDomain(admin?.email)}</b>{' '}
 					email to join your workspace.
 				</Text>
-				<Divider className="m-0 border-none pt-1" />
+				<Box pt="4" width="full" />
 			</div>
 		</Tooltip>
 	)

--- a/frontend/src/pages/NewProject/NewProjectPage.tsx
+++ b/frontend/src/pages/NewProject/NewProjectPage.tsx
@@ -12,7 +12,6 @@ import { namedOperations } from '@graph/operations'
 import { Box, Callout, Stack, Text } from '@highlight-run/ui/components'
 import analytics from '@util/analytics'
 import { client } from '@util/graph'
-import { Divider } from 'antd'
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
@@ -147,7 +146,7 @@ const NewProjectPage = ({ workspace_id }: { workspace_id: string }) => {
 								}}
 							/>
 						</Box>
-						<Divider className="m-0" />
+						<Box borderTop="dividerWeak" width="full" />
 						<Box
 							py="8"
 							px="12"

--- a/frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.tsx
@@ -154,17 +154,6 @@ const SourcemapSettings = () => {
 				>
 					<ProgressBarTable
 						loading={loading}
-						columns={[
-							{
-								title: 'Sourcemap',
-								dataIndex: 'key',
-								key: 'key',
-								width: '100%',
-								render: (key) => (
-									<div className={styles.listRow}>{key}</div>
-								),
-							},
-						]}
 						data={visibleFileKeys?.map((file) => ({
 							key: file,
 							file: file,


### PR DESCRIPTION
Addresses #8635

This PR completes the migration for antd Divider and Progress components across Graphing, NewProject, and ErrorMetrics pages by replacing them with native \@highlight-run/ui/components\ implementations (Box layout equivalents).