### PR TITLE
refactor: remove antd Divider from Alerts and Graphing pages (#8635)

### DIFF
--- a/frontend/src/pages/Alerts/AlertForm/index.tsx
+++ b/frontend/src/pages/Alerts/AlertForm/index.tsx
@@ -1,4 +1,4 @@
-import {
+﻿import {
 	Box,
 	Button,
 	Callout,
@@ -13,7 +13,6 @@ import {
 	Tag,
 	Text,
 } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
 import React, { PropsWithChildren, useEffect, useMemo, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { useNavigate, useSearchParams } from 'react-router-dom'
@@ -640,7 +639,7 @@ export const AlertForm: React.FC = () => {
 										/>
 									</LabeledRow>
 								</SidebarSection>
-								<Divider className="m-0" />
+								<Box borderTop="dividerWeak" />
 								<SidebarSection>
 									<Box cssClass={style.editorSection}>
 										<Box cssClass={style.editorHeader}>
@@ -718,7 +717,7 @@ export const AlertForm: React.FC = () => {
 															</Callout>
 														)}
 												</SidebarSection>
-												<Divider className="m-0" />
+												<Box borderTop="dividerWeak" />
 												<SidebarSection>
 													{productType ===
 													ProductType.Events ? (
@@ -775,7 +774,7 @@ export const AlertForm: React.FC = () => {
 														!isErrorAlert)) && (
 													<>
 														<Box px="12">
-															<Divider className="m-0" />
+															<Box borderTop="dividerWeak" />
 														</Box>
 														<SidebarSection>
 															<LabeledRow
@@ -850,7 +849,7 @@ export const AlertForm: React.FC = () => {
 										)}
 									</Box>
 								</SidebarSection>
-								<Divider className="m-0" />
+								<Box borderTop="dividerWeak" />
 								<SidebarSection>
 									<LabeledRow
 										label="Alert threshold type"
@@ -970,7 +969,7 @@ export const AlertForm: React.FC = () => {
 										</>
 									)}
 								</SidebarSection>
-								<Divider className="m-0" />
+								<Box borderTop="dividerWeak" />
 								<SidebarSection>
 									<DestinationInput
 										initialDestinations={

--- a/frontend/src/pages/Graphing/GraphingEditor/FormPanel/VisualizationSection.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor/FormPanel/VisualizationSection.tsx
@@ -1,6 +1,5 @@
-import * as React from 'react'
-import { Input, Select, Text } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
+﻿import * as React from 'react'
+import { Box, Input, Select, Text } from '@highlight-run/ui/components'
 
 import { useProjectId } from '@/hooks/useProjectId'
 import { useGraphingEditorContext } from '@/pages/Graphing/GraphingEditor/GraphingEditorContext'
@@ -102,7 +101,7 @@ export const VisualizationSection: React.FC<Props> = ({ isPreview }) => {
 					disabled={isPreview}
 				/>
 			</LabeledRow>
-			<Divider className="m-0" />
+			<Box borderTop="dividerWeak" />
 			<Text weight="bold">Visualization</Text>
 			<LabeledRow label="View type" name="viewType">
 				<OptionDropdown

--- a/frontend/src/pages/Graphing/GraphingEditor/FormPanel/index.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor/FormPanel/index.tsx
@@ -1,5 +1,4 @@
-import { Box, Form, Stack } from '@highlight-run/ui/components'
-import { Divider } from 'antd'
+﻿import { Box, Form, Stack } from '@highlight-run/ui/components'
 import React, { useMemo } from 'react'
 
 import { OptionDropdown } from '@/pages/Graphing/OptionDropdown'
@@ -74,7 +73,7 @@ export const FormPanel: React.FC<Props> = ({
 			<Form>
 				<Stack gap="16">
 					<VisualizationSection isPreview={isPreview} />
-					<Divider className="m-0" />
+					<Box borderTop="dividerWeak" />
 					<SidebarSection isError={errors.length > 0}>
 						<Box>
 							<Box cssClass={style.editorHeader}>


### PR DESCRIPTION
/claim #8635

## Summary
Remove all antd Divider dependencies from Alerts and Graphing Editor pages, replacing them with the native Box component from @highlight-run/ui.

## Changes
- **AlertForm**: Replace 5 antd <Divider className='m-0' /> with <Box borderTop='dividerWeak' />
- **FormPanel (GraphingEditor)**: Replace antd Divider with Box
- **VisualizationSection (GraphingEditor)**: Replace antd Divider with Box, add Box to imports

## Rationale
Part of the ongoing effort to remove antd from workspace/project settings (#8635). These Divider components are pure visual separators that map directly to the design system's Box border tokens.