### PR TITLE
fix: Replace antd Select with @components/Select in GitHubSettingsModal

### DIFF
--- a/.changeset/fine-trees-wave.md
+++ b/.changeset/fine-trees-wave.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+fix: Replace antd Select with @components/Select in GitHubSettingsModal

--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -15,7 +15,7 @@ import {
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
+import Select from '@components/Select/Select'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -121,7 +121,7 @@ const GithubSettingsForm = ({
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
 				id: repo.key,
-				label: repo.name.split('/').pop(),
+				displayValue: repo.name.split('/').pop(),
 				value: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
@@ -166,7 +166,7 @@ const GithubSettingsForm = ({
 								.pop()}
 							options={githubOptions}
 							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
+							optionFilterProp="displayValue"
 							filterOption
 							showSearch
 						/>


### PR DESCRIPTION
## Summary

Part of https://github.com/highlight/highlight/issues/8635

Replaces the direct antd `Select` import in `GitHubSettingsModal.tsx` with the project's own `@components/Select/Select` wrapper.

## Changes

- **Import change**: `import { Select } from 'antd'` → `import Select from '@components/Select/Select'`
- **Options format**: Changed `label` to `displayValue` to match the wrapper's `OptionType` API
- **Filter prop**: Updated `optionFilterProp="label"` to `optionFilterProp="displayValue"`

## Testing

- No runtime behavior changes — the wrapper internally uses AntDesignSelect with the same underlying functionality
- The `@components/Select/Select` wrapper is already used elsewhere in the codebase (ErrorFiltersForm, etc.)

## Screenshots

N/A — visual output unchanged