### PR TITLE
[OpenAI Codex] Remove legacy button from pending invites

### DIFF
--- a/frontend/src/pages/WorkspaceTeam/components/PendingInvites.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/PendingInvites.tsx
@@ -1,5 +1,4 @@
 import { AdminAvatar } from '@components/Avatar/Avatar'
-import Button from '@components/Button/Button/Button'
 import Card from '@components/Card/Card'
 import PopConfirm from '@components/PopConfirm/PopConfirm'
 import Table from '@components/Table/Table'
@@ -9,8 +8,9 @@ import {
 	useGetWorkspacePendingInvitesQuery,
 } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
-import { Box } from '@highlight-run/ui/components'
+import { Box, ButtonIcon } from '@highlight-run/ui/components'
 import SvgTrashIconSolid from '@icons/TrashIconSolid'
+import analytics from '@util/analytics'
 import { useAuthorization } from '@util/authorization/authorization'
 import { POLICY_NAMES } from '@util/authorization/authorizationPolicies'
 import { titleCaseString } from '@util/string'
@@ -161,13 +161,17 @@ const TABLE_COLUMNS = [
 					}}
 					okButtonProps={{ danger: true }}
 				>
-					<Button
+					<ButtonIcon
 						className={styles.removeTeamMemberButton}
-						trackingId="DeleteInvite"
-						iconButton
-					>
-						<SvgTrashIconSolid />
-					</Button>
+						kind="secondary"
+						emphasis="low"
+						size="small"
+						shape="square"
+						icon={<SvgTrashIconSolid />}
+						onClick={() => {
+							analytics.track('Button-DeleteInvite')
+						}}
+					/>
 				</PopConfirm>
 			)
 		},


### PR DESCRIPTION
/claim #8635

## Summary
- Replace the legacy Ant Design-backed `@components/Button/Button/Button` import in `PendingInvites` with Highlight UI `ButtonIcon`.
- Preserve the existing trash icon, PopConfirm confirmation flow, delete mutation path, and `Button-DeleteInvite` analytics event.
- Keep this scoped to one workspace-team UI file; no GraphQL, auth, table, routing, or backend behavior changes.

## Verification
- `npx -y prettier@3.3.3 --check frontend/src/pages/WorkspaceTeam/components/PendingInvites.tsx`
- `npx -y esbuild@0.19.5 frontend/src/pages/WorkspaceTeam/components/PendingInvites.tsx --bundle '--external:*' --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=/tmp/highlight-pending-invites.mjs --log-level=error`
- `rg -n '@components/Button/Button/Button|trackingId="DeleteInvite"|iconButton' frontend/src/pages/WorkspaceTeam/components/PendingInvites.tsx` -> no matches
- `git diff --check`

## Demo note
This is a no-visual-diff component migration for the pending invite remove icon button. The confirm/delete behavior is unchanged; the code path now uses Highlight UI `ButtonIcon` instead of the legacy Ant Design-backed wrapper.

Prepared with AI assistance and manually reviewed before submission.