### PR TITLE
fix: resolve #8614

### DIFF
--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.module.css
@@ -3,6 +3,10 @@
 	grid-gap: var(--size-large);
 	grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
+.sectionTitle {
+	margin-top: var(--size-large);
+	margin-bottom: var(--size-medium);
+}
 .modalBtn {
 	padding-bottom: 4px !important;
 	padding-top: 4px !important;

--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
@@ -26,6 +26,7 @@ import { useMicrosoftTeamsBot } from '@/pages/IntegrationsPage/components/Micros
 
 import layoutStyles from '../../components/layout/LeadAlignLayout.module.css'
 import styles from './IntegrationsPage.module.css'
+import { partitionIntegrations } from './utils'
 
 const IntegrationsPage = () => {
 	const { isSlackConnectedToWorkspace, loading: loadingSlack } = useSlackBot()
@@ -181,6 +182,18 @@ const IntegrationsPage = () => {
 
 	useEffect(() => analytics.page('Integrations'), [])
 
+	const { connected, available } = partitionIntegrations(integrations)
+
+	const renderIntegration = (integration: (typeof integrations)[number]) => (
+		<Integration
+			integration={integration}
+			key={integration.key}
+			showModalDefault={popUpModal === integration.key}
+			showSettingsDefault={configureIntegration === integration.key}
+			loading={loading}
+		/>
+	)
+
 	return (
 		<>
 			<Helmet>
@@ -192,19 +205,24 @@ const IntegrationsPage = () => {
 					Supercharge your workflows and attach Highlight with the
 					tools you use everyday.
 				</p>
-				<div className={styles.integrationsContainer}>
-					{integrations.map((integration) => (
-						<Integration
-							integration={integration}
-							key={integration.key}
-							showModalDefault={popUpModal === integration.key}
-							showSettingsDefault={
-								configureIntegration === integration.key
-							}
-							loading={loading}
-						/>
-					))}
-				</div>
+				{loading || connected.length === 0 ? (
+					<div className={styles.integrationsContainer}>
+						{integrations.map(renderIntegration)}
+					</div>
+				) : (
+					<>
+						<h3 className={styles.sectionTitle}>Connected</h3>
+						<div className={styles.integrationsContainer}>
+							{connected.map(renderIntegration)}
+						</div>
+						<h3 className={styles.sectionTitle}>
+							All integrations
+						</h3>
+						<div className={styles.integrationsContainer}>
+							{available.map(renderIntegration)}
+						</div>
+					</>
+				)}
 			</LeadAlignLayout>
 		</>
 	)

--- a/frontend/src/pages/IntegrationsPage/utils.test.ts
+++ b/frontend/src/pages/IntegrationsPage/utils.test.ts
@@ -1,0 +1,25 @@
+import { partitionIntegrations } from './utils'
+
+describe('partitionIntegrations', () => {
+	it('splits integrations into connected and available by defaultEnable', () => {
+		const integrations = [
+			{ key: 'slack', defaultEnable: true },
+			{ key: 'linear', defaultEnable: false },
+			{ key: 'github', defaultEnable: true },
+		]
+
+		const { connected, available } = partitionIntegrations(integrations)
+
+		expect(connected.map((i) => i.key)).toEqual(['slack', 'github'])
+		expect(available.map((i) => i.key)).toEqual(['linear'])
+	})
+
+	it('treats a missing defaultEnable as available', () => {
+		const integrations = [{ key: 'vercel' }, { key: 'discord' }]
+
+		const { connected, available } = partitionIntegrations(integrations)
+
+		expect(connected).toHaveLength(0)
+		expect(available.map((i) => i.key)).toEqual(['vercel', 'discord'])
+	})
+})

--- a/frontend/src/pages/IntegrationsPage/utils.ts
+++ b/frontend/src/pages/IntegrationsPage/utils.ts
@@ -1,0 +1,15 @@
+export interface PartitionedIntegrations<T> {
+	connected: T[]
+	available: T[]
+}
+
+/**
+ * Splits integrations into the ones that are already connected and the ones
+ * that are still available to connect, preserving their original order.
+ */
+export const partitionIntegrations = <T extends { defaultEnable?: boolean }>(
+	integrations: T[],
+): PartitionedIntegrations<T> => ({
+	connected: integrations.filter((integration) => integration.defaultEnable),
+	available: integrations.filter((integration) => !integration.defaultEnable),
+})


### PR DESCRIPTION
Resolves #8614.

Redesigned the integrations page to group cards into "Connected" and "All integrations" sections via a new pure `partitionIntegrations` helper (with a Vitest unit test) and a `.sectionTitle` style; falls back to the original flat grid while loading or when nothing is connected.

/claim #8614