### PR TITLE
refactor: replace user auth legacy button import

### DIFF
--- a/frontend/src/pages/UserSettings/Auth/Auth.tsx
+++ b/frontend/src/pages/UserSettings/Auth/Auth.tsx
@@ -1,5 +1,5 @@
 import Alert from '@components/Alert/Alert'
-import Button from '@components/Button/Button/Button'
+import { Button } from '@components/Button'
 import { FieldsBox } from '@components/FieldsBox/FieldsBox'
 import Input from '@components/Input/Input'
 import Space from '@components/Space/Space'


### PR DESCRIPTION
## Summary
- Replace the legacy `@components/Button/Button/Button` import in `UserSettings/Auth/Auth.tsx` with the current `@components/Button` export.

## Validation
- `npx -y prettier@3.3.3 --check frontend/src/pages/UserSettings/Auth/Auth.tsx`
- `npx -y esbuild@0.19.5 frontend/src/pages/UserSettings/Auth/Auth.tsx --bundle '--external:*' --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=/tmp/highlight-user-auth-button.mjs --log-level=error`
- `git diff --check`

/claim #8635