### PR TITLE
Remove antd usage from workspace and project settings

### DIFF
--- a/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
@@ -1,8 +1,7 @@
 import { LoadingBar } from '@components/Loading/Loading'
-import Select from '@components/Select/Select'
 import { toast } from '@components/Toaster'
-import { Stack } from '@highlight-run/ui/components'
-import { Text } from 'recharts'
+import { Select, Stack } from '@highlight-run/ui/components'
+import type { SelectOption } from '@highlight-run/ui/components'
 
 import BoxLabel from '@/components/BoxLabel/BoxLabel'
 import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
@@ -40,15 +39,15 @@ export const ErrorFiltersForm = () => {
 				<div className={styles.inputAndButtonRow}>
 					<Select
 						className={styles.input}
-						mode="tags"
+						creatable
+						displayMode="tags"
+						filterable
 						placeholder="TypeError: Failed to fetch"
 						value={data?.projectSettings?.error_filters || []}
-						notFoundContent={
-							<Text>
-								Provide a regex pattern to filter out errors.
-							</Text>
-						}
-						onChange={(patterns: string[]) => {
+						onValueChange={(options: SelectOption[]) => {
+							const patterns = options.map((option) =>
+								String(option.value),
+							)
 							patterns.filter(isValidRegex)
 							setAllProjectSettings((currentProjectSettings) =>
 								currentProjectSettings?.projectSettings

--- a/frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx
@@ -1,6 +1,6 @@
 import { LoadingBar } from '@components/Loading/Loading'
-import Select from '@components/Select/Select'
-import { Stack } from '@highlight-run/ui/components'
+import { Select, Stack } from '@highlight-run/ui/components'
+import type { SelectOption } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
 
 import BoxLabel from '@/components/BoxLabel/BoxLabel'
@@ -28,16 +28,20 @@ export const ErrorSettingsForm = () => {
 					info="Enter JSON expressions to use for grouping your errors."
 				/>
 				<Select
-					mode="tags"
+					creatable
+					displayMode="tags"
+					filterable
 					placeholder="$.context.messages[0]"
 					value={data?.projectSettings?.error_json_paths || []}
-					onChange={(paths: string[]) => {
+					onValueChange={(paths: SelectOption[]) => {
 						setAllProjectSettings((currentProjectSettings) =>
 							currentProjectSettings?.projectSettings
 								? {
 										projectSettings: {
 											...currentProjectSettings.projectSettings,
-											error_json_paths: paths,
+											error_json_paths: paths.map(
+												(path) => String(path.value),
+											),
 										},
 									}
 								: currentProjectSettings,

--- a/frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx
@@ -1,9 +1,8 @@
 import { LoadingBar } from '@components/Loading/Loading'
-import Select from '@components/Select/Select'
-import TextHighlighter from '@components/TextHighlighter/TextHighlighter'
 import { toast } from '@components/Toaster'
 import { useGetIdentifierSuggestionsQuery } from '@graph/hooks'
-import { Form, Stack } from '@highlight-run/ui/components'
+import { Form, Select, Stack } from '@highlight-run/ui/components'
+import type { SelectOption } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
 import { useState } from 'react'
 
@@ -15,7 +14,6 @@ export const ExcludedUsersForm = () => {
 	const { project_id } = useParams<{
 		project_id: string
 	}>()
-	const [identifierQuery, setIdentifierQuery] = useState('')
 	const [invalidExcludedUsers, setInvalidExcludedUsers] = useState<string[]>(
 		[],
 	)
@@ -46,18 +44,11 @@ export const ExcludedUsersForm = () => {
 		: (identifierSuggestionsApiResponse?.identifier_suggestion || []).map(
 				(suggestion) => ({
 					value: suggestion,
-					displayValue: (
-						<TextHighlighter
-							searchWords={[identifierQuery]}
-							textToHighlight={suggestion}
-						/>
-					),
-					id: suggestion,
+					name: suggestion,
 				}),
 			)
 
 	const handleIdentifierSearch = (query = '') => {
-		setIdentifierQuery(query)
 		refetchIdentifierSuggestions({ query, project_id })
 	}
 
@@ -77,15 +68,21 @@ export const ExcludedUsersForm = () => {
 						name="Filtered users"
 					>
 						<Select
-							mode="tags"
+							creatable
+							displayMode="tags"
+							filterable
 							placeholder=".*@yourdomain.com"
 							value={
 								data?.projectSettings?.excluded_users ||
 								undefined
 							}
-							onSearch={handleIdentifierSearch}
+							onSearchValueChange={handleIdentifierSearch}
 							options={identifierSuggestions}
-							onChange={(excluded: string[]) => {
+							resultsLoading={identifierSuggestionsLoading}
+							onValueChange={(options: SelectOption[]) => {
+								const excluded = options.map((option) =>
+									String(option.value),
+								)
 								const validRegexes: string[] = []
 								const invalidRegexes: string[] = []
 								excluded.forEach((expression) => {

--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -10,12 +10,13 @@ import {
 	IconSolidQuestionMarkCircle,
 	IconSolidTrash,
 	IconSolidX,
+	Select,
 	Text,
 	TextLink,
 	Tooltip,
 } from '@highlight-run/ui/components'
+import type { SelectOption } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -120,8 +121,7 @@ const GithubSettingsForm = ({
 	const githubOptions = useMemo(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
-				id: repo.key,
-				label: repo.name.split('/').pop(),
+				name: repo.name.split('/').pop() ?? repo.name,
 				value: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
@@ -155,20 +155,15 @@ const GithubSettingsForm = ({
 							aria-label="GitHub repository"
 							className={styles.repoSelect}
 							placeholder="Search repos..."
-							onSelect={(repo: string) =>
+							onValueChange={(repo: SelectOption) =>
 								formStore.setValue(
 									formStore.names.githubRepo,
-									repo,
+									String(repo.value),
 								)
 							}
-							value={formState.values.githubRepo
-								?.split('/')
-								.pop()}
+							value={formState.values.githubRepo ?? undefined}
 							options={githubOptions}
-							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
-							filterOption
-							showSearch
+							filterable
 						/>
 						<ButtonIcon
 							kind="secondary"

--- a/frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.tsx
@@ -2,13 +2,13 @@ import Card from '@components/Card/Card'
 import CopyText from '@components/CopyText/CopyText'
 import Input from '@components/Input/Input'
 import ProgressBarTable from '@components/ProgressBarTable/ProgressBarTable'
-import Select from '@components/Select/Select'
 import {
 	useGetProjectQuery,
 	useGetSourcemapFilesLazyQuery,
 	useGetSourcemapVersionsQuery,
 } from '@graph/hooks'
-import { Box, Stack } from '@highlight-run/ui/components'
+import { Box, Select, Stack } from '@highlight-run/ui/components'
+import type { SelectOption } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
 import { debounce } from 'lodash'
 import React, { useEffect } from 'react'
@@ -129,15 +129,18 @@ const SourcemapSettings = () => {
 										className={styles.versionSelect}
 										placeholder="Select a version of your app"
 										options={versions.map((v) => ({
-											id: v,
+											name: v,
 											value: v,
-											displayValue: v,
 										}))}
-										onChange={setSelectedVersion}
-										value={selectedVersion}
-										notFoundContent={
-											<p>No sourcemaps found</p>
+										onValueChange={(
+											version: SelectOption,
+										) =>
+											setSelectedVersion(
+												String(version.value),
+											)
 										}
+										value={selectedVersion}
+										filterable
 									/>
 								</div>
 							)}

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -6,9 +6,8 @@ import {
 	useUpdateAllowedEmailOriginsMutation,
 } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
-import { Box, Select, Text } from '@highlight-run/ui/components'
+import { Box, Select, SwitchButton, Text } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
-import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
 import React, { useState } from 'react'
 
 import { getEmailDomain } from '@/util/email'
@@ -61,9 +60,8 @@ export const AutoJoinForm: React.FC = () => {
 		}
 	}
 
-	const handleCheckboxChange = (event: CheckboxChangeEvent) => {
-		const checked = event.target.checked
-		if (checked) {
+	const handleAutoJoinToggle = () => {
+		if (autoJoinDomains.length === 0) {
 			onChangeMsg([adminsEmailDomain], 'Successfully enabled auto-join!')
 		} else {
 			onChangeMsg([], 'Successfully disabled auto-join!')
@@ -85,9 +83,12 @@ export const AutoJoinForm: React.FC = () => {
 		>
 			<div className={styles.container}>
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
-					<Checkbox
+					<SwitchButton
+						type="button"
+						size="xxSmall"
+						aria-label="Toggle auto-approved email domains"
 						checked={autoJoinDomains.length > 0}
-						onChange={handleCheckboxChange}
+						onChange={handleAutoJoinToggle}
 					/>
 					<Text>Auto-approved email domains</Text>
 				</Box>


### PR DESCRIPTION
## Summary

Part of #8635.

- Replace the remaining antd-backed selects in project/workspace settings with @highlight-run/ui Select.
- Replace the workspace auto-join antd Checkbox with @highlight-run/ui SwitchButton.
- Preserve the existing settings values by mapping SelectOption values back to strings before updating project settings state.

## How did you test this change?

- `corepack yarn workspace @highlight-run/ui build`
- `corepack yarn workspace @highlight-run/frontend lint --quiet --no-error-on-unmatched-pattern src/pages/WorkspaceTeam/components/AutoJoinForm.tsx src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx src/pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm.tsx src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.tsx`
- `git diff --check`

## Are there any deployment considerations?

None.

## Does this work require review from our design team?

No.
