### PR TITLE
fix(frontend): correct inverted use1024 flag in bytesToPrettyString

### DIFF
--- a/frontend/src/pages/Player/MetadataPanel/MetadataPanel.tsx
+++ b/frontend/src/pages/Player/MetadataPanel/MetadataPanel.tsx
@@ -249,6 +249,7 @@ const MetadataPanel = () => {
 			keyDisplayValue: 'RAM',
 			valueDisplayValue: bytesToPrettyString(
 				session.deviceMemory! * 1024 * 1024,
+				true,
 			),
 		})
 	}

--- a/frontend/src/util/string/index.test.ts
+++ b/frontend/src/util/string/index.test.ts
@@ -1,4 +1,4 @@
-import { validateEmail } from './index'
+import { bytesToPrettyString, validateEmail } from './index'
 
 describe('validateEmail', () => {
 	const CASES = [
@@ -13,5 +13,19 @@ describe('validateEmail', () => {
 
 	it.each(CASES)('should validate %s as %s', (email, expected) => {
 		expect(validateEmail(email as string)).toBe(expected as Boolean)
+	})
+})
+
+describe('bytesToPrettyString', () => {
+	// 1000 bytes sits exactly on the boundary between the two modes: with a
+	// 1024 (binary) divisor it stays under the threshold and renders as raw
+	// bytes, while with a 1000 (decimal/SI) divisor it rolls over to kB. So
+	// the input cleanly distinguishes which divisor the flag selected.
+	it('uses a 1024 divisor when use1024 is true', () => {
+		expect(bytesToPrettyString(1000, true)).toBe('1000 B')
+	})
+
+	it('uses a 1000 divisor when use1024 is false', () => {
+		expect(bytesToPrettyString(1000, false)).toBe('1.0 kB')
 	})
 })

--- a/frontend/src/util/string/index.ts
+++ b/frontend/src/util/string/index.ts
@@ -54,7 +54,7 @@ export const bytesToPrettyString = (
 	use1024 = false,
 	decimalPoints = 1,
 ) => {
-	const thresh = use1024 ? 1000 : 1024
+	const thresh = use1024 ? 1024 : 1000
 
 	if (Math.abs(bytes) < thresh) {
 		return bytes + ' B'


### PR DESCRIPTION
`bytesToPrettyString` (`frontend/src/util/string/index.ts`) has its binary/decimal flag inverted: `const thresh = use1024 ? 1000 : 1024`. It came from the MDN `humanFileSize` snippet whose flag was `si`; renaming `si` → `use1024` without swapping the branches inverted the meaning, so requesting binary units (`use1024=true`) divides by 1000 and decimal divides by 1024 — the opposite of the name.

This swaps the branch to `use1024 ? 1024 : 1000`, and updates the one RAM call site (`MetadataPanel.tsx`) to pass `true` so its rendered output stays byte-identical. Adds boundary tests for both modes.

Verified red-green by transpiling the source with the repo's own esbuild (vitest does not run locally under Node 26). `prettier --check`, `eslint`, and `tsc --noEmit` are clean on the changed files.