### PR TITLE
Replace Heroku integration legacy buttons

### DIFF
--- a/.changeset/plain-boxes-draw.md
+++ b/.changeset/plain-boxes-draw.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+Replace Heroku integration legacy buttons

--- a/frontend/src/pages/IntegrationsPage/components/HerokuIntegration/HerokuIntegration.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/HerokuIntegration/HerokuIntegration.module.css
@@ -3,10 +3,6 @@
 	padding-top: 4px !important;
 }
 
-.modalBtnIcon {
-	margin-right: 0.5rem;
-}
-
 .modalSubTitle {
 	color: var(--color-gray-500) !important;
 	font-size: 16px;

--- a/frontend/src/pages/IntegrationsPage/components/HerokuIntegration/HerokuIntegration.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/HerokuIntegration/HerokuIntegration.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button/Button/Button'
+import { Button } from '@components/Button'
 import { Form } from '@highlight-run/ui/components'
 import AppsIcon from '@icons/AppsIcon'
 import PlugIcon from '@icons/PlugIcon'
@@ -36,8 +36,10 @@ const HerokuIntegration: React.FC<
 				</p>
 				<footer>
 					<Button
-						trackingId="IntegrationDisconnectCancel-Heroku"
+						trackingId="Button-IntegrationDisconnectCancel-Heroku"
 						className={styles.modalBtn}
+						kind="secondary"
+						emphasis="medium"
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(true)
@@ -46,17 +48,16 @@ const HerokuIntegration: React.FC<
 						Cancel
 					</Button>
 					<Button
-						trackingId="IntegrationDisconnectSave-Heroku"
+						trackingId="Button-IntegrationDisconnectSave-Heroku"
 						className={styles.modalBtn}
-						type="primary"
-						danger
+						kind="danger"
+						iconLeft={<PlugIcon />}
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(false)
 							removeHerokuIntegrationFromProject(project_id)
 						}}
 					>
-						<PlugIcon className={styles.modalBtnIcon} />
 						Disconnect Heroku
 					</Button>
 				</footer>
@@ -98,8 +99,10 @@ const HerokuIntegration: React.FC<
 			</Form>
 			<footer>
 				<Button
-					trackingId="IntegrationConfigurationCancel-Heroku"
+					trackingId="Button-IntegrationConfigurationCancel-Heroku"
 					className={styles.modalBtn}
+					kind="secondary"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(false)
@@ -108,17 +111,18 @@ const HerokuIntegration: React.FC<
 					Cancel
 				</Button>
 				<Button
-					trackingId="IntegrationConfigurationSave-Heroku"
+					trackingId="Button-IntegrationConfigurationSave-Heroku"
 					className={styles.modalBtn}
-					type="primary"
+					kind="primary"
+					emphasis="high"
+					iconLeft={<AppsIcon />}
 					disabled={!tokens.filter((t) => t.length >= 38).length}
 					onClick={async () => {
 						setModalOpen(false)
 						await addHerokuToProject(tokens, project_id)
 					}}
 				>
-					<AppsIcon className={styles.modalBtnIcon} /> Connect
-					Highlight with Heroku
+					Connect Highlight with Heroku
 				</Button>
 			</footer>
 		</>


### PR DESCRIPTION
/claim #8635

## Summary
- Replace the Heroku integration config legacy Ant Design-backed Button wrapper with the current tracked Button wrapper.
- Map the existing cancel, disconnect, and connect buttons to Highlight UI button variants while preserving the existing `Button-...Heroku` analytics event names.
- Keep the scope to Heroku Button usage only; the Heroku token Select and integration logic are unchanged.

## Verification
- `git diff --check`
- `npm exec --yes esbuild@0.19.5 -- frontend/src/pages/IntegrationsPage/components/HerokuIntegration/HerokuIntegration.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=/tmp/highlight-heroku-integration.mjs --log-level=error`
- `npm exec --yes prettier@3.3.3 -- --check frontend/src/pages/IntegrationsPage/components/HerokuIntegration/HerokuIntegration.tsx frontend/src/pages/IntegrationsPage/components/HerokuIntegration/HerokuIntegration.module.css`