### PR TITLE
Replace EventDetails legacy info tooltip

### DIFF
--- a/.changeset/polite-bees-deny.md
+++ b/.changeset/polite-bees-deny.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+Replace EventDetails legacy info tooltip

--- a/frontend/src/pages/Player/RightPlayerPanel/components/EventDetails/EventDetails.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/EventDetails/EventDetails.tsx
@@ -1,13 +1,14 @@
-import InfoTooltip from '@components/InfoTooltip/InfoTooltip'
 import { PreviousNextGroup } from '@components/PreviousNextGroup/PreviousNextGroup'
 import { TableList } from '@components/TableList/TableList'
 import {
 	Badge,
 	Box,
 	ButtonIcon,
+	IconSolidInformationCircle,
 	IconSolidX,
 	Tag,
 	Text,
+	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
 import {
@@ -132,12 +133,20 @@ const EventDetails = React.memo(({ event }: { event: HighlightEvent }) => {
 							alignItems="center"
 							style={{ width: 12, height: 12 }}
 						>
-							<InfoTooltip
-								color={EVENT_TYPES_TO_COLORS[displayName]}
-								title={getTimelineEventTooltipText(
+							<Tooltip
+								trigger={
+									<IconSolidInformationCircle
+										color={
+											EVENT_TYPES_TO_COLORS[displayName]
+										}
+										size={12}
+									/>
+								}
+							>
+								{getTimelineEventTooltipText(
 									details.title || '',
 								)}
-							/>
+							</Tooltip>
 						</Box>
 					}
 				/>


### PR DESCRIPTION
/claim #8635

## Summary
- Replace the Player event details legacy `InfoTooltip` wrapper usage with the current `@highlight-run/ui` Tooltip.
- Render the existing information icon directly as the Tooltip trigger while preserving the event-type color.
- Keep the event timeline, payload rendering, and keyboard navigation logic unchanged.

## Verification
- `git diff --check`
- `npm exec --yes esbuild@0.19.5 -- frontend/src/pages/Player/RightPlayerPanel/components/EventDetails/EventDetails.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=/tmp/highlight-event-details.mjs --log-level=error`
- `npm exec --yes prettier@3.3.3 -- --check frontend/src/pages/Player/RightPlayerPanel/components/EventDetails/EventDetails.tsx`