### PR TITLE
Replace JsonViewer legacy download button

### DIFF
--- a/.changeset/big-papers-kneel.md
+++ b/.changeset/big-papers-kneel.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+Replace JsonViewer legacy download button

--- a/frontend/src/components/JsonViewer/JsonViewer.tsx
+++ b/frontend/src/components/JsonViewer/JsonViewer.tsx
@@ -1,6 +1,10 @@
-import Button from '@components/Button/Button/Button'
-import Tooltip from '@components/Tooltip/Tooltip'
-import SvgDownloadIcon from '@icons/DownloadIcon'
+import {
+	Box,
+	ButtonIcon,
+	IconSolidDownload,
+	Text,
+	Tooltip,
+} from '@highlight-run/ui/components'
 // @ts-expect-error
 import { specific } from 'react-files-hooks'
 import ReactJson, { ReactJsonViewProps } from 'react-json-view'
@@ -29,22 +33,31 @@ const JsonViewer = ({
 	return (
 		<div className={styles.container}>
 			{allowDownload && (
-				<Tooltip title="Download this as JSON" placement="left">
-					<Button
-						className={styles.downloadButton}
-						trackingId="JsonViewerDownload"
-						iconButton
-						type="text"
-						size="small"
-						onClick={() => {
-							download({
-								data: JSON.stringify(props.src, undefined, 2),
-								name: downloadFileName,
-							})
-						}}
-					>
-						<SvgDownloadIcon />
-					</Button>
+				<Tooltip
+					trigger={
+						<ButtonIcon
+							cssClass={styles.downloadButton}
+							trackingId="JsonViewerDownload"
+							kind="secondary"
+							size="xSmall"
+							shape="square"
+							emphasis="low"
+							icon={<IconSolidDownload />}
+							onClick={() => {
+								download({
+									data: JSON.stringify(props.src, undefined, 2),
+									name: downloadFileName,
+								})
+							}}
+						/>
+					}
+					delayed
+				>
+					<Box p="4">
+						<Text userSelect="none" color="n11">
+							Download this as JSON
+						</Text>
+					</Box>
 				</Tooltip>
 			)}
 			<ReactJson


### PR DESCRIPTION
## Summary

- replace the legacy Ant Design-backed JsonViewer download button with @highlight-run/ui ButtonIcon
- keep the existing tooltip text, download behavior, CSS positioning, and JsonViewerDownload tracking id

## Validation

- Not run locally; authored through the GitHub web editor and verified the raw file content in the fork.

/claim #8635