### PR TITLE
Replace GitHub settings repo select

### DIFF
--- a/.changeset/red-ravens-burn.md
+++ b/.changeset/red-ravens-burn.md
@@ -1,0 +1,5 @@
+---
+"@highlight-run/frontend": patch
+---
+
+Replace GitHub settings repo select

--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -150,10 +150,10 @@ const GithubSettingsForm = ({
 					name="githubRepo"
 				>
 					<Box display="flex" alignItems="center" gap="8">
-						<Select
-							aria-label="GitHub repository"
-							className={styles.repoSelect}
-							placeholder="Search repos..."
+						<Box cssClass={styles.repoSelect}>
+							<Select
+								aria-label="GitHub repository"
+								placeholder="Search repos..."
 							onValueChange={(repo) =>
 								formStore.setValue(
 									formStore.names.githubRepo,
@@ -162,8 +162,9 @@ const GithubSettingsForm = ({
 							}
 							value={formState.values.githubRepo ?? undefined}
 							options={githubOptions}
-							filterable
-						/>
+								filterable
+							/>
+						</Box>
 						<ButtonIcon
 							kind="secondary"
 							emphasis="medium"

--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -154,14 +154,14 @@ const GithubSettingsForm = ({
 							<Select
 								aria-label="GitHub repository"
 								placeholder="Search repos..."
-							onValueChange={(repo) =>
-								formStore.setValue(
-									formStore.names.githubRepo,
-									repo.value as string,
-								)
-							}
-							value={formState.values.githubRepo ?? undefined}
-							options={githubOptions}
+								onValueChange={(repo) =>
+									formStore.setValue(
+										formStore.names.githubRepo,
+										repo.value as string,
+									)
+								}
+								value={formState.values.githubRepo ?? undefined}
+								options={githubOptions}
 								filterable
 							/>
 						</Box>

--- a/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
+++ b/frontend/src/pages/ProjectSettings/GitHubSettingsModal/GitHubSettingsModal.tsx
@@ -10,12 +10,12 @@ import {
 	IconSolidQuestionMarkCircle,
 	IconSolidTrash,
 	IconSolidX,
+	Select,
 	Text,
 	TextLink,
 	Tooltip,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
-import { Select } from 'antd'
 import { useMemo } from 'react'
 
 import { GitHubRepo, Service } from '@/graph/generated/schemas'
@@ -120,8 +120,7 @@ const GithubSettingsForm = ({
 	const githubOptions = useMemo(
 		() =>
 			githubRepos.map((repo: GitHubRepo) => ({
-				id: repo.key,
-				label: repo.name.split('/').pop(),
+				name: repo.name.split('/').pop() ?? repo.name,
 				value: repo.repo_id.replace(
 					'https://api.github.com/repos/',
 					'',
@@ -155,20 +154,15 @@ const GithubSettingsForm = ({
 							aria-label="GitHub repository"
 							className={styles.repoSelect}
 							placeholder="Search repos..."
-							onSelect={(repo: string) =>
+							onValueChange={(repo) =>
 								formStore.setValue(
 									formStore.names.githubRepo,
-									repo,
+									repo.value as string,
 								)
 							}
-							value={formState.values.githubRepo
-								?.split('/')
-								.pop()}
+							value={formState.values.githubRepo ?? undefined}
 							options={githubOptions}
-							notFoundContent={<span>No repos found</span>}
-							optionFilterProp="label"
-							filterOption
-							showSearch
+							filterable
 						/>
 						<ButtonIcon
 							kind="secondary"


### PR DESCRIPTION
## Summary

- replace the ProjectSettings GitHub repository dropdown with the Highlight UI Select component
- keep repository search, option values, clearing behavior, and form submission semantics
- remove the remaining direct antd Select import from the GitHub settings modal

## Validation

- Not run locally; authored through the GitHub web editor and reviewed against existing Highlight UI Select usage in project settings.

/claim #8635