### PR TITLE
Remove AntD tooltip wrapper from rage click settings

### DIFF
--- a/frontend/src/pages/ProjectSettings/RageClicksForm/RageClicksForm.tsx
+++ b/frontend/src/pages/ProjectSettings/RageClicksForm/RageClicksForm.tsx
@@ -1,12 +1,32 @@
-import InfoTooltip from '@components/InfoTooltip/InfoTooltip'
 import { LoadingBar } from '@components/Loading/Loading'
-import { Box, Form, Stack } from '@highlight-run/ui/components'
+import {
+	Box,
+	Form,
+	IconSolidInformationCircle,
+	Stack,
+	Tooltip,
+} from '@highlight-run/ui/components'
+import { vars } from '@highlight-run/ui/vars'
 import { useParams } from '@util/react-router/useParams'
 import { useEffect, useState } from 'react'
 
 import BorderBox from '@/components/BorderBox/BorderBox'
 import BoxLabel from '@/components/BoxLabel/BoxLabel'
 import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
+
+const RageClickTooltip = ({ title }: { title: string }) => (
+	<Tooltip
+		trigger={
+			<IconSolidInformationCircle
+				color={vars.theme.interactive.fill.secondary.content.onDisabled}
+				size={13}
+			/>
+		}
+		renderInLine
+	>
+		{title}
+	</Tooltip>
+)
 
 export const RageClicksForm = () => {
 	const { project_id } = useParams<{
@@ -60,10 +80,7 @@ export const RageClicksForm = () => {
 							type="number"
 							value={rageClickWindowSeconds}
 							labelTag={
-								<InfoTooltip
-									title="The maximum time allowed between clicks in a rage click event"
-									size="small"
-								/>
+								<RageClickTooltip title="The maximum time allowed between clicks in a rage click event" />
 							}
 							onChange={(e) => {
 								const val = Number(e.target.value)
@@ -86,10 +103,7 @@ export const RageClicksForm = () => {
 						<Form.Input
 							label="Radius (pixels)"
 							labelTag={
-								<InfoTooltip
-									title="The maximum distance allowed between clicks in a rage click event"
-									size="small"
-								/>
+								<RageClickTooltip title="The maximum distance allowed between clicks in a rage click event" />
 							}
 							name="rage_click_radius_pixels"
 							type="number"
@@ -116,10 +130,7 @@ export const RageClicksForm = () => {
 							name="rage_click_minimum_clicks"
 							label="Minimum clicks"
 							labelTag={
-								<InfoTooltip
-									title="The minimum number of clicks needed to be considered a rage click event"
-									size="small"
-								/>
+								<RageClickTooltip title="The minimum number of clicks needed to be considered a rage click event" />
 							}
 							type="number"
 							value={rageClickCount}


### PR DESCRIPTION
/claim #8635

## Summary
- replaced the AntD-backed `InfoTooltip` usage in `RageClicksForm` with the current `@highlight-run/ui` `Tooltip` and `IconSolidInformationCircle` pattern
- kept the rage-click form state, field names, min values, and project-settings update behavior unchanged
- scoped to one Project Settings file to avoid overlap with larger AntD-removal PRs

## Validation
- `npx -y prettier@3.3.3 --check frontend/src/pages/ProjectSettings/RageClicksForm/RageClicksForm.tsx`
- `npx -y esbuild@0.19.5 frontend/src/pages/ProjectSettings/RageClicksForm/RageClicksForm.tsx --bundle --external:* --loader:.tsx=tsx --loader:.ts=ts --loader:.css=empty --format=esm --outfile=$env:TEMP\rage-clicks-form-check.mjs --log-level=error`
- `rg -n "InfoTooltip|antd" frontend/src/pages/ProjectSettings/RageClicksForm/RageClicksForm.tsx` returned no matches
- `git diff --check`

No runtime demo video is attached because this is a small static component migration with unchanged form behavior; the validation above confirms the touched file formats, parses, and no longer references the AntD-backed wrapper.
