### PR TITLE
Replace Microsoft Teams integration legacy buttons

### DIFF
--- a/frontend/src/pages/IntegrationsPage/components/MicrosoftTeamsIntegration/MicrosoftTeamsIntegrationConfig.module.css
+++ b/frontend/src/pages/IntegrationsPage/components/MicrosoftTeamsIntegration/MicrosoftTeamsIntegrationConfig.module.css
@@ -3,10 +3,6 @@
 	padding-top: 4px !important;
 }
 
-.modalBtnIcon {
-	margin-right: 0.5rem;
-}
-
 .modalSubTitle {
 	color: var(--color-gray-500) !important;
 	font-size: 16px;

--- a/frontend/src/pages/IntegrationsPage/components/MicrosoftTeamsIntegration/MicrosoftTeamsIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/MicrosoftTeamsIntegration/MicrosoftTeamsIntegrationConfig.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button/Button/Button'
+import { Button } from '@components/Button'
 import AppsIcon from '@icons/AppsIcon'
 import PlugIcon from '@icons/PlugIcon'
 import {
@@ -29,8 +29,10 @@ const MicrosoftTeamsIntegrationConfig: React.FC<
 				</p>
 				<footer>
 					<Button
-						trackingId="IntegrationDisconnectCancel-MicrosoftTeams"
+						trackingId="Button-IntegrationDisconnectCancel-MicrosoftTeams"
 						className={styles.modalBtn}
+						kind="secondary"
+						emphasis="medium"
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(true)
@@ -39,10 +41,10 @@ const MicrosoftTeamsIntegrationConfig: React.FC<
 						Cancel
 					</Button>
 					<Button
-						trackingId="IntegrationDisconnectSave-MicrosoftTeams"
+						trackingId="Button-IntegrationDisconnectSave-MicrosoftTeams"
 						className={styles.modalBtn}
-						type="primary"
-						danger
+						kind="danger"
+						iconLeft={<PlugIcon />}
 						onClick={() => {
 							setModalOpen(false)
 							setIntegrationEnabled(false)
@@ -51,7 +53,6 @@ const MicrosoftTeamsIntegrationConfig: React.FC<
 							)
 						}}
 					>
-						<PlugIcon className={styles.modalBtnIcon} />
 						Disconnect Microsoft Teams
 					</Button>
 				</footer>
@@ -67,8 +68,10 @@ const MicrosoftTeamsIntegrationConfig: React.FC<
 			</p>
 			<footer>
 				<Button
-					trackingId="IntegrationConfigurationCancel-MicrosoftTeams"
+					trackingId="Button-IntegrationConfigurationCancel-MicrosoftTeams"
 					className={styles.modalBtn}
+					kind="secondary"
+					emphasis="medium"
 					onClick={() => {
 						setModalOpen(false)
 						setIntegrationEnabled(false)
@@ -77,13 +80,14 @@ const MicrosoftTeamsIntegrationConfig: React.FC<
 					Cancel
 				</Button>
 				<Button
-					trackingId="IntegrationConfigurationSave-MicrosoftTeams"
+					trackingId="Button-IntegrationConfigurationSave-MicrosoftTeams"
 					className={styles.modalBtn}
-					type="primary"
+					kind="primary"
+					emphasis="high"
+					iconLeft={<AppsIcon />}
 					href={microsoftTeamsAuthUrl}
 				>
-					<AppsIcon className={styles.modalBtnIcon} /> Connect
-					Highlight with Microsoft Teams
+					Connect Highlight with Microsoft Teams
 				</Button>
 			</footer>
 		</>


### PR DESCRIPTION
/claim #8635

## Summary
- replace the Microsoft Teams integration legacy Ant Design-backed Button wrapper with the current tracked Button wrapper
- map cancel/connect/disconnect buttons to the new Button API using kind, emphasis, and iconLeft props
- remove the obsolete modal icon spacing class after moving icons into Button iconLeft

## Validation
- Reviewed the GitHub compare diff for the touched TSX and CSS files
- Not run locally; changes were authored through the GitHub web editor without a local checkout
