### PR TITLE
docs(8032): document sveltekit backend instrumentation

### DIFF
--- a/docs-content/getting-started/4_server/2_js/1_overview.md
+++ b/docs-content/getting-started/4_server/2_js/1_overview.md
@@ -36,6 +36,9 @@ updatedAt: 2022-04-01T19:52:59.000Z
     <DocsCard title="Node.js" href="../js/nodejs">
         {"Get started with Node.js"}
     </DocsCard>
+    <DocsCard title="SvelteKit" href="../js/sveltekit">
+        {"Get started with SvelteKit"}
+    </DocsCard>
     <DocsCard title="Pino" href="../js/pino">
         {"Get started with Pino"}
     </DocsCard>

--- a/docs-content/getting-started/4_server/2_js/sveltekit.md
+++ b/docs-content/getting-started/4_server/2_js/sveltekit.md
@@ -1,0 +1,11 @@
+---
+title: SvelteKit
+heading: SvelteKit Quick Start
+metaTitle: SvelteKit Quick Start
+slug: sveltekit
+createdAt: 2024-03-01T00:00:00.000Z
+updatedAt: 2024-03-01T00:00:00.000Z
+quickstart: true
+---
+
+<QuickStart content={quickStartContent["server"]["js"]["sveltekit"]}/>

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -138,6 +138,7 @@ import { ElixirOtherReorganizedContent } from './server/elixir/other'
 import { ReactNativeContent } from './frontend/react-native'
 import { siteUrl } from '../../utils/urls'
 import { NextJsTracesReorganizedContent } from './server/js/nextjs'
+import { JSSvelteKitReorganizedContent } from './server/js/sveltekit'
 import { AWSLambdaTracingSteps } from './server/serverless/shared-snippets-aws-lambda'
 
 export type QuickStartContent = {
@@ -206,6 +207,7 @@ export enum QuickStartType {
 	JSNextjs = 'nextjs',
 	JSManual = 'manual',
 	JSNestjs = 'nestjs',
+	JSSvelteKit = 'sveltekit',
 	JSWinston = 'winston',
 	JSPino = 'pino',
 	JStRPC = 'trpc',
@@ -456,6 +458,7 @@ export const quickStartContent = {
 			[QuickStartType.JSHono]: JSHonoReorganizedContent,
 			[QuickStartType.JSNodejs]: JSNodeReorganizedContent,
 			[QuickStartType.JSNestjs]: JSNestReorganizedContent,
+			[QuickStartType.JSSvelteKit]: JSSvelteKitReorganizedContent,
 			[QuickStartType.JStRPC]: JStRPCReorganizedContent,
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,
@@ -601,6 +604,7 @@ export const quickStartContentReorganized = {
 			[QuickStartType.JSHono]: JSHonoReorganizedContent,
 			[QuickStartType.JSNodejs]: JSNodeReorganizedContent,
 			[QuickStartType.JSNestjs]: JSNestReorganizedContent,
+			[QuickStartType.JSSvelteKit]: JSSvelteKitReorganizedContent,
 			[QuickStartType.JStRPC]: JStRPCReorganizedContent,
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,

--- a/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
@@ -3,11 +3,11 @@ import {
 	identifySnippet,
 	initializeSnippet,
 	packageInstallSnippet,
-	setupBackendSnippet,
 	verifySnippet,
 } from './shared-snippets'
 
 import { QuickStartContent } from '../QuickstartContent'
+import { siteUrl } from '../../../utils/urls'
 
 const svelteKitInitCodeSnippet = `// hooks.client.ts
 ...
@@ -79,6 +79,9 @@ export default config;`,
 		identifySnippet,
 		verifySnippet,
 		configureSourcemapsCI(),
-		setupBackendSnippet,
+		{
+			title: 'Instrument your SvelteKit backend.',
+			content: `The next step is instrumenting your SvelteKit backend to tie logs, errors, and traces to your frontend sessions. Set up \`@highlight-run/node\` in your \`src/hooks.server.ts\` file to capture server-side errors and traces. Read more in our [SvelteKit backend instrumentation](${siteUrl('/docs/getting-started/server/js/sveltekit')}) docs.`,
+		},
 	],
 }

--- a/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
@@ -1,0 +1,131 @@
+import { QuickStartContent } from '../../QuickstartContent'
+import { verifyLogs } from '../shared-snippets-logging'
+import { frontendInstallSnippet } from '../shared-snippets-monitoring'
+import { verifyTraces } from '../shared-snippets-tracing'
+import {
+	jsGetSnippet,
+	manualError,
+	verifyError,
+} from './shared-snippets-monitoring'
+
+export const JSSvelteKitReorganizedContent: QuickStartContent = {
+	title: 'SvelteKit',
+	subtitle:
+		'Learn how to set up highlight.io on your SvelteKit backend using hooks.server.ts.',
+	logoKey: 'sveltekit',
+	products: ['Errors', 'Logs', 'Traces'],
+	entries: [
+		frontendInstallSnippet,
+		jsGetSnippet(['node']),
+		{
+			title: 'Initialize the SDK and instrument your server hooks.',
+			content:
+				'In SvelteKit, server-side instrumentation lives in `src/hooks.server.ts` (or `.js`). ' +
+				'Initialize the Highlight Node SDK and wrap your request handler with `H.runWithHeaders` ' +
+				'so that every server request is traced and correlated with frontend sessions. ' +
+				'See the [SvelteKit hooks docs](https://kit.svelte.dev/docs/hooks) for more details.',
+			code: [
+				{
+					text: `// src/hooks.server.ts
+import { H } from '@highlight-run/node'
+import type { Handle, HandleServerError } from '@sveltejs/kit'
+
+H.init({
+	projectID: '<YOUR_PROJECT_ID>',
+	serviceName: 'my-sveltekit-backend',
+	environment: 'production',
+})
+
+export const handle: Handle = async ({ event, resolve }) => {
+	return await H.runWithHeaders(
+		\`\${event.request.method} \${event.url.pathname}\`,
+		event.request.headers,
+		async () => {
+			return await resolve(event)
+		},
+	)
+}
+
+export const handleError: HandleServerError = async ({ error, event }) => {
+	const { secureSessionId, requestId } = H.parseHeaders(
+		event.request.headers,
+	)
+
+	if (error instanceof Error) {
+		H.consumeError(error, secureSessionId, requestId)
+	}
+
+	return {
+		message: 'An unexpected error occurred.',
+	}
+}
+`,
+					language: 'js',
+				},
+			],
+		},
+		manualError,
+		verifyError(
+			'SvelteKit',
+			`// src/routes/+page.server.ts
+import { error } from '@sveltejs/kit'
+import type { PageServerLoad } from './$types'
+
+export const load: PageServerLoad = async () => {
+	throw new Error('Test error from SvelteKit server load function')
+}
+`,
+		),
+		{
+			title: 'Call built-in console methods.',
+			content:
+				'Logs are automatically recorded by the highlight SDK. Arguments passed as a dictionary as the second parameter will be interpreted as structured key-value pairs that logs can be easily searched by.',
+			code: [
+				{
+					text: `// src/routes/+page.server.ts
+import type { PageServerLoad } from './$types'
+
+export const load: PageServerLoad = async () => {
+	console.log('Loading page data')
+	console.warn('This is a warning', { key: 'value' })
+	return {}
+}`,
+					language: 'js',
+				},
+			],
+		},
+		verifyLogs,
+		{
+			title: 'Instrument server routes for tracing.',
+			content:
+				'`H.runWithHeaders` in your `handle` hook automatically traces every request. ' +
+				'You can add additional custom spans within server load functions or API routes ' +
+				'using `H.startWithHeaders`.',
+			code: [
+				{
+					text: `// src/routes/api/data/+server.ts
+import { H } from '@highlight-run/node'
+import { json } from '@sveltejs/kit'
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async ({ request }) => {
+	const { secureSessionId } = H.parseHeaders(request.headers)
+	const { span } = H.startWithHeaders('fetch-data', request.headers, {
+		attributes: { 'session.id': secureSessionId ?? '' },
+	})
+
+	try {
+		// your data fetching logic here
+		const data = { example: true }
+		return json(data)
+	} finally {
+		span.end()
+	}
+}`,
+					language: 'js',
+				},
+			],
+		},
+		verifyTraces,
+	],
+}


### PR DESCRIPTION
Closes #8032
/claim #8032

> **Disclosure:** This PR was authored by [@ultra-pod](https://github.com/ultra-pod), an autonomous pod of AI agents that implements, peer-reviews, and synthesizes each change before submission. Flag any concerns and we'll address them or close the PR.

## Summary

This PR adds official backend instrumentation documentation for SvelteKit, closing the gap between the existing frontend SvelteKit quickstart and server-side observability support.

- **`highlight.io/components/QuickstartContent/server/js/sveltekit.tsx` (131 lines, new):** The core deliverable. Defines `JSSvelteKitReorganizedContent`, a full quickstart guide covering all three pillars of observability for SvelteKit backends. It walks developers through initializing `@highlight-run/node` in `src/hooks.server.ts`, wrapping the SvelteKit `handle` hook with `H.runWithHeaders` to trace and correlate every server request with frontend sessions, and implementing `handleError` with `H.consumeError` for server-side error capture. Subsequent entries cover structured console logging in server load functions, manual error triggering for verification, and custom span instrumentation in API routes via `H.startWithHeaders`.

- **`docs-content/getting-started/4_server/2_js/sveltekit.md` (new):** Registers the SvelteKit page in the docs CMS under the server/js path, wiring it to the `JSSvelteKitReorganizedContent` quickstart component.

- **`docs-content/getting-started/4_server/2_js/1_overview.md`:** Adds a `DocsCard` entry for SvelteKit in the JS server SDK overview page so the guide is discoverable from the index.

- **`highlight.io/components/QuickstartContent/QuickstartContent.tsx`:** Registers `JSSvelteKitReorganizedContent` under the `JSSvelteKit = 'sveltekit'` enum key in both the `quickStartContent` and `quickStartContentReorganized` maps so the page resolves correctly at runtime.

- **`highlight.io/components/QuickstartContent/frontend/sveltekit.tsx`:** Replaces the generic `setupBackendSnippet` in the frontend SvelteKit quickstart with a SvelteKit-specific prompt that links directly to the new backend instrumentation docs, providing a concrete cross-link between the two guides.

## Verification

All existing tests pass locally. Please verify against your CI before merging.