### PR TITLE
docs: add SvelteKit server quickstart

### DIFF
--- a/docs-content/getting-started/4_server/2_js/1_overview.md
+++ b/docs-content/getting-started/4_server/2_js/1_overview.md
@@ -36,6 +36,9 @@ updatedAt: 2022-04-01T19:52:59.000Z
     <DocsCard title="Node.js" href="../js/nodejs">
         {"Get started with Node.js"}
     </DocsCard>
+    <DocsCard title="SvelteKit" href="../js/sveltekit">
+        {"Get started with SvelteKit"}
+    </DocsCard>
     <DocsCard title="Pino" href="../js/pino">
         {"Get started with Pino"}
     </DocsCard>

--- a/docs-content/getting-started/4_server/2_js/1_overview.md
+++ b/docs-content/getting-started/4_server/2_js/1_overview.md
@@ -1,4 +1,4 @@
----
+﻿---
 toc: Overview
 title: Highlight Integration in Javascript / Typescript
 slug: js

--- a/docs-content/getting-started/4_server/2_js/sveltekit.md
+++ b/docs-content/getting-started/4_server/2_js/sveltekit.md
@@ -34,15 +34,13 @@ H.init({
 })
 
 export const handle: Handle = async ({ event, resolve }) => {
-	return H.runWithHeaders(
-		`${event.request.method} ${event.url.pathname}`,
-		event.request.headers,
-		async () => resolve(event),
+	return H.runWithHeaders('sveltekit.handle', event.request.headers, () =>
+		resolve(event),
 	)
 }
 ```
 
-`H.runWithHeaders()` reads the incoming SvelteKit request headers and propagates Highlight context to spans created while `resolve(event)` runs. When your frontend Highlight setup sends tracing headers, server traces can be connected back to the originating session and request.
+`H.runWithHeaders()` takes a span name, the incoming request headers, and a callback. When your frontend Highlight setup sends tracing headers, server traces can be connected back to the originating session and request.
 
 ## Report uncaught server errors
 
@@ -54,15 +52,11 @@ import { H } from '@highlight-run/node'
 import type { HandleServerError } from '@sveltejs/kit'
 
 export const handleError: HandleServerError = ({ error, event }) => {
-	const { secureSessionId, requestId } = H.parseHeaders(
-		event.request.headers,
-	)
+	const parsed = H.parseHeaders(event.request.headers)
+	const reportedError =
+		error instanceof Error ? error : new Error(String(error))
 
-	H.consumeError(
-		error instanceof Error ? error : new Error(String(error)),
-		secureSessionId,
-		requestId,
-	)
+	H.consumeError(reportedError, parsed.secureSessionId, parsed.requestId)
 }
 ```
 
@@ -71,11 +65,9 @@ export const handleError: HandleServerError = ({ error, event }) => {
 If you need to report exceptions outside of `handleError`, use the Highlight SDK with headers from the active SvelteKit request event.
 
 ```ts
-const { secureSessionId, requestId } = H.parseHeaders(
-	event.request.headers,
-)
+const parsed = H.parseHeaders(event.request.headers)
 
-H.consumeError(error, secureSessionId, requestId)
+H.consumeError(error, parsed.secureSessionId, parsed.requestId)
 ```
 
 ## Verify the setup
@@ -84,8 +76,18 @@ Create a temporary server endpoint that throws an error, then request it locally
 
 ```ts
 // src/routes/error/+server.ts
-export const GET = () => {
-	throw new Error('sample SvelteKit server error!')
+import { H } from '@highlight-run/node'
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async ({ request }) => {
+	const { span } = H.startWithHeaders('sveltekit.server.route', request.headers)
+
+	try {
+		console.info('Highlight captured this server log from SvelteKit')
+		throw new Error('sample SvelteKit server error!')
+	} finally {
+		span.end()
+	}
 }
 ```
 

--- a/docs-content/getting-started/4_server/2_js/sveltekit.md
+++ b/docs-content/getting-started/4_server/2_js/sveltekit.md
@@ -1,0 +1,92 @@
+---
+title: SvelteKit
+heading: SvelteKit Server Quick Start
+metaTitle: SvelteKit Server Quick Start
+slug: sveltekit
+createdAt: 2026-06-05T00:00:00.000Z
+updatedAt: 2026-06-05T00:00:00.000Z
+---
+
+This guide shows how to set up highlight.io server-side instrumentation for a SvelteKit app running on a Node-compatible adapter.
+
+## Install the Node SDK
+
+Install [@highlight-run/node](https://www.npmjs.com/package/@highlight-run/node) with your package manager.
+
+```bash
+npm install --save @highlight-run/node
+```
+
+## Initialize Highlight in your server hook
+
+Initialize the Highlight Node SDK in `hooks.server.ts` with your project ID. Set `serviceName`, `serviceVersion`, and `environment` so traces, logs, and errors are grouped clearly in Highlight.
+
+```ts
+// hooks.server.ts
+import { H } from '@highlight-run/node'
+import type { Handle } from '@sveltejs/kit'
+
+H.init({
+	projectID: '<YOUR_PROJECT_ID>',
+	serviceName: 'my-sveltekit-app',
+	serviceVersion: 'git-sha',
+	environment: 'production',
+})
+
+export const handle: Handle = async ({ event, resolve }) => {
+	return H.runWithHeaders(
+		`${event.request.method} ${event.url.pathname}`,
+		event.request.headers,
+		async () => resolve(event),
+	)
+}
+```
+
+`H.runWithHeaders()` reads the incoming SvelteKit request headers and propagates Highlight context to spans created while `resolve(event)` runs. When your frontend Highlight setup sends tracing headers, server traces can be connected back to the originating session and request.
+
+## Report uncaught server errors
+
+Use SvelteKit's `handleError` hook to report uncaught server-side errors. `H.parseHeaders()` extracts the Highlight session and request IDs from the active request.
+
+```ts
+// hooks.server.ts
+import { H } from '@highlight-run/node'
+import type { HandleServerError } from '@sveltejs/kit'
+
+export const handleError: HandleServerError = ({ error, event }) => {
+	const { secureSessionId, requestId } = H.parseHeaders(
+		event.request.headers,
+	)
+
+	H.consumeError(
+		error instanceof Error ? error : new Error(String(error)),
+		secureSessionId,
+		requestId,
+	)
+}
+```
+
+## Report manual errors
+
+If you need to report exceptions outside of `handleError`, use the Highlight SDK with headers from the active SvelteKit request event.
+
+```ts
+const { secureSessionId, requestId } = H.parseHeaders(
+	event.request.headers,
+)
+
+H.consumeError(error, secureSessionId, requestId)
+```
+
+## Verify the setup
+
+Create a temporary server endpoint that throws an error, then request it locally or in a deployed environment.
+
+```ts
+// src/routes/error/+server.ts
+export const GET = () => {
+	throw new Error('sample SvelteKit server error!')
+}
+```
+
+After calling the route, verify that the error appears in [Highlight errors](https://app.highlight.io/errors). Then make a normal server request and check [Highlight traces](https://app.highlight.io/traces) for the SvelteKit request span.

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -106,6 +106,7 @@ import { JSFirebaseReorganizedContent } from './server/js/firebase'
 import { JSHonoReorganizedContent } from './server/js/hono'
 import { JSNodeReorganizedContent } from './server/js/nodejs'
 import { JSNestReorganizedContent } from './server/js/nestjs'
+import { JSSvelteKitReorganizedContent } from './server/js/sveltekit'
 import { JStRPCReorganizedContent } from './server/js/trpc'
 import { JSPinoHTTPJSONLogReorganizedContent } from './server/js/pino'
 import { JSWinstonHTTPJSONLogReorganizedContent } from './server/js/winston'
@@ -456,6 +457,7 @@ export const quickStartContent = {
 			[QuickStartType.JSHono]: JSHonoReorganizedContent,
 			[QuickStartType.JSNodejs]: JSNodeReorganizedContent,
 			[QuickStartType.JSNestjs]: JSNestReorganizedContent,
+			[QuickStartType.SvelteKit]: JSSvelteKitReorganizedContent,
 			[QuickStartType.JStRPC]: JStRPCReorganizedContent,
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,
@@ -601,6 +603,7 @@ export const quickStartContentReorganized = {
 			[QuickStartType.JSHono]: JSHonoReorganizedContent,
 			[QuickStartType.JSNodejs]: JSNodeReorganizedContent,
 			[QuickStartType.JSNestjs]: JSNestReorganizedContent,
+			[QuickStartType.SvelteKit]: JSSvelteKitReorganizedContent,
 			[QuickStartType.JStRPC]: JStRPCReorganizedContent,
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,

--- a/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
@@ -1,0 +1,115 @@
+import { QuickStartContent } from '../../QuickstartContent'
+import { verifyLogs } from '../shared-snippets-logging'
+import { frontendInstallSnippet } from '../shared-snippets-monitoring'
+import { verifyTraces } from '../shared-snippets-tracing'
+import { jsGetSnippet, verifyError } from './shared-snippets-monitoring'
+
+const hooksServerSnippet = `// src/hooks.server.ts
+import { H } from '@highlight-run/node'
+import type { Handle, HandleServerError } from '@sveltejs/kit'
+
+H.init({
+	projectID: '<YOUR_PROJECT_ID>',
+	serviceName: 'my-sveltekit-app',
+	serviceVersion: 'git-sha',
+	environment: 'production',
+})
+
+export const handle: Handle = async ({ event, resolve }) => {
+	return H.runWithHeaders(
+		'sveltekit.handle',
+		event.request.headers,
+		() => resolve(event),
+	)
+}
+
+export const handleError: HandleServerError = ({ error, event }) => {
+	const parsed = H.parseHeaders(event.request.headers)
+	const reportedError =
+		error instanceof Error ? error : new Error(String(error))
+
+	H.consumeError(reportedError, parsed.secureSessionId, parsed.requestId)
+}
+`
+
+const routeSnippet = `// src/routes/api/highlight-test/+server.ts
+import { H } from '@highlight-run/node'
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async ({ request }) => {
+	const { span } = H.startWithHeaders('sveltekit.server.route', request.headers)
+
+	try {
+		console.info('Highlight captured this server log from SvelteKit')
+		return new Response('ok')
+	} finally {
+		span.end()
+	}
+}
+`
+
+export const JSSvelteKitReorganizedContent: QuickStartContent = {
+	title: 'SvelteKit',
+	subtitle:
+		'Learn how to set up highlight.io backend instrumentation in SvelteKit.',
+	logoKey: 'sveltekit',
+	products: ['Errors', 'Logs', 'Traces'],
+	entries: [
+		frontendInstallSnippet,
+		jsGetSnippet(['node']),
+		{
+			title: 'Add private Highlight environment variables.',
+			content:
+				'Configure your SvelteKit server runtime with `HIGHLIGHT_PROJECT_ID`. ' +
+				'You can also set `HIGHLIGHT_SERVICE_NAME`, `HIGHLIGHT_SERVICE_VERSION`, and `HIGHLIGHT_ENVIRONMENT` to control how backend telemetry is grouped in Highlight.',
+			code: [
+				{
+					text: `HIGHLIGHT_PROJECT_ID=<YOUR_PROJECT_ID>
+HIGHLIGHT_SERVICE_NAME=sveltekit
+HIGHLIGHT_SERVICE_VERSION=git-sha
+HIGHLIGHT_ENVIRONMENT=production`,
+					language: 'bash',
+				},
+			],
+		},
+		{
+			title: 'Initialize Highlight in the SvelteKit server hook.',
+			content:
+				'Use `src/hooks.server.ts` so every server request is wrapped before it reaches your load functions or endpoint handlers. SvelteKit exposes request headers as a Web `Headers` object, so pass `event.request.headers` directly to the Highlight SDK.',
+			code: [
+				{
+					text: hooksServerSnippet,
+					language: 'ts',
+				},
+			],
+		},
+		verifyError(
+			'SvelteKit',
+			`// src/routes/api/highlight-error/+server.ts
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async () => {
+	throw new Error('Highlight SvelteKit server test')
+}
+`,
+		),
+		{
+			title: 'Verify server logs and traces.',
+			content:
+				'Call a SvelteKit endpoint that logs and creates a span. The request is already wrapped by `hooks.server.ts`, so logs and child spans are linked to the incoming Highlight headers.',
+			code: [
+				{
+					text: routeSnippet,
+					language: 'ts',
+				},
+			],
+		},
+		verifyLogs,
+		verifyTraces,
+		{
+			title: 'Confirm your adapter runs on Node.js.',
+			content:
+				'The `@highlight-run/node` SDK must run in a Node-compatible SvelteKit adapter. If a route is deployed to an edge runtime, use the Cloudflare or OpenTelemetry setup for that edge target instead.',
+		},
+	],
+}


### PR DESCRIPTION
Adds a server-side SvelteKit quickstart and wires it into the quickstart registry so the docs surface the new backend guide.

Closes #8032
