### PR TITLE
feat: add Elixir SDK for error monitoring and logging

### DIFF
--- a/sdk/highlight-elixir/.gitignore
+++ b/sdk/highlight-elixir/.gitignore
@@ -1,0 +1,27 @@
+# Dependencies
+deps/
+_build/
+
+# Generated on crash
+erl_crash.dump
+
+# Temporary files
+*.ez
+*.beam
+
+# Mix lock (for SDK, we check it in)
+# mix.lock
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# ElixirLS
+.elixir_ls/

--- a/sdk/highlight-elixir/CHANGELOG.md
+++ b/sdk/highlight-elixir/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2024-01-01
+
+### Added
+
+- Initial release of the Elixir SDK for Highlight.io
+- Error monitoring via `Highlight.record_exception/2`
+- Logging support via `Highlight.log/2` and `Highlight.log/3`
+- Phoenix framework integration with Plug and LiveView hooks
+- OpenTelemetry-based instrumentation
+- Configuration via options or environment variables
+- Auto-instrumentation of Elixir Logger

--- a/sdk/highlight-elixir/LICENSE
+++ b/sdk/highlight-elixir/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2020-present Highlight Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/sdk/highlight-elixir/README.md
+++ b/sdk/highlight-elixir/README.md
@@ -1,0 +1,159 @@
+# highlight-elixir
+
+Official Elixir SDK for [Highlight.io](https://highlight.io) error monitoring and logging.
+
+[![Hex.pm](https://img.shields.io/hexpm/v/highlight.svg)](https://hex.pm/packages/highlight)
+[![Docs](https://img.shields.io/badge/docs-hexpm-blue.svg)](https://hexdocs.pm/highlight)
+
+## Installation
+
+Add `highlight` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:highlight, "~> 0.1.0"}
+  ]
+end
+```
+
+## Configuration
+
+Configure Highlight in your `config/config.exs`:
+
+```elixir
+config :highlight,
+  project_id: "YOUR_PROJECT_ID"
+```
+
+Or set the environment variable:
+
+```bash
+export HIGHLIGHT_PROJECT_ID="YOUR_PROJECT_ID"
+```
+
+## Usage
+
+### Initialize the SDK
+
+Add Highlight initialization to your application startup:
+
+```elixir
+# lib/my_app/application.ex
+defmodule MyApp.Application do
+  use Application
+
+  def start(_type, _args) do
+    Highlight.init(
+      project_id: "YOUR_PROJECT_ID",
+      service_name: "my-app",
+      environment: "production"
+    )
+
+    # ... your other children
+  end
+end
+```
+
+### Record Exceptions
+
+Capture exceptions manually using `Highlight.record_exception/2`:
+
+```elixir
+try do
+  risky_operation()
+rescue
+  e ->
+    Highlight.record_exception(e,
+      attributes: %{"user.id" => "123", "component" => "auth"}
+    )
+end
+```
+
+### Logging
+
+Send log messages to Highlight:
+
+```elixir
+Highlight.log(:info, "User signed in")
+Highlight.log(:error, "Database connection failed", %{"host" => "db.example.com"})
+```
+
+### Phoenix Integration
+
+#### Plug
+
+Add the Highlight plug to your pipeline in `router.ex`:
+
+```elixir
+pipeline :browser do
+  plug Highlight.Phoenix.Plug
+end
+```
+
+#### Error Handler
+
+Handle errors in your `endpoint.ex` or error handler:
+
+```elixir
+# In your error handler module
+def handle_errors(conn, %{kind: kind, reason: reason, stack: stack}) do
+  Highlight.Phoenix.handle_error(conn, kind, reason, stack)
+end
+```
+
+#### LiveView
+
+Use the LiveView hook for automatic error capturing:
+
+```elixir
+defmodule MyAppWeb.PageLive do
+  use MyAppWeb, :live_view
+  use Highlight.Phoenix.LiveViewHook
+
+  # Your live view code...
+end
+```
+
+## Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `project_id` | `String.t()` | Required | Your Highlight project ID |
+| `otlp_endpoint` | `String.t()` | `"https://otel.highlight.io:4318"` | OTLP endpoint URL |
+| `service_name` | `String.t()` | `"elixir-app"` | Service name for tracing |
+| `service_version` | `String.t()` | `""` | Service version |
+| `environment` | `String.t()` | `""` | Deployment environment |
+| `instrument_logging` | `boolean()` | `true` | Auto-instrument Logger |
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `HIGHLIGHT_PROJECT_ID` | Your Highlight project ID |
+| `HIGHLIGHT_ENVIRONMENT` | Deployment environment |
+
+## Development
+
+### Setup
+
+```bash
+mix deps.get
+mix compile
+```
+
+### Run Tests
+
+```bash
+mix test
+```
+
+### Generate Documentation
+
+```bash
+mix docs
+```
+
+## License
+
+Apache License 2.0

--- a/sdk/highlight-elixir/config/config.exs
+++ b/sdk/highlight-elixir/config/config.exs
@@ -1,0 +1,4 @@
+import Config
+
+config :logger,
+  level: :info

--- a/sdk/highlight-elixir/lib/highlight.ex
+++ b/sdk/highlight-elixir/lib/highlight.ex
@@ -1,0 +1,181 @@
+defmodule Highlight do
+  @moduledoc """
+  Elixir SDK for [Highlight.io](https://highlight.io) error monitoring and logging.
+
+  This SDK provides integration with Highlight for:
+  - Error monitoring via `record_exception/1`
+  - Logging support via `log/2` and `log/3`
+  - Phoenix framework integration
+
+  ## Configuration
+
+      config :highlight,
+        project_id: "YOUR_PROJECT_ID",
+        otlp_endpoint: "https://otel.highlight.io:4318"
+
+  ## Usage
+
+      # In your application startup (e.g., application.ex)
+      Highlight.init(project_id: "YOUR_PROJECT_ID")
+
+      # Record an exception
+      try do
+        risky_operation()
+      rescue
+        e -> Highlight.record_exception(e)
+      end
+
+      # Log a message
+      Highlight.log(:info, "Application started")
+  """
+
+  alias Highlight.Config
+  alias Highlight.Tracer
+
+  require Logger
+
+  @otlp_endpoint "https://otel.highlight.io:4318"
+
+  @doc """
+  Initializes the Highlight SDK.
+
+  ## Options
+
+    * `:project_id` - Your Highlight project ID (required)
+    * `:otlp_endpoint` - Custom OTLP endpoint (defaults to `https://otel.highlight.io:4318`)
+    * `:service_name` - Service name for tracing (defaults to application name)
+    * `:service_version` - Service version (optional)
+    * `:environment` - Deployment environment (optional)
+    * `:instrument_logging` - Whether to auto-instrument Logger (defaults to `true`)
+
+  ## Examples
+
+      Highlight.init(project_id: "abc123")
+
+      Highlight.init(
+        project_id: "abc123",
+        service_name: "my_app",
+        environment: "production",
+        instrument_logging: true
+      )
+  """
+  def init(opts \\ []) do
+    project_id = opts[:project_id] || System.get_env("HIGHLIGHT_PROJECT_ID")
+
+    unless project_id do
+      raise ArgumentError, """
+      Highlight project_id is required.
+      Pass it via opts: Highlight.init(project_id: "YOUR_PROJECT_ID")
+      Or set the HIGHLIGHT_PROJECT_ID environment variable.
+      """
+    end
+
+    config = %Config{
+      project_id: project_id,
+      otlp_endpoint: opts[:otlp_endpoint] || @otlp_endpoint,
+      service_name: opts[:service_name] || default_service_name(),
+      service_version: opts[:service_version] || "",
+      environment: opts[:environment] || System.get_env("HIGHLIGHT_ENVIRONMENT") || "",
+      instrument_logging: Keyword.get(opts, :instrument_logging, true)
+    }
+
+    Highlight.ConfigStore.put(config)
+    Highlight.SpanProcessor.setup(config)
+
+    if config.instrument_logging do
+      Highlight.LoggerHandler.attach()
+    end
+
+    Logger.info("Highlight SDK initialized for project #{config.project_id}")
+    :ok
+  end
+
+  @doc """
+  Records an exception with Highlight.
+
+  This function captures an exception and associates it with the current
+  OpenTelemetry span, following the OTEL exception reporting spec.
+
+  ## Options
+
+    * `:attributes` - Additional key-value attributes to attach to the error
+
+  ## Examples
+
+      Highlight.record_exception(%RuntimeError{message: "something went wrong"})
+
+      Highlight.record_exception(exception,
+        attributes: %{"user.id" => "123", "component" => "auth"}
+      )
+  """
+  @spec record_exception(Exception.t(), keyword()) :: :ok
+  def record_exception(exception, opts \\ []) do
+    attributes = Keyword.get(opts, :attributes, %{})
+
+    case OpenTelemetry.Tracer.current_span_ctx() do
+      ctx when ctx != :undefined ->
+        Tracer.record_exception(exception, attributes)
+        :ok
+
+      _ ->
+        Tracer.record_exception_in_new_span(exception, attributes)
+        :ok
+    end
+  end
+
+  @doc """
+  Logs a message to Highlight with the given severity level.
+
+  ## Parameters
+
+    * `level` - Log severity (`:debug`, `:info`, `:warning`, `:error`, `:critical`)
+    * `message` - The log message string
+
+  ## Examples
+
+      Highlight.log(:info, "User signed in")
+      Highlight.log(:error, "Database connection failed")
+  """
+  @spec log(atom(), String.t()) :: :ok
+  def log(level, message) do
+    log(level, message, %{})
+  end
+
+  @doc """
+  Logs a message to Highlight with attributes.
+
+  ## Examples
+
+      Highlight.log(:info, "Order placed", %{"order.id" => "456", "amount" => "99.99"})
+  """
+  @spec log(atom(), String.t(), map()) :: :ok
+  def log(level, message, attributes) do
+    Tracer.record_log(level, message, attributes)
+    :ok
+  end
+
+  @doc """
+  Flushes any buffered telemetry data to the Highlight backend.
+  """
+  @spec flush() :: :ok
+  def flush do
+    Highlight.SpanProcessor.flush()
+    :ok
+  end
+
+  @doc """
+  Gracefully shuts down the Highlight SDK, flushing any remaining data.
+  """
+  @spec shutdown() :: :ok
+  def shutdown do
+    Highlight.SpanProcessor.shutdown()
+    Highlight.LoggerHandler.detach()
+    Highlight.ConfigStore.clear()
+    :ok
+  end
+
+  defp default_service_name do
+    Application.get_env(:highlight, :service_name) ||
+      Application.get_env(:app, :name, "elixir-app") |> to_string()
+  end
+end

--- a/sdk/highlight-elixir/lib/highlight/application.ex
+++ b/sdk/highlight-elixir/lib/highlight/application.ex
@@ -1,0 +1,14 @@
+defmodule Highlight.Application do
+  @moduledoc false
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    children = [
+      Highlight.ConfigStore
+    ]
+
+    opts = [strategy: :one_for_one, name: Highlight.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/sdk/highlight-elixir/lib/highlight/config.ex
+++ b/sdk/highlight-elixir/lib/highlight/config.ex
@@ -1,0 +1,38 @@
+defmodule Highlight.Config do
+  @moduledoc false
+
+  @enforce_keys [:project_id]
+  defstruct [
+    :project_id,
+    :otlp_endpoint,
+    :service_name,
+    :service_version,
+    :environment,
+    instrument_logging: true
+  ]
+
+  @type t :: %__MODULE__{
+          project_id: String.t(),
+          otlp_endpoint: String.t(),
+          service_name: String.t(),
+          service_version: String.t(),
+          environment: String.t(),
+          instrument_logging: boolean()
+        }
+
+  @otlp_default_endpoint "https://otel.highlight.io:4318"
+
+  @doc """
+  Creates a new Config struct with defaults applied.
+  """
+  def new(opts \\ []) do
+    %__MODULE__{
+      project_id: Keyword.fetch!(opts, :project_id),
+      otlp_endpoint: Keyword.get(opts, :otlp_endpoint, @otlp_default_endpoint),
+      service_name: Keyword.get(opts, :service_name, "elixir-app"),
+      service_version: Keyword.get(opts, :service_version, ""),
+      environment: Keyword.get(opts, :environment, ""),
+      instrument_logging: Keyword.get(opts, :instrument_logging, true)
+    }
+  end
+end

--- a/sdk/highlight-elixir/lib/highlight/config_store.ex
+++ b/sdk/highlight-elixir/lib/highlight/config_store.ex
@@ -1,0 +1,42 @@
+defmodule Highlight.ConfigStore do
+  @moduledoc false
+
+  use Agent
+
+  @doc false
+  def start_link(_opts) do
+    Agent.start_link(fn -> nil end, name: __MODULE__)
+  end
+
+  @doc """
+  Stores the Highlight configuration.
+  """
+  @spec put(Highlight.Config.t()) :: :ok
+  def put(config) do
+    Agent.update(__MODULE__, fn _old -> config end)
+  end
+
+  @doc """
+  Retrieves the current Highlight configuration, or `nil` if not initialized.
+  """
+  @spec get() :: Highlight.Config.t() | nil
+  def get do
+    Agent.get(__MODULE__, fn config -> config end)
+  end
+
+  @doc """
+  Returns true if the SDK has been initialized.
+  """
+  @spec initialized?() :: boolean()
+  def initialized? do
+    get() != nil
+  end
+
+  @doc """
+  Clears the stored configuration.
+  """
+  @spec clear() :: :ok
+  def clear do
+    Agent.update(__MODULE, fn _old -> nil end)
+  end
+end

--- a/sdk/highlight-elixir/lib/highlight/logger_handler.ex
+++ b/sdk/highlight-elixir/lib/highlight/logger_handler.ex
@@ -1,0 +1,98 @@
+defmodule Highlight.LoggerHandler do
+  @moduledoc false
+
+  require Logger
+
+  @handler_id "highlight-logger-handler"
+
+  @doc """
+  Attaches the Highlight logger handler to Elixir's Logger.
+  """
+  @spec attach() :: :ok | {:error, :already_exists}
+  def attach do
+    config = %{
+      level: :info,
+      enabled: true
+    }
+
+    case Logger.add_handler(@handler_id, __MODULE__, config) do
+      :ok ->
+        :ok
+
+      {:error, :already_exists} ->
+        :ok
+    end
+  end
+
+  @doc """
+  Detaches the Highlight logger handler.
+  """
+  @spec detach() :: :ok | {:error, :not_found}
+  def detach do
+    Logger.remove_handler(@handler_id)
+  end
+
+  @doc """
+  Logger handler callback. Called for every log message.
+  """
+  @impl true
+  def handle_event(event, _config) do
+    if Highlight.ConfigStore.initialized?() do
+      log_message = format_log_message(event)
+      level = map_level(event.level)
+
+      Highlight.Tracer.record_log(level, log_message, extract_metadata(event))
+    end
+  end
+
+  def handle_event(_event, _config) do
+    :ok
+  end
+
+  @doc false
+  def handle_config(config) do
+    {:ok, config}
+  end
+
+  defp format_log_message(%{msg: {format, args}}) do
+    try do
+      :io_lib.format(format, args) |> IO.iodata_to_binary()
+    rescue
+      _ ->
+        "log event"
+    end
+  rescue
+    _ ->
+      "log event"
+  end
+
+  defp format_log_message(%{msg: msg}) when is_binary(msg), do: msg
+  defp format_log_message(%{msg: msg}), do: inspect(msg)
+  defp format_log_message(_), do: "log event"
+
+  defp map_level(:emergency), do: :critical
+  defp map_level(:alert), do: :critical
+  defp map_level(:critical), do: :critical
+  defp map_level(:error), do: :error
+  defp map_level(:warning), do: :warning
+  defp map_level(:notice), do: :info
+  defp map_level(:info), do: :info
+  defp map_level(:debug), do: :debug
+  defp map_level(_), do: :info
+
+  defp extract_metadata(%{meta: meta}) do
+    %{}
+    |> maybe_put(:module, meta[:module])
+    |> maybe_put(:function, meta[:function])
+    |> maybe_put(:file, meta[:file])
+    |> maybe_put(:line, meta[:line])
+    |> maybe_put(:domain, meta[:domain])
+    |> maybe_put(:error_logger, meta[:error_logger])
+    |> Map.new(fn {k, v} -> {Atom.to_string(k), v} end)
+  end
+
+  defp extract_metadata(_), do: %{}
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/sdk/highlight-elixir/lib/highlight/phoenix.ex
+++ b/sdk/highlight-elixir/lib/highlight/phoenix.ex
@@ -1,0 +1,101 @@
+defmodule Highlight.Phoenix do
+  @moduledoc """
+  Phoenix framework integration for Highlight.
+
+  This module provides a Plug and LiveView hooks for automatic error monitoring
+  and logging in Phoenix applications.
+
+  ## Usage
+
+  Add the plug to your `router.ex`:
+
+      pipeline :browser do
+        plug Highlight.Phoenix.Plug
+      end
+
+  Add error handling to your `endpoint.ex` or error handler:
+
+      def handle_errors(conn, %{kind: kind, reason: reason, stack: stack}) do
+        Highlight.Phoenix.handle_error(conn, kind, reason, stack)
+      end
+  """
+
+  @highlight_request_header "x-highlight-request"
+
+  @doc """
+  Extracts Highlight session and request IDs from request headers.
+
+  Returns a map with `:session_id` and `:request_id` keys, or `nil`
+  if the headers are not present.
+  """
+  @spec parse_headers(map()) :: %{session_id: String.t(), request_id: String.t()} | nil
+  def parse_headers(headers) when is_map(headers) do
+    case get_header(headers, @highlight_request_header) do
+      nil ->
+        nil
+
+      value ->
+        case String.split(value, "/", parts: 2) do
+          [session_id, request_id] ->
+            %{session_id: session_id, request_id: request_id}
+
+          _ ->
+            nil
+        end
+    end
+  end
+
+  @doc false
+  def parse_headers(_), do: nil
+
+  @doc """
+  Handles a Phoenix error by recording it with Highlight.
+
+  This function should be called from your error handler.
+  """
+  @spec handle_error(Plug.Conn.t(), atom(), Exception.t(), list()) :: Plug.Conn.t()
+  def handle_error(conn, _kind, reason, _stack) do
+    if Highlight.ConfigStore.initialized?() do
+      config = Highlight.ConfigStore.get()
+      headers = extract_headers(conn)
+
+      attributes = %{
+        "highlight.source" => "backend",
+        "http.method" => conn.method,
+        "http.url" => "#{conn.scheme}://#{conn.host}#{conn.request_path}"
+      }
+
+      attributes =
+        case parse_headers(headers) do
+          %{session_id: sid, request_id: rid} ->
+            attributes
+            |> Map.put("highlight.session_id", sid)
+            |> Map.put("highlight.trace_id", rid)
+
+          nil ->
+            attributes
+        end
+
+      attributes =
+        attributes
+        |> Map.put("http.status_code", conn.status)
+
+      Highlight.record_exception(reason, attributes: attributes)
+    end
+
+    conn
+  end
+
+  defp extract_headers(conn) do
+    conn.req_headers
+    |> Enum.into(%{})
+  end
+
+  defp get_header(headers, key) do
+    key_lower = String.downcase(key)
+
+    Enum.find_value(headers, nil, fn {k, v} ->
+      if String.downcase(k) == key_lower, do: v
+    end)
+  end
+end

--- a/sdk/highlight-elixir/lib/highlight/phoenix/live_view_hook.ex
+++ b/sdk/highlight-elixir/lib/highlight/phoenix/live_view_hook.ex
@@ -1,0 +1,54 @@
+defmodule Highlight.Phoenix.LiveViewHook do
+  @moduledoc """
+  Phoenix LiveView hook for Highlight error monitoring.
+
+  Attach this hook to your LiveView to automatically capture exceptions.
+
+  ## Usage
+
+      defmodule MyAppWeb.PageLive do
+        use MyAppWeb, :live_view
+        use Highlight.Phoenix.LiveViewHook
+
+        ...
+      end
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      import Highlight.Phoenix.LiveViewHook
+
+      @before_compile Highlight.Phoenix.LiveViewHook
+
+      def handle_event(event, params, socket) do
+        try do
+          super(event, params, socket)
+        rescue
+          e ->
+            Highlight.record_exception(e, attributes: %{
+              "live_view.event" => event,
+              "live_view.id" => socket.id
+            })
+            reraise e, __STACKTRACE__
+        end
+      end
+    end
+  end
+
+  defmacro __before_compile__(_env) do
+    quote do
+      def handle_params(params, uri, socket) do
+        try do
+          super(params, uri, socket)
+        rescue
+          e ->
+            Highlight.record_exception(e, attributes: %{
+              "live_view.uri" => uri,
+              "live_view.id" => socket.id
+            })
+            reraise e, __STACKTRACE__
+        end
+      end
+    end
+  end
+end

--- a/sdk/highlight-elixir/lib/highlight/phoenix/plug.ex
+++ b/sdk/highlight-elixir/lib/highlight/phoenix/plug.ex
@@ -1,0 +1,26 @@
+defmodule Highlight.Phoenix.Plug do
+  @moduledoc """
+  A Plug for Phoenix that sets up Highlight tracing context.
+
+  This plug extracts the Highlight session and request IDs from the request
+  headers and stores them in the connection for use during the request lifecycle.
+
+  ## Usage
+
+      plug Highlight.Phoenix.Plug
+  """
+
+  @behaviour Plug
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts) do
+    headers = conn.req_headers |> Enum.into(%{})
+    highlight_ctx = Highlight.Phoenix.parse_headers(headers)
+
+    conn
+    |> Plug.Conn.put_private(:highlight_ctx, highlight_ctx)
+  end
+end

--- a/sdk/highlight-elixir/lib/highlight/span_processor.ex
+++ b/sdk/highlight-elixir/lib/highlight/span_processor.ex
@@ -1,0 +1,91 @@
+defmodule Highlight.SpanProcessor do
+  @moduledoc false
+
+  require Logger
+
+  @doc """
+  Sets up the OpenTelemetry SDK with Highlight's configuration.
+
+  Configures the tracer provider, span processors, and resource attributes
+  to send telemetry data to the Highlight backend.
+  """
+  @spec setup(Highlight.Config.t()) :: :ok
+  def setup(config) do
+    resource = build_resource(config)
+
+    exporter =
+      OpenTelemetry.Exporter.OTLP.new(
+        endpoint: "#{config.otlp_endpoint}/v1/traces",
+        compression: :gzip
+      )
+
+    batch_processor =
+      {OpenTelemetry.BatchSpanProcessor,
+       exporter: exporter,
+       schedule_delay: :timer.seconds(5),
+       max_queue_size: 1024 * 1024,
+       max_export_batch_size: 128 * 1024}
+
+    highlight_processor = {Highlight.SpanProcessor.HighlightProcessor, []}
+
+    :application.ensure_all_started(:opentelemetry)
+
+    :opentelemetry.set_tracer_provider(%{
+      id: :highlight_tracer_provider,
+      resource: resource,
+      span_processors: [highlight_processor, batch_processor],
+      sampler: {OpenTelemetry.Sampler.parent_based, %{root: OpenTelemetry.Sampler.trace_id_ratio_based(1.0)}},
+      telemetry_distro: %{name: "highlight-elixir", version: Highlight.MixProject.project()[:version]}
+    })
+
+    :ok
+  rescue
+    e ->
+      Logger.warning("Failed to setup OpenTelemetry for Highlight: #{inspect(e)}")
+      :ok
+  end
+
+  @doc """
+  Flushes all span processors.
+  """
+  @spec flush() :: :ok
+  def flush do
+    try do
+      :opentelemetry.force_flush()
+    rescue
+      _ -> :ok
+    end
+  end
+
+  @doc """
+  Shuts down the OpenTelemetry provider.
+  """
+  @spec shutdown() :: :ok
+  def shutdown do
+    try do
+      :opentelemetry.shutdown()
+    rescue
+      _ -> :ok
+    end
+  end
+
+  defp build_resource(config) do
+    base_attrs = %{
+      "highlight.project_id" => config.project_id,
+      "telemetry.distro.name" => "highlight-elixir",
+      "telemetry.distro.version" => Highlight.MixProject.project()[:version] || "0.1.0"
+    }
+
+    attrs =
+      base_attrs
+      |> maybe_put("service.name", config.service_name)
+      |> maybe_put("service.version", config.service_version)
+      |> maybe_put("deployment.environment", config.environment)
+
+    OpenTelemetry.Resource.create(attrs)
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, _key, ""), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/sdk/highlight-elixir/lib/highlight/span_processor/highlight_processor.ex
+++ b/sdk/highlight-elixir/lib/highlight/span_processor/highlight_processor.ex
@@ -1,0 +1,27 @@
+defmodule Highlight.SpanProcessor.HighlightProcessor do
+  @moduledoc false
+  @behaviour OpenTelemetry.SpanProcessor
+
+  @impl true
+  def on_start(span, _parent_ctx) do
+    config = Highlight.ConfigStore.get()
+
+    if config do
+      OpenTelemetry.Span.set_attributes(span, %{
+        "highlight.project_id" => config.project_id
+      })
+    end
+
+    span
+  end
+
+  @impl true
+  def on_end(span, _timeout \\ 5_000) do
+    span
+  end
+
+  @impl true
+  def shutdown(_timeout \\ 5_000) do
+    :ok
+  end
+end

--- a/sdk/highlight-elixir/lib/highlight/tracer.ex
+++ b/sdk/highlight-elixir/lib/highlight/tracer.ex
@@ -1,0 +1,125 @@
+defmodule Highlight.Tracer do
+  @moduledoc false
+
+  require Logger
+
+  @tracer_name "highlight-elixir"
+  @error_span_name "highlight.error"
+  @log_span_name "highlight.log"
+
+  @doc """
+  Records an exception on the current OpenTelemetry span.
+  """
+  @spec record_exception(Exception.t(), map()) :: :ok
+  def record_exception(exception, attributes \\ %{}) do
+    span_ctx = OpenTelemetry.Tracer.current_span_ctx()
+
+    if span_ctx != :undefined do
+      exception_type = exception.__struct__ |> Module.split() |> List.last()
+      message = Exception.message(exception)
+      stacktrace = Exception.format_stacktrace(__STACKTRACE__)
+
+      event_attrs = %{
+        "exception.type" => exception_type,
+        "exception.message" => message,
+        "exception.stacktrace" => stacktrace
+      }
+
+      merged_attrs = Map.merge(event_attrs, map_attributes(attributes))
+
+      OpenTelemetry.Span.add_event(
+        span_ctx,
+        "exception",
+        merged_attrs
+      )
+
+      OpenTelemetry.Span.set_status(span_ctx, OpenTelemetry.status(:error, message))
+    end
+
+    :ok
+  end
+
+  @doc """
+  Records an exception by creating a new error span.
+  Used when there is no active span context.
+  """
+  @spec record_exception_in_new_span(Exception.t(), map()) :: :ok
+  def record_exception_in_new_span(exception, attributes \\ %{}) do
+    attributes = Map.put(attributes, "highlight.source", "backend")
+
+    OpenTelemetry.Tracer.with_span @error_span_name,
+      attributes: map_attributes(attributes),
+      kind: :client do
+      exception_type = exception.__struct__ |> Module.split() |> List.last()
+      message = Exception.message(exception)
+
+      OpenTelemetry.Span.set_status(OpenTelemetry.status(:error, message))
+
+      OpenTelemetry.Span.add_event("exception", %{
+        "exception.type" => exception_type,
+        "exception.message" => message
+      })
+    end
+
+    :ok
+  end
+
+  @doc """
+  Records a log message as an OpenTelemetry span event.
+  """
+  @spec record_log(atom(), String.t(), map()) :: :ok
+  def record_log(level, message, attributes \\ %{}) do
+    span_ctx = OpenTelemetry.Tracer.current_span_ctx()
+
+    config = Highlight.ConfigStore.get()
+
+    log_attrs =
+      %{
+        "log.severity" => format_log_level(level),
+        "log.message" => message
+      }
+      |> maybe_put_project_id(config)
+      |> Map.merge(map_attributes(attributes))
+
+    if span_ctx != :undefined and is_span_recording?(span_ctx) do
+      OpenTelemetry.Span.add_event(span_ctx, "log", log_attrs)
+    else
+      OpenTelemetry.Tracer.with_span @log_span_name,
+        attributes: log_attrs,
+        kind: :internal do
+        :ok
+      end
+    end
+
+    :ok
+  end
+
+  defp is_span_recording?(span_ctx) do
+    case OpenTelemetry.Span.kind(span_ctx) do
+      kind when is_atom(kind) -> true
+      _ -> false
+    end
+  rescue
+    _ -> true
+  end
+
+  defp map_attributes(map) when is_map(map) do
+    Enum.into(map, %{}, fn {k, v} ->
+      key = if is_atom(k), do: Atom.to_string(k), else: to_string(k)
+      {key, v}
+    end)
+  end
+
+  defp map_attributes(_), do: %{}
+
+  defp maybe_put_project_id(attrs, nil), do: attrs
+  defp maybe_put_project_id(attrs, config), do: Map.put(attrs, "highlight.project_id", config.project_id)
+
+  defp format_log_level(:debug), do: "DEBUG"
+  defp format_log_level(:info), do: "INFO"
+  defp format_log_level(:warning), do: "WARNING"
+  defp format_log_level(:error), do: "ERROR"
+  defp format_log_level(:critical), do: "CRITICAL"
+  defp format_log_level(level) when is_atom(level), do: level |> Atom.to_string() |> String.upcase()
+  defp format_log_level(_), do: "UNKNOWN"
+end

--- a/sdk/highlight-elixir/mix.exs
+++ b/sdk/highlight-elixir/mix.exs
@@ -1,0 +1,68 @@
+defmodule Highlight.MixProject do
+  use Mix.Project
+
+  @version "0.1.0"
+  @source_url "https://github.com/highlight/highlight"
+
+  def project do
+    [
+      app: :highlight,
+      version: @version,
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      elixirc_paths: elixirc_paths(Mix.env()),
+      name: "Highlight",
+      description: "Elixir SDK for Highlight.io error monitoring and logging",
+      source_url: @source_url,
+      docs: docs(),
+      package: package(),
+      aliases: aliases()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: {Highlight.Application, []}
+    ]
+  end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  defp deps do
+    [
+      {:opentelemetry_api, "~> 1.3"},
+      {:opentelemetry, "~> 1.4"},
+      {:opentelemetry_exporter_otlp, "~> 1.6"},
+      {:opentelemetry_semantic_conventions, "~> 1.25"},
+      {:jason, "~> 1.4"},
+      {:telemetry, "~> 1.2"},
+      {:ex_doc, "~> 0.31", only: :dev, runtime: false}
+    ]
+  end
+
+  defp docs do
+    [
+      main: "readme",
+      extras: ["README.md", "CHANGELOG.md"],
+      source_ref: "v#{@version}"
+    ]
+  end
+
+  defp package do
+    [
+      maintainers: ["Highlight"],
+      licenses: ["Apache-2.0"],
+      links: %{"GitHub" => @source_url}
+    ]
+  end
+
+  defp aliases do
+    [
+      setup: ["deps.get", "compile"],
+      test: ["test --trace"]
+    ]
+  end
+end

--- a/sdk/highlight-elixir/test/highlight/config_store_test.exs
+++ b/sdk/highlight-elixir/test/highlight/config_store_test.exs
@@ -1,0 +1,52 @@
+defmodule Highlight.ConfigStoreTest do
+  use ExUnit.Case, async: false
+
+  alias Highlight.ConfigStore
+
+  setup do
+    on_exit(fn ->
+      ConfigStore.clear()
+    end)
+  end
+
+  test "returns nil when not initialized" do
+    ConfigStore.clear()
+    assert ConfigStore.get() == nil
+  end
+
+  test "initialized? returns false when not initialized" do
+    ConfigStore.clear()
+    refute ConfigStore.initialized?()
+  end
+
+  test "stores and retrieves config" do
+    config = %Highlight.Config{
+      project_id: "test-123",
+      otlp_endpoint: "http://localhost:4318",
+      service_name: "test-service",
+      service_version: "1.0.0",
+      environment: "test"
+    }
+
+    ConfigStore.put(config)
+    assert ConfigStore.get() == config
+    assert ConfigStore.initialized?()
+  end
+
+  test "clear removes config" do
+    config = %Highlight.Config{
+      project_id: "test-123",
+      otlp_endpoint: "http://localhost:4318",
+      service_name: "test-service",
+      service_version: "1.0.0",
+      environment: "test"
+    }
+
+    ConfigStore.put(config)
+    assert ConfigStore.initialized?()
+
+    ConfigStore.clear()
+    refute ConfigStore.initialized?()
+    assert ConfigStore.get() == nil
+  end
+end

--- a/sdk/highlight-elixir/test/highlight/logger_handler_test.exs
+++ b/sdk/highlight-elixir/test/highlight/logger_handler_test.exs
@@ -1,0 +1,25 @@
+defmodule Highlight.LoggerHandlerTest do
+  use ExUnit.Case, async: false
+
+  alias Highlight.ConfigStore
+  alias Highlight.LoggerHandler
+
+  setup do
+    on_exit(fn ->
+      LoggerHandler.detach()
+      ConfigStore.clear()
+    end)
+  end
+
+  describe "attach/0 and detach/0" do
+    test "attaches and detaches handler" do
+      assert :ok = LoggerHandler.attach()
+      assert :ok = LoggerHandler.detach()
+    end
+
+    test "attach returns :ok when already attached" do
+      assert :ok = LoggerHandler.attach()
+      assert :ok = LoggerHandler.attach()
+    end
+  end
+end

--- a/sdk/highlight-elixir/test/highlight/phoenix_test.exs
+++ b/sdk/highlight-elixir/test/highlight/phoenix_test.exs
@@ -1,0 +1,47 @@
+defmodule Highlight.PhoenixTest do
+  use ExUnit.Case, async: false
+
+  alias Highlight.ConfigStore
+  alias Highlight.Phoenix
+
+  setup do
+    on_exit(fn ->
+      ConfigStore.clear()
+    end)
+  end
+
+  describe "parse_headers/1" do
+    test "parses valid highlight request header" do
+      headers = %{"x-highlight-request" => "session123/request456"}
+
+      result = Phoenix.parse_headers(headers)
+      assert result.session_id == "session123"
+      assert result.request_id == "request456"
+    end
+
+    test "returns nil when header is missing" do
+      result = Phoenix.parse_headers(%{})
+      assert result == nil
+    end
+
+    test "returns nil when header format is invalid" do
+      headers = %{"x-highlight-request" => "no-slash"}
+
+      result = Phoenix.parse_headers(headers)
+      assert result == nil
+    end
+
+    test "handles case-insensitive header lookup" do
+      headers = %{"X-Highlight-Request" => "sid/rid"}
+
+      result = Phoenix.parse_headers(headers)
+      assert result.session_id == "sid"
+      assert result.request_id == "rid"
+    end
+
+    test "returns nil for non-map input" do
+      assert Phoenix.parse_headers(nil) == nil
+      assert Phoenix.parse_headers("invalid") == nil
+    end
+  end
+end

--- a/sdk/highlight-elixir/test/highlight/tracer_test.exs
+++ b/sdk/highlight-elixir/test/highlight/tracer_test.exs
@@ -1,0 +1,87 @@
+defmodule Highlight.TracerTest do
+  use ExUnit.Case, async: false
+
+  alias Highlight.ConfigStore
+  alias Highlight.Tracer
+
+  setup do
+    on_exit(fn ->
+      ConfigStore.clear()
+    end)
+  end
+
+  describe "record_exception/2" do
+    test "records exception with default attributes" do
+      ConfigStore.put(%Highlight.Config{
+        project_id: "test",
+        otlp_endpoint: "https://otel.highlight.io:4318",
+        service_name: "test-app",
+        service_version: "",
+        environment: "test"
+      })
+
+      exception = %RuntimeError{message: "test error"}
+
+      # This should not raise even without an active span
+      assert :ok = Tracer.record_exception(exception)
+    end
+
+    test "records exception with custom attributes" do
+      ConfigStore.put(%Highlight.Config{
+        project_id: "test",
+        otlp_endpoint: "https://otel.highlight.io:4318",
+        service_name: "test-app",
+        service_version: "",
+        environment: "test"
+      })
+
+      exception = %RuntimeError{message: "test error"}
+      attributes = %{"user.id" => "123", "component" => "auth"}
+
+      assert :ok = Tracer.record_exception(exception, attributes)
+    end
+  end
+
+  describe "record_exception_in_new_span/2" do
+    test "records exception in a new span" do
+      ConfigStore.put(%Highlight.Config{
+        project_id: "test",
+        otlp_endpoint: "https://otel.highlight.io:4318",
+        service_name: "test-app",
+        service_version: "",
+        environment: "test"
+      })
+
+      exception = %RuntimeError{message: "test error"}
+
+      assert :ok = Tracer.record_exception_in_new_span(exception)
+    end
+  end
+
+  describe "record_log/3" do
+    test "records a log message" do
+      ConfigStore.put(%Highlight.Config{
+        project_id: "test",
+        otlp_endpoint: "https://otel.highlight.io:4318",
+        service_name: "test-app",
+        service_version: "",
+        environment: "test"
+      })
+
+      assert :ok = Tracer.record_log(:info, "test log message")
+    end
+
+    test "records a log with attributes" do
+      ConfigStore.put(%Highlight.Config{
+        project_id: "test",
+        otlp_endpoint: "https://otel.highlight.io:4318",
+        service_name: "test-app",
+        service_version: "",
+        environment: "test"
+      })
+
+      assert :ok =
+               Tracer.record_log(:error, "failed", %{"component" => "db"})
+    end
+  end
+end

--- a/sdk/highlight-elixir/test/highlight_test.exs
+++ b/sdk/highlight-elixir/test/highlight_test.exs
@@ -1,0 +1,107 @@
+defmodule HighlightTest do
+  use ExUnit.Case, async: false
+
+  alias Highlight.ConfigStore
+
+  setup do
+    on_exit(fn ->
+      ConfigStore.clear()
+    end)
+  end
+
+  describe "init/1" do
+    test "raises ArgumentError when no project_id is provided" do
+      System.delete_env("HIGHLIGHT_PROJECT_ID")
+
+      assert_raise ArgumentError, fn ->
+        Highlight.init()
+      end
+    end
+
+    test "initializes with project_id from opts" do
+      assert :ok = Highlight.init(project_id: "test-project-123")
+
+      config = ConfigStore.get()
+      assert config.project_id == "test-project-123"
+      assert config.otlp_endpoint == "https://otel.highlight.io:4318"
+    end
+
+    test "initializes with project_id from environment variable" do
+      System.put_env("HIGHLIGHT_PROJECT_ID", "env-project-456")
+
+      assert :ok = Highlight.init()
+
+      config = ConfigStore.get()
+      assert config.project_id == "env-project-456"
+
+      System.delete_env("HIGHLIGHT_PROJECT_ID")
+    end
+
+    test "accepts custom options" do
+      assert :ok =
+               Highlight.init(
+                 project_id: "custom",
+                 service_name: "my-service",
+                 service_version: "1.0.0",
+                 environment: "production",
+                 otlp_endpoint: "http://localhost:4318",
+                 instrument_logging: false
+               )
+
+      config = ConfigStore.get()
+      assert config.project_id == "custom"
+      assert config.service_name == "my-service"
+      assert config.service_version == "1.0.0"
+      assert config.environment == "production"
+      assert config.otlp_endpoint == "http://localhost:4318"
+      assert config.instrument_logging == false
+    end
+  end
+
+  describe "record_exception/2" do
+    test "records an exception" do
+      Highlight.init(project_id: "test")
+
+      exception = %RuntimeError{message: "test error"}
+      assert :ok = Highlight.record_exception(exception)
+    end
+
+    test "records an exception with attributes" do
+      Highlight.init(project_id: "test")
+
+      exception = %RuntimeError{message: "test error"}
+
+      assert :ok =
+               Highlight.record_exception(exception,
+                 attributes: %{"user.id" => "123"}
+               )
+    end
+  end
+
+  describe "log/2 and log/3" do
+    test "logs a message" do
+      Highlight.init(project_id: "test")
+      assert :ok = Highlight.log(:info, "test message")
+    end
+
+    test "logs a message with attributes" do
+      Highlight.init(project_id: "test")
+      assert :ok = Highlight.log(:error, "something failed", %{"component" => "db"})
+    end
+  end
+
+  describe "shutdown/0" do
+    test "shuts down gracefully" do
+      Highlight.init(project_id: "test")
+      assert :ok = Highlight.shutdown()
+      assert ConfigStore.get() == nil
+    end
+  end
+
+  describe "flush/0" do
+    test "flushes without error" do
+      Highlight.init(project_id: "test")
+      assert :ok = Highlight.flush()
+    end
+  end
+end

--- a/sdk/highlight-elixir/test/test_helper.exs
+++ b/sdk/highlight-elixir/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
Adds Elixir SDK supporting error monitoring and logging per the otel exception reporting spec.

## Changes

-  - Initialize the SDK with project ID and configuration
-  - Record exceptions following the OTEL exception reporting spec
-  and  - Send log messages to Highlight
-  - Plug for extracting Highlight request context
-  - Error handler for Phoenix applications
-  - LiveView hook for automatic error capturing
-  - Auto-instrumentation of Elixir Logger
- OpenTelemetry-based tracing with batch span processing
- Configurable via options or environment variables (, )

## Usage



Closes #5082