### PR TITLE
fix: Replace join workspace legacy button

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #10546
+
+Replace join workspace legacy button


### PR DESCRIPTION
Closes #10546

Replace join workspace legacy button

/claim #10546