### PR TITLE
docs: document SvelteKit backend instrumentation

### DIFF
--- a/docs-content/getting-started/4_server/2_js/1_overview.md
+++ b/docs-content/getting-started/4_server/2_js/1_overview.md
@@ -39,6 +39,9 @@ updatedAt: 2022-04-01T19:52:59.000Z
     <DocsCard title="Pino" href="../js/pino">
         {"Get started with Pino"}
     </DocsCard>
+    <DocsCard title="SvelteKit" href="../js/sveltekit">
+        {"Get started with SvelteKit"}
+    </DocsCard>
     <DocsCard title="tRPC" href="../js/trpc">
         {"Get started with tRPC"}
     </DocsCard>

--- a/docs-content/getting-started/4_server/2_js/sveltekit.md
+++ b/docs-content/getting-started/4_server/2_js/sveltekit.md
@@ -1,0 +1,10 @@
+---
+toc: SvelteKit
+title: SvelteKit Quick Start
+slug: sveltekit
+createdAt: 2026-08-05T00:00:00.000Z
+updatedAt: 2026-08-05T00:00:00.000Z
+quickstart: true
+---
+
+<QuickStart content={quickStartContent["server"]["js"]["sveltekit"]}/>

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -106,6 +106,7 @@ import { JSFirebaseReorganizedContent } from './server/js/firebase'
 import { JSHonoReorganizedContent } from './server/js/hono'
 import { JSNodeReorganizedContent } from './server/js/nodejs'
 import { JSNestReorganizedContent } from './server/js/nestjs'
+import { JSSvelteKitReorganizedContent } from './server/js/sveltekit'
 import { JStRPCReorganizedContent } from './server/js/trpc'
 import { JSPinoHTTPJSONLogReorganizedContent } from './server/js/pino'
 import { JSWinstonHTTPJSONLogReorganizedContent } from './server/js/winston'
@@ -208,6 +209,7 @@ export enum QuickStartType {
 	JSNestjs = 'nestjs',
 	JSWinston = 'winston',
 	JSPino = 'pino',
+	JSSvelteKit = 'sveltekit',
 	JStRPC = 'trpc',
 	HTTPOTLP = 'curl',
 	Syslog = 'syslog',
@@ -456,6 +458,7 @@ export const quickStartContent = {
 			[QuickStartType.JSHono]: JSHonoReorganizedContent,
 			[QuickStartType.JSNodejs]: JSNodeReorganizedContent,
 			[QuickStartType.JSNestjs]: JSNestReorganizedContent,
+			[QuickStartType.JSSvelteKit]: JSSvelteKitReorganizedContent,
 			[QuickStartType.JStRPC]: JStRPCReorganizedContent,
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,
@@ -601,6 +604,7 @@ export const quickStartContentReorganized = {
 			[QuickStartType.JSHono]: JSHonoReorganizedContent,
 			[QuickStartType.JSNodejs]: JSNodeReorganizedContent,
 			[QuickStartType.JSNestjs]: JSNestReorganizedContent,
+			[QuickStartType.JSSvelteKit]: JSSvelteKitReorganizedContent,
 			[QuickStartType.JStRPC]: JStRPCReorganizedContent,
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,

--- a/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
@@ -1,0 +1,91 @@
+import { QuickStartContent } from '../../QuickstartContent'
+import { verifyLogs } from '../shared-snippets-logging'
+import { frontendInstallSnippet } from '../shared-snippets-monitoring'
+import { verifyTraces } from '../shared-snippets-tracing'
+import { jsGetSnippet, verifyError } from './shared-snippets-monitoring'
+
+export const JSSvelteKitReorganizedContent: QuickStartContent = {
+	title: 'SvelteKit',
+	subtitle: 'Learn how to set up highlight.io in SvelteKit.',
+	logoKey: 'sveltekit',
+	products: ['Errors', 'Logs', 'Traces'],
+	entries: [
+		frontendInstallSnippet,
+		jsGetSnippet(['node']),
+		{
+			title: 'Add Highlight to your SvelteKit server hooks.',
+			content:
+				'There is no dedicated `@highlight-run/sveltekit` package, so SvelteKit uses the generic `@highlight-run/node` SDK. ' +
+				'Call `H.init()` once at module scope in `src/hooks.server.ts` so the SDK is ready before any request is served, then export SvelteKit\'s `handleError` hook. ' +
+				'`handleError` is the hook that actually needs to run to report page, load and endpoint errors: `resolve()` converts those errors into a response internally rather than re-throwing them, ' +
+				'so wrapping `resolve(event)` in a try/catch inside a `handle` hook will not see them. ' +
+				'`H.parseHeaders()` takes the request `Headers` directly and returns the `secureSessionId` and `requestId` that map the error back onto the browser session. ' +
+				'Note that `@highlight-run/node` targets Node.js runtimes only — if you deploy to an edge runtime such as Cloudflare Workers or Vercel Edge, use `@highlight-run/cloudflare` instead.',
+			code: [
+				{
+					text: `import { H, type NodeOptions } from '@highlight-run/node'
+import type { HandleServerError } from '@sveltejs/kit'
+
+const highlightConfig: NodeOptions = {
+	projectID: '<YOUR_PROJECT_ID>',
+	serviceName: 'my-sveltekit-app',
+	serviceVersion: 'git-sha',
+	environment: 'production',
+}
+
+H.init(highlightConfig)
+
+export const handleError: HandleServerError = async ({ error, event, message }) => {
+	const { secureSessionId, requestId } = H.parseHeaders(event.request.headers)
+
+	await H.consumeAndFlush(error instanceof Error ? error : new Error(String(error)), secureSessionId, requestId, {
+		url: event.request.url,
+	})
+
+	return { message }
+}`,
+					language: 'js',
+				},
+			],
+		},
+		{
+			title: 'Optionally, report errors manually from an endpoint.',
+			content:
+				'Wrap the body of a `+server.ts` endpoint in a try/catch when you want to report the error yourself and still control the response your client receives. ' +
+				'`H.consumeAndFlush()` awaits delivery before returning, which matters on short-lived Node platforms (AWS Lambda, Vercel and Netlify Node functions) where the process can be frozen as soon as a response is sent.',
+			code: [
+				{
+					text: `// src/routes/api/example/+server.ts
+import { json } from '@sveltejs/kit'
+import { H } from '@highlight-run/node'
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async (event) => {
+	const { secureSessionId, requestId } = H.parseHeaders(event.request.headers)
+
+	try {
+		// do something dangerous...
+		throw new Error('oh no!')
+	} catch (error) {
+		await H.consumeAndFlush(error as Error, secureSessionId, requestId)
+
+		return json({ error: 'Internal Server Error' }, { status: 500 })
+	}
+}`,
+					language: 'js',
+				},
+			],
+		},
+		verifyError(
+			'SvelteKit',
+			`// src/routes/api/sample-error/+server.ts
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async () => {
+	throw new Error('sample error!')
+}`,
+		),
+		verifyLogs,
+		verifyTraces,
+	],
+}


### PR DESCRIPTION
There's no dedicated `@highlight-run/sveltekit` package, so this adds a SvelteKit entry to the JS server quickstart following the same structure as Express/Node.js/Hono/tRPC:

- `highlight.io/components/QuickstartContent/server/js/sveltekit.tsx` — QuickStartContent entry
- `docs-content/getting-started/4_server/2_js/sveltekit.md` — thin doc page wired to it
- A SvelteKit card on the JS server overview page

Covers wiring the generic `@highlight-run/node` SDK into `hooks.server.ts` via the `handleError` hook — this is the hook SvelteKit actually calls for page/load/endpoint errors, since `resolve()` converts those into a response internally rather than throwing (a `try/catch` around `resolve()` in `handle` would not see them). Also shows manual `H.consumeAndFlush` reporting from a `+server.ts` endpoint, and notes that `@highlight-run/node` is Node-only — edge deployments need `@highlight-run/cloudflare`.

/claim #8032