### PR TITLE
docs: add SvelteKit server instrumentation

### DIFF
--- a/docs-content/getting-started/3_browser/6_sveltekit.md
+++ b/docs-content/getting-started/3_browser/6_sveltekit.md
@@ -6,3 +6,5 @@ quickstart: true
 ---
 
 <QuickStart content={quickStartContent["client"]["js"]["svelte-kit"]}/>
+
+To capture server-side errors, logs, and traces, continue with the [SvelteKit server quick start](../4_server/2_js/sveltekit.md).

--- a/docs-content/getting-started/4_server/2_js/1_overview.md
+++ b/docs-content/getting-started/4_server/2_js/1_overview.md
@@ -39,6 +39,9 @@ updatedAt: 2022-04-01T19:52:59.000Z
     <DocsCard title="Pino" href="../js/pino">
         {"Get started with Pino"}
     </DocsCard>
+    <DocsCard title="SvelteKit" href="../js/sveltekit">
+        {"Get started with SvelteKit"}
+    </DocsCard>
     <DocsCard title="tRPC" href="../js/trpc">
         {"Get started with tRPC"}
     </DocsCard>

--- a/docs-content/getting-started/4_server/2_js/sveltekit.md
+++ b/docs-content/getting-started/4_server/2_js/sveltekit.md
@@ -1,0 +1,8 @@
+---
+toc: SvelteKit
+title: SvelteKit Server Quick Start
+slug: sveltekit
+quickstart: true
+---
+
+<QuickStart content={quickStartContent["server"]["js"]["sveltekit"]}/>

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -106,6 +106,7 @@ import { JSFirebaseReorganizedContent } from './server/js/firebase'
 import { JSHonoReorganizedContent } from './server/js/hono'
 import { JSNodeReorganizedContent } from './server/js/nodejs'
 import { JSNestReorganizedContent } from './server/js/nestjs'
+import { JSSvelteKitReorganizedContent } from './server/js/sveltekit'
 import { JStRPCReorganizedContent } from './server/js/trpc'
 import { JSPinoHTTPJSONLogReorganizedContent } from './server/js/pino'
 import { JSWinstonHTTPJSONLogReorganizedContent } from './server/js/winston'
@@ -208,6 +209,7 @@ export enum QuickStartType {
 	JSNestjs = 'nestjs',
 	JSWinston = 'winston',
 	JSPino = 'pino',
+	JSSvelteKit = 'sveltekit',
 	JStRPC = 'trpc',
 	HTTPOTLP = 'curl',
 	Syslog = 'syslog',
@@ -456,6 +458,7 @@ export const quickStartContent = {
 			[QuickStartType.JSHono]: JSHonoReorganizedContent,
 			[QuickStartType.JSNodejs]: JSNodeReorganizedContent,
 			[QuickStartType.JSNestjs]: JSNestReorganizedContent,
+			[QuickStartType.JSSvelteKit]: JSSvelteKitReorganizedContent,
 			[QuickStartType.JStRPC]: JStRPCReorganizedContent,
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,
@@ -601,6 +604,7 @@ export const quickStartContentReorganized = {
 			[QuickStartType.JSHono]: JSHonoReorganizedContent,
 			[QuickStartType.JSNodejs]: JSNodeReorganizedContent,
 			[QuickStartType.JSNestjs]: JSNestReorganizedContent,
+			[QuickStartType.JSSvelteKit]: JSSvelteKitReorganizedContent,
 			[QuickStartType.JStRPC]: JStRPCReorganizedContent,
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,

--- a/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
@@ -3,10 +3,10 @@ import {
 	identifySnippet,
 	initializeSnippet,
 	packageInstallSnippet,
-	setupBackendSnippet,
 	verifySnippet,
 } from './shared-snippets'
 
+import { siteUrl } from '../../../utils/urls'
 import { QuickStartContent } from '../QuickstartContent'
 
 const svelteKitInitCodeSnippet = `// hooks.client.ts
@@ -43,7 +43,7 @@ export const SvelteKitContent: QuickStartContent = {
 		{
 			...initializeSnippet,
 			content:
-				'In SvelteKit, we recommend initializing highlight.io in the `hooks.client.js` or `hooks.client.ts` file. You can find more details about this file in the SvelteKit docs [here](https://kit.svelte.dev/docs/hooks). To get started, we recommend setting `tracingOrigins` and `networkRecording` so that we can pass a header to pair frontend and backend errors. \n\n\n' +
+				'In SvelteKit, we recommend initializing highlight.io in the `hooks.client.js` or `hooks.client.ts` file. You can find more details about this file in the SvelteKit docs [here](https://kit.svelte.dev/docs/hooks). Set `tracingOrigins` so the browser SDK sends the correlation header used to pair frontend sessions with backend errors. Enable `networkRecording` when you also want to capture request and response details. \n\n\n' +
 				`Grab your project ID from [app.highlight.io/setup](https://app.highlight.io/setup), and pass it as the first parameter of the \`H.init()\` method.`,
 			code: [
 				{
@@ -79,6 +79,11 @@ export default config;`,
 		identifySnippet,
 		verifySnippet,
 		configureSourcemapsCI(),
-		setupBackendSnippet,
+		{
+			title: 'Instrument your SvelteKit server. (optional)',
+			content: `Use the [SvelteKit server quick start](${siteUrl(
+				'/docs/getting-started/server/js/sveltekit',
+			)}) to capture server errors, logs, and traces and connect them to browser sessions.`,
+		},
 	],
 }

--- a/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
@@ -1,0 +1,163 @@
+import { QuickStartContent } from '../../QuickstartContent'
+import { verifyLogs } from '../shared-snippets-logging'
+import { frontendInstallSnippet } from '../shared-snippets-monitoring'
+import { verifyTraces } from '../shared-snippets-tracing'
+import { jsGetSnippet, verifyError } from './shared-snippets-monitoring'
+
+const hooksServerSnippet = `// src/hooks.server.ts
+import { building } from '$app/environment'
+import { env } from '$env/dynamic/private'
+import { H } from '@highlight-run/node'
+import type { Handle, HandleServerError } from '@sveltejs/kit'
+
+const projectID = env.HIGHLIGHT_PROJECT_ID
+
+if (!building) {
+	if (!projectID) {
+		throw new Error('HIGHLIGHT_PROJECT_ID is required')
+	}
+
+	if (!H.isInitialized()) {
+		H.init({
+			projectID,
+			serviceName: env.HIGHLIGHT_SERVICE_NAME ?? 'my-sveltekit-app',
+			serviceVersion: env.HIGHLIGHT_SERVICE_VERSION,
+			environment: env.HIGHLIGHT_ENVIRONMENT ?? 'production',
+		})
+	}
+}
+
+// SvelteKit uses Web Headers. A plain record lets the Node SDK and
+// OpenTelemetry read x-highlight-request and W3C trace headers reliably.
+const toHighlightHeaders = (headers: Headers): Record<string, string> =>
+	Object.fromEntries(headers.entries())
+
+const withHighlight: Handle = async ({ event, resolve }) => {
+	if (building || !H.isInitialized()) {
+		return resolve(event)
+	}
+
+	const headers = toHighlightHeaders(event.request.headers)
+	const route = event.route.id ?? 'unknown'
+
+	const response = await H.runWithHeaders(
+		\`\${event.request.method} \${route}\`,
+		headers,
+		() => resolve(event),
+	)
+
+	// Flush after runWithHeaders closes the request span. This also delivers
+	// errors queued by handleError before a short-lived Node function freezes.
+	if (response.status >= 500) {
+		await H.flush()
+	}
+
+	return response
+}
+
+export const handle = withHighlight
+
+export const handleError: HandleServerError = ({
+	error,
+	event,
+	status,
+	message,
+}) => {
+	if (building || !H.isInitialized()) {
+		return { message }
+	}
+
+	const { secureSessionId, requestId } = H.parseHeaders(
+		event.request.headers,
+	)
+	const reportedError =
+		error instanceof Error ? error : new Error(String(error))
+
+	H.consumeError(reportedError, secureSessionId, requestId, {
+		'http.request.method': event.request.method,
+		'http.route': event.route.id ?? 'unknown',
+		'http.response.status_code': status,
+	})
+
+	// Keep SvelteKit's safe public message instead of exposing the exception.
+	return { message }
+}`
+
+const sequenceSnippet = `// If hooks.server.ts already exports another Handle, compose it instead of
+// replacing it. Keep withHighlight first so its context wraps later hooks.
+import { sequence } from '@sveltejs/kit/hooks'
+
+export const handle = sequence(withHighlight, existingHandle)`
+
+export const JSSvelteKitReorganizedContent: QuickStartContent = {
+	title: 'SvelteKit',
+	subtitle:
+		'Learn how to capture SvelteKit server errors, logs, and traces with highlight.io.',
+	logoKey: 'sveltekit',
+	products: ['Errors', 'Logs', 'Traces'],
+	entries: [
+		frontendInstallSnippet,
+		jsGetSnippet(['node']),
+		{
+			title: 'Configure private server environment variables.',
+			content:
+				'Add your Highlight project ID to the private environment used by the SvelteKit server. ' +
+				'`HIGHLIGHT_SERVICE_NAME`, `HIGHLIGHT_SERVICE_VERSION`, and `HIGHLIGHT_ENVIRONMENT` are optional but make deployments easier to distinguish.',
+			code: [
+				{
+					text: `HIGHLIGHT_PROJECT_ID=<YOUR_PROJECT_ID>
+HIGHLIGHT_SERVICE_NAME=my-sveltekit-app
+HIGHLIGHT_SERVICE_VERSION=git-sha
+HIGHLIGHT_ENVIRONMENT=production`,
+					language: 'bash',
+				},
+			],
+		},
+		{
+			title: 'Instrument requests and report server errors.',
+			content:
+				'Initialize `@highlight-run/node` once at module scope in `src/hooks.server.ts`. ' +
+				'Wrap `resolve(event)` with `H.runWithHeaders(name, headers, callback)` so request logs and child spans share the incoming trace and Highlight session context. ' +
+				'SvelteKit provides a Web `Headers` object. Convert it to a fresh plain record before `H.runWithHeaders` so OpenTelemetry can extract and inject the enumerable `traceparent`, `tracestate`, `baggage`, and `x-highlight-request` carrier fields. `H.parseHeaders` can read Web `Headers` directly.\n\n' +
+				"SvelteKit turns unexpected errors from server load functions and endpoints into responses, so a `try/catch` around `resolve` is not sufficient. Queue those exceptions synchronously from `handleError`; after `resolve` returns a 5xx response, `handle` flushes the error and completed request span before a short-lived Node runtime can freeze. Expected errors created with SvelteKit's `error(...)` helper do not invoke `handleError` and must be reported manually if you want to capture them.\n\n" +
+				'The `building` guard prevents SDK initialization and telemetry while SvelteKit prerenders routes during the build.',
+			code: [
+				{
+					text: hooksServerSnippet,
+					language: 'ts',
+				},
+			],
+		},
+		{
+			title: 'Compose Highlight with existing server hooks. (optional)',
+			content:
+				"If your app already exports a `handle` hook, use SvelteKit's `sequence` helper rather than replacing it. " +
+				'Put `withHighlight` first so authentication, routing, and endpoint work runs inside the Highlight context.',
+			code: [
+				{
+					text: sequenceSnippet,
+					language: 'ts',
+				},
+			],
+		},
+		verifyError(
+			'SvelteKit server',
+			`// src/routes/api/highlight-test/+server.ts
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = () => {
+	console.info('Highlight captured this SvelteKit server request')
+	throw new Error('Highlight SvelteKit server test')
+}`,
+		),
+		verifyLogs,
+		verifyTraces,
+		{
+			title: 'Troubleshoot missing or unlinked telemetry.',
+			content:
+				'`@highlight-run/node` requires a Node-compatible SvelteKit adapter or serverless Node runtime; it does not run in Cloudflare Workers or other edge runtimes. A fully static adapter has no request-time server process, so only dynamic SSR routes and endpoints can produce server telemetry.\n\n' +
+				"If server telemetry arrives without a linked browser session, confirm the browser SDK's `tracingOrigins` includes the SvelteKit server origin and that proxies or cross-origin CORS rules preserve the `x-highlight-request` header. " +
+				'For an edge deployment, use the Cloudflare or native OpenTelemetry server setup instead. If you catch an error and return a successful response, call `H.consumeAndFlush` manually because the 5xx flush path will not run.',
+		},
+	],
+}


### PR DESCRIPTION
/claim #8032

## Summary

- add a dedicated SvelteKit server quickstart for errors, logs, and traces
- document `hooks.server.ts` initialization, request context with `H.runWithHeaders`, Web `Headers` conversion, `handleError`, 5xx flushing, and composition with `sequence`
- cover build/prerender guards plus Node, edge, and static-adapter limitations
- register the page in the JS server overview and both quickstart maps, then link it from the browser SvelteKit guide
- clarify that `tracingOrigins` links browser sessions to server telemetry while `networkRecording` controls request and response capture

## Demo

![Rendered SvelteKit server quickstart](https://raw.githubusercontent.com/losnah-think/highlight/bounty-assets-8032/.github/bounty-assets/8032/sveltekit-top.png)

[Watch the 57-second rendered-doc walkthrough](https://raw.githubusercontent.com/losnah-think/highlight/bounty-assets-8032/.github/bounty-assets/8032/sveltekit-demo.webm)

## How did you test this change?

- Prettier on all 6 touched TSX and Markdown files
- ESLint on the 3 touched TSX files
- strict TypeScript check of the extracted `hooks.server.ts` example
- `git diff --check`
- Highlight production Next build completed; all 314 static pages, including `/docs/getting-started/server/js/sveltekit`, were generated
- loaded the production page locally with Playwright, confirmed the new navigation item and all 9 quickstart steps, and recorded the linked walkthrough

The local page only reported expected third-party analytics failures; no document rendering errors occurred.

## Are there any deployment considerations?

None. This is documentation and quickstart registry wiring only.

## Does this work require review from our design team?

No.

AI-assisted with OpenAI Codex and manually reviewed against the current `@highlight-run/node` APIs and rendered production output.