### PR TITLE
docs: add SvelteKit server instrumentation quickstart

### DIFF
--- a/docs-content/getting-started/4_server/2_js/1_overview.md
+++ b/docs-content/getting-started/4_server/2_js/1_overview.md
@@ -36,6 +36,9 @@ updatedAt: 2022-04-01T19:52:59.000Z
     <DocsCard title="Node.js" href="../js/nodejs">
         {"Get started with Node.js"}
     </DocsCard>
+    <DocsCard title="SvelteKit" href="../js/sveltekit">
+        {"Get started with SvelteKit"}
+    </DocsCard>
     <DocsCard title="Pino" href="../js/pino">
         {"Get started with Pino"}
     </DocsCard>

--- a/docs-content/getting-started/4_server/2_js/sveltekit.md
+++ b/docs-content/getting-started/4_server/2_js/sveltekit.md
@@ -1,0 +1,11 @@
+---
+title: SvelteKit
+heading: SvelteKit Server Quick Start
+metaTitle: SvelteKit Server Quick Start
+slug: sveltekit
+createdAt: 2026-08-12T00:00:00.000Z
+updatedAt: 2026-08-12T00:00:00.000Z
+quickstart: true
+---
+
+<QuickStart content={quickStartContent["server"]["js"]["svelte-kit"]}/>

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -138,6 +138,7 @@ import { ElixirOtherReorganizedContent } from './server/elixir/other'
 import { ReactNativeContent } from './frontend/react-native'
 import { siteUrl } from '../../utils/urls'
 import { NextJsTracesReorganizedContent } from './server/js/nextjs'
+import { JSSvelteKitReorganizedContent } from './server/js/sveltekit'
 import { AWSLambdaTracingSteps } from './server/serverless/shared-snippets-aws-lambda'
 
 export type QuickStartContent = {
@@ -461,6 +462,7 @@ export const quickStartContent = {
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSManual]: JSManualTracesReorganizedContent,
 			[QuickStartType.JSNextjs]: NextJsTracesReorganizedContent,
+			[QuickStartType.SvelteKit]: JSSvelteKitReorganizedContent,
 		},
 		php: {
 			title: 'PHP',
@@ -605,6 +607,7 @@ export const quickStartContentReorganized = {
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSManual]: JSManualTracesReorganizedContent,
+			[QuickStartType.SvelteKit]: JSSvelteKitReorganizedContent,
 			[QuickStartType.OTLP]: OTLPReorganizedContent,
 		},
 	},

--- a/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
@@ -3,10 +3,10 @@ import {
 	identifySnippet,
 	initializeSnippet,
 	packageInstallSnippet,
-	setupBackendSnippet,
 	verifySnippet,
 } from './shared-snippets'
 
+import { siteUrl } from '../../../utils/urls'
 import { QuickStartContent } from '../QuickstartContent'
 
 const svelteKitInitCodeSnippet = `// hooks.client.ts
@@ -79,6 +79,9 @@ export default config;`,
 		identifySnippet,
 		verifySnippet,
 		configureSourcemapsCI(),
-		setupBackendSnippet,
+		{
+			title: 'Instrument your SvelteKit server.',
+			content: `The browser SDK records sessions and client errors. To record server errors, logs, and traces and connect them to those sessions, follow the [SvelteKit server quickstart](${siteUrl('/docs/getting-started/server/js/sveltekit')}).`,
+		},
 	],
 }

--- a/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
@@ -1,0 +1,117 @@
+import { QuickStartContent } from '../../QuickstartContent'
+import { verifyLogs } from '../shared-snippets-logging'
+import { frontendInstallSnippet } from '../shared-snippets-monitoring'
+import { verifyTraces } from '../shared-snippets-tracing'
+import { jsGetSnippet, verifyError } from './shared-snippets-monitoring'
+
+export const JSSvelteKitReorganizedContent: QuickStartContent = {
+	title: 'SvelteKit',
+	subtitle:
+		'Learn how to instrument a SvelteKit server running in a Node.js runtime.',
+	logoKey: 'sveltekit',
+	products: ['Errors', 'Logs', 'Traces'],
+	entries: [
+		frontendInstallSnippet,
+		jsGetSnippet(['node']),
+		{
+			title: 'Instrument src/hooks.server.ts.',
+			content:
+				'Initialize the Node SDK once when the server module loads. The `handle` hook creates a request span and propagates the incoming trace and Highlight session context while SvelteKit resolves the request. Convert the web-standard `Headers` object to the plain header record accepted by the Node SDK. The separate `handleError` hook reports unexpected errors from server loads, actions, rendering, and endpoints. SvelteKit does not call `handleError` for expected errors created with its `error(...)` helper.',
+			code: [
+				{
+					language: 'ts',
+					text: `// src/hooks.server.ts
+import { building } from '$app/environment'
+import { H } from '@highlight-run/node'
+import type { Handle, HandleServerError } from '@sveltejs/kit'
+
+if (!building && !H.isInitialized()) {
+	H.init({
+		projectID: '<YOUR_PROJECT_ID>',
+		serviceName: 'my-sveltekit-server',
+		serviceVersion: 'git-sha',
+		environment: 'production',
+	})
+}
+
+export const handle: Handle = async ({ event, resolve }) => {
+	if (building) {
+		return resolve(event)
+	}
+
+	const spanName = \`\${event.request.method} \${
+		event.route.id ?? event.url.pathname
+	}\`
+	const headers = Object.fromEntries(event.request.headers)
+
+	return H.runWithHeaders(spanName, headers, () => resolve(event))
+}
+
+export const handleError: HandleServerError = async ({
+	error,
+	event,
+	message,
+}) => {
+	if (H.isInitialized()) {
+		const headers = Object.fromEntries(event.request.headers)
+		const { secureSessionId, requestId } = H.parseHeaders(headers)
+		const reportedError =
+			error instanceof Error
+				? error
+				: new Error('A non-Error value was thrown by the SvelteKit server')
+
+		H.consumeError(reportedError, secureSessionId, requestId)
+	}
+
+	// Return only SvelteKit's safe message to the client.
+	return { message }
+}`,
+				},
+			],
+		},
+		{
+			title: 'Compose with existing server hooks.',
+			content:
+				"If your app already exports a `handle` hook, keep each concern separate and compose the handlers with SvelteKit's `sequence` helper. Put Highlight first so its context surrounds the rest of the request pipeline.",
+			code: [
+				{
+					language: 'ts',
+					text: `// src/hooks.server.ts
+import { sequence } from '@sveltejs/kit/hooks'
+import type { Handle } from '@sveltejs/kit'
+
+const withHighlight: Handle = async ({ event, resolve }) => {
+	if (building) {
+		return resolve(event)
+	}
+
+	const spanName = \`\${event.request.method} \${
+		event.route.id ?? event.url.pathname
+	}\`
+	const headers = Object.fromEntries(event.request.headers)
+
+	return H.runWithHeaders(spanName, headers, () => resolve(event))
+}
+
+export const handle = sequence(withHighlight, yourExistingHandle)`,
+				},
+			],
+		},
+		{
+			title: 'Check your deployment runtime.',
+			content:
+				'`@highlight-run/node` requires a Node.js runtime, such as `adapter-node` or a provider adapter configured for Node.js. It is not compatible with edge runtimes; use the relevant edge integration, such as the [Cloudflare Workers quickstart](https://www.highlight.io/docs/getting-started/server/js/cloudflare), instead. Fully prerendered sites built with `adapter-static` have no production SvelteKit server to instrument. The `building` guard above also keeps prerendering out of production telemetry. On short-lived serverless functions, use `await H.consumeAndFlush(...)` instead of `H.consumeError(...)` when the runtime may exit before queued telemetry is sent.',
+		},
+		verifyError(
+			'SvelteKit server',
+			`// src/routes/api/highlight-test/+server.ts
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = () => {
+	throw new Error('Highlight SvelteKit server test error')
+}`,
+		),
+		verifyLogs,
+		verifyTraces,
+	],
+}


### PR DESCRIPTION
### Summary

- add a dedicated SvelteKit server quickstart and wire it into the Server/JS navigation
- document current `@highlight-run/node` request context and SvelteKit server-error handling
- explain Node, edge, static, prerender, and serverless runtime behavior
- cross-link the existing browser guide for full-stack setup

### Validation

- Prettier check on all changed files
- targeted ESLint and `highlight.io` lint
- extracted TypeScript snippets type-checked against current repository packages
- `turbo run build --filter=highlight.io...` (19/19 tasks, 314/314 static pages)
- production page rendered and visually inspected in headless Chromium

### Demo

[Watch/download the 22-second rendered-page demo](https://github.com/alexsmolya/highlight/releases/download/highlight-8032-demo/sveltekit-server-demo.mp4)

/claim #8032
