### PR TITLE
fix(deps): bump basic-ftp to 5.3.1 to remediate CVE-2026-27699

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
 		"cookie@^0.6.0": "0.7.2",
 		"cookie@~0.4.1": "0.7.2",
 		"debug@4.1.1": "4.3.7",
+		"basic-ftp": "^5.2.0",
 		"lodash-es@^4.17.21": "patch:lodash-es@npm%3A4.17.21#./.yarn/patches/lodash-es-npm-4.17.21-b45832dfce.patch",
 		"protobufjs": "patch:protobufjs@npm%3Alatest#~/.yarn/patches/protobufjs-npm-7.2.6-4bb38caa1d.patch",
 		"semver@7.3.5": "7.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28890,10 +28890,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"basic-ftp@npm:^5.0.2":
-  version: 5.0.3
-  resolution: "basic-ftp@npm:5.0.3"
-  checksum: 10/8f69811a7f4088c5ae39025f1a662522aad517b4065365fbbe80676dc9ccf7a188463dfcb2d9573af2af859d7de70015f612c20a04a311b520efbf7c21dc1ff2
+"basic-ftp@npm:^5.2.0":
+  version: 5.3.1
+  resolution: "basic-ftp@npm:5.3.1"
+  checksum: 10/9232ee155114efafadf5adee86a6750208653a9071e53e9803dceac61a66b3ba3974771ff2490ff28f1a118fdfb806ffcc488f64609e61a9cedb52480b312843
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps `basic-ftp` from **5.0.3 → 5.3.1** to remediate **CVE-2026-27699** (critical severity path traversal, NVD Critical, known exploit available per VulnCheck). Flagged by Wiz on the `session-screenshots` lambda; first detected 2026-03-25.

This ports the one-line `resolutions` entry that `launchdarkly/observability` used to fix the same alert (their #1017, "bump critical Dependabot npm deps via resolutions"). The resulting lockfile entry — 5.3.1, checksum `9232ee1551…` — is byte-identical to observability's.

## Why a resolution rather than a dependency upgrade

The vulnerable package is transitive, reached only through `puppeteer-core`:

```
render -> puppeteer-core@22.15.0 -> proxy-agent
       -> pac-proxy-agent -> get-uri@6.0.1 -> basic-ftp@^5.0.2
```

`get-uri@6.0.1` requests `^5.0.2`, and no `puppeteer-core` release moves off that range, so there is no upgrade path from the direct dependency. A root-level `resolutions` pin is the only fix, which is the same conclusion observability reached.

## Verification

- `yarn workspaces focus render`, then confirmed the exact file Wiz flagged — `render/node_modules/puppeteer-core/node_modules/basic-ftp/package.json` — now reads `5.3.1`.
- `yarn workspace render build` is clean (tsup, 3 entrypoints).
- Re-running lockfile resolution produces no further diff, so the lockfile is at a stable fixed point (what an `--immutable` CI install enforces).
- `basic-ftp@5.3.1` declares `engines.node >=10.0.0` and has **zero** runtime dependencies, so it is safe on the lambda's current `nodejs20.x` and on any newer runtime. Its only consumer is `get-uri`, which uses it solely to resolve `ftp://` URIs during PAC proxy resolution — a path this lambda never exercises.

## Deploy note

The lockfile change alone does not remediate the deployed function. Wiz will keep reporting 5.0.3 until `render` is republished:

```
cd render && yarn publish
```

which rebuilds, uploads to `s3://highlight-lambda-code/session-screenshots.zip`, and runs `update-function-code` for both `session-screenshots` and `session-activity`.

## Out of scope / follow-ups

- **`nodejs20.x` is EOL (2026-04-30).** Not fixable in this repo — the `session-screenshots` function has no IaC here (`render/package.json` only calls `update-function-code`), so the runtime is set out-of-band and needs `aws lambda update-function-configuration --runtime nodejs22.x`. nodejs20.x/22.x/24.x are all Amazon Linux 2023 and `@sparticuz/chromium@126.0.0` ships `al2023.tar.br`, so 22.x is a same-OS, low-risk move; 24.x is not explicitly validated by that package.
- **`fast-xml-parser@4.4.1`** (ReDoS / billion-laughs) is in the same lambda bundle via `@aws-sdk/core@3.629.0`; observability bumped it to 4.5.4+ in the same PR. Left out to keep this change scoped to the Wiz ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
