### PR TITLE
feat(highlight.io): redirect landing page to launchdarkly.com

### DIFF
--- a/highlight.io/next.config.ts
+++ b/highlight.io/next.config.ts
@@ -427,6 +427,16 @@ const nextConfig: Promise<NextConfig> = withHighlightConfig({
 				destination: '/docs/general/integrations/wordpress-integration',
 				permanent: true,
 			},
+			// Keep last: highlight.io is sunset, so any page without a more
+			// specific redirect above goes to launchdarkly.com. Next internals,
+			// API routes and public assets are excluded so that the
+			// sitemap.xml and /blog/rss.xml rewrites keep serving -- rewrites
+			// are applied after redirects, so a bare catch-all would eat them.
+			{
+				source: '/:path((?!_next/|api/|images/|videos/|styles/|favicon\\.ico|robots\\.txt|sitemap\\.xml|blog/rss\\.xml).*)',
+				destination: 'https://launchdarkly.com/',
+				permanent: true,
+			},
 		]
 	},
 	async headers() {


### PR DESCRIPTION
## Summary

highlight.io is sunset (the migration deadline was February 28, 2026), so send the landing site to LaunchDarkly.

This is one catch-all redirect appended to the end of `redirects()` in `highlight.io/next.config.ts`. Redirects are first-match-wins, so **anything with a more specific redirect above keeps its existing behavior** — most importantly the ~55 migrated blog posts, which still go to their `launchdarkly.com/docs/tutorials/<slug>` pages. Everything else `308`s to `https://launchdarkly.com/`.

> This is the simple alternative to #10611, which additionally maps each docs page to its individual LaunchDarkly equivalent. Only one of the two should merge.

### Exclusions

The source uses a negative lookahead excluding `_next/`, `api/`, `images/`, `videos/`, `styles/`, `favicon.ico`, `robots.txt`, `sitemap.xml` and `blog/rss.xml`. Rewrites are applied *after* redirects, so a bare catch-all would eat the `sitemap.xml` and `/blog/rss.xml` rewrites and crawlers would lose the ability to discover the `308`s.

### Two consequences worth knowing

Both follow from leaving existing redirects untouched, and both are fine if we accept that docs land on the LaunchDarkly home page:

1. **Docs go to the root, not to a specific page.** `/docs/getting-started/server/go/gin` and friends all land on `https://launchdarkly.com/`. #10611 is the version that maps them per-page.
2. **The pre-existing internal `/docs/... -> /docs/...` redirects now chain.** For example `/docs` `307`s to `/docs/general/welcome`, which then `308`s to `https://launchdarkly.com/`. Correct destination, one extra hop. Relatedly, the `DOCS_REDIRECTS` table in `highlight.io/middleware.ts` becomes unreachable, because `next.config` redirects are evaluated before middleware — so legacy URLs like `/docs/api/hidentify` now go straight to the root instead of hopping through it. Left in place to keep this diff to a single file.

## How did you test this change?

No full build; validated the routing table directly.

- Next's own `loadCustomRoutes` compiles all 68 redirects with no validation errors, including the negative-lookahead source.
- Resolved paths through Next's real matcher (`getPathMatch` from `next/dist/shared/lib/router/utils/path-match`) against the assembled `redirects()` output:

| Request | Result |
| --- | --- |
| `/blog/worker-pools`, `/blog/what-is-opentelemetry` | `…/docs/tutorials/<slug>` (unchanged) |
| `/blog/post/opensearch-for-a-write-heavy-workload` | `…/docs/tutorials/opensearch-for-a-write-heavy-workload` (unchanged) |
| `/blog`, `/blog/tag/*`, unmapped post | `https://launchdarkly.com/` |
| `/`, `/pricing`, `/customers/*`, `/compare/*`, `/for/*`, `/terms`, `/r/*` | `https://launchdarkly.com/` |
| `/docs/general/welcome`, `/docs/getting-started/server/go/gin` | `https://launchdarkly.com/` |
| `/docs`, `/docs/general`, `/docs/getting-started` | internal hop first, then `https://launchdarkly.com/` |
| `/docs/api/hidentify`, `/docs/nextjs` (previously middleware) | `https://launchdarkly.com/` |
| `/careers/*`, `/community`, `/github` | unchanged external targets |
| `/api/*`, `/sitemap.xml`, `/blog/rss.xml`, `/robots.txt`, `/images/*`, `/videos/*`, `/_next/*` | not redirected |

- `tsc --noEmit` clean and `next lint` clean; prettier reports no change.
- Note: `highlight.io/tsconfig.json` has a pre-existing `TS6379` composite/incremental conflict. It reproduces on `main` and is unrelated to this change.

## Are there any deployment considerations?

Yes — `permanent: true` means `308`, which browsers cache aggressively. Rolling back after deploy will not immediately restore highlight.io for users who have already been redirected. If we want an easy escape hatch, flipping this one entry to `permanent: false` (`307`) makes it revertible at the cost of SEO consolidation.

## Does this work require review from our design team?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
