### PR TITLE
docs: document sveltekit backend instrumentation (#8032)

### DIFF
--- a/docs-content/getting-started/4_server/2_js/1_overview.md
+++ b/docs-content/getting-started/4_server/2_js/1_overview.md
@@ -39,6 +39,9 @@ updatedAt: 2022-04-01T19:52:59.000Z
     <DocsCard title="Pino" href="../js/pino">
         {"Get started with Pino"}
     </DocsCard>
+    <DocsCard title="SvelteKit" href="../js/sveltekit">
+        {"Get started with SvelteKit"}
+    </DocsCard>
     <DocsCard title="tRPC" href="../js/trpc">
         {"Get started with tRPC"}
     </DocsCard>

--- a/docs-content/getting-started/4_server/2_js/sveltekit.md
+++ b/docs-content/getting-started/4_server/2_js/sveltekit.md
@@ -1,0 +1,11 @@
+---
+toc: SvelteKit
+title: SvelteKit Quick Start
+slug: sveltekit
+createdAt: 2024-01-01T00:00:00.000Z
+updatedAt: 2024-01-01T00:00:00.000Z
+quickstart: true
+---
+
+<QuickStart content={quickStartContent["server"]["js"]["svelte-kit"]}/>
+

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -104,6 +104,7 @@ import { JSCloudflareReorganizedContent } from './server/js/cloudflare'
 import { JSExpressReorganizedContent } from './server/js/express'
 import { JSFirebaseReorganizedContent } from './server/js/firebase'
 import { JSHonoReorganizedContent } from './server/js/hono'
+import { JSSvelteKitReorganizedContent } from './server/js/sveltekit'
 import { JSNodeReorganizedContent } from './server/js/nodejs'
 import { JSNestReorganizedContent } from './server/js/nestjs'
 import { JStRPCReorganizedContent } from './server/js/trpc'
@@ -461,6 +462,7 @@ export const quickStartContent = {
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSManual]: JSManualTracesReorganizedContent,
 			[QuickStartType.JSNextjs]: NextJsTracesReorganizedContent,
+			[QuickStartType.SvelteKit]: JSSvelteKitReorganizedContent,
 		},
 		php: {
 			title: 'PHP',
@@ -605,6 +607,7 @@ export const quickStartContentReorganized = {
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogReorganizedContent,
 			[QuickStartType.JSManual]: JSManualTracesReorganizedContent,
+			[QuickStartType.SvelteKit]: JSSvelteKitReorganizedContent,
 			[QuickStartType.OTLP]: OTLPReorganizedContent,
 		},
 	},

--- a/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/server/js/sveltekit.tsx
@@ -1,0 +1,66 @@
+import { QuickStartContent } from '../../QuickstartContent'
+import { frontendInstallSnippet } from '../shared-snippets-monitoring'
+import { jsGetSnippet, verifyError } from './shared-snippets-monitoring'
+
+export const JSSvelteKitReorganizedContent: QuickStartContent = {
+	title: 'SvelteKit',
+	subtitle: 'Learn how to set up highlight.io in SvelteKit.',
+	logoKey: 'sveltekit',
+	products: ['Errors'],
+	entries: [
+		frontendInstallSnippet,
+		jsGetSnippet(['node']),
+		{
+			title: 'Initialize the Highlight SDK.',
+			content:
+				'Initialize the [Highlight JS SDK](https://www.highlight.io/docs/sdk/nodejs) in the SvelteKit [server hooks](https://svelte.dev/docs/kit/hooks#Server-hooks) file, `src/hooks.server.ts`.',
+			code: [
+				{
+					text: `// src/hooks.server.ts
+import { H } from '@highlight-run/node'
+
+H.init({
+  projectID: '<YOUR_PROJECT_ID>',
+  serviceName: '<YOUR_SERVICE_NAME>',
+})`,
+					language: 'ts',
+				},
+			],
+		},
+		{
+			title: 'Add the SvelteKit error handler.',
+			content:
+				'Use the SvelteKit [`handleError`](https://svelte.dev/docs/kit/hooks#Server-hooks-handleError) hook to report server errors to Highlight. Parsing the request headers links backend errors to the frontend session.',
+			code: [
+				{
+					text: `// src/hooks.server.ts
+import { H } from '@highlight-run/node'
+import type { HandleServerError } from '@sveltejs/kit'
+
+H.init({
+  projectID: '<YOUR_PROJECT_ID>',
+  serviceName: '<YOUR_SERVICE_NAME>',
+})
+
+export const handleError: HandleServerError = ({ error, event }) => {
+  const { secureSessionId, requestId } = H.parseHeaders(
+    event.request.headers,
+  )
+  H.consumeError(error as Error, secureSessionId, requestId)
+}`,
+					language: 'ts',
+				},
+			],
+		},
+		verifyError(
+			'sveltekit',
+			`// src/routes/+page.ts
+import type { RequestHandler } from '@sveltejs/kit'
+
+export const GET: RequestHandler = async () => {
+  throw new Error('sample error!')
+  return new Response('Hello World!')
+}`,
+		),
+	],
+}


### PR DESCRIPTION
/claim #8032

Adds a SvelteKit backend instrumentation quickstart mirroring the Express server doc. It covers installing @highlight-run/node, initializing the Highlight SDK in src/hooks.server.ts, and reporting errors via SvelteKit's handleError hook with header-based session linking.